### PR TITLE
feat(release): Add certification workflow

### DIFF
--- a/.agents/skills/cryptad-interop-performance-gates/SKILL.md
+++ b/.agents/skills/cryptad-interop-performance-gates/SKILL.md
@@ -1,17 +1,19 @@
 ---
 name: cryptad-interop-performance-gates
-description: "Maintain Cryptad's Hyphanet interop and performance regression gates under tools/interop, tools/perf, CI jobs, and release-readiness documentation."
+description: "Maintain Cryptad's Hyphanet interop, performance regression, and release-certification evidence gates under tools/interop, tools/perf, tools/release-certification, CI jobs, and release-readiness documentation."
 ---
 
 # Cryptad interop and performance gates
 
-Use this skill before changing `tools/interop`, `tools/perf`, related CI jobs, or release-gate
-documentation.
+Use this skill before changing `tools/interop`, `tools/perf`, `tools/release-certification`,
+related CI jobs, or release-gate documentation.
 
 ## Read first
 
 - Hyphanet interop gate: `tools/interop/README.md`
 - Performance regression gate: `tools/perf/README.md`
+- Release certification workflow: `docs/release-certification.md`
+- Release certification tooling: `tools/release-certification/README.md`
 - Release readiness gates: `docs/cryptad-release-workflow-and-runbook.md`
 - Phase 3 platform closeout context: `docs/phase-3-platform-primacy-closeout.md`
 
@@ -57,10 +59,45 @@ PERF_MODE=collect PERF_SKIP_BUILD=1 tools/perf/run-performance-smoke.sh
 - Do not update `tools/perf/baselines/performance-smoke.json` only to silence a regression. Record
   before/after summaries, host or runner details, Java version, commit SHA, and the rationale.
 
+## Release certification gate
+
+- `tools/release-certification/release_certification.py` aggregates interop, performance,
+  app-platform, catalog, app-owned UI, legacy-admin retirement, and CI metadata into:
+
+```text
+build/release-certification/release-certification-summary.json
+build/release-certification/release-certification-report.md
+build/release-certification/artifacts/
+```
+
+- `tools/release-certification/app_platform_smoke.py` produces the app-platform summary consumed by
+  the aggregator. It keeps `--self-test` offline and Python-only.
+- The wrapper resolves relative `--out-dir` values under the repository root, then runs the
+  app-platform smoke collector before aggregation.
+- Normal local commands:
+
+```bash
+python3 tools/release-certification/release_certification.py --self-test
+python3 tools/release-certification/app_platform_smoke.py --self-test
+tools/release-certification/run-release-certification.sh
+tools/release-certification/run-release-certification.sh --mode release-candidate --out-dir build/release-certification
+```
+
+- Release-candidate mode fails when required evidence is missing, skipped, malformed, wrong-mode,
+  or failing unless a release-manager waiver is recorded.
+- Do not publish private signing keys, form passwords, app tokens, browser-session tokens, raw
+  request bodies, private insert URIs, non-localhost endpoint metadata, or unsanitized local paths.
+  The aggregator filters `artifacts/private-insert-uris.json` even when interop summaries reference
+  it.
+
 ## CI and release notes
 
 - `.github/workflows/ci.yml` runs `interop-smoke` on push/PR, `interop-extended` on schedule/manual,
-  interop self-tests on the multi-OS matrix, performance self-tests on the multi-OS matrix, and
-  `performance-smoke` on schedule/manual.
-- Release notes should mention interop/performance gate changes only when they affect release
-  readiness, operator confidence, app/platform behavior, or packager workflows.
+  interop self-tests on the multi-OS matrix, performance self-tests on the multi-OS matrix,
+  release-certification self-tests on the multi-OS matrix, and `performance-smoke` on
+  schedule/manual.
+- `.github/workflows/release-certification.yml` runs scheduled/manual/release-ref certification,
+  uploads sanitized certification artifacts, and uses `release-candidate` mode for `release/**`
+  branches and `v*` tags.
+- Release notes should mention interop, performance, or certification gate changes only when they
+  affect release readiness, operator confidence, app/platform behavior, or packager workflows.

--- a/.agents/skills/cryptad-platform-apps/SKILL.md
+++ b/.agents/skills/cryptad-platform-apps/SKILL.md
@@ -20,6 +20,7 @@ Load only the docs needed for the change:
 - AppHost runtime/log/token boundary: `docs/apphost-runtime-hardening.md`
 - App-token permission matrix and audit model: `docs/app-permissions-and-audit.md`
 - Legacy admin replacement map and usage counters: `docs/legacy-retirement-plan.md`
+- App-platform release evidence: `docs/release-certification.md`
 
 ## Ownership map
 
@@ -71,6 +72,23 @@ Load only the docs needed for the change:
   controls, not hard OS isolation.
 - Legacy admin retirement changes must update both the code map
   (`LegacyAdminRetirementRegistry`) and `docs/legacy-retirement-plan.md`.
+- Release-certification evidence must not expose private signing keys, app process tokens,
+  browser-session tokens, form passwords, raw request bodies, private insert URIs, non-localhost
+  endpoint metadata, or unsanitized local paths. Optional live AppHost smoke reads the form password
+  from `CRYPTAD_CERT_FORM_PASSWORD`; do not pass it as a command-line argument.
+
+## Release certification smoke
+
+- `tools/release-certification/app_platform_smoke.py` is the app-platform evidence collector for
+  release certification. It validates first-party staged bundles, static UI/SDK coherence,
+  `crypta-app init/validate/pack`, signed bundle evidence, signed catalog evidence,
+  legacy-admin retirement state, and optional localhost-only live AppHost lifecycle evidence.
+- `pr` mode must stay fast and offline-safe. It must not require a live node, signing keys, Hyphanet
+  downloads, or production credentials.
+- `release-candidate` mode treats missing required signed bundle/catalog/app-platform evidence as
+  failing unless a release-manager waiver is recorded by the aggregator.
+- Keep app smoke self-tests Python-only and deterministic. Use fixtures or fake CLI helpers instead
+  of network or Java dependencies for regression coverage where possible.
 
 ## Validation
 
@@ -89,6 +107,7 @@ Use `$cryptad-build-test` for Gradle rules and timeouts. Common focused checks:
 ./gradlew :apps:queue-manager:test
 ./gradlew :apps:publisher:test
 ./gradlew stageFirstPartyApps
+python3 tools/release-certification/app_platform_smoke.py --self-test
 ```
 
 When changing route contracts or bridge wiring, also run the relevant root router/toadlet tests
@@ -97,3 +116,11 @@ with `./gradlew :test --tests *PlatformApiRouterTest --tests *PlatformApiToadlet
 When changing `crypta-app` command wiring or distribution behavior, also run
 `./gradlew :platform-devtools:installDist` and smoke the generated
 `platform-devtools/build/install/crypta-app/bin/crypta-app --help` launcher.
+
+When changing signed bundle/catalog, static UI, SDK, AppHost lifecycle, or legacy-admin retirement
+evidence behavior, also run:
+
+```bash
+python3 tools/release-certification/app_platform_smoke.py --self-test
+tools/release-certification/run-release-certification.sh --mode pr --skip-gradle --skip-git-metadata
+```

--- a/.agents/skills/cryptad-release-workflow/SKILL.md
+++ b/.agents/skills/cryptad-release-workflow/SKILL.md
@@ -29,9 +29,10 @@ Build: 2
 - Stabilization only: allow critical fixes/docs/release tasks; avoid large refactors.
 - Do not rebase/squash release merges.
 - Use `docs/cryptad-release-workflow-and-runbook.md` as the detailed release-readiness source of
-  truth. Current release gates include first-party app staging/signing/verification, catalog and
-  app-owned UI smoke when those surfaces ship, `crypta-app` CLI smoke when developer tooling
-  changes, Hyphanet interop smoke/soak evidence, and the packaged-node performance smoke.
+  truth. Current release gates include the release certification report, first-party app
+  staging/signing/verification, catalog and app-owned UI smoke, `crypta-app` CLI smoke, legacy-admin
+  retirement evidence, Hyphanet interop smoke/soak evidence, and the packaged-node performance
+  smoke.
 
 ---
 
@@ -47,6 +48,16 @@ git checkout -b release/<build-number>
    Follow the release gates in `docs/cryptad-release-workflow-and-runbook.md`; load
    `$cryptad-build-test`, `$cryptad-platform-apps`, and `$cryptad-interop-performance-gates` when
    those areas are involved.
+
+   Before promotion, generate or verify the release-candidate certification artifacts:
+   ```sh
+   tools/release-certification/run-release-certification.sh \
+     --mode release-candidate \
+     --out-dir build/release-certification
+   ```
+   Preserve `build/release-certification/release-certification-summary.json`,
+   `build/release-certification/release-certification-report.md`, and sanitized
+   `build/release-certification/artifacts/`.
 
 3) Stabilize on `release/<build-number>` (critical fixes only). Keep diffs minimal.
 
@@ -80,12 +91,19 @@ git push origin v<build-number>
 ## Checklist
 - [ ] `build.gradle.kts` version is the intended integer build number.
 - [ ] CI green on `release/<build-number>`.
+- [ ] Release certification report generated in `release-candidate` mode and required evidence
+      passed or has an explicit release-manager waiver.
 - [ ] First-party AppHost bundles staged, signed, and verified when shipping app-platform artifacts.
 - [ ] `crypta-app` CLI smoke completed when `:platform-devtools` changed.
+- [ ] Signed catalog, app-owned UI, and legacy-admin retirement evidence are present in the
+      certification summary.
 - [ ] Hyphanet interop smoke passed or CI evidence recorded; extended interop captured when
       compatibility-sensitive behavior changed.
 - [ ] Performance smoke passed or scheduled/manual CI evidence recorded when release readiness or
       performance-sensitive changes require it.
+- [ ] Release record excludes `artifacts/private-insert-uris.json`, private signing keys, form
+      passwords, app tokens, browser-session tokens, raw request bodies, and unsanitized local
+      paths.
 - [ ] Tag `v<build-number>` created.
 - [ ] Merged to `main` with `--no-ff` (no squash), then back-merged to `develop` with `--no-ff`.
 - [ ] Branches and tag pushed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,35 @@ jobs:
         shell: bash
         run: ${{ matrix.python_cmd }} tools/perf/perf_smoke.py --self-test
 
+  release-certification-self-test:
+    name: release certification self-test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            python_cmd: python3
+          - os: macos-latest
+            python_cmd: python3
+          - os: windows-latest
+            python_cmd: py -3
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Run release certification self-tests
+        shell: bash
+        run: |
+          ${{ matrix.python_cmd }} tools/release-certification/release_certification.py --self-test
+          ${{ matrix.python_cmd }} tools/release-certification/app_platform_smoke.py --self-test
+
   dependency-submission:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
 

--- a/.github/workflows/release-certification.yml
+++ b/.github/workflows/release-certification.yml
@@ -1,0 +1,118 @@
+name: Release Certification
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Certification mode.
+        required: true
+        default: nightly
+        type: choice
+        options:
+          - pr
+          - nightly
+          - release-candidate
+      extended-gates:
+        description: Run extended interop soak in addition to smoke/performance evidence.
+        required: true
+        default: false
+        type: boolean
+  schedule:
+    - cron: '47 5 * * *'
+  push:
+    branches: [ 'release/**' ]
+    tags: [ 'v*' ]
+
+jobs:
+  certify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    permissions:
+      contents: read
+      actions: write
+    env:
+      CERT_MODE: ${{ github.event_name == 'push' && 'release-candidate' || github.event.inputs.mode || 'nightly' }}
+      RUN_EXTENDED_GATES: ${{ github.event.inputs['extended-gates'] || 'false' }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # v5
+
+      - name: Run release certification self-tests
+        run: |
+          python3 tools/release-certification/release_certification.py --self-test
+          python3 tools/release-certification/app_platform_smoke.py --self-test
+
+      - name: Run Hyphanet interop smoke
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          INTEROP_MODE: smoke
+        run: tools/interop/run-hyphanet-interop-smoke.sh
+
+      - name: Run extended Hyphanet interop
+        if: env.RUN_EXTENDED_GATES == 'true'
+        continue-on-error: true
+        env:
+          INTEROP_MODE: extended
+          INTEROP_ENABLE_USK_SUBSCRIBE_SOAK: '1'
+          INTEROP_ENABLE_PERSISTENT_REPLAY: '1'
+          INTEROP_ENABLE_OPENNET: '0'
+          INTEROP_SOAK_DURATION_SECONDS: '900'
+          INTEROP_SOAK_POLL_INTERVAL_SECONDS: '15'
+          INTEROP_EXTENDED_TIMEOUT_SECONDS: '3600'
+          INTEROP_OUT_DIR: build/interop-extended
+          INTEROP_TIMEOUT_SECONDS: '3600'
+          INTEROP_SKIP_BUILD: '1'
+        run: tools/interop/run-hyphanet-interop-smoke.sh
+
+      - name: Run performance smoke
+        continue-on-error: true
+        env:
+          PERF_MODE: smoke
+          PERF_OUT_DIR: build/perf-smoke
+          PERF_TIMEOUT_SECONDS: '900'
+          PERF_SKIP_BUILD: '1'
+        run: tools/perf/run-performance-smoke.sh
+
+      - name: Generate release certification report
+        env:
+          CRYPTAD_CERT_MODE: ${{ env.CERT_MODE }}
+          CRYPTAD_APP_SIGNING_KEY_ID: ${{ secrets.CRYPTAD_APP_SIGNING_KEY_ID }}
+          CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64: ${{ secrets.CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64 }}
+          CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64: ${{ secrets.CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64 }}
+          CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE: ${{ secrets.CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE }}
+          CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE: ${{ secrets.CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE }}
+        run: |
+          tools/release-certification/run-release-certification.sh \
+            --mode "$CERT_MODE" \
+            --out-dir build/release-certification
+
+      - name: Upload release certification artifacts
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-certification-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            build/release-certification/release-certification-summary.json
+            build/release-certification/release-certification-report.md
+            build/release-certification/artifacts/
+            build/release-certification/app-platform-smoke/summary.json
+            build/release-certification/app-platform-smoke/app-platform-smoke-report.md
+            build/release-certification/app-platform-smoke/artifacts/
+            !**/private-insert-uris.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **$cryptad-launcher-ui** — Work on the Swing launcher: start/stop logic, logging, keyboard shortcuts, FlatLaf/theme handling, and Windows specifics.
 - **$cryptad-packaging** — Build and troubleshoot distributions and installers (assembleCryptadDist, jpackage, Windows wrapper assets, Flatpak, Linux DEB/RPM behavior).
 - **$cryptad-platform-apps** — Work on Platform API v1, AppHost, signed app bundles/catalogs, app-owned static UI, the browser SDK, app permissions/audit, and legacy admin retirement routing.
-- **$cryptad-interop-performance-gates** — Maintain the Hyphanet interop and performance regression gates under `tools/interop`, `tools/perf`, and CI/release readiness docs.
+- **$cryptad-interop-performance-gates** — Maintain Hyphanet interop, performance regression, and release-certification evidence gates under `tools/interop`, `tools/perf`, `tools/release-certification`, and CI/release readiness docs.
 - **$improve-unit-test-coverage-for-current-changes** — Improve unit test coverage for the current uncommitted Java changes with targeted Gradle runs and one final full-suite pass.
 - **$cryptad-runtime-debugging** — Debug live or reproducible Cryptad JVM failures on Windows, macOS, and Linux using `jcmd`, `jdb`, thread dumps, and the default JDWP listener on `127.0.0.1:5005`.
 - **$cryptad-write-release-notes** — Draft or review GitHub release notes and changelog artifacts for Cryptad builds, including `changelog-full.md`, `changelog-short.txt`, and `changelog-full.txt`.
@@ -54,7 +54,7 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **Environment detection:** Treat `AppEnv` as the single source of truth. Load `$cryptad-appenv` before touching OS/arch/sandbox/service detection code.
 - **Updater:** For any changes touching CoreUpdater descriptors, endpoints, or UI, load `$cryptad-core-updater`.
 - **App platform:** For Platform API, AppHost, app catalogs/bundles, app-owned UI routes, the browser SDK, app permission/audit, or legacy admin retirement routing, load `$cryptad-platform-apps`.
-- **Interop/performance gates:** For `tools/interop`, `tools/perf`, related CI jobs, or release-gate evidence, load `$cryptad-interop-performance-gates`.
+- **Interop/performance/certification gates:** For `tools/interop`, `tools/perf`, `tools/release-certification`, related CI jobs, or release-gate evidence, load `$cryptad-interop-performance-gates`.
 - **Packaging/Installers:** For dist builds, installers, or Flatpak, load `$cryptad-packaging`.
 - **Runtime debugging:** For live deadlocks, hangs, blocked threads, stalled requests, or JDWP debugging with `jcmd` / `jdb`, load `$cryptad-runtime-debugging`.
 - **Branch workflow questions:** For branch model/merge/tag/version policy questions, load `$cryptad-git-workflow`.

--- a/README.md
+++ b/README.md
@@ -463,6 +463,7 @@ Key docs:
 - [AppHost runtime hardening](docs/apphost-runtime-hardening.md)
 - [App permissions and audit](docs/app-permissions-and-audit.md)
 - [Legacy admin retirement plan](docs/legacy-retirement-plan.md)
+- [Release certification](docs/release-certification.md)
 
 ## Hyphanet Interop Gate
 
@@ -499,6 +500,37 @@ Smoke run when the local environment is prepared:
 ```bash
 tools/perf/run-performance-smoke.sh
 ```
+
+## Release Certification
+
+Release-candidate evidence is aggregated by the release certification tooling under
+`tools/release-certification/`. It consumes the interop, performance, app-platform, catalog,
+app-owned UI, legacy-admin retirement, and CI summaries and writes a redacted report plus a stable
+JSON companion.
+
+Fast self-tests:
+
+```bash
+python3 tools/release-certification/release_certification.py --self-test
+python3 tools/release-certification/app_platform_smoke.py --self-test
+```
+
+Generate a local report:
+
+```bash
+tools/release-certification/run-release-certification.sh
+```
+
+Generate release-candidate evidence:
+
+```bash
+tools/release-certification/run-release-certification.sh \
+  --mode release-candidate \
+  --out-dir build/release-certification
+```
+
+See [docs/release-certification.md](docs/release-certification.md) for required evidence,
+waivers, optional live-node evidence, and redaction rules.
 
 ## Testing
 

--- a/docs/cryptad-release-workflow-and-runbook.md
+++ b/docs/cryptad-release-workflow-and-runbook.md
@@ -1,8 +1,8 @@
 # Cryptad Release Workflow and Runbook
 
-> Updated April 25, 2026, to cover the CoreUpdater package-based distribution flow, signed
-> first-party app bundles, signed app catalogs, app-owned static UI routing, and the lightweight
-> performance regression gate.
+> Updated May 1, 2026, to cover the release certification report that aggregates interop,
+> performance, app-platform, catalog, app-owned UI, legacy-admin retirement, and CI evidence for a
+> release candidate.
 
 ## Overview
 - Purpose: publish a Cryptad release so running nodes discover a new `info/<edition>` descriptor, download OS-specific installers, and guide operators through installation without self-replacing the running JAR.
@@ -49,39 +49,56 @@
 Treat these as release blockers, in order:
 
 1. **Normal Gradle checks** - run the standard repository build and test path before any publish step. For release readiness, this means the usual Gradle verification path for the branch, including `./gradlew clean build` and any project-required test tasks used in CI.
-2. **First-party app staging** - stage repo-owned AppHost bundles with the app module tasks or `./gradlew stageFirstPartyApps`. The app workflow source of truth is [app-distribution.md](app-distribution.md).
-3. **First-party app signing and verification** - sign with the intended release or staging key inputs, then verify with the matching trusted public key inputs. Gate promotion on successful `./gradlew signFirstPartyApps` and `./gradlew verifyFirstPartyApps` runs. Keep private signing keys outside the repository.
-4. **App catalog smoke, when catalog sources ship** - verify each signed catalog source refreshes,
+2. **Release certification report** - generate the release-candidate report after the source gates
+   below have produced their summaries:
+   ```bash
+   tools/release-certification/run-release-certification.sh \
+     --mode release-candidate \
+     --out-dir build/release-certification
+   ```
+   Preserve `build/release-certification/release-certification-summary.json`,
+   `build/release-certification/release-certification-report.md`, and the sanitized
+   `build/release-certification/artifacts/` directory as release-candidate evidence. The workflow
+   is documented in [release-certification.md](release-certification.md).
+3. **First-party app staging** - stage repo-owned AppHost bundles with the app module tasks or `./gradlew stageFirstPartyApps`. The app workflow source of truth is [app-distribution.md](app-distribution.md).
+4. **First-party app signing and verification** - sign with the intended release or staging key inputs, then verify with the matching trusted public key inputs. Gate promotion on successful `./gradlew signFirstPartyApps` and `./gradlew verifyFirstPartyApps` runs. Keep private signing keys outside the repository.
+5. **App catalog smoke, when catalog sources ship** - verify each signed catalog source refreshes,
    validates artifact size/SHA-256, extracts safely, and can install or update through
    `/api/v1/app-catalogs`. The catalog contract is documented in
    [app-catalogs.md](app-catalogs.md).
-5. **Developer app CLI smoke, when `:platform-devtools` changes** - run
+6. **Developer app CLI smoke, when `:platform-devtools` changes** - run
    `./gradlew :platform-devtools:test` and `./gradlew :platform-devtools:installDist`, then verify
    `platform-devtools/build/install/crypta-app/bin/crypta-app --help`. The CLI contract is
    documented in [app-dev-cli.md](app-dev-cli.md).
-6. **App-owned UI smoke, when static UI apps ship** - open the advertised `uiUrl` for at least one
+7. **App-owned UI smoke, when static UI apps ship** - open the advertised `uiUrl` for at least one
    static UI app, confirm nested-entry assets load under `/apps/{appId}/`, and verify no
    filesystem path leaks appear in error responses. The route contract is documented in
    [app-owned-ui.md](app-owned-ui.md).
-7. **Hyphanet interop Tier 1 smoke** - run the packaged-node compatibility smoke locally on Linux
+8. **Legacy-admin retirement evidence** - record the current retirement map and diagnostics shape
+   before any release promotion. The certification report must include primary-replaced, retained,
+   and pending surface counts, confirm primary-replaced surfaces are absent from Web Shell fallback
+   navigation, and confirm direct fallback URLs remain documented. Optional live evidence may read
+   `GET /api/v1/diagnostics`; those counters are process-local and are not durable audit logs. The
+   retirement source of truth is [legacy-retirement-plan.md](legacy-retirement-plan.md).
+9. **Hyphanet interop Tier 1 smoke** - run the packaged-node compatibility smoke locally on Linux
    when the environment is prepared, or verify that the CI `interop-smoke` job passed for the
    release candidate. The gate is documented in
    [tools/interop/README.md](../tools/interop/README.md) and summarized in
    [phase-3-platform-primacy-closeout.md](phase-3-platform-primacy-closeout.md).
-8. **Interop Tier 2 extended soak, when compatibility-sensitive behavior changed** - run or verify
+10. **Interop Tier 2 extended soak, when compatibility-sensitive behavior changed** - run or verify
    the scheduled/manual `interop-extended` job when the release changes FCP, peer handling,
    datastore persistence, restart behavior, USK/SSK request handling, packaging layout, or node
    startup. Record `SubscribeUSK` duration, persistent request replay identifier, opennet enabled
    status, timeout settings, host OS, baseline, and the final `summary.json` path in the release
    record.
-9. **Interop failure artifacts** - if an interop gate fails, preserve `build/interop-smoke/` or
+11. **Interop failure artifacts** - if an interop gate fails, preserve `build/interop-smoke/` or
    `build/interop-extended/` from the local run or CI uploaded artifact before rerunning or cleaning
    the workspace. Do not publish `artifacts/private-insert-uris.json`; CI uploads exclude it.
-10. **Performance regression smoke** - run the packaged performance smoke locally or verify the
+12. **Performance regression smoke** - run the packaged performance smoke locally or verify the
    scheduled/manual `performance-smoke` CI job when preparing a release candidate. The gate is
    documented in [tools/perf/README.md](../tools/perf/README.md). Treat deterministic asset-size
    failures as release blockers unless a maintainer records an accepted baseline update or waiver.
-11. **Performance evidence, when performance-sensitive behavior changed** - run or verify the
+13. **Performance evidence, when performance-sensitive behavior changed** - run or verify the
     performance smoke when the release changes startup, packaging layout, Platform API, Web Shell,
     SDK assets, first-party app bundles, FCP startup, storage, routing, persistence, or JVM/runtime
     packaging. Record the command, mode, host OS or runner label, Java version, baseline path,
@@ -195,6 +212,19 @@ Treat these as release blockers, in order:
   maintainer-reviewed baseline update. Environment-sensitive startup, FCP, and Platform API timing
   regressions should be investigated on comparable hardware before promotion. CI uploads
   `summary.json` and `artifacts/` from the scheduled/manual `performance-smoke` job.
+- Generate the release certification report after the interop, performance, and app-platform
+  evidence exists:
+  ```bash
+  tools/release-certification/run-release-certification.sh \
+    --mode release-candidate \
+    --out-dir build/release-certification
+  ```
+  Inspect `build/release-certification/release-certification-report.md` and
+  `build/release-certification/release-certification-summary.json`. Missing required evidence,
+  failed required evidence, or missing signed bundle/catalog evidence blocks release-candidate
+  promotion unless a release manager records an explicit waiver. Do not attach
+  `artifacts/private-insert-uris.json`, private signing keys, form passwords, app tokens, browser
+  session tokens, raw request bodies, or unsanitized local paths to the release record.
 
 ## Production Rollout
 - Publish descriptor and artifacts to the production USK.

--- a/docs/legacy-retirement-plan.md
+++ b/docs/legacy-retirement-plan.md
@@ -112,6 +112,7 @@ filesystem paths, request bodies, or remote addresses.
     "surfaces": [
       {
         "id": "queue-downloads",
+        "title": "Download queue",
         "path": "/downloads/",
         "state": "PRIMARY_REPLACED",
         "replacementUrl": "/apps/queue-manager/",

--- a/docs/phase-3-platform-primacy-closeout.md
+++ b/docs/phase-3-platform-primacy-closeout.md
@@ -2,9 +2,10 @@
 
 This document records the Phase 3 Platform Primacy state after PR-194: what landed, which modules
 owned the platform surfaces at closeout, which release gates must pass, and which work stayed
-deferred at that snapshot. Later Phase 4 app-platform work has since added signed app catalogs and
-app-owned static UI routes; those current contracts live in [app-catalogs.md](app-catalogs.md) and
-[app-owned-ui.md](app-owned-ui.md).
+deferred at that snapshot. Later app-platform work has since added signed app catalogs,
+app-owned static UI routes, and release-certification evidence aggregation. Current contracts live
+in [app-catalogs.md](app-catalogs.md), [app-owned-ui.md](app-owned-ui.md), and
+[release-certification.md](release-certification.md).
 
 ## Status
 
@@ -153,7 +154,11 @@ Treat these gates as blockers before promoting a release that ships the platform
    persistence, restart behavior, USK/SSK request handling, packaging layout, or node startup.
 10. Run or verify the packaged-node performance smoke when release readiness or
    performance-sensitive changes require it.
-11. Preserve `build/interop-smoke/` or `build/interop-extended/` diagnostics when an interop run
+11. Generate `build/release-certification/release-certification-report.md` and
+   `build/release-certification/release-certification-summary.json` after the source gates have
+   produced their summaries. The report aggregates interop, performance, app-platform, catalog,
+   app-owned UI, legacy-admin retirement, and CI evidence for the release candidate.
+12. Preserve `build/interop-smoke/` or `build/interop-extended/` diagnostics when an interop run
    fails or when Tier 2 evidence is part of the release record. Shared diagnostics must exclude
    `artifacts/private-insert-uris.json`.
 

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -41,6 +41,10 @@ Generate a lightweight local report:
 tools/release-certification/run-release-certification.sh
 ```
 
+The wrapper may be invoked from outside the repository. Relative `--out-dir` values are resolved
+under the repository root so shell cleanup, app-platform smoke output, and aggregation read the same
+evidence directory.
+
 Generate a release-candidate report:
 
 ```bash

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -1,0 +1,138 @@
+# Release certification
+
+Release certification is the reproducible evidence bundle for a Cryptad release candidate.  It
+aggregates compatibility, performance, app-platform, catalog, app-owned UI, legacy-admin
+retirement, and CI metadata into one redacted report.
+
+The generated artifacts are:
+
+```text
+build/release-certification/release-certification-summary.json
+build/release-certification/release-certification-report.md
+build/release-certification/artifacts/
+```
+
+The Markdown report is intended for human release review.  The JSON summary is the stable
+machine-readable companion for later automation and report comparison.
+
+## Modes
+
+| Mode | Purpose | Behavior |
+| --- | --- | --- |
+| `pr` | Quick local or normal PR evidence. | Runs Python-only certification and lightweight app-platform checks.  It does not require a live node, signing keys, Hyphanet baseline download, or packaged-node smoke. |
+| `nightly` | Scheduled/manual evidence aggregation. | Records missing optional evidence as warnings and can run heavier app-platform checks. |
+| `release-candidate` | Strict release gate. | Fails when required evidence is missing, skipped, or failing unless a release-manager waiver is recorded. |
+
+## Run locally
+
+The release-certification tools require Python 3.10 or newer and use only the Python standard
+library.
+
+Run self-tests first:
+
+```bash
+python3 tools/release-certification/release_certification.py --self-test
+python3 tools/release-certification/app_platform_smoke.py --self-test
+```
+
+Generate a lightweight local report:
+
+```bash
+tools/release-certification/run-release-certification.sh
+```
+
+Generate a release-candidate report:
+
+```bash
+tools/release-certification/run-release-certification.sh \
+  --mode release-candidate \
+  --out-dir build/release-certification
+```
+
+The wrapper consumes the existing gate outputs when present:
+
+```text
+build/interop-smoke/summary.json
+build/interop-extended/summary.json
+build/perf-smoke/summary.json
+build/perf-smoke/artifacts/perf-report.md
+build/release-certification/app-platform-smoke/summary.json
+```
+
+Run the source gates before the release-candidate aggregation when their evidence is required:
+
+```bash
+tools/interop/run-hyphanet-interop-smoke.sh
+INTEROP_MODE=extended INTEROP_SKIP_BUILD=1 tools/interop/run-hyphanet-interop-smoke.sh
+tools/perf/run-performance-smoke.sh
+```
+
+## Required evidence
+
+Release-candidate mode requires these evidence ids:
+
+| Evidence id | Source | Required condition |
+| --- | --- | --- |
+| `interop.smoke` | `build/interop-smoke/summary.json` | Tier 1 Hyphanet interop smoke passed with CHK, SSK, USK, peer exchange, and restart-recovery coverage. |
+| `performance.smoke` | `build/perf-smoke/summary.json` | Performance smoke did not fail required metrics or deterministic regression thresholds. |
+| `app-platform.first-party` | App-platform smoke summary. | First-party staged apps have valid manifests, launchers, static UI assets, and SDK wiring. |
+| `app-platform.devtools-cli` | App-platform smoke summary. | `crypta-app init`, `validate`, and `pack` work for a generated sample app. |
+| `app-platform.signed-bundles` | App-platform smoke summary. | First-party and sample bundle signing/verification evidence exists with configured non-production or release signing inputs. |
+| `catalog.smoke` | App-platform smoke summary. | Signed catalog create/sign/verify evidence exists and records digest, catalog id, and app id without private key material. |
+| `app-ui.smoke` | App-platform smoke summary. | First-party static UI and `crypta-platform.js` remain coherent and do not expose process-token names. |
+| `legacy.retirement` | App-platform smoke summary. | The legacy-admin retirement registry is visible, counts are stable, replaced surfaces are absent from primary shell fallback links, and direct fallback URLs remain documented. |
+
+`interop.extended` is optional in the machine gate but required by the release runbook when a
+release changes compatibility-sensitive behavior.  `apphost.live` is optional stronger evidence
+because normal PR and scheduled CI must not require a live local node or operator form password.
+
+## Waivers
+
+Use waivers sparingly and only with a concrete release-manager reason:
+
+```bash
+tools/release-certification/run-release-certification.sh \
+  --mode release-candidate \
+  --waive interop.extended="No FCP, peer, datastore, restart, USK/SSK, packaging, or startup compatibility behavior changed."
+```
+
+A waiver turns that evidence item into `warn`, records `details.waived=true`, and includes the
+reason in `details.waiverReason`.  Waivers are visible in both the report and the JSON summary.
+
+Do not use waivers to hide failed required smoke evidence.  Fix the failing gate or record a
+release-manager decision that explicitly accepts the risk.
+
+## Optional live-node evidence
+
+Live AppHost evidence is opt-in:
+
+```bash
+CRYPTAD_CERT_APP_SMOKE_LIVE=1 \
+CRYPTAD_CERT_NODE_BASE_URL=http://127.0.0.1:<port> \
+CRYPTAD_CERT_FORM_PASSWORD=<redacted> \
+tools/release-certification/run-release-certification.sh --mode nightly
+```
+
+When enabled, the app-platform smoke runner uses the generated sample app and localhost Platform
+API routes to install, read runtime status, start, stop, update, uninstall, and read diagnostics.
+The live smoke only records localhost metadata, status codes, and redacted JSON response summaries.
+It does not write the form password, raw request bodies, app process tokens, or browser-session
+tokens.
+
+## Redaction
+
+The report and copied artifacts must not contain:
+
+- private signing keys;
+- app process tokens;
+- app browser session tokens;
+- the host/operator form password;
+- raw request bodies;
+- full query strings that may contain secrets;
+- private insert URIs;
+- absolute developer-specific filesystem paths;
+- non-localhost remote addresses.
+
+`artifacts/private-insert-uris.json` from interop runs must never be uploaded or pasted into a
+public release record.  The certification aggregator filters that private artifact reference and
+copies only sanitized summaries and public reports into `build/release-certification/artifacts/`.

--- a/tools/interop/README.md
+++ b/tools/interop/README.md
@@ -301,6 +301,12 @@ Important files:
 - `artifacts/kept-processes.json` is written only when `INTEROP_KEEP_WORKDIR=1`.
 - `logs/*.stdout.log` and `logs/*.stderr.log` capture each launched process.
 
+The release certification workflow consumes `build/interop-smoke/summary.json` as required
+`interop.smoke` evidence and `build/interop-extended/summary.json` as optional
+`interop.extended` evidence unless compatibility-sensitive behavior makes Tier 2 mandatory under
+the release runbook. The certification aggregator filters `artifacts/private-insert-uris.json`
+even if a source summary references it.
+
 `summary.json` uses these top-level fields:
 
 | Field | Meaning |
@@ -395,7 +401,9 @@ blocked until the project pins a portable baseline artifact for those platforms.
 
 A release record should name the host OS, baseline, command line, timeout settings, whether opennet
 was enabled, the `SubscribeUSK` duration, persistent replay identifier, and the final
-`summary.json` path. Release records must not include `artifacts/private-insert-uris.json`.
+`summary.json` path. The release certification report copies sanitized interop summaries into
+`build/release-certification/artifacts/`. Release records must not include
+`artifacts/private-insert-uris.json`.
 
 ## Release-readiness expectations
 

--- a/tools/perf/README.md
+++ b/tools/perf/README.md
@@ -167,6 +167,10 @@ Node working directories live under `build/perf-smoke/work/` during a run. CI up
 Logs under `artifacts/logs/` are sanitized before reports are written; token-like values,
 password-like values, private URIs, and local workspace or home-directory prefixes are redacted.
 
+The release certification workflow consumes `build/perf-smoke/summary.json` as required
+`performance.smoke` evidence and copies the sanitized `artifacts/perf-report.md` into
+`build/release-certification/artifacts/` when present.
+
 ## Baselines
 
 `tools/perf/baselines/performance-smoke.json` is a checked-in smoke baseline with conservative
@@ -200,6 +204,10 @@ CI has two jobs:
 
 Regular pull requests get the Python self-test without the full node smoke. That keeps the default
 PR path low-flake while preserving scheduled/manual evidence for release candidates.
+
+The separate `release-certification` workflow can run the performance smoke before generating
+`build/release-certification/release-certification-report.md` and
+`build/release-certification/release-certification-summary.json`.
 
 ## Interpreting results
 

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -1,0 +1,145 @@
+# Release certification tooling
+
+This directory contains the release-candidate evidence aggregator used by the release runbook.
+
+The tooling requires Python 3.10 or newer and depends only on the Python standard library.  The
+self-tests do not start Cryptad, download a Hyphanet baseline, require signing keys, or contact the
+network.
+
+## Commands
+
+Run the Python-only self-tests:
+
+```bash
+python3 tools/release-certification/release_certification.py --self-test
+python3 tools/release-certification/app_platform_smoke.py --self-test
+```
+
+Generate a quick local report without running expensive Gradle or node gates:
+
+```bash
+tools/release-certification/run-release-certification.sh
+```
+
+Generate release-candidate evidence under the standard output directory:
+
+```bash
+tools/release-certification/run-release-certification.sh \
+  --mode release-candidate \
+  --out-dir build/release-certification
+```
+
+The wrapper runs the app-platform smoke collector, then aggregates existing interop and
+performance summaries when they are present.  In `pr` mode it skips Gradle by default so local and
+normal CI use stay lightweight.  Set `CRYPTAD_CERT_RUN_GRADLE=1` or pass `--mode nightly` or
+`--mode release-candidate` to run the app-platform Gradle staging and CLI checks.
+
+## Outputs
+
+The stable release evidence outputs are:
+
+```text
+build/release-certification/
+  release-certification-summary.json
+  release-certification-report.md
+  artifacts/
+  app-platform-smoke/
+    summary.json
+    app-platform-smoke-report.md
+    artifacts/
+```
+
+The summary uses stable evidence ids and status values:
+
+```text
+pass
+warn
+fail
+skip
+missing
+```
+
+Each item contains `id`, `status`, `requiredForReleaseCandidate`, `summary`, `source`, and
+`details`.
+
+## Required release-candidate evidence
+
+Release-candidate mode fails when required evidence is missing, skipped, or failing unless a waiver
+is recorded.  The required evidence ids are:
+
+```text
+interop.smoke
+performance.smoke
+app-platform.first-party
+app-platform.devtools-cli
+app-platform.signed-bundles
+catalog.smoke
+app-ui.smoke
+legacy.retirement
+```
+
+`interop.extended` and `apphost.live` are recorded as optional stronger evidence.  Extended interop
+is still required by the release runbook when compatibility-sensitive behavior changed.  Live
+AppHost lifecycle evidence is optional because normal PR CI must not require a running node or
+operator credentials.
+
+Record an explicit waiver when a release manager accepts missing optional or replacement evidence:
+
+```bash
+tools/release-certification/run-release-certification.sh \
+  --mode release-candidate \
+  --waive interop.extended="No compatibility-sensitive behavior changed in this release."
+```
+
+Waivers change the evidence item to `warn`, preserve the original reason in `details`, and keep the
+release-candidate gate from failing for that item.
+
+## App-platform smoke
+
+The app-platform smoke runner validates first-party staged app manifests, static app UI/SDK
+coherence, the `crypta-app` developer CLI, signed bundle evidence when signing inputs are present,
+signed catalog authoring/verification, and the legacy-admin retirement map.
+
+Signing inputs use the documented first-party app environment variables:
+
+```text
+CRYPTAD_APP_SIGNING_KEY_ID
+CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64
+CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE
+CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64
+CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE
+```
+
+In `pr` and `nightly` modes, missing signing inputs are recorded as skipped or warning evidence.
+In `release-candidate` mode, missing signed bundle or signed catalog evidence is a failing required
+item.
+
+Optional live-node AppHost lifecycle smoke is enabled only when requested:
+
+```bash
+CRYPTAD_CERT_APP_SMOKE_LIVE=1 \
+CRYPTAD_CERT_NODE_BASE_URL=http://127.0.0.1:8888 \
+CRYPTAD_CERT_FORM_PASSWORD=<redacted> \
+tools/release-certification/run-release-certification.sh --mode nightly
+```
+
+The live smoke only records localhost node metadata.  It redacts the form password and does not
+write raw request bodies.
+
+## Redaction
+
+Certification outputs must remain suitable for release-candidate evidence.  Do not upload or paste:
+
+- private signing keys;
+- app process tokens;
+- browser-session tokens;
+- the host/operator form password;
+- raw request bodies;
+- full query strings that may contain secrets;
+- private insert URIs;
+- developer-specific absolute filesystem paths;
+- non-localhost remote endpoint metadata.
+
+The aggregator sanitizes paths as `<repo>`, `<workdir>`, `<home>`, or `<path>` placeholders.  It
+also filters `artifacts/private-insert-uris.json` from interop evidence even when the source
+`summary.json` mentions that private diagnostics file.

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -21,6 +21,10 @@ Generate a quick local report without running expensive Gradle or node gates:
 tools/release-certification/run-release-certification.sh
 ```
 
+The wrapper can be run from any working directory. Relative `--out-dir` values are resolved under
+the repository root before shell cleanup, app-platform smoke generation, and certification
+aggregation run.
+
 Generate release-candidate evidence under the standard output directory:
 
 ```bash

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -1,0 +1,2140 @@
+#!/usr/bin/env python3
+"""Collect app-platform release-certification smoke evidence.
+
+The smoke runner keeps its self-test Python-only and offline.  Normal runs can
+optionally invoke Gradle and the installed ``crypta-app`` launcher to validate
+first-party staged apps, sample app packaging, signed bundles, signed catalogs,
+app-owned static UI, and legacy-admin retirement state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import html.parser
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+TOOL_NAME = "app-platform-smoke"
+SCHEMA_VERSION = 1
+MODES = ("pr", "nightly", "release-candidate")
+DEFAULT_OUT_DIR = Path("build/release-certification/app-platform-smoke")
+SUMMARY_FILE_NAME = "summary.json"
+REPORT_FILE_NAME = "app-platform-smoke-report.md"
+APP_IDS = ("queue-manager", "publisher")
+SECRET_COMMAND_VALUE_OPTIONS = {
+    "--private-key-base64",
+    "--private-key-file",
+    "--trusted-public-key-base64",
+}
+SENSITIVE_KEY_PATTERN = (
+    r"CRYPTAD_APP_TOKEN|formPassword|browserSessionToken|X-Crypta-App-Session|"
+    r"authorization|cookie|set-cookie|private[-_ ]?key|token|password|passwd|secret|credential"
+)
+SENSITIVE_RE = re.compile(
+    rf"({SENSITIVE_KEY_PATTERN})",
+    re.IGNORECASE,
+)
+SENSITIVE_HEADER_RE = re.compile(
+    r"(?P<prefix>\b(?:Authorization|Cookie|Set-Cookie|X-Crypta-App-Session)\s*:\s*)"
+    r"(?P<value>[^\r\n]*)",
+    re.IGNORECASE,
+)
+SENSITIVE_ASSIGNMENT_RE = re.compile(
+    r"(?P<prefix>(?<![A-Za-z0-9_])(?P<key_quote>[\"']?)"
+    r"(?P<key>[A-Za-z_][A-Za-z0-9_.-]*)"
+    r"(?P=key_quote)\s*[:=]\s*)"
+    r"(?:(?P<value_quote>[\"'])(?P<quoted_value>[^\"'\r\n]*)(?P=value_quote)|"
+    r"(?P<value>(?:(?:Bearer|Basic|Digest)\s+)?[^\s,;&}\]]+))",
+    re.IGNORECASE,
+)
+URI_KEY_RE = re.compile(r"\b(?:CHK|SSK|USK)@[^\s\])},;\"']+")
+ABSOLUTE_PATH_RE = re.compile(r"(?<![A-Za-z0-9_:/.\->])/(?:[A-Za-z0-9._ -]+/)+[A-Za-z0-9._ -]+")
+WINDOWS_DRIVE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_:/.\->])(?:[A-Za-z]:[\\/](?:[^\\/:*?\"<>|\r\n]+[\\/])*[^\\/:*?\"<>|\r\n]+[\\/]?)"
+)
+WINDOWS_UNC_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_:/.\->])(?:\\\\[^\\/:*?\"<>|\r\n]+\\[^\\/:*?\"<>|\r\n]+(?:\\[^\\/:*?\"<>|\r\n]+)*\\?)"
+)
+FILE_URI_PATH_RE = re.compile(r"\bfile://(?P<path>[^\s\])},;\"']+)")
+ROUTE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_:/.\->])/(?:api/v1|apps|app/node|\.well-known)(?:/[^\s\])},;\"'?]*)?"
+)
+NON_SECRET_METADATA_SUFFIXES = (
+    "available",
+    "configured",
+    "enabled",
+    "excluded",
+    "present",
+    "redacted",
+    "required",
+    "source",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class Settings:
+    workspace_root: Path
+    out_dir: Path
+    mode: str
+    skip_gradle: bool
+    cli_path: Path | None
+    live: bool
+    live_base_url: str
+    live_form_password: str
+    timeout_seconds: int
+
+
+@dataclasses.dataclass(frozen=True)
+class CommandResult:
+    args: list[str]
+    exit_code: int
+    stdout: str
+    stderr: str
+    duration_ms: int
+
+
+@dataclasses.dataclass(frozen=True)
+class EvidenceItem:
+    id: str
+    status: str
+    required_for_release_candidate: bool
+    summary: str
+    source: str
+    details: dict[str, Any]
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "requiredForReleaseCandidate": self.required_for_release_candidate,
+            "summary": self.summary,
+            "source": self.source,
+            "details": self.details,
+        }
+
+
+class ScriptExtractor(html.parser.HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.scripts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "script":
+            return
+        values = dict(attrs)
+        src = values.get("src")
+        if src:
+            self.scripts.append(src)
+
+
+def utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def display_path(path: Path | str, workspace_root: Path, out_dir: Path | None = None) -> str:
+    raw = str(path)
+    if not raw:
+        return ""
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        return raw.replace("\\", "/")
+    try:
+        return "<repo>/" + candidate.resolve().relative_to(workspace_root.resolve()).as_posix()
+    except ValueError:
+        pass
+    if out_dir is not None:
+        try:
+            relative = candidate.resolve().relative_to(out_dir.resolve())
+            out_dir_display = display_path(out_dir, workspace_root)
+            if not relative.parts:
+                return out_dir_display
+            return f"{out_dir_display}/{relative.as_posix()}"
+        except ValueError:
+            pass
+    try:
+        return "<workdir>/" + candidate.resolve().relative_to(Path(tempfile.gettempdir()).resolve()).as_posix()
+    except ValueError:
+        return "<path>/" + candidate.name
+
+
+def summary_source(settings: Settings) -> str:
+    return display_path(settings.out_dir / SUMMARY_FILE_NAME, settings.workspace_root, settings.out_dir)
+
+
+def replace_absolute_path_prefix(text: str, prefix: str, replacement: str) -> str:
+    if not prefix or prefix in {"/", "\\"}:
+        return text
+    normalized = prefix.rstrip("/\\")
+    if not normalized:
+        return text
+    pattern = re.compile(rf"(?<![A-Za-z0-9_:/.\->]){re.escape(normalized)}(?=$|[/\\])")
+    return pattern.sub(replacement, text)
+
+
+def path_leaf(path_text: str) -> str:
+    stripped = path_text.rstrip("\\/")
+    leaf = re.split(r"[\\/]+", stripped)[-1]
+    return leaf or "path"
+
+
+def scrub_absolute_path_match(match: re.Match[str]) -> str:
+    return "<path>/" + path_leaf(match.group(0))
+
+
+def scrub_file_uri_match(match: re.Match[str]) -> str:
+    return "file://<path>/" + path_leaf(match.group("path"))
+
+
+def scrub_sensitive_assignment_match(match: re.Match[str]) -> str:
+    if not should_redact_key_name(match.group("key")):
+        return match.group(0)
+    value_quote = match.group("value_quote") or ""
+    return match.group("prefix") + value_quote + "<redacted>" + value_quote
+
+
+def protect_route_paths(text: str) -> tuple[str, list[tuple[str, str]]]:
+    routes: list[tuple[str, str]] = []
+
+    def replace_route(match: re.Match[str]) -> str:
+        token = f"__CRYPTAD_ROUTE_{len(routes)}__"
+        routes.append((token, match.group(0)))
+        return token
+
+    return ROUTE_PATH_RE.sub(replace_route, text), routes
+
+
+def restore_route_paths(text: str, routes: list[tuple[str, str]]) -> str:
+    restored = text
+    for token, route in routes:
+        restored = restored.replace(token, route)
+    return restored
+
+
+def normalize_redacted_separators(text: str) -> str:
+    def normalize_match(match: re.Match[str]) -> str:
+        return match.group("prefix") + match.group("tail").replace("\\", "/")
+
+    return re.sub(
+        r"(?P<prefix><(?:repo|home|workdir|path)>)(?P<tail>(?:[\\/][^\s\])},;\"']*)?)",
+        normalize_match,
+        text,
+    )
+
+
+def scrub_text(text: str, workspace_root: Path) -> str:
+    redacted = SENSITIVE_HEADER_RE.sub(lambda match: match.group("prefix") + "<redacted>", text)
+    redacted = SENSITIVE_ASSIGNMENT_RE.sub(scrub_sensitive_assignment_match, redacted)
+    redacted = URI_KEY_RE.sub("<redacted-uri>", redacted)
+    redacted = FILE_URI_PATH_RE.sub(scrub_file_uri_match, redacted)
+    redacted, protected_routes = protect_route_paths(redacted)
+    root_text = str(workspace_root.resolve())
+    redacted = redacted.replace(root_text, "<repo>")
+    redacted = redacted.replace(root_text.replace("\\", "/"), "<repo>")
+    home = str(Path.home())
+    if home and home != "/":
+        redacted = replace_absolute_path_prefix(redacted, home, "<home>")
+    redacted = replace_absolute_path_prefix(redacted, tempfile.gettempdir(), "<workdir>")
+    redacted = WINDOWS_UNC_PATH_RE.sub(scrub_absolute_path_match, redacted)
+    redacted = WINDOWS_DRIVE_PATH_RE.sub(scrub_absolute_path_match, redacted)
+    redacted = ABSOLUTE_PATH_RE.sub(scrub_absolute_path_match, redacted)
+    redacted = normalize_redacted_separators(redacted)
+    return restore_route_paths(redacted, protected_routes)
+
+
+def normalize_key_name(key_hint: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", key_hint.lower())
+
+
+def should_redact_key_name(key_hint: str) -> bool:
+    normalized = normalize_key_name(key_hint)
+    if not normalized:
+        return False
+    if normalized.endswith(NON_SECRET_METADATA_SUFFIXES):
+        return False
+    if normalized in {
+        "authorization",
+        "cookie",
+        "setcookie",
+        "credential",
+        "cryptadapptoken",
+        "formpassword",
+        "privatekey",
+        "secret",
+        "token",
+        "password",
+        "passwd",
+        "browsersessiontoken",
+        "xcryptaappsession",
+    }:
+        return True
+    return any(fragment in normalized for fragment in ("privatekey", "token", "password", "passwd", "secret", "credential"))
+
+
+def sanitize_value(value: Any, workspace_root: Path, key_hint: str = "") -> Any:
+    if should_redact_key_name(key_hint):
+        return "<redacted>"
+    if isinstance(value, dict):
+        return {str(key): sanitize_value(child, workspace_root, str(key)) for key, child in value.items()}
+    if isinstance(value, list):
+        return [sanitize_value(child, workspace_root, key_hint) for child in value]
+    if isinstance(value, str):
+        return scrub_text(value, workspace_root)
+    return value
+
+
+def is_local_live_host(host: str) -> bool:
+    return host in {"127.0.0.1", "localhost", "::1"}
+
+
+def live_base_url_details(base_url: str) -> dict[str, Any]:
+    if not base_url:
+        return {"baseUrl": "missing", "localhostOnly": False}
+    parsed = urllib.parse.urlparse(base_url)
+    host = parsed.hostname or ""
+    if not is_local_live_host(host):
+        return {"baseUrl": "<redacted-remote-url>", "localhostOnly": False}
+    netloc = host
+    if parsed.port is not None:
+        netloc = f"{host}:{parsed.port}"
+    scheme = parsed.scheme or "http"
+    return {"baseUrl": f"{scheme}://{netloc}", "localhostOnly": True}
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value, encoding="utf-8")
+
+
+def parse_properties(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            raise ValueError(f"{path}:{line_number}: expected key=value")
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"{path}:{line_number}: blank property key")
+        if key in result:
+            raise ValueError(f"{path}:{line_number}: duplicate property key: {key}")
+        result[key] = value.strip()
+    return result
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run_command(
+    args: list[str],
+    settings: Settings,
+    log_name: str,
+    timeout_seconds: int | None = None,
+    env: dict[str, str] | None = None,
+) -> CommandResult:
+    logs_dir = settings.out_dir / "artifacts" / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    started = time.monotonic()
+    merged_env = os.environ.copy()
+    if env:
+        merged_env.update(env)
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=str(settings.workspace_root),
+            env=merged_env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_seconds or settings.timeout_seconds,
+            check=False,
+        )
+        exit_code = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+    except subprocess.TimeoutExpired as exc:
+        exit_code = 124
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = (exc.stderr if isinstance(exc.stderr, str) else "") + "\nCommand timed out."
+    except OSError as exc:
+        exit_code = 127
+        stdout = ""
+        stderr = str(exc)
+    duration_ms = int((time.monotonic() - started) * 1000)
+    result = CommandResult(args=args, exit_code=exit_code, stdout=stdout, stderr=stderr, duration_ms=duration_ms)
+    write_text(logs_dir / f"{log_name}.stdout.log", scrub_text(stdout, settings.workspace_root))
+    write_text(logs_dir / f"{log_name}.stderr.log", scrub_text(stderr, settings.workspace_root))
+    return result
+
+
+def gradle_command(settings: Settings, tasks: list[str], log_name: str) -> CommandResult | None:
+    if settings.skip_gradle:
+        return None
+    wrapper = settings.workspace_root / ("gradlew.bat" if platform.system() == "Windows" else "gradlew")
+    return run_command([str(wrapper), *tasks], settings, log_name, timeout_seconds=1200)
+
+
+def command_ok(result: CommandResult | None) -> bool:
+    return result is None or result.exit_code == 0
+
+
+def command_details(result: CommandResult | None, settings: Settings) -> dict[str, Any]:
+    if result is None:
+        return {"skipped": True, "reason": "Gradle execution was skipped by configuration."}
+    return {
+        "exitCode": result.exit_code,
+        "durationMs": result.duration_ms,
+        "command": redact_command(result.args, settings),
+    }
+
+
+def redact_command(args: list[str], settings: Settings) -> list[str]:
+    redacted: list[str] = []
+    skip_next = False
+    for arg in args:
+        if skip_next:
+            redacted.append("<redacted>")
+            skip_next = False
+            continue
+        if arg in SECRET_COMMAND_VALUE_OPTIONS:
+            redacted.append(arg)
+            skip_next = True
+        elif "private" in arg.lower() and "key" in arg.lower() and "=" in arg:
+            key, _ = arg.split("=", 1)
+            redacted.append(key + "=<redacted>")
+        else:
+            redacted.append(scrub_text(arg, settings.workspace_root))
+    return redacted
+
+
+def root_consequence(settings: Settings, release_candidate_status: str, non_rc_status: str = "warn") -> str:
+    return release_candidate_status if settings.mode == "release-candidate" else non_rc_status
+
+
+def first_party_app_specs(settings: Settings) -> list[dict[str, Any]]:
+    return [
+        {
+            "appId": "queue-manager",
+            "name": "Queue Manager",
+            "stagedDir": settings.workspace_root / "apps/queue-manager/build/cryptad-app/queue-manager",
+            "sourceDir": settings.workspace_root / "apps/queue-manager/src/staged",
+            "launcher": "bin/queue-manager.sh",
+            "permissions": {"queue.read", "queue.write"},
+        },
+        {
+            "appId": "publisher",
+            "name": "Publisher",
+            "stagedDir": settings.workspace_root / "apps/publisher/build/cryptad-app/publisher",
+            "sourceDir": settings.workspace_root / "apps/publisher/src/staged",
+            "launcher": "bin/publisher.sh",
+            "permissions": {"queue.read", "queue.write", "content.insert"},
+        },
+    ]
+
+
+def validate_app_bundle(bundle_dir: Path, spec: dict[str, Any], settings: Settings) -> tuple[bool, list[str], dict[str, Any]]:
+    errors: list[str] = []
+    details: dict[str, Any] = {"bundleDir": display_path(bundle_dir, settings.workspace_root)}
+    manifest_path = bundle_dir / "cryptad-app.properties"
+    if not manifest_path.is_file():
+        errors.append("cryptad-app.properties is missing")
+        return False, errors, details
+    try:
+        manifest = parse_properties(manifest_path)
+    except ValueError as exc:
+        errors.append(str(exc))
+        return False, errors, details
+    details["manifest"] = {
+        "appId": manifest.get("app.id"),
+        "name": manifest.get("app.name"),
+        "version": manifest.get("app.version"),
+        "uiMode": manifest.get("app.ui.mode"),
+        "uiEntry": manifest.get("app.ui.entry"),
+        "permissions": sorted(filter(None, manifest.get("app.permissions", "").split(","))),
+    }
+    for key in ("app.id", "app.name", "app.version"):
+        if not manifest.get(key):
+            errors.append(f"{key} is missing")
+    if manifest.get("app.id") != spec["appId"]:
+        errors.append(f"app.id expected {spec['appId']}, got {manifest.get('app.id')}")
+    if manifest.get("app.name") != spec["name"]:
+        errors.append(f"app.name expected {spec['name']}, got {manifest.get('app.name')}")
+    if manifest.get("app.ui.mode") != "static":
+        errors.append("app.ui.mode must be static")
+    if manifest.get("app.ui.entry") != "static/index.html":
+        errors.append("app.ui.entry must be static/index.html")
+    declared_permissions = set(filter(None, manifest.get("app.permissions", "").split(",")))
+    if not spec["permissions"].issubset(declared_permissions):
+        errors.append("manifest permissions are incomplete")
+    for relative in (spec["launcher"], "static/index.html", "static/app.js", "static/app.css", "static/crypta-platform.js"):
+        if not (bundle_dir / relative).is_file():
+            errors.append(f"{relative} is missing")
+    static_errors, static_details = validate_static_ui_files(bundle_dir / "static", settings)
+    errors.extend(static_errors)
+    details.update(static_details)
+    return not errors, errors, details
+
+
+def validate_static_ui_files(static_dir: Path, settings: Settings) -> tuple[list[str], dict[str, Any]]:
+    errors: list[str] = []
+    details: dict[str, Any] = {}
+    index = static_dir / "index.html"
+    app_js = static_dir / "app.js"
+    sdk = static_dir / "crypta-platform.js"
+    if index.is_file():
+        scripts = extract_scripts(index)
+        normalized_scripts = [normalize_static_script_ref(script) for script in scripts]
+        details["scripts"] = scripts
+        if "crypta-platform.js" not in normalized_scripts:
+            errors.append("index.html does not load crypta-platform.js")
+        if "app.js" in normalized_scripts and "crypta-platform.js" in normalized_scripts:
+            if normalized_scripts.index("crypta-platform.js") > normalized_scripts.index("app.js"):
+                errors.append("index.html must load crypta-platform.js before app.js")
+    if app_js.is_file():
+        app_text = app_js.read_text(encoding="utf-8")
+        if "CryptaPlatform.bootstrap.load" not in app_text:
+            errors.append("app.js does not call CryptaPlatform.bootstrap.load")
+    if sdk.is_file():
+        sdk_text = sdk.read_text(encoding="utf-8")
+        if "window.CryptaPlatform" not in sdk_text:
+            errors.append("crypta-platform.js does not expose window.CryptaPlatform")
+        if "X-Crypta-App-Session" not in sdk_text:
+            errors.append("crypta-platform.js does not use X-Crypta-App-Session")
+    for file_path in static_dir.glob("**/*"):
+        if not file_path.is_file():
+            continue
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+        for forbidden in ("CRYPTAD_APP_TOKEN", "formPassword", "localStorage.setItem", "sessionStorage.setItem"):
+            if forbidden in text:
+                errors.append(f"{display_path(file_path, settings.workspace_root)} contains forbidden text {forbidden}")
+    canonical_sdk = settings.workspace_root / "platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js"
+    if sdk.is_file() and canonical_sdk.is_file():
+        details["sdkMatchesCanonical"] = sha256_file(sdk) == sha256_file(canonical_sdk)
+        if not details["sdkMatchesCanonical"]:
+            errors.append("staged SDK does not match canonical SDK resource")
+    return errors, details
+
+
+def normalize_static_script_ref(script: str) -> str:
+    value = script.split("?", 1)[0].split("#", 1)[0]
+    while value.startswith("./"):
+        value = value[2:]
+    return value
+
+
+def extract_scripts(path: Path) -> list[str]:
+    parser = ScriptExtractor()
+    parser.feed(path.read_text(encoding="utf-8"))
+    return parser.scripts
+
+
+def check_source_static_ui(settings: Settings) -> tuple[bool, list[str], dict[str, Any]]:
+    errors: list[str] = []
+    details: dict[str, Any] = {}
+    for spec in first_party_app_specs(settings):
+        static_dir = spec["sourceDir"] / "static"
+        app_errors, app_details = validate_static_ui_files(static_dir, settings)
+        errors.extend(f"{spec['appId']}: {error}" for error in app_errors)
+        details[spec["appId"]] = app_details
+    sdk_path = settings.workspace_root / "platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js"
+    if not sdk_path.is_file():
+        errors.append("canonical SDK resource is missing")
+    else:
+        details["sdkResource"] = display_path(sdk_path, settings.workspace_root)
+    return not errors, errors, details
+
+
+def find_cli(settings: Settings) -> Path | None:
+    if settings.cli_path is not None:
+        return settings.cli_path
+    script = "crypta-app.bat" if platform.system() == "Windows" else "crypta-app"
+    candidate = settings.workspace_root / "platform-devtools/build/install/crypta-app/bin" / script
+    if candidate.is_file():
+        return candidate
+    return None
+
+
+def run_cli(cli: Path, args: list[str], settings: Settings, log_name: str) -> CommandResult:
+    return run_command([str(cli), *args], settings, log_name, timeout_seconds=180)
+
+
+def remove_existing_path(path: Path) -> None:
+    if path.is_dir() and not path.is_symlink():
+        shutil.rmtree(path)
+    else:
+        path.unlink(missing_ok=True)
+
+
+def write_live_smoke_launcher(sample_dir: Path) -> None:
+    launcher = sample_dir / "bin/start.sh"
+    launcher.parent.mkdir(parents=True, exist_ok=True)
+    launcher.write_text(
+        """#!/usr/bin/env sh
+set -eu
+
+child=""
+cleanup() {
+  if [ -n "$child" ]; then
+    kill "$child" 2>/dev/null || true
+  fi
+  exit 0
+}
+
+trap cleanup INT TERM
+
+while :; do
+  sleep 60 &
+  child="$!"
+  wait "$child" 2>/dev/null || true
+  child=""
+done
+""",
+        encoding="utf-8",
+    )
+    launcher.chmod(0o755)
+
+
+def signing_inputs(env: dict[str, str]) -> dict[str, Any]:
+    key_id = env.get("CRYPTAD_APP_SIGNING_KEY_ID", "").strip()
+    private_file = env.get("CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE", "").strip()
+    private_base64 = env.get("CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64", "").strip()
+    public_file = env.get("CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE", "").strip()
+    public_base64 = env.get("CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64", "").strip()
+    return {
+        "keyId": key_id,
+        "privateFile": private_file,
+        "privateBase64": bool(private_base64),
+        "publicFile": public_file,
+        "publicBase64": bool(public_base64),
+        "hasPrivate": bool(private_file or private_base64),
+        "hasPublic": bool(public_file or public_base64),
+        "complete": bool(key_id and (private_file or private_base64) and (public_file or public_base64)),
+    }
+
+
+def sign_args(bundle_dir: Path, inputs: dict[str, Any]) -> list[str]:
+    args = ["sign", "--bundle-dir", str(bundle_dir), "--key-id", inputs["keyId"]]
+    if inputs["privateFile"]:
+        args.extend(["--private-key-file", inputs["privateFile"]])
+    else:
+        args.extend(["--private-key-env", "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64"])
+    return args
+
+
+def verify_args(bundle_dir: Path, inputs: dict[str, Any]) -> list[str]:
+    args = ["verify", "--bundle-dir", str(bundle_dir), "--trusted-key-id", inputs["keyId"]]
+    if inputs["publicFile"]:
+        args.extend(["--trusted-public-key-file", inputs["publicFile"]])
+    else:
+        args.extend(["--trusted-public-key-base64", os.environ.get("CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64", "")])
+    return args
+
+
+def catalog_sign_args(catalog_file: Path, inputs: dict[str, Any]) -> list[str]:
+    args = ["catalog", "sign", "--catalog-file", str(catalog_file), "--key-id", inputs["keyId"]]
+    if inputs["privateFile"]:
+        args.extend(["--private-key-file", inputs["privateFile"]])
+    else:
+        args.extend(["--private-key-env", "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64"])
+    return args
+
+
+def catalog_verify_args(catalog_file: Path, inputs: dict[str, Any]) -> list[str]:
+    args = ["catalog", "verify", "--catalog-file", str(catalog_file), "--trusted-key-id", inputs["keyId"]]
+    if inputs["publicFile"]:
+        args.extend(["--trusted-public-key-file", inputs["publicFile"]])
+    else:
+        args.extend(["--trusted-public-key-base64", os.environ.get("CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64", "")])
+    return args
+
+
+def collect_first_party_evidence(settings: Settings, cli: Path | None) -> EvidenceItem:
+    gradle_result = gradle_command(settings, ["stageFirstPartyApps"], "gradle-stage-first-party-apps")
+    errors: list[str] = []
+    details: dict[str, Any] = {"stageCommand": command_details(gradle_result, settings), "apps": {}}
+    if gradle_result is not None and gradle_result.exit_code != 0:
+        errors.append("stageFirstPartyApps failed")
+    for spec in first_party_app_specs(settings):
+        ok, app_errors, app_details = validate_app_bundle(spec["stagedDir"], spec, settings)
+        details["apps"][spec["appId"]] = app_details
+        if not ok:
+            errors.extend(f"{spec['appId']}: {error}" for error in app_errors)
+        if cli is not None and spec["stagedDir"].is_dir():
+            result = run_cli(cli, ["validate", "--bundle-dir", str(spec["stagedDir"])], settings, f"crypta-app-validate-{spec['appId']}")
+            details["apps"][spec["appId"]]["cliValidate"] = command_details(result, settings)
+            if result.exit_code != 0:
+                errors.append(f"crypta-app validate failed for {spec['appId']}")
+    if errors:
+        return EvidenceItem(
+            "app-platform.first-party",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "First-party staged app validation found problems.",
+            summary_source(settings),
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "app-platform.first-party",
+        "pass",
+        True,
+        "First-party staged app manifests and static assets passed.",
+        summary_source(settings),
+        details,
+    )
+
+
+def sample_workspace(settings: Settings) -> Path:
+    work_dir = settings.out_dir / "work"
+    work_dir.mkdir(parents=True, exist_ok=True)
+    return work_dir
+
+
+def collect_cli_evidence(settings: Settings, cli: Path | None) -> tuple[EvidenceItem, dict[str, Path]]:
+    details: dict[str, Any] = {}
+    sample_paths: dict[str, Path] = {}
+    install_result = gradle_command(settings, [":platform-devtools:installDist"], "gradle-platform-devtools-installDist")
+    details["installDistCommand"] = command_details(install_result, settings)
+    cli = find_cli(settings)
+    if install_result is not None and install_result.exit_code != 0:
+        return (
+            EvidenceItem(
+                "app-platform.devtools-cli",
+                root_consequence(settings, "fail"),
+                True,
+                "platform-devtools installDist failed.",
+                summary_source(settings),
+                details,
+            ),
+            sample_paths,
+        )
+    if cli is None or not cli.is_file():
+        return (
+            EvidenceItem(
+                "app-platform.devtools-cli",
+                root_consequence(settings, "missing"),
+                True,
+                "crypta-app launcher is missing.",
+                summary_source(settings),
+                details,
+            ),
+            sample_paths,
+        )
+    details["cliPath"] = display_path(cli, settings.workspace_root)
+    sample_dir = sample_workspace(settings) / "cert-smoke-app"
+    sample_zip = sample_workspace(settings) / "cert-smoke-app-0.1.0.zip"
+    remove_existing_path(sample_dir)
+    init_result = run_cli(
+        cli,
+        [
+            "init",
+            "--dir",
+            str(sample_dir),
+            "--app-id",
+            "cert-smoke",
+            "--name",
+            "Certification Smoke",
+            "--version",
+            "0.1.0",
+            "--ui-mode",
+            "static",
+            "--permission",
+            "queue.read",
+            "--overwrite",
+        ],
+        settings,
+        "crypta-app-init-sample",
+    )
+    launcher_error = ""
+    if init_result.exit_code == 0:
+        try:
+            write_live_smoke_launcher(sample_dir)
+        except OSError as exc:
+            launcher_error = scrub_text(str(exc), settings.workspace_root)
+    validate_result = run_cli(cli, ["validate", "--bundle-dir", str(sample_dir)], settings, "crypta-app-validate-sample")
+    remove_existing_path(sample_zip)
+    pack_result = run_cli(
+        cli,
+        ["pack", "--bundle-dir", str(sample_dir), "--output", str(sample_zip), "--overwrite"],
+        settings,
+        "crypta-app-pack-sample",
+    )
+    details["sample"] = {
+        "appId": "cert-smoke",
+        "bundleDir": display_path(sample_dir, settings.workspace_root),
+        "zip": display_path(sample_zip, settings.workspace_root),
+        "init": command_details(init_result, settings),
+        "launcherRewritten": not launcher_error and init_result.exit_code == 0,
+        "validate": command_details(validate_result, settings),
+        "pack": command_details(pack_result, settings),
+    }
+    if launcher_error:
+        details["sample"]["launcherError"] = launcher_error
+    sample_paths.update({"bundleDir": sample_dir, "zip": sample_zip, "cli": cli})
+    pack_output_exists = sample_zip.is_file()
+    details["sample"]["zipExists"] = pack_output_exists
+    if pack_output_exists:
+        details["sample"]["zipSha256"] = sha256_file(sample_zip)
+        details["sample"]["zipSizeBytes"] = sample_zip.stat().st_size
+    failed = [name for name, result in (("init", init_result), ("validate", validate_result), ("pack", pack_result)) if result.exit_code != 0]
+    if launcher_error:
+        failed.append("launcher")
+    if pack_result.exit_code == 0 and not pack_output_exists:
+        failed.append("pack-output")
+    if failed:
+        return (
+            EvidenceItem(
+                "app-platform.devtools-cli",
+                root_consequence(settings, "fail"),
+                True,
+                "crypta-app sample init, validate, or pack failed.",
+                summary_source(settings),
+                {"failedSteps": failed, **details},
+            ),
+            sample_paths,
+        )
+    return (
+        EvidenceItem(
+            "app-platform.devtools-cli",
+            "pass",
+            True,
+            "crypta-app init, validate, and pack passed.",
+            summary_source(settings),
+            details,
+        ),
+        sample_paths,
+    )
+
+
+def collect_signed_bundle_evidence(settings: Settings, sample_paths: dict[str, Path]) -> EvidenceItem:
+    inputs = signing_inputs(os.environ)
+    details: dict[str, Any] = {
+        "keyIdPresent": bool(inputs["keyId"]),
+        "privateKeyPresent": inputs["hasPrivate"],
+        "publicKeyPresent": inputs["hasPublic"],
+        "privateKeySource": "file" if inputs["privateFile"] else ("environment" if inputs["privateBase64"] else "missing"),
+        "publicKeySource": "file" if inputs["publicFile"] else ("environment" if inputs["publicBase64"] else "missing"),
+    }
+    source = summary_source(settings)
+    if not inputs["complete"]:
+        status = "fail" if settings.mode == "release-candidate" else "skip"
+        return EvidenceItem(
+            "app-platform.signed-bundles",
+            status,
+            True,
+            "Signing key inputs are not complete; signed bundle verification was not run.",
+            source,
+            details,
+        )
+    gradle_result = gradle_command(settings, ["signFirstPartyApps", "verifyFirstPartyApps"], "gradle-sign-verify-first-party-apps")
+    details["firstPartySignVerifyCommand"] = command_details(gradle_result, settings)
+    failures: list[str] = []
+    if gradle_result is None:
+        details["firstPartySignVerifyRan"] = False
+        if settings.mode == "release-candidate":
+            failures.append("first-party sign/verify Gradle task was skipped")
+    elif gradle_result.exit_code != 0:
+        details["firstPartySignVerifyRan"] = True
+        failures.append("first-party sign/verify Gradle task failed")
+    else:
+        details["firstPartySignVerifyRan"] = True
+    cli = sample_paths.get("cli")
+    sample_dir = sample_paths.get("bundleDir")
+    if cli and sample_dir and sample_dir.is_dir():
+        sign_result = run_cli(cli, sign_args(sample_dir, inputs), settings, "crypta-app-sign-sample")
+        verify_result = run_cli(cli, verify_args(sample_dir, inputs), settings, "crypta-app-verify-sample")
+        details["sampleSign"] = command_details(sign_result, settings)
+        details["sampleVerify"] = command_details(verify_result, settings)
+        if sign_result.exit_code != 0:
+            failures.append("sample bundle sign failed")
+        if verify_result.exit_code != 0:
+            failures.append("sample bundle verify failed")
+        sample_zip = sample_paths.get("zip")
+        if sample_zip and sign_result.exit_code == 0 and verify_result.exit_code == 0:
+            repack_result = run_cli(
+                cli,
+                ["pack", "--bundle-dir", str(sample_dir), "--output", str(sample_zip), "--overwrite"],
+                settings,
+                "crypta-app-pack-signed-sample",
+            )
+            details["sampleRepackAfterSigning"] = command_details(repack_result, settings)
+            if repack_result.exit_code != 0:
+                failures.append("signed sample bundle repack failed")
+            elif sample_zip.is_file():
+                details["signedSampleZipSha256"] = sha256_file(sample_zip)
+                details["signedSampleZipSizeBytes"] = sample_zip.stat().st_size
+    else:
+        failures.append("sample bundle was unavailable for signing")
+    if failures:
+        return EvidenceItem(
+            "app-platform.signed-bundles",
+            "fail",
+            True,
+            "Signed bundle smoke failed.",
+            source,
+            {"failures": failures, **details},
+        )
+    return EvidenceItem(
+        "app-platform.signed-bundles",
+        "pass",
+        True,
+        "First-party and sample bundle signing evidence passed.",
+        source,
+        details,
+    )
+
+
+def collect_catalog_evidence(settings: Settings, sample_paths: dict[str, Path]) -> EvidenceItem:
+    source = summary_source(settings)
+    cli = sample_paths.get("cli")
+    sample_zip = sample_paths.get("zip")
+    details: dict[str, Any] = {}
+    if not cli or not sample_zip or not sample_zip.is_file():
+        return EvidenceItem("catalog.smoke", root_consequence(settings, "missing"), True, "Sample ZIP or crypta-app CLI is unavailable for catalog smoke.", source, details)
+    catalog_dir = sample_workspace(settings) / "catalog"
+    catalog_dir.mkdir(parents=True, exist_ok=True)
+    descriptor = catalog_dir / "entry.properties"
+    catalog_file = catalog_dir / "cryptad-app-catalog.properties"
+    signature_file = catalog_dir / "cryptad-app-catalog.signature"
+    descriptor.write_text(
+        "\n".join(
+            [
+                f"artifact.path={sample_zip.resolve()}",
+                f"bundle.uri={sample_zip.resolve().as_uri()}",
+                "summary=Certification smoke app.",
+                "name=Certification Smoke",
+                "permissions=queue.read",
+                "app.id=cert-smoke",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    remove_existing_path(catalog_file)
+    remove_existing_path(signature_file)
+    create_result = run_cli(
+        cli,
+        [
+            "catalog",
+            "create",
+            "--catalog-file",
+            str(catalog_file),
+            "--catalog-id",
+            "cert-smoke",
+            "--name",
+            "Certification Smoke Apps",
+            "--generated-at",
+            "2026-05-01T00:00:00Z",
+            "--entry",
+            str(descriptor),
+            "--overwrite",
+        ],
+        settings,
+        "crypta-app-catalog-create",
+    )
+    details["create"] = command_details(create_result, settings)
+    if create_result.exit_code != 0:
+        return EvidenceItem("catalog.smoke", root_consequence(settings, "fail"), True, "Catalog creation failed.", source, details)
+    catalog_exists = catalog_file.is_file()
+    details["catalogExists"] = catalog_exists
+    if not catalog_exists:
+        return EvidenceItem(
+            "catalog.smoke",
+            root_consequence(settings, "fail"),
+            True,
+            "Catalog creation did not produce catalog output.",
+            source,
+            details,
+        )
+    catalog = parse_properties(catalog_file)
+    details["catalog"] = {
+        "catalogId": catalog.get("catalog.id"),
+        "catalogVersion": catalog.get("catalog.version"),
+        "entries": catalog.get("catalog.entries"),
+        "appId": catalog.get("app.cert-smoke.id"),
+        "bundleSha256": catalog.get("app.cert-smoke.bundle.sha256"),
+        "bundleSizeBytes": catalog.get("app.cert-smoke.bundle.size.bytes"),
+        "catalogSha256": sha256_file(catalog_file),
+    }
+    inputs = signing_inputs(os.environ)
+    details["signingInputs"] = {
+        "keyIdPresent": bool(inputs["keyId"]),
+        "privateKeyPresent": inputs["hasPrivate"],
+        "publicKeyPresent": inputs["hasPublic"],
+    }
+    if not inputs["complete"]:
+        status = "fail" if settings.mode == "release-candidate" else "warn"
+        return EvidenceItem(
+            "catalog.smoke",
+            status,
+            True,
+            "Catalog creation passed, but signing key inputs are incomplete.",
+            source,
+            details,
+        )
+    sign_result = run_cli(cli, catalog_sign_args(catalog_file, inputs), settings, "crypta-app-catalog-sign")
+    verify_result = run_cli(cli, catalog_verify_args(catalog_file, inputs), settings, "crypta-app-catalog-verify")
+    details["sign"] = command_details(sign_result, settings)
+    details["verify"] = command_details(verify_result, settings)
+    if sign_result.exit_code != 0 or verify_result.exit_code != 0:
+        return EvidenceItem("catalog.smoke", "fail", True, "Signed catalog smoke failed.", source, details)
+    return EvidenceItem("catalog.smoke", "pass", True, "Catalog create, sign, and verify smoke passed.", source, details)
+
+
+def collect_app_ui_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    source_ok, source_errors, source_details = check_source_static_ui(settings)
+    staged_errors: list[str] = []
+    staged_details: dict[str, Any] = {}
+    for spec in first_party_app_specs(settings):
+        static_dir = spec["stagedDir"] / "static"
+        errors, details = validate_static_ui_files(static_dir, settings)
+        staged_errors.extend(f"{spec['appId']}: {error}" for error in errors)
+        staged_details[spec["appId"]] = details
+    errors = source_errors + staged_errors
+    details = {"sourceStaticUi": source_details, "stagedStaticUi": staged_details}
+    if errors:
+        return EvidenceItem(
+            "app-ui.smoke",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "App-owned UI or SDK smoke found problems.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem("app-ui.smoke", "pass", True, "App-owned UI and SDK smoke passed.", source, details)
+
+
+def legacy_counts_from_registry_text(text: str) -> dict[str, int]:
+    start = text.index("List.of(")
+    end = text.index("private static final Map", start)
+    block = text[start:end]
+    return {
+        "PRIMARY_REPLACED": len(re.findall(r"\n\s+replaced\(", block)),
+        "PENDING": len(re.findall(r"\n\s+pendingWizard\(", block)) + len(re.findall(r"\n\s+pending\(", block)),
+        "RETAINED": len(re.findall(r"\n\s+retained\(", block)),
+        "INFRASTRUCTURE": len(re.findall(r"\n\s+infrastructure\(", block)),
+    }
+
+
+def java_method_body(text: str, method_name: str) -> str:
+    pattern = re.compile(
+        r"\b(?:public|private)\s+static\s+[\w<>, ?]+\s+"
+        + re.escape(method_name)
+        + r"\s*\([^)]*\)\s*\{",
+        re.DOTALL,
+    )
+    match = pattern.search(text)
+    if match is None:
+        return ""
+    open_brace = match.end() - 1
+    depth = 0
+    for offset in range(open_brace, len(text)):
+        char = text[offset]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[open_brace + 1 : offset]
+    return ""
+
+
+def legacy_fallback_link_checks(text: str) -> dict[str, bool]:
+    fallback_body = java_method_body(text, "webShellFallbackSurfaces")
+    replaced_body = java_method_body(text, "replaced")
+    navigation_body = java_method_body(text, "shouldPromoteInLegacyNavigation")
+    replaced_marks_no_fallback = bool(
+        re.search(
+            r"LegacyAdminRetirementState\.PRIMARY_REPLACED\b.*?,\s*true\s*,\s*false\s*\)\s*;",
+            replaced_body,
+            re.DOTALL,
+        )
+    )
+    fallback_filters_include_flag = bool(
+        re.search(r"\.filter\s*\(\s*LegacyAdminSurface::includeInWebShellFallbackLinks\s*\)", fallback_body)
+    )
+    fallback_filters_primary_state = bool(
+        re.search(r"state\(\)\s*!=\s*LegacyAdminRetirementState\.PRIMARY_REPLACED", fallback_body)
+    )
+    navigation_excludes_primary = bool(
+        re.search(r"state\(\)\s*!=\s*LegacyAdminRetirementState\.PRIMARY_REPLACED", navigation_body)
+    )
+    primary_replaced_excluded = fallback_filters_primary_state or (
+        fallback_filters_include_flag and replaced_marks_no_fallback
+    )
+    return {
+        "fallbackMethodFound": bool(fallback_body),
+        "replacedHelperFound": bool(replaced_body),
+        "replacedHelperDisablesFallbackLinks": replaced_marks_no_fallback,
+        "fallbackFiltersIncludeFlag": fallback_filters_include_flag,
+        "fallbackFiltersPrimaryState": fallback_filters_primary_state,
+        "primaryReplacedExcludedFromFallbackLinks": primary_replaced_excluded,
+        "primaryReplacedAbsentFromPrimaryNavigation": navigation_excludes_primary,
+    }
+
+
+def collect_legacy_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    registry = settings.workspace_root / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java"
+    docs = settings.workspace_root / "docs/legacy-retirement-plan.md"
+    errors: list[str] = []
+    details: dict[str, Any] = {}
+    if not registry.is_file():
+        errors.append("LegacyAdminRetirementRegistry.java is missing")
+    else:
+        registry_text = registry.read_text(encoding="utf-8")
+        counts = legacy_counts_from_registry_text(registry_text)
+        fallback_checks = legacy_fallback_link_checks(registry_text)
+        details["stateCounts"] = counts
+        details["totalRegisteredSurfaces"] = sum(counts.values())
+        details["primaryReplacedSurfaces"] = counts["PRIMARY_REPLACED"]
+        details["pendingSurfaces"] = counts["PENDING"]
+        details["retainedSurfaces"] = counts["RETAINED"]
+        details["fallbackLinkChecks"] = fallback_checks
+        details["primaryReplacedAbsentFromFallbackLinks"] = fallback_checks[
+            "primaryReplacedExcludedFromFallbackLinks"
+        ]
+        details["primaryReplacedAbsentFromPrimaryNavigation"] = fallback_checks[
+            "primaryReplacedAbsentFromPrimaryNavigation"
+        ]
+        docs_text = re.sub(r"\s+", " ", docs.read_text(encoding="utf-8")) if docs.is_file() else ""
+        details["fallbackDirectUrlsRemainDocumented"] = "Direct legacy URLs remain reachable" in docs_text
+        if counts["PRIMARY_REPLACED"] < 1:
+            errors.append("No PRIMARY_REPLACED surfaces were found")
+        if not details["primaryReplacedAbsentFromFallbackLinks"]:
+            errors.append("PRIMARY_REPLACED surfaces may still appear in Web Shell fallback links")
+        if not details["primaryReplacedAbsentFromPrimaryNavigation"]:
+            errors.append("PRIMARY_REPLACED surfaces may still appear in primary legacy navigation")
+        if not details["fallbackDirectUrlsRemainDocumented"]:
+            errors.append("Legacy fallback/direct URL behavior is not documented")
+    if errors:
+        return EvidenceItem("legacy.retirement", "fail", True, "Legacy-admin retirement evidence is incomplete.", source, {"errors": errors, **details})
+    return EvidenceItem("legacy.retirement", "pass", True, "Legacy-admin retirement map is visible and stable.", source, details)
+
+
+def build_http_request(
+    method: str, url: str, form_password: str = "", data: dict[str, str] | None = None
+) -> urllib.request.Request:
+    payload: bytes | None = None
+    headers = {"Accept": "application/json"}
+    params = data or {}
+    if method in {"POST", "DELETE"} and form_password:
+        params = {**params, "formPassword": form_password}
+    if method in {"POST", "DELETE"} and params:
+        payload = urllib.parse.urlencode(params).encode("utf-8")
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+    elif params:
+        url = url + ("&" if "?" in url else "?") + urllib.parse.urlencode(params)
+    return urllib.request.Request(url, data=payload, method=method, headers=headers)
+
+
+def http_request_json(
+    method: str, url: str, form_password: str = "", data: dict[str, str] | None = None
+) -> tuple[int, Any]:
+    request = build_http_request(method, url, form_password, data)
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            return response.status, json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        try:
+            value = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            value = {"error": {"message": body[:200]}}
+        return exc.code, value
+
+
+def diagnostics_body_summary(body: Any) -> dict[str, Any]:
+    if not isinstance(body, dict):
+        return {"diagnosticsBodyType": type(body).__name__}
+    summary: dict[str, Any] = {}
+    section_count = body.get("sectionCount")
+    if isinstance(section_count, int):
+        summary["sectionCount"] = section_count
+    sections = body.get("sections")
+    if isinstance(sections, list):
+        summary["sectionCount"] = len(sections)
+    legacy_admin = body.get("legacyAdmin")
+    if isinstance(legacy_admin, dict):
+        surfaces = legacy_admin.get("surfaces")
+        if isinstance(surfaces, list):
+            summary["legacyAdminSurfaceCount"] = len(surfaces)
+            counts = [
+                surface.get("count")
+                for surface in surfaces
+                if isinstance(surface, dict) and isinstance(surface.get("count"), int)
+            ]
+            summary["legacyAdminTotalCount"] = sum(counts)
+    if not summary:
+        summary["diagnosticsBodyReceived"] = True
+    return summary
+
+
+def live_response_details(path: str, body: Any, workspace_root: Path) -> dict[str, Any]:
+    if path == "/diagnostics":
+        return {"bodySummary": diagnostics_body_summary(body)}
+    return {"body": sanitize_value(body, workspace_root)}
+
+
+def collect_live_cleanup_steps(root: str, settings: Settings) -> list[dict[str, Any]]:
+    cleanup_steps: list[dict[str, Any]] = []
+    for method, path in (("POST", "/apps/cert-smoke/stop"), ("DELETE", "/apps/cert-smoke")):
+        cleanup_step: dict[str, Any] = {"method": method, "path": path}
+        try:
+            status, body = http_request_json(method, root + path, settings.live_form_password, {})
+            cleanup_step["status"] = status
+            cleanup_step.update(live_response_details(path, body, settings.workspace_root))
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            cleanup_step["error"] = scrub_text(str(exc), settings.workspace_root)
+        cleanup_steps.append(cleanup_step)
+    return cleanup_steps
+
+
+def failed_live_evidence(
+    source: str,
+    details: dict[str, Any],
+    root: str,
+    settings: Settings,
+    installed: bool,
+    summary: str = "Live AppHost lifecycle smoke failed.",
+) -> EvidenceItem:
+    if installed:
+        details["cleanupSteps"] = collect_live_cleanup_steps(root, settings)
+    return EvidenceItem("apphost.live", "fail", False, summary, source, details)
+
+
+def collect_live_evidence(settings: Settings, sample_paths: dict[str, Path]) -> EvidenceItem:
+    source = summary_source(settings)
+    if not settings.live:
+        return EvidenceItem("apphost.live", "skip", False, "Live AppHost lifecycle smoke was not requested.", source, {"enabled": False})
+    details: dict[str, Any] = {"enabled": True, **live_base_url_details(settings.live_base_url)}
+    if not settings.live_base_url:
+        return EvidenceItem("apphost.live", "fail", False, "Live AppHost smoke was requested without CRYPTAD_CERT_NODE_BASE_URL.", source, details)
+    host = urllib.parse.urlparse(settings.live_base_url).hostname or ""
+    if not is_local_live_host(host):
+        return EvidenceItem("apphost.live", "fail", False, "Live AppHost smoke only records localhost node evidence.", source, details)
+    if not settings.live_form_password:
+        return EvidenceItem("apphost.live", "fail", False, "Live AppHost smoke was requested without CRYPTAD_CERT_FORM_PASSWORD.", source, details)
+    staged_dir = sample_paths.get("bundleDir")
+    if not staged_dir or not staged_dir.is_dir():
+        return EvidenceItem("apphost.live", "fail", False, "Live AppHost smoke needs the generated sample staged bundle.", source, details)
+    root = settings.live_base_url.rstrip("/") + "/api/v1"
+    steps: list[dict[str, Any]] = []
+    installed = False
+    try:
+        for method, path, data in (
+            ("GET", "/apps", {}),
+            ("DELETE", "/apps/cert-smoke", {}),
+            ("POST", "/apps/install", {"stagedDir": str(staged_dir.resolve())}),
+            ("GET", "/apps/cert-smoke/runtime", {}),
+            ("POST", "/apps/cert-smoke/start", {}),
+            ("GET", "/apps/cert-smoke/runtime", {}),
+            ("POST", "/apps/cert-smoke/stop", {}),
+            ("POST", "/apps/cert-smoke/update", {"stagedDir": str(staged_dir.resolve())}),
+            ("DELETE", "/apps/cert-smoke", {}),
+            ("GET", "/diagnostics", {}),
+        ):
+            status, body = http_request_json(method, root + path, settings.live_form_password, data)
+            step = {"method": method, "path": path, "status": status}
+            step.update(live_response_details(path, body, settings.workspace_root))
+            steps.append(step)
+            if status >= 400 and not (method == "DELETE" and path == "/apps/cert-smoke" and status == 404):
+                details["steps"] = steps
+                return failed_live_evidence(source, details, root, settings, installed)
+            if method == "POST" and path == "/apps/install":
+                installed = True
+            elif method == "DELETE" and path == "/apps/cert-smoke" and status < 500:
+                installed = False
+    except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+        details["steps"] = steps
+        details["error"] = scrub_text(str(exc), settings.workspace_root)
+        return failed_live_evidence(source, details, root, settings, installed)
+    details["steps"] = steps
+    return EvidenceItem("apphost.live", "pass", False, "Live AppHost install/start/status/stop/update/uninstall smoke passed.", source, details)
+
+
+def overall_status(mode: str, evidence: list[EvidenceItem]) -> str:
+    if any(item.required_for_release_candidate and item.status == "fail" for item in evidence):
+        return "fail"
+    if mode == "release-candidate" and any(
+        item.required_for_release_candidate and item.status in {"missing", "skip"} for item in evidence
+    ):
+        return "fail"
+    if any(item.status in {"warn", "skip", "missing", "fail"} for item in evidence):
+        return "warn"
+    return "pass"
+
+
+def render_report(summary: dict[str, Any]) -> str:
+    lines = [
+        "# App Platform Smoke Report",
+        "",
+        f"- Mode: `{summary['mode']}`",
+        f"- Status: `{summary['status']}`",
+        f"- Generated: `{summary['generatedAt']}`",
+        "",
+        "| Evidence | Status | Required for RC | Summary |",
+        "| --- | --- | --- | --- |",
+    ]
+    for item in summary["evidence"]:
+        summary_text = str(item["summary"]).replace("|", "\\|")
+        lines.append(
+            f"| `{item['id']}` | `{item['status']}` | "
+            f"{'yes' if item['requiredForReleaseCandidate'] else 'no'} | "
+            f"{summary_text} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_summary(settings: Settings, evidence: list[EvidenceItem]) -> dict[str, Any]:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "tool": TOOL_NAME,
+        "mode": settings.mode,
+        "status": overall_status(settings.mode, evidence),
+        "generatedAt": utc_now(),
+        "summaryPath": display_path(settings.out_dir / SUMMARY_FILE_NAME, settings.workspace_root, settings.out_dir),
+        "reportPath": display_path(settings.out_dir / REPORT_FILE_NAME, settings.workspace_root, settings.out_dir),
+        "evidence": [item.to_json() for item in evidence],
+        "redaction": {
+            "secretMaterialRedacted": True,
+            "rawRequestBodiesExcluded": True,
+            "absolutePathsSanitized": True,
+        },
+    }
+
+
+def run(settings: Settings) -> tuple[dict[str, Any], int]:
+    settings.out_dir.mkdir(parents=True, exist_ok=True)
+    remove_existing_path(settings.out_dir / "artifacts")
+    cli = find_cli(settings)
+    cli_item, sample_paths = collect_cli_evidence(settings, cli)
+    cli = sample_paths.get("cli") if sample_paths.get("cli") else find_cli(settings)
+    evidence = [
+        collect_first_party_evidence(settings, cli if isinstance(cli, Path) else None),
+        cli_item,
+        collect_signed_bundle_evidence(settings, sample_paths),
+        collect_catalog_evidence(settings, sample_paths),
+        collect_app_ui_evidence(settings),
+        collect_legacy_evidence(settings),
+        collect_live_evidence(settings, sample_paths),
+    ]
+    sanitized_evidence = [
+        EvidenceItem(
+            item.id,
+            item.status,
+            item.required_for_release_candidate,
+            scrub_text(item.summary, settings.workspace_root),
+            item.source,
+            dict(sanitize_value(item.details, settings.workspace_root)),
+        )
+        for item in evidence
+    ]
+    summary = build_summary(settings, sanitized_evidence)
+    write_json(settings.out_dir / SUMMARY_FILE_NAME, summary)
+    write_text(settings.out_dir / REPORT_FILE_NAME, render_report(summary))
+    exit_code = 1 if settings.mode == "release-candidate" and summary["status"] == "fail" else 0
+    return summary, exit_code
+
+
+def settings_from_args(args: argparse.Namespace) -> Settings:
+    workspace = args.workspace_root.resolve()
+    out_dir = (workspace / args.out_dir).resolve() if not args.out_dir.is_absolute() else args.out_dir.resolve()
+    mode = args.mode or os.environ.get("CRYPTAD_CERT_MODE", "pr")
+    if mode not in MODES:
+        raise SystemExit(f"--mode must be one of {', '.join(MODES)}")
+    live = args.live or os.environ.get("CRYPTAD_CERT_APP_SMOKE_LIVE") == "1"
+    cli_path = args.cli_path.resolve() if args.cli_path else None
+    return Settings(
+        workspace_root=workspace,
+        out_dir=out_dir,
+        mode=mode,
+        skip_gradle=args.skip_gradle,
+        cli_path=cli_path,
+        live=live,
+        live_base_url=args.node_base_url or os.environ.get("CRYPTAD_CERT_NODE_BASE_URL", ""),
+        live_form_password=os.environ.get("CRYPTAD_CERT_FORM_PASSWORD", ""),
+        timeout_seconds=args.timeout_seconds,
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="Run Python-only self-tests.")
+    parser.add_argument("--workspace-root", type=Path, default=Path.cwd())
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--mode", choices=MODES, default=None)
+    parser.add_argument("--skip-gradle", action="store_true", help="Do not invoke Gradle tasks.")
+    parser.add_argument("--cli-path", type=Path, help="Path to an installed crypta-app launcher.")
+    parser.add_argument("--live", action="store_true", help="Run optional live-node AppHost lifecycle smoke.")
+    parser.add_argument("--node-base-url", default="", help="Live-node base URL for optional AppHost smoke.")
+    parser.add_argument("--timeout-seconds", type=int, default=900)
+    return parser
+
+
+def run_self_test(repo_root: Path) -> None:
+    fixture_dir = repo_root / "tools/release-certification/fixtures"
+    catalog_fixture = fixture_dir / "self-test-catalog.properties"
+    registry_fixture = fixture_dir / "self-test-legacy-registry.java-fragment"
+    catalog = parse_properties(catalog_fixture)
+    assert catalog["catalog.id"] == "cert-smoke"
+    assert catalog["app.cert-smoke.bundle.sha256"] == "0" * 64
+    registry_text = registry_fixture.read_text(encoding="utf-8")
+    counts = legacy_counts_from_registry_text(registry_text)
+    assert counts == {
+        "PRIMARY_REPLACED": 2,
+        "PENDING": 2,
+        "RETAINED": 1,
+        "INFRASTRUCTURE": 1,
+    }, counts
+    fallback_checks = legacy_fallback_link_checks(registry_text)
+    assert fallback_checks["primaryReplacedExcludedFromFallbackLinks"] is True, fallback_checks
+    assert fallback_checks["primaryReplacedAbsentFromPrimaryNavigation"] is True, fallback_checks
+    unsafe_registry_text = registry_text.replace("true,\n        false);", "true,\n        true);", 1)
+    unsafe_fallback_checks = legacy_fallback_link_checks(unsafe_registry_text)
+    assert unsafe_fallback_checks["primaryReplacedExcludedFromFallbackLinks"] is False, unsafe_fallback_checks
+    parser_options = {
+        option
+        for action in build_parser()._actions
+        for option in action.option_strings
+    }
+    assert "--form-password" not in parser_options, parser_options
+    previous_form_password = os.environ.get("CRYPTAD_CERT_FORM_PASSWORD")
+    os.environ["CRYPTAD_CERT_FORM_PASSWORD"] = "env-only-form-password"
+    try:
+        env_settings = settings_from_args(
+            build_parser().parse_args(
+                [
+                    "--workspace-root",
+                    str(repo_root),
+                    "--out-dir",
+                    "build/release-certification/app-platform-smoke",
+                    "--live",
+                ]
+            )
+        )
+    finally:
+        if previous_form_password is None:
+            os.environ.pop("CRYPTAD_CERT_FORM_PASSWORD", None)
+        else:
+            os.environ["CRYPTAD_CERT_FORM_PASSWORD"] = previous_form_password
+    assert env_settings.live_form_password == "env-only-form-password", env_settings
+    redacted_secret_command = redact_command(
+        [
+            "crypta-app",
+            "sign",
+            "--private-key-file",
+            "/mnt/secrets/prod-key.pem",
+            "--private-key-base64",
+            "base64-secret",
+        ],
+        env_settings,
+    )
+    assert redacted_secret_command == [
+        "crypta-app",
+        "sign",
+        "--private-key-file",
+        "<redacted>",
+        "--private-key-base64",
+        "<redacted>",
+    ], redacted_secret_command
+    assert "prod-key.pem" not in json.dumps(redacted_secret_command), redacted_secret_command
+    assert normalize_static_script_ref("./app.js?cache=1#main") == "app.js"
+    with tempfile.TemporaryDirectory(prefix="cryptad-app-script-order-self-test-") as static_name:
+        static_dir = Path(static_name)
+        (static_dir / "index.html").write_text(
+            '<script src="app.js"></script><script src="crypta-platform.js"></script>\n',
+            encoding="utf-8",
+        )
+        (static_dir / "app.js").write_text(
+            'CryptaPlatform.bootstrap.load({ appId: "cert-smoke" });\n',
+            encoding="utf-8",
+        )
+        canonical_sdk = repo_root / "platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js"
+        if canonical_sdk.is_file():
+            shutil.copy2(canonical_sdk, static_dir / "crypta-platform.js")
+        else:
+            (static_dir / "crypta-platform.js").write_text(
+                'window.CryptaPlatform={}; X="X-Crypta-App-Session";\n',
+                encoding="utf-8",
+            )
+        script_errors, _ = validate_static_ui_files(static_dir, env_settings)
+    assert "index.html must load crypta-platform.js before app.js" in script_errors, script_errors
+    scrubbed = scrub_text("key file /mnt/secrets/signing/key.pem token=hunter2 USK@private/insert", repo_root)
+    assert "/mnt/secrets/signing/key.pem" not in scrubbed
+    assert "hunter2" not in scrubbed
+    assert "USK@private" not in scrubbed
+    repo_tmp_path = repo_root / "build/tmp-release-certification/app-platform-smoke/summary.json"
+    assert (
+        scrub_text(str(repo_tmp_path), repo_root)
+        == "<repo>/build/tmp-release-certification/app-platform-smoke/summary.json"
+    )
+    assert (
+        normalize_redacted_separators(r"<repo>\build\tmp-release-certification\app-platform-smoke\summary.json")
+        == "<repo>/build/tmp-release-certification/app-platform-smoke/summary.json"
+    )
+    windows_scrubbed = scrub_text(
+        r"key file D:\keys\signing.pem and \\builder\share\certs\catalog.pem",
+        repo_root,
+    )
+    assert r"D:\keys" not in windows_scrubbed, windows_scrubbed
+    assert r"\\builder\share" not in windows_scrubbed, windows_scrubbed
+    assert "<path>/signing.pem" in windows_scrubbed, windows_scrubbed
+    assert "<path>/catalog.pem" in windows_scrubbed, windows_scrubbed
+    file_uri_scrubbed = scrub_text(
+        "metadata file:///home/alice/signing/key.pem file:///D:/keys/catalog.pem",
+        repo_root,
+    )
+    assert "/home/alice/signing" not in file_uri_scrubbed, file_uri_scrubbed
+    assert "D:/keys" not in file_uri_scrubbed, file_uri_scrubbed
+    assert "file://<path>/key.pem" in file_uri_scrubbed, file_uri_scrubbed
+    assert "file://<path>/catalog.pem" in file_uri_scrubbed, file_uri_scrubbed
+    route_scrubbed = scrub_text(
+        "/apps/install /apps/cert-smoke/runtime /api/v1/diagnostics "
+        "/mnt/secrets/signing/key.pem",
+        repo_root,
+    )
+    assert "/apps/install" in route_scrubbed, route_scrubbed
+    assert "/apps/cert-smoke/runtime" in route_scrubbed, route_scrubbed
+    assert "/api/v1/diagnostics" in route_scrubbed, route_scrubbed
+    assert "/mnt/secrets/signing/key.pem" not in route_scrubbed, route_scrubbed
+    assert "<path>/key.pem" in route_scrubbed, route_scrubbed
+    signing_metadata = sanitize_value(
+        {
+            "privateKeyPresent": False,
+            "privateKeySource": "missing",
+            "publicKeyPresent": True,
+            "publicKeySource": "environment",
+            "secretMaterialRedacted": True,
+            "privateKey": "actual-secret",
+            "privateKeyFile": "/mnt/secrets/signing/key.pem",
+            "token": "runtime-token",
+            "path": "/apps/cert-smoke/runtime",
+        },
+        repo_root,
+    )
+    assert signing_metadata["privateKeyPresent"] is False, signing_metadata
+    assert signing_metadata["privateKeySource"] == "missing", signing_metadata
+    assert signing_metadata["publicKeyPresent"] is True, signing_metadata
+    assert signing_metadata["publicKeySource"] == "environment", signing_metadata
+    assert signing_metadata["secretMaterialRedacted"] is True, signing_metadata
+    assert signing_metadata["privateKey"] == "<redacted>", signing_metadata
+    assert signing_metadata["privateKeyFile"] == "<redacted>", signing_metadata
+    assert signing_metadata["token"] == "<redacted>", signing_metadata
+    assert signing_metadata["path"] == "/apps/cert-smoke/runtime", signing_metadata
+    credential_scrubbed = scrub_text(
+        'Authorization: Bearer app-secret\n'
+        'Cookie: session=abc; csrf=def\n'
+        '{"token":"json-secret","authorization":"Bearer json-secret","password":"pw",'
+        '"X-Crypta-App-Session":"browser-session"} '
+        "authorization=Bearer inline-secret "
+        "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64=base64-secret "
+        "privateKeyBase64=key-secret clientSecret=client-secret api_password=api-secret "
+        "privateKeyPresent=false",
+        repo_root,
+    )
+    for forbidden in (
+        "Bearer app-secret",
+        "session=abc",
+        "csrf=def",
+        "json-secret",
+        '"pw"',
+        "browser-session",
+        "inline-secret",
+        "base64-secret",
+        "key-secret",
+        "client-secret",
+        "api-secret",
+    ):
+        assert forbidden not in credential_scrubbed, credential_scrubbed
+    assert "Authorization: <redacted>" in credential_scrubbed, credential_scrubbed
+    assert "Cookie: <redacted>" in credential_scrubbed, credential_scrubbed
+    assert '"token":"<redacted>"' in credential_scrubbed, credential_scrubbed
+    assert "authorization=<redacted>" in credential_scrubbed, credential_scrubbed
+    assert "privateKeyPresent=false" in credential_scrubbed, credential_scrubbed
+    delete_request = build_http_request(
+        "DELETE", "http://127.0.0.1:8888/api/v1/apps/cert-smoke", "hunter2"
+    )
+    assert delete_request.data == b"formPassword=hunter2"
+    assert "formPassword" not in delete_request.full_url
+    assert delete_request.get_header("Content-type") == "application/x-www-form-urlencoded"
+
+    get_request = build_http_request(
+        "GET", "http://127.0.0.1:8888/api/v1/apps", data={"page": "one"}
+    )
+    assert get_request.data is None
+    assert get_request.full_url.endswith("?page=one")
+    remote_live_settings = Settings(
+        workspace_root=repo_root.resolve(),
+        out_dir=(repo_root / DEFAULT_OUT_DIR).resolve(),
+        mode="pr",
+        skip_gradle=True,
+        cli_path=None,
+        live=True,
+        live_base_url="https://node.example.invalid:9443/admin?token=hunter2",
+        live_form_password="secret",
+        timeout_seconds=1,
+    )
+    remote_item = collect_live_evidence(remote_live_settings, {})
+    remote_encoded = json.dumps(remote_item.to_json(), sort_keys=True)
+    assert remote_item.status == "fail", remote_item
+    assert "<redacted-remote-url>" in remote_encoded, remote_encoded
+    for forbidden in ("node.example.invalid", "hunter2", "https://"):
+        assert forbidden not in remote_encoded, f"remote live URL leaked {forbidden}"
+    assert (
+        overall_status(
+            "release-candidate",
+            [EvidenceItem("catalog.smoke", "missing", True, "missing", "<repo>/summary.json", {})],
+        )
+        == "fail"
+    )
+    assert (
+        overall_status(
+            "pr",
+            [EvidenceItem("catalog.smoke", "missing", True, "missing", "<repo>/summary.json", {})],
+        )
+        == "warn"
+    )
+    with tempfile.TemporaryDirectory(prefix="cryptad-app-smoke-self-test-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        make_self_test_workspace(workspace)
+        fake_cli = make_fake_cli(workspace)
+        settings = Settings(
+            workspace_root=workspace.resolve(),
+            out_dir=(workspace / DEFAULT_OUT_DIR).resolve(),
+            mode="pr",
+            skip_gradle=True,
+            cli_path=fake_cli,
+            live=False,
+            live_base_url="",
+            live_form_password="",
+            timeout_seconds=60,
+        )
+        summary, exit_code = run(settings)
+        assert exit_code == 0, summary
+        assert summary["status"] in {"pass", "warn"}, summary
+        evidence_by_id = {item["id"]: item for item in summary["evidence"]}
+        assert evidence_by_id["app-platform.first-party"]["status"] == "pass"
+        assert evidence_by_id["app-platform.devtools-cli"]["status"] == "pass"
+        assert evidence_by_id["catalog.smoke"]["status"] in {"warn", "pass"}
+        encoded = json.dumps(summary, sort_keys=True)
+        for forbidden in ("CRYPTAD_APP_TOKEN=secret", "formPassword=hunter2", str(workspace)):
+            assert forbidden not in encoded, f"self-test leaked {forbidden}"
+        stale_log = settings.out_dir / "artifacts/logs/stale-from-previous-run.log"
+        stale_log.parent.mkdir(parents=True, exist_ok=True)
+        stale_log.write_text("old command output\n", encoding="utf-8")
+        rerun_summary, rerun_exit_code = run(settings)
+        assert rerun_exit_code == 0, rerun_summary
+        assert not stale_log.exists(), stale_log
+        stale_sample_dir = sample_workspace(settings) / "cert-smoke-app"
+        stale_sample_dir.mkdir(parents=True, exist_ok=True)
+        stale_digest = stale_sample_dir / "cryptad-app.digest"
+        stale_signature = stale_sample_dir / "cryptad-app.signature"
+        stale_digest.write_text("digest=stale\n", encoding="utf-8")
+        stale_signature.write_text("signature=stale\n", encoding="utf-8")
+        fresh_cli_item, fresh_sample_paths = collect_cli_evidence(settings, fake_cli)
+        assert fresh_cli_item.status == "pass", fresh_cli_item
+        assert fresh_sample_paths["bundleDir"].is_dir(), fresh_sample_paths
+        assert not stale_digest.exists(), stale_digest
+        assert not stale_signature.exists(), stale_signature
+        fresh_launcher = fresh_sample_paths["bundleDir"] / "bin/start.sh"
+        fresh_launcher_text = fresh_launcher.read_text(encoding="utf-8")
+        assert "trap cleanup INT TERM" in fresh_launcher_text, fresh_launcher_text
+        assert "sleep 60" in fresh_launcher_text, fresh_launcher_text
+        if os.name != "nt":
+            assert os.access(fresh_launcher, os.X_OK), fresh_launcher
+
+        previous_skip_pack_output = os.environ.get("CRYPTAD_APP_SMOKE_FAKE_SKIP_PACK_OUTPUT")
+        os.environ["CRYPTAD_APP_SMOKE_FAKE_SKIP_PACK_OUTPUT"] = "1"
+        try:
+            missing_pack_settings = dataclasses.replace(
+                settings,
+                out_dir=(workspace / "build/missing-pack-smoke").resolve(),
+                mode="release-candidate",
+            )
+            stale_zip = sample_workspace(missing_pack_settings) / "cert-smoke-app-0.1.0.zip"
+            stale_zip.parent.mkdir(parents=True, exist_ok=True)
+            stale_zip.write_bytes(b"stale")
+            missing_pack_item, _ = collect_cli_evidence(missing_pack_settings, fake_cli)
+        finally:
+            if previous_skip_pack_output is None:
+                os.environ.pop("CRYPTAD_APP_SMOKE_FAKE_SKIP_PACK_OUTPUT", None)
+            else:
+                os.environ["CRYPTAD_APP_SMOKE_FAKE_SKIP_PACK_OUTPUT"] = previous_skip_pack_output
+        assert missing_pack_item.status == "fail", missing_pack_item
+        assert "pack-output" in missing_pack_item.details["failedSteps"], missing_pack_item
+        assert missing_pack_item.details["sample"]["zipExists"] is False, missing_pack_item
+        assert not stale_zip.exists(), stale_zip
+
+        previous_skip_catalog_output = os.environ.get("CRYPTAD_APP_SMOKE_FAKE_SKIP_CATALOG_OUTPUT")
+        os.environ["CRYPTAD_APP_SMOKE_FAKE_SKIP_CATALOG_OUTPUT"] = "1"
+        try:
+            missing_catalog_settings = dataclasses.replace(
+                settings,
+                out_dir=(workspace / "build/missing-catalog-smoke").resolve(),
+                mode="release-candidate",
+            )
+            missing_catalog_zip = sample_workspace(missing_catalog_settings) / "cert-smoke-app-0.1.0.zip"
+            missing_catalog_zip.parent.mkdir(parents=True, exist_ok=True)
+            missing_catalog_zip.write_bytes(b"zip")
+            stale_catalog_dir = sample_workspace(missing_catalog_settings) / "catalog"
+            stale_catalog_dir.mkdir(parents=True, exist_ok=True)
+            stale_catalog = stale_catalog_dir / "cryptad-app-catalog.properties"
+            stale_signature = stale_catalog_dir / "cryptad-app-catalog.signature"
+            stale_catalog.write_text("catalog.id=stale\n", encoding="utf-8")
+            stale_signature.write_text("signature=stale\n", encoding="utf-8")
+            missing_catalog_item = collect_catalog_evidence(
+                missing_catalog_settings,
+                {"cli": fake_cli, "zip": missing_catalog_zip},
+            )
+        finally:
+            if previous_skip_catalog_output is None:
+                os.environ.pop("CRYPTAD_APP_SMOKE_FAKE_SKIP_CATALOG_OUTPUT", None)
+            else:
+                os.environ["CRYPTAD_APP_SMOKE_FAKE_SKIP_CATALOG_OUTPUT"] = previous_skip_catalog_output
+        assert missing_catalog_item.status == "fail", missing_catalog_item
+        assert missing_catalog_item.details["catalogExists"] is False, missing_catalog_item
+        assert not stale_catalog.exists(), stale_catalog
+        assert not stale_signature.exists(), stale_signature
+
+        signing_env_names = (
+            "CRYPTAD_APP_SIGNING_KEY_ID",
+            "CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE",
+            "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64",
+            "CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE",
+            "CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64",
+        )
+        previous_signing_env = {name: os.environ.get(name) for name in signing_env_names}
+        os.environ["CRYPTAD_APP_SIGNING_KEY_ID"] = "cert-smoke"
+        os.environ.pop("CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE", None)
+        os.environ["CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64"] = "ZmFrZQ=="
+        os.environ.pop("CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE", None)
+        os.environ["CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64"] = "ZmFrZQ=="
+        try:
+            rc_skip_gradle_settings = dataclasses.replace(
+                settings,
+                out_dir=(workspace / "build/rc-skip-gradle-signing-smoke").resolve(),
+                mode="release-candidate",
+                skip_gradle=True,
+            )
+            rc_cli_item, rc_sample_paths = collect_cli_evidence(rc_skip_gradle_settings, fake_cli)
+            assert rc_cli_item.status == "pass", rc_cli_item
+            rc_signed_item = collect_signed_bundle_evidence(rc_skip_gradle_settings, rc_sample_paths)
+        finally:
+            for name, value in previous_signing_env.items():
+                if value is None:
+                    os.environ.pop(name, None)
+                else:
+                    os.environ[name] = value
+        assert rc_signed_item.status == "fail", rc_signed_item
+        assert rc_signed_item.details["firstPartySignVerifyRan"] is False, rc_signed_item
+        assert "first-party sign/verify Gradle task was skipped" in rc_signed_item.details["failures"], rc_signed_item
+
+        live_calls: list[tuple[str, str]] = []
+        original_http_request_json = http_request_json
+
+        def fake_http_request_json(
+            method: str, url: str, form_password: str = "", data: dict[str, str] | None = None
+        ) -> tuple[int, Any]:
+            parsed_path = urllib.parse.urlparse(url).path.removeprefix("/api/v1")
+            live_calls.append((method, parsed_path))
+            if method == "GET" and parsed_path == "/apps":
+                return 200, {"apps": []}
+            if method == "DELETE" and parsed_path == "/apps/cert-smoke":
+                return 404, {"missing": True}
+            if method == "POST" and parsed_path == "/apps/install":
+                return 200, {"installed": True}
+            if method == "GET" and parsed_path == "/apps/cert-smoke/runtime":
+                return 500, {"error": "boom"}
+            if method == "POST" and parsed_path == "/apps/cert-smoke/stop":
+                return 200, {"stopped": True}
+            return 200, {}
+
+        globals()["http_request_json"] = fake_http_request_json
+        try:
+            live_failure_settings = dataclasses.replace(
+                settings,
+                live=True,
+                live_base_url="http://127.0.0.1:8888",
+                live_form_password="secret",
+            )
+            live_bundle_dir = sample_workspace(settings) / "cert-smoke-app"
+            assert live_bundle_dir.is_dir(), live_bundle_dir
+            live_failure_item = collect_live_evidence(live_failure_settings, {"bundleDir": live_bundle_dir})
+        finally:
+            globals()["http_request_json"] = original_http_request_json
+        assert live_failure_item.status == "fail", live_failure_item
+        cleanup_paths = [(step["method"], step["path"]) for step in live_failure_item.details["cleanupSteps"]]
+        assert ("POST", "/apps/cert-smoke/stop") in cleanup_paths, live_failure_item
+        assert ("DELETE", "/apps/cert-smoke") in cleanup_paths, live_failure_item
+        assert live_calls[-2:] == cleanup_paths, live_calls
+
+        live_success_calls: list[tuple[str, str]] = []
+
+        def fake_success_http_request_json(
+            method: str, url: str, form_password: str = "", data: dict[str, str] | None = None
+        ) -> tuple[int, Any]:
+            parsed_path = urllib.parse.urlparse(url).path.removeprefix("/api/v1")
+            live_success_calls.append((method, parsed_path))
+            if method == "GET" and parsed_path == "/apps":
+                return 200, {"apps": []}
+            if method == "GET" and parsed_path == "/diagnostics":
+                return 200, {
+                    "sectionCount": 2,
+                    "plainTextExport": "Peer 198.51.100.10 operator-private-line",
+                    "sections": [
+                        {"title": "Node", "lines": ["operator-private-line"]},
+                        {"title": "Peers", "lines": ["198.51.100.10"]},
+                    ],
+                    "legacyAdmin": {
+                        "surfaces": [
+                            {"id": "queue", "path": "/queue/", "state": "PRIMARY_REPLACED", "count": 3},
+                            {"id": "stats", "path": "/stats/", "state": "PENDING", "count": 2},
+                        ]
+                    },
+                }
+            return 200, {"ok": True}
+
+        globals()["http_request_json"] = fake_success_http_request_json
+        try:
+            live_success_item = collect_live_evidence(live_failure_settings, {"bundleDir": live_bundle_dir})
+        finally:
+            globals()["http_request_json"] = original_http_request_json
+        assert live_success_item.status == "pass", live_success_item
+        diagnostics_step = next(
+            step for step in live_success_item.details["steps"] if step["path"] == "/diagnostics"
+        )
+        assert diagnostics_step["bodySummary"] == {
+            "sectionCount": 2,
+            "legacyAdminSurfaceCount": 2,
+            "legacyAdminTotalCount": 5,
+        }, diagnostics_step
+        assert "body" not in diagnostics_step, diagnostics_step
+        live_success_encoded = json.dumps(live_success_item.to_json(), sort_keys=True)
+        for forbidden in ("plainTextExport", "operator-private-line", "198.51.100.10", "sections"):
+            assert forbidden not in live_success_encoded, live_success_encoded
+        assert ("GET", "/diagnostics") in live_success_calls, live_success_calls
+
+        external_out_dir = Path(temp_name) / "external-app-smoke"
+        external_settings = dataclasses.replace(settings, out_dir=external_out_dir.resolve())
+        external_summary, external_exit_code = run(external_settings)
+        assert external_exit_code == 0, external_summary
+        assert external_summary["summaryPath"].startswith("<workdir>/"), external_summary
+        assert external_summary["reportPath"].startswith("<workdir>/"), external_summary
+        assert (external_out_dir / SUMMARY_FILE_NAME).is_file(), external_summary
+        assert str(external_out_dir) not in json.dumps(external_summary, sort_keys=True), external_summary
+
+
+def make_self_test_workspace(workspace: Path) -> None:
+    sdk = workspace / "platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js"
+    sdk.parent.mkdir(parents=True, exist_ok=True)
+    sdk.write_text("window.CryptaPlatform = {}; const h = 'X-Crypta-App-Session';\n", encoding="utf-8")
+    for app_id, display_name, launcher, permissions in (
+        ("queue-manager", "Queue Manager", "queue-manager.sh", "queue.read,queue.write"),
+        ("publisher", "Publisher", "publisher.sh", "queue.read,queue.write,content.insert"),
+    ):
+        project = "queue-manager" if app_id == "queue-manager" else "publisher"
+        source = workspace / f"apps/{project}/src/staged"
+        staged = workspace / f"apps/{project}/build/cryptad-app/{app_id}"
+        for root in (source, staged):
+            (root / "bin").mkdir(parents=True, exist_ok=True)
+            (root / "static").mkdir(parents=True, exist_ok=True)
+            (root / "bin" / launcher).write_text("#!/usr/bin/env sh\nexit 0\n", encoding="utf-8")
+            (root / "static/index.html").write_text(
+                "<!doctype html><script src=\"./crypta-platform.js\"></script><script src=\"./app.js\"></script>",
+                encoding="utf-8",
+            )
+            (root / "static/app.js").write_text(
+                f"CryptaPlatform.bootstrap.load({{ appId: '{app_id}' }});\n",
+                encoding="utf-8",
+            )
+            (root / "static/app.css").write_text("body { color: #111; }\n", encoding="utf-8")
+            shutil.copy2(sdk, root / "static/crypta-platform.js")
+        (staged / "cryptad-app.properties").write_text(
+            "\n".join(
+                [
+                    "manifest.version=1",
+                    f"app.id={app_id}",
+                    f"app.name={display_name}",
+                    "app.version=0.1.0",
+                    f"app.exec=bin/{launcher}",
+                    "app.ui.mode=static",
+                    "app.ui.entry=static/index.html",
+                    f"app.permissions={permissions}",
+                    "quota.data.bytes=0",
+                    "quota.cache.bytes=0",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    registry = workspace / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text((Path(__file__).parent / "fixtures" / "self-test-legacy-registry.java-fragment").read_text(encoding="utf-8"), encoding="utf-8")
+    docs = workspace / "docs/legacy-retirement-plan.md"
+    docs.parent.mkdir(parents=True, exist_ok=True)
+    docs.write_text("Direct legacy URLs remain reachable for fallback.\n", encoding="utf-8")
+
+
+def fake_cli_python_source() -> str:
+    return r'''#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+
+def option_value(args, name):
+    for index, value in enumerate(args):
+        if value == name and index + 1 < len(args):
+            return args[index + 1]
+    return ""
+
+
+def write_text(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def init_app(args):
+    directory_text = option_value(args, "--dir")
+    if not directory_text:
+        return 2
+    directory = Path(directory_text)
+    (directory / "bin").mkdir(parents=True, exist_ok=True)
+    (directory / "static").mkdir(parents=True, exist_ok=True)
+    write_text(
+        directory / "cryptad-app.properties",
+        "\n".join(
+            [
+                "manifest.version=1",
+                "app.id=cert-smoke",
+                "app.name=Certification Smoke",
+                "app.version=0.1.0",
+                "app.exec=bin/start.sh",
+                "app.ui.mode=static",
+                "app.ui.entry=static/index.html",
+                "app.permissions=queue.read",
+            ]
+        )
+        + "\n",
+    )
+    write_text(directory / "bin/start.sh", "#!/usr/bin/env sh\nexit 0\n")
+    write_text(
+        directory / "static/index.html",
+        '<script src="./crypta-platform.js"></script><script src="./app.js"></script>\n',
+    )
+    write_text(
+        directory / "static/app.js",
+        'CryptaPlatform.bootstrap.load({ appId: "cert-smoke" });\n',
+    )
+    write_text(directory / "static/app.css", "body{}\n")
+    write_text(
+        directory / "static/crypta-platform.js",
+        'window.CryptaPlatform={}; X="X-Crypta-App-Session";\n',
+    )
+    return 0
+
+
+def pack_app(args):
+    output_text = option_value(args, "--output")
+    if os.environ.get("CRYPTAD_APP_SMOKE_FAKE_SKIP_PACK_OUTPUT") == "1":
+        return 0
+    if not output_text:
+        return 2
+    output = Path(output_text)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(b"zip")
+    return 0
+
+
+def create_catalog(args):
+    catalog_text = option_value(args, "--catalog-file")
+    if os.environ.get("CRYPTAD_APP_SMOKE_FAKE_SKIP_CATALOG_OUTPUT") == "1":
+        return 0
+    if not catalog_text:
+        return 2
+    catalog = Path(catalog_text)
+    write_text(
+        catalog,
+        """catalog.version=1
+catalog.id=cert-smoke
+catalog.name=Certification Smoke Apps
+catalog.generatedAt=2026-05-01T00:00:00Z
+catalog.entries=cert-smoke
+app.cert-smoke.id=cert-smoke
+app.cert-smoke.name=Certification Smoke
+app.cert-smoke.version=0.1.0
+app.cert-smoke.summary=Certification smoke app.
+app.cert-smoke.bundle.uri=file:///tmp/cert-smoke.zip
+app.cert-smoke.bundle.sha256=0000000000000000000000000000000000000000000000000000000000000000
+app.cert-smoke.bundle.size.bytes=3
+app.cert-smoke.bundle.type=zip
+app.cert-smoke.permissions=queue.read
+""",
+    )
+    return 0
+
+
+def main():
+    if len(sys.argv) < 2:
+        return 0
+    command = sys.argv[1]
+    args = sys.argv[2:]
+    if command == "init":
+        return init_app(args)
+    if command == "validate":
+        return 0
+    if command == "pack":
+        return pack_app(args)
+    if command == "catalog":
+        subcommand = args[0] if args else ""
+        if subcommand == "create":
+            return create_catalog(args[1:])
+        if subcommand in {"sign", "verify"}:
+            return 0
+    if command in {"sign", "verify"}:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def make_fake_cli(workspace: Path) -> Path:
+    bin_dir = workspace / "platform-devtools/build/install/crypta-app/bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    cli = bin_dir / ("crypta-app.bat" if platform.system() == "Windows" else "crypta-app")
+    if platform.system() == "Windows":
+        helper = bin_dir / "crypta-app-fake.py"
+        helper.write_text(fake_cli_python_source(), encoding="utf-8")
+        cli.write_text(
+            """@echo off
+py -3 "%~dp0crypta-app-fake.py" %*
+if not errorlevel 9009 exit /b %ERRORLEVEL%
+python3 "%~dp0crypta-app-fake.py" %*
+exit /b %ERRORLEVEL%
+""",
+            encoding="utf-8",
+        )
+    else:
+        cli.write_text(
+            """#!/usr/bin/env sh
+set -eu
+cmd="$1"
+shift
+case "$cmd" in
+  init)
+    dir=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--dir" ]; then dir="$2"; shift 2; else shift; fi
+    done
+    mkdir -p "$dir/bin" "$dir/static"
+    printf '%s\n' 'manifest.version=1' 'app.id=cert-smoke' 'app.name=Certification Smoke' 'app.version=0.1.0' 'app.exec=bin/start.sh' 'app.ui.mode=static' 'app.ui.entry=static/index.html' 'app.permissions=queue.read' > "$dir/cryptad-app.properties"
+    printf '%s\n' '#!/usr/bin/env sh' 'exit 0' > "$dir/bin/start.sh"
+    printf '%s\n' '<script src="./crypta-platform.js"></script><script src="./app.js"></script>' > "$dir/static/index.html"
+    printf '%s\n' 'CryptaPlatform.bootstrap.load({ appId: "cert-smoke" });' > "$dir/static/app.js"
+    printf '%s\n' 'body{}' > "$dir/static/app.css"
+    printf '%s\n' 'window.CryptaPlatform={}; X="X-Crypta-App-Session";' > "$dir/static/crypta-platform.js"
+    ;;
+  validate)
+    exit 0
+    ;;
+  pack)
+    out=""
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--output" ]; then out="$2"; shift 2; else shift; fi
+    done
+    if [ "${CRYPTAD_APP_SMOKE_FAKE_SKIP_PACK_OUTPUT:-0}" = "1" ]; then
+      exit 0
+    fi
+    printf 'zip' > "$out"
+    ;;
+  catalog)
+    sub="$1"; shift
+    case "$sub" in
+      create)
+        catalog=""
+        while [ "$#" -gt 0 ]; do
+          if [ "$1" = "--catalog-file" ]; then catalog="$2"; shift 2; else shift; fi
+        done
+        if [ "${CRYPTAD_APP_SMOKE_FAKE_SKIP_CATALOG_OUTPUT:-0}" = "1" ]; then
+          exit 0
+        fi
+        cat > "$catalog" <<'CATALOG'
+catalog.version=1
+catalog.id=cert-smoke
+catalog.name=Certification Smoke Apps
+catalog.generatedAt=2026-05-01T00:00:00Z
+catalog.entries=cert-smoke
+app.cert-smoke.id=cert-smoke
+app.cert-smoke.name=Certification Smoke
+app.cert-smoke.version=0.1.0
+app.cert-smoke.summary=Certification smoke app.
+app.cert-smoke.bundle.uri=file:///tmp/cert-smoke.zip
+app.cert-smoke.bundle.sha256=0000000000000000000000000000000000000000000000000000000000000000
+app.cert-smoke.bundle.size.bytes=3
+app.cert-smoke.bundle.type=zip
+app.cert-smoke.permissions=queue.read
+CATALOG
+        ;;
+      sign|verify)
+        exit 0
+        ;;
+    esac
+    ;;
+  sign|verify)
+    exit 0
+    ;;
+esac
+""",
+            encoding="utf-8",
+        )
+        cli.chmod(0o755)
+    return cli
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.self_test:
+        run_self_test(Path(__file__).resolve().parents[2])
+        print("app-platform-smoke self-test passed")
+        return 0
+    settings = settings_from_args(args)
+    summary, exit_code = run(settings)
+    print(f"App platform smoke {summary['status']}: {settings.out_dir / SUMMARY_FILE_NAME}")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -146,6 +146,17 @@ def utc_now() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
+def path_prefix_variants(path: Path | str) -> list[str]:
+    variants: list[str] = []
+    for candidate in (Path(path), Path(path).resolve()):
+        candidate_text = str(candidate)
+        for value in (candidate_text, candidate_text.replace("\\", "/")):
+            normalized = value.rstrip("/\\")
+            if normalized and normalized not in variants:
+                variants.append(normalized)
+    return variants
+
+
 def display_path(path: Path | str, workspace_root: Path, out_dir: Path | None = None) -> str:
     raw = str(path)
     if not raw:
@@ -242,9 +253,8 @@ def scrub_text(text: str, workspace_root: Path) -> str:
     redacted = URI_KEY_RE.sub("<redacted-uri>", redacted)
     redacted = FILE_URI_PATH_RE.sub(scrub_file_uri_match, redacted)
     redacted, protected_routes = protect_route_paths(redacted)
-    root_text = str(workspace_root.resolve())
-    redacted = redacted.replace(root_text, "<repo>")
-    redacted = redacted.replace(root_text.replace("\\", "/"), "<repo>")
+    for root_text in path_prefix_variants(workspace_root):
+        redacted = replace_absolute_path_prefix(redacted, root_text, "<repo>")
     home = str(Path.home())
     if home and home != "/":
         redacted = replace_absolute_path_prefix(redacted, home, "<home>")
@@ -1497,6 +1507,20 @@ def run_self_test(repo_root: Path) -> None:
         scrub_text(str(repo_tmp_path), repo_root)
         == "<repo>/build/tmp-release-certification/app-platform-smoke/summary.json"
     )
+    with tempfile.TemporaryDirectory(prefix="cryptad-app-smoke-symlink-target-") as target_name:
+        with tempfile.TemporaryDirectory(prefix="cryptad-app-smoke-symlink-parent-") as link_parent_name:
+            symlink_root = Path(link_parent_name) / "repo-link"
+            try:
+                symlink_root.symlink_to(Path(target_name), target_is_directory=True)
+            except (NotImplementedError, OSError):
+                symlink_root = None
+            if symlink_root is not None:
+                symlink_repo_root = symlink_root / "repo"
+                symlink_path = symlink_repo_root / "build/tmp-release-certification/app-platform-smoke/summary.json"
+                assert (
+                    scrub_text(str(symlink_path), symlink_repo_root)
+                    == "<repo>/build/tmp-release-certification/app-platform-smoke/summary.json"
+                )
     assert (
         normalize_redacted_separators(r"<repo>\build\tmp-release-certification\app-platform-smoke\summary.json")
         == "<repo>/build/tmp-release-certification/app-platform-smoke/summary.json"

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -1297,7 +1297,10 @@ def overall_status(mode: str, evidence: list[EvidenceItem]) -> str:
         item.required_for_release_candidate and item.status in {"missing", "skip"} for item in evidence
     ):
         return "fail"
-    if any(item.status in {"warn", "skip", "missing", "fail"} for item in evidence):
+    if any(
+        item.status in {"warn", "missing", "fail"} or (item.required_for_release_candidate and item.status == "skip")
+        for item in evidence
+    ):
         return "warn"
     return "pass"
 
@@ -1646,6 +1649,23 @@ def run_self_test(repo_root: Path) -> None:
             [EvidenceItem("catalog.smoke", "missing", True, "missing", "<repo>/summary.json", {})],
         )
         == "warn"
+    )
+    assert (
+        overall_status(
+            "pr",
+            [EvidenceItem("apphost.live", "skip", False, "not requested", "<repo>/summary.json", {})],
+        )
+        == "pass"
+    )
+    assert (
+        overall_status(
+            "release-candidate",
+            [
+                EvidenceItem("catalog.smoke", "pass", True, "passed", "<repo>/summary.json", {}),
+                EvidenceItem("apphost.live", "skip", False, "not requested", "<repo>/summary.json", {}),
+            ],
+        )
+        == "pass"
     )
     with tempfile.TemporaryDirectory(prefix="cryptad-app-smoke-self-test-") as temp_name:
         workspace = Path(temp_name) / "repo"

--- a/tools/release-certification/fixtures/self-test-app-platform-smoke.json
+++ b/tools/release-certification/fixtures/self-test-app-platform-smoke.json
@@ -1,0 +1,84 @@
+{
+  "evidence": [
+    {
+      "details": {
+        "apps": [
+          "queue-manager",
+          "publisher"
+        ]
+      },
+      "id": "app-platform.first-party",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "First-party staged app manifests and static assets passed."
+    },
+    {
+      "details": {
+        "sampleAppId": "cert-smoke"
+      },
+      "id": "app-platform.devtools-cli",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "crypta-app init, validate, and pack passed."
+    },
+    {
+      "details": {
+        "keyId": "dev-local"
+      },
+      "id": "app-platform.signed-bundles",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "First-party and sample bundle signing evidence passed."
+    },
+    {
+      "details": {
+        "catalogId": "cert-smoke"
+      },
+      "id": "catalog.smoke",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Catalog create, sign, and verify smoke passed."
+    },
+    {
+      "details": {
+        "sdkResource": "platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js"
+      },
+      "id": "app-ui.smoke",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "App-owned UI and SDK smoke passed."
+    },
+    {
+      "details": {
+        "pendingSurfaces": 2,
+        "primaryReplacedSurfaces": 14,
+        "retainedSurfaces": 4
+      },
+      "id": "legacy.retirement",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Legacy-admin retirement map is visible and stable."
+    },
+    {
+      "details": {
+        "enabled": false
+      },
+      "id": "apphost.live",
+      "requiredForReleaseCandidate": false,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "skip",
+      "summary": "Live AppHost lifecycle smoke was not requested."
+    }
+  ],
+  "generatedAt": "2026-05-01T00:00:00Z",
+  "mode": "release-candidate",
+  "schemaVersion": 1,
+  "status": "pass",
+  "tool": "app-platform-smoke"
+}

--- a/tools/release-certification/fixtures/self-test-catalog.properties
+++ b/tools/release-certification/fixtures/self-test-catalog.properties
@@ -1,0 +1,14 @@
+catalog.version=1
+catalog.id=cert-smoke
+catalog.name=Certification Smoke Apps
+catalog.generatedAt=2026-05-01T00:00:00Z
+catalog.entries=cert-smoke
+app.cert-smoke.id=cert-smoke
+app.cert-smoke.name=Certification Smoke
+app.cert-smoke.version=0.1.0
+app.cert-smoke.summary=Certification smoke app.
+app.cert-smoke.bundle.uri=file:///tmp/cert-smoke.zip
+app.cert-smoke.bundle.sha256=0000000000000000000000000000000000000000000000000000000000000000
+app.cert-smoke.bundle.size.bytes=3
+app.cert-smoke.bundle.type=zip
+app.cert-smoke.permissions=queue.read

--- a/tools/release-certification/fixtures/self-test-interop-extended.json
+++ b/tools/release-certification/fixtures/self-test-interop-extended.json
@@ -1,0 +1,57 @@
+{
+  "artifacts": [
+    "artifacts/interop-report.md",
+    "artifacts/usk-subscribe-soak.json",
+    "artifacts/persistent-request-replay.json"
+  ],
+  "baseline": {
+    "kind": "fixture",
+    "name": "hyphanet",
+    "sha256": "0123456789abcdef",
+    "version": "1506"
+  },
+  "enabled_flows": [
+    "handshake",
+    "peer_exchange",
+    "chk_cross_fetch",
+    "ssk_cross_fetch",
+    "usk_smoke",
+    "usk_subscribe_soak",
+    "persistent_request_replay",
+    "restart_recovery"
+  ],
+  "flows": {
+    "chk_cross_fetch": {
+      "status": "passed"
+    },
+    "handshake": {
+      "status": "passed"
+    },
+    "peer_exchange": {
+      "status": "passed"
+    },
+    "persistent_request_replay": {
+      "status": "passed"
+    },
+    "restart_recovery": {
+      "status": "passed"
+    },
+    "ssk_cross_fetch": {
+      "status": "passed"
+    },
+    "usk_smoke": {
+      "status": "passed"
+    },
+    "usk_subscribe_soak": {
+      "status": "passed"
+    }
+  },
+  "mode": "extended",
+  "restart_recovery_checks": [
+    "cryptad_fcp_reconnected",
+    "cryptad_identity_stable",
+    "peer_relationship_reconnected"
+  ],
+  "restart_recovery_level": "restart-and-refetch",
+  "status": "success"
+}

--- a/tools/release-certification/fixtures/self-test-interop-smoke.json
+++ b/tools/release-certification/fixtures/self-test-interop-smoke.json
@@ -1,0 +1,56 @@
+{
+  "artifacts": [
+    "artifacts/interop-report.md",
+    "artifacts/private-insert-uris.json"
+  ],
+  "baseline": {
+    "kind": "fixture",
+    "name": "hyphanet",
+    "sha256": "0123456789abcdef",
+    "version": "1506"
+  },
+  "enabled_flows": [
+    "handshake",
+    "peer_exchange",
+    "chk_cross_fetch",
+    "ssk_cross_fetch",
+    "usk_smoke",
+    "restart_recovery"
+  ],
+  "flows": {
+    "chk_cross_fetch": {
+      "status": "passed"
+    },
+    "handshake": {
+      "status": "passed"
+    },
+    "peer_exchange": {
+      "status": "passed"
+    },
+    "restart_recovery": {
+      "status": "passed"
+    },
+    "ssk_cross_fetch": {
+      "status": "passed"
+    },
+    "usk_smoke": {
+      "status": "passed"
+    }
+  },
+  "mode": "smoke",
+  "restart_recovery_checks": [
+    "cryptad_fcp_reconnected",
+    "cryptad_identity_stable",
+    "peer_relationship_reconnected",
+    "persistent_requests_listed_before_and_after_restart",
+    "hyphanet_refetched_cryptad_chk_after_restart",
+    "hyphanet_refetched_cryptad_ssk_after_restart",
+    "hyphanet_refetched_cryptad_usk_after_restart"
+  ],
+  "restart_recovery_level": "restart-and-refetch",
+  "status": "success",
+  "uris": [
+    "USK@private/self-test"
+  ],
+  "workspace_root": "/tmp/private/workspace"
+}

--- a/tools/release-certification/fixtures/self-test-legacy-registry.java-fragment
+++ b/tools/release-certification/fixtures/self-test-legacy-registry.java-fragment
@@ -1,0 +1,41 @@
+final class LegacyAdminRetirementRegistry {
+  private static final List<LegacyAdminSurface> SURFACES =
+      List.of(
+          infrastructure("web-shell", "Web Shell", "/app/node/", "Shell."),
+          replaced("alerts", "Alerts", "/alerts/", "/app/node/#alerts", "Shell alerts", "Done."),
+          replaced("downloads", "Downloads", "/downloads/", "/apps/queue-manager/", "Queue Manager", "Done."),
+          pendingWizard("first-time-wizard", "First-time wizard", "/wizard/", "Pending."),
+          pending("node-to-node-message", "N2NTM", "/send_n2ntm/", null, null, "Pending.", true),
+          retained("help", "Help", "/help/", "Retained."));
+
+  private static final Map<String, LegacyAdminSurface> SURFACES_BY_ID = surfacesById();
+
+  public static List<LegacyAdminSurface> webShellFallbackSurfaces() {
+    return SURFACES.stream().filter(LegacyAdminSurface::includeInWebShellFallbackLinks).toList();
+  }
+
+  public static boolean shouldPromoteInLegacyNavigation(String legacyPath) {
+    return findByLegacyPath(legacyPath)
+        .map(surface -> surface.state() != LegacyAdminRetirementState.PRIMARY_REPLACED)
+        .orElse(true);
+  }
+
+  private static LegacyAdminSurface replaced(
+      String id,
+      String title,
+      String legacyPath,
+      String replacementUrl,
+      String replacementLabel,
+      String notes) {
+    return new LegacyAdminSurface(
+        id,
+        title,
+        legacyPath,
+        LegacyAdminRetirementState.PRIMARY_REPLACED,
+        replacementUrl,
+        replacementLabel,
+        notes,
+        true,
+        false);
+  }
+}

--- a/tools/release-certification/fixtures/self-test-perf-smoke.json
+++ b/tools/release-certification/fixtures/self-test-perf-smoke.json
@@ -1,0 +1,40 @@
+{
+  "baseline": {
+    "path": "tools/perf/baselines/performance-smoke.json",
+    "updated": false,
+    "version": 1
+  },
+  "comparison": {
+    "not_compared": [],
+    "regressions": [],
+    "skipped": [],
+    "status": "pass",
+    "warnings": []
+  },
+  "duration_ms": 1234,
+  "environment": {
+    "os": "Linux",
+    "python": "3.12"
+  },
+  "finished_at": "2026-05-01T00:00:01Z",
+  "metrics": {
+    "apps.publisher_static_bytes": {
+      "status": "collected",
+      "unit": "bytes",
+      "value": 2048
+    },
+    "apps.queue_manager_static_bytes": {
+      "status": "collected",
+      "unit": "bytes",
+      "value": 2048
+    },
+    "distribution.exists": {
+      "status": "collected",
+      "unit": "boolean",
+      "value": true
+    }
+  },
+  "mode": "smoke",
+  "started_at": "2026-05-01T00:00:00Z",
+  "status": "success"
+}

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -705,7 +705,10 @@ def determine_overall_status(mode: str, evidence: list[EvidenceItem]) -> tuple[s
         for item in evidence
         if item.required_for_release_candidate and item.status == "warn" and not item.details.get("waived")
     ]
-    any_warnish = any(item.status in {"warn", "missing", "skip", "fail"} for item in evidence)
+    any_warnish = any(
+        item.status in {"warn", "missing", "fail"} or (item.required_for_release_candidate and item.status == "skip")
+        for item in evidence
+    )
     if mode == "release-candidate":
         if required_bad:
             return "fail", False
@@ -1017,8 +1020,17 @@ def run_self_test(repo_root: Path) -> None:
         )
         summary, exit_code = run(settings)
         assert exit_code == 0, summary
-        assert summary["status"] in {"pass", "warn"}, summary
+        assert summary["status"] == "pass", summary
         assert summary["releaseCandidatePassed"] is True, summary
+        optional_skip_status, optional_skip_release_passed = determine_overall_status(
+            "release-candidate",
+            [
+                EvidenceItem("catalog.smoke", "pass", True, "passed", "<repo>/summary.json", {}),
+                EvidenceItem("apphost.live", "skip", False, "not requested", "<repo>/summary.json", {}),
+            ],
+        )
+        assert optional_skip_status == "pass", optional_skip_status
+        assert optional_skip_release_passed is True, optional_skip_release_passed
         report = (out_dir / REPORT_FILE_NAME).read_text(encoding="utf-8")
         assert "Release Certification Report" in report
         encoded = json.dumps(summary, sort_keys=True)

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -140,6 +140,17 @@ def write_text(path: Path, value: str) -> None:
     path.write_text(value, encoding="utf-8")
 
 
+def path_prefix_variants(path: Path | str) -> list[str]:
+    variants: list[str] = []
+    for candidate in (Path(path), Path(path).resolve()):
+        candidate_text = str(candidate)
+        for value in (candidate_text, candidate_text.replace("\\", "/")):
+            normalized = value.rstrip("/\\")
+            if normalized and normalized not in variants:
+                variants.append(normalized)
+    return variants
+
+
 def display_path(path: Path | str, workspace_root: Path, out_dir: Path | None = None) -> str:
     raw = str(path)
     if raw == "":
@@ -238,14 +249,12 @@ def scrub_text(text: str, workspace_root: Path, out_dir: Path | None = None) -> 
     redacted, protected_routes = protect_route_paths(redacted)
     for artifact_name in PRIVATE_ARTIFACT_NAMES:
         redacted = redacted.replace(artifact_name, "<redacted-private-artifact>")
-    root_text = str(workspace_root.resolve())
-    redacted = redacted.replace(root_text, "<repo>")
-    redacted = redacted.replace(root_text.replace("\\", "/"), "<repo>")
+    for root_text in path_prefix_variants(workspace_root):
+        redacted = replace_absolute_path_prefix(redacted, root_text, "<repo>")
     if out_dir is not None:
-        out_text = str(out_dir.resolve())
         out_display = display_path(out_dir, workspace_root)
-        redacted = redacted.replace(out_text, out_display)
-        redacted = redacted.replace(out_text.replace("\\", "/"), out_display)
+        for out_text in path_prefix_variants(out_dir):
+            redacted = replace_absolute_path_prefix(redacted, out_text, out_display)
     home = str(Path.home())
     if home and home != "/":
         redacted = replace_absolute_path_prefix(redacted, home, "<home>")
@@ -1101,6 +1110,23 @@ def run_self_test(repo_root: Path) -> None:
             scrub_text(str(repo_tmp_path), workspace, out_dir)
             == "<repo>/build/tmp-release-certification/release-certification-summary.json"
         )
+        with tempfile.TemporaryDirectory(prefix="cryptad-cert-symlink-target-") as target_name:
+            with tempfile.TemporaryDirectory(prefix="cryptad-cert-symlink-parent-") as link_parent_name:
+                symlink_root = Path(link_parent_name) / "repo-link"
+                try:
+                    symlink_root.symlink_to(Path(target_name), target_is_directory=True)
+                except (NotImplementedError, OSError):
+                    symlink_root = None
+                if symlink_root is not None:
+                    symlink_workspace = symlink_root / "repo"
+                    symlink_out_dir = symlink_workspace / "build/release-certification"
+                    symlink_path = (
+                        symlink_workspace / "build/tmp-release-certification/release-certification-summary.json"
+                    )
+                    assert (
+                        scrub_text(str(symlink_path), symlink_workspace, symlink_out_dir)
+                        == "<repo>/build/tmp-release-certification/release-certification-summary.json"
+                    )
         assert (
             normalize_redacted_separators(r"<repo>\build\tmp-release-certification\release-certification-summary.json")
             == "<repo>/build/tmp-release-certification/release-certification-summary.json"

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -1,0 +1,1306 @@
+#!/usr/bin/env python3
+"""Aggregate release-candidate evidence into a redacted certification report.
+
+The tool intentionally depends only on the Python standard library.  It consumes
+the existing interop, performance, and app-platform smoke summaries and emits a
+single Markdown report plus a stable JSON companion for release-candidate
+evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+TOOL_NAME = "release-certification"
+SCHEMA_VERSION = 1
+DEFAULT_OUT_DIR = Path("build/release-certification")
+SUMMARY_FILE_NAME = "release-certification-summary.json"
+REPORT_FILE_NAME = "release-certification-report.md"
+CERT_STATUSES = ("pass", "warn", "fail", "skip", "missing")
+MODES = ("pr", "nightly", "release-candidate")
+PRIVATE_ARTIFACT_NAMES = ("private-insert-uris.json",)
+SENSITIVE_KEY_PATTERN = (
+    r"token|password|passwd|secret|credential|authorization|cookie|set-cookie|"
+    r"private[-_ ]?key|formPassword|browserSessionToken|CRYPTAD_APP_TOKEN|X-Crypta-App-Session"
+)
+SENSITIVE_KEY_RE = re.compile(
+    rf"({SENSITIVE_KEY_PATTERN})",
+    re.IGNORECASE,
+)
+SENSITIVE_HEADER_RE = re.compile(
+    r"(?P<prefix>\b(?:Authorization|Cookie|Set-Cookie|X-Crypta-App-Session)\s*:\s*)"
+    r"(?P<value>[^\r\n]*)",
+    re.IGNORECASE,
+)
+SENSITIVE_ASSIGNMENT_RE = re.compile(
+    r"(?P<prefix>(?<![A-Za-z0-9_])(?P<key_quote>[\"']?)"
+    r"(?P<key>[A-Za-z_][A-Za-z0-9_.-]*)"
+    r"(?P=key_quote)\s*[:=]\s*)"
+    r"(?:(?P<value_quote>[\"'])(?P<quoted_value>[^\"'\r\n]*)(?P=value_quote)|"
+    r"(?P<value>(?:(?:Bearer|Basic|Digest)\s+)?[^\s,;&}\]]+))",
+    re.IGNORECASE,
+)
+URI_KEY_RE = re.compile(r"\b(?:CHK|SSK|USK)@[^\s\])},;\"']+")
+URL_USERINFO_RE = re.compile(r"(\b[a-z][a-z0-9+.-]*://)[^/\s:@]+:[^/\s@]+@", re.IGNORECASE)
+ABSOLUTE_PATH_RE = re.compile(r"(?<![A-Za-z0-9_:/.\->])/(?:[A-Za-z0-9._ -]+/)+[A-Za-z0-9._ -]+")
+WINDOWS_DRIVE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_:/.\->])(?:[A-Za-z]:[\\/](?:[^\\/:*?\"<>|\r\n]+[\\/])*[^\\/:*?\"<>|\r\n]+[\\/]?)"
+)
+WINDOWS_UNC_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_:/.\->])(?:\\\\[^\\/:*?\"<>|\r\n]+\\[^\\/:*?\"<>|\r\n]+(?:\\[^\\/:*?\"<>|\r\n]+)*\\?)"
+)
+FILE_URI_PATH_RE = re.compile(r"\bfile://(?P<path>[^\s\])},;\"']+)")
+ROUTE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_:/.\->])/(?:api/v1|apps|app/node|\.well-known)(?:/[^\s\])},;\"'?]*)?"
+)
+NON_SECRET_METADATA_SUFFIXES = (
+    "available",
+    "configured",
+    "enabled",
+    "excluded",
+    "present",
+    "redacted",
+    "required",
+    "source",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class EvidenceItem:
+    """Stable evidence record written into the certification summary."""
+
+    id: str
+    status: str
+    required_for_release_candidate: bool
+    summary: str
+    source: str
+    details: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "requiredForReleaseCandidate": self.required_for_release_candidate,
+            "summary": self.summary,
+            "source": self.source,
+            "details": self.details,
+        }
+
+
+@dataclasses.dataclass(frozen=True)
+class Settings:
+    workspace_root: Path
+    out_dir: Path
+    mode: str
+    interop_smoke_summary: Path
+    interop_extended_summary: Path
+    perf_smoke_summary: Path
+    app_platform_summary: Path
+    waivers: dict[str, str]
+    metadata: dict[str, str]
+    skip_git_metadata: bool
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def read_json(path: Path) -> dict[str, Any] | None:
+    if not path.is_file():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(value, dict):
+        return None
+    return value
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value, encoding="utf-8")
+
+
+def display_path(path: Path | str, workspace_root: Path, out_dir: Path | None = None) -> str:
+    raw = str(path)
+    if raw == "":
+        return ""
+    path_value = Path(raw)
+    if not path_value.is_absolute():
+        return scrub_text(raw.replace("\\", "/"), workspace_root, out_dir)
+    resolved = path_value
+    try:
+        relative = resolved.resolve().relative_to(workspace_root.resolve())
+        return f"<repo>/{relative.as_posix()}"
+    except ValueError:
+        pass
+    if out_dir is not None:
+        try:
+            relative = resolved.resolve().relative_to(out_dir.resolve())
+            out_dir_display = display_path(out_dir, workspace_root)
+            if not relative.parts:
+                return out_dir_display
+            return f"{out_dir_display}/{relative.as_posix()}"
+        except ValueError:
+            pass
+    try:
+        relative = resolved.resolve().relative_to(Path(tempfile.gettempdir()).resolve())
+        return f"<workdir>/{relative.as_posix()}"
+    except ValueError:
+        return "<path>/" + resolved.name
+
+
+def replace_absolute_path_prefix(text: str, prefix: str, replacement: str) -> str:
+    if not prefix or prefix in {"/", "\\"}:
+        return text
+    normalized = prefix.rstrip("/\\")
+    if not normalized:
+        return text
+    pattern = re.compile(rf"(?<![A-Za-z0-9_:/.\->]){re.escape(normalized)}(?=$|[/\\])")
+    return pattern.sub(replacement, text)
+
+
+def path_leaf(path_text: str) -> str:
+    stripped = path_text.rstrip("\\/")
+    leaf = re.split(r"[\\/]+", stripped)[-1]
+    return leaf or "path"
+
+
+def scrub_absolute_path_match(match: re.Match[str]) -> str:
+    return "<path>/" + path_leaf(match.group(0))
+
+
+def scrub_file_uri_match(match: re.Match[str]) -> str:
+    return "file://<path>/" + path_leaf(match.group("path"))
+
+
+def scrub_sensitive_assignment_match(match: re.Match[str]) -> str:
+    if not should_redact_key_name(match.group("key")):
+        return match.group(0)
+    value_quote = match.group("value_quote") or ""
+    return match.group("prefix") + value_quote + "<redacted>" + value_quote
+
+
+def protect_route_paths(text: str) -> tuple[str, list[tuple[str, str]]]:
+    routes: list[tuple[str, str]] = []
+
+    def replace_route(match: re.Match[str]) -> str:
+        token = f"__CRYPTAD_ROUTE_{len(routes)}__"
+        routes.append((token, match.group(0)))
+        return token
+
+    return ROUTE_PATH_RE.sub(replace_route, text), routes
+
+
+def restore_route_paths(text: str, routes: list[tuple[str, str]]) -> str:
+    restored = text
+    for token, route in routes:
+        restored = restored.replace(token, route)
+    return restored
+
+
+def normalize_redacted_separators(text: str) -> str:
+    def normalize_match(match: re.Match[str]) -> str:
+        return match.group("prefix") + match.group("tail").replace("\\", "/")
+
+    return re.sub(
+        r"(?P<prefix><(?:repo|home|workdir|path)>)(?P<tail>(?:[\\/][^\s\])},;\"']*)?)",
+        normalize_match,
+        text,
+    )
+
+
+def scrub_text(text: str, workspace_root: Path, out_dir: Path | None = None) -> str:
+    redacted = URL_USERINFO_RE.sub(r"\1<redacted>@", text)
+    redacted = SENSITIVE_HEADER_RE.sub(lambda match: match.group("prefix") + "<redacted>", redacted)
+    redacted = SENSITIVE_ASSIGNMENT_RE.sub(scrub_sensitive_assignment_match, redacted)
+    redacted = URI_KEY_RE.sub("<redacted-uri>", redacted)
+    redacted = FILE_URI_PATH_RE.sub(scrub_file_uri_match, redacted)
+    redacted, protected_routes = protect_route_paths(redacted)
+    for artifact_name in PRIVATE_ARTIFACT_NAMES:
+        redacted = redacted.replace(artifact_name, "<redacted-private-artifact>")
+    root_text = str(workspace_root.resolve())
+    redacted = redacted.replace(root_text, "<repo>")
+    redacted = redacted.replace(root_text.replace("\\", "/"), "<repo>")
+    if out_dir is not None:
+        out_text = str(out_dir.resolve())
+        out_display = display_path(out_dir, workspace_root)
+        redacted = redacted.replace(out_text, out_display)
+        redacted = redacted.replace(out_text.replace("\\", "/"), out_display)
+    home = str(Path.home())
+    if home and home != "/":
+        redacted = replace_absolute_path_prefix(redacted, home, "<home>")
+    redacted = replace_absolute_path_prefix(redacted, tempfile.gettempdir(), "<workdir>")
+    redacted = WINDOWS_UNC_PATH_RE.sub(scrub_absolute_path_match, redacted)
+    redacted = WINDOWS_DRIVE_PATH_RE.sub(scrub_absolute_path_match, redacted)
+    redacted = ABSOLUTE_PATH_RE.sub(scrub_absolute_path_match, redacted)
+    redacted = normalize_redacted_separators(redacted)
+    return restore_route_paths(redacted, protected_routes)
+
+
+def normalize_key_name(key_hint: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", key_hint.lower())
+
+
+def should_redact_key_name(key_hint: str) -> bool:
+    normalized = normalize_key_name(key_hint)
+    if not normalized:
+        return False
+    if normalized.endswith(NON_SECRET_METADATA_SUFFIXES):
+        return False
+    if normalized in {
+        "authorization",
+        "cookie",
+        "setcookie",
+        "credential",
+        "cryptadapptoken",
+        "formpassword",
+        "privatekey",
+        "secret",
+        "token",
+        "password",
+        "passwd",
+        "browsersessiontoken",
+        "xcryptaappsession",
+    }:
+        return True
+    return any(fragment in normalized for fragment in ("privatekey", "token", "password", "passwd", "secret", "credential"))
+
+
+def sanitize_value(value: Any, workspace_root: Path, out_dir: Path | None = None, key_hint: str = "") -> Any:
+    if should_redact_key_name(key_hint):
+        return "<redacted>"
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, child in value.items():
+            key_text = str(key)
+            result[key_text] = sanitize_value(child, workspace_root, out_dir, key_text)
+        return result
+    if isinstance(value, list):
+        sanitized = [sanitize_value(child, workspace_root, out_dir, key_hint) for child in value]
+        return [
+            child
+            for child in sanitized
+            if not (isinstance(child, str) and "<redacted-private-artifact>" in child)
+        ]
+    if isinstance(value, str):
+        return scrub_text(value, workspace_root, out_dir)
+    return value
+
+
+def normalize_evidence_status(status: str) -> str:
+    normalized = status.strip().lower()
+    if normalized in CERT_STATUSES:
+        return normalized
+    if normalized in {"success", "passed", "ok", "collected"}:
+        return "pass"
+    if normalized in {"warning", "warn"}:
+        return "warn"
+    if normalized in {"failure", "failed", "error"}:
+        return "fail"
+    if normalized in {"skipped"}:
+        return "skip"
+    return "missing"
+
+
+def with_waiver(
+    item: EvidenceItem, waivers: dict[str, str], workspace_root: Path, out_dir: Path
+) -> EvidenceItem:
+    reason = waivers.get(item.id)
+    if not reason or item.status == "pass":
+        return item
+    safe_reason = scrub_text(reason, workspace_root, out_dir)
+    details = dict(item.details)
+    details["waived"] = True
+    details["waiverReason"] = safe_reason
+    return EvidenceItem(
+        id=item.id,
+        status="warn",
+        required_for_release_candidate=item.required_for_release_candidate,
+        summary=f"{item.summary} Waiver recorded: {safe_reason}",
+        source=item.source,
+        details=details,
+    )
+
+
+def sanitize_evidence_item(item: EvidenceItem, workspace_root: Path, out_dir: Path) -> EvidenceItem:
+    return EvidenceItem(
+        id=item.id,
+        status=item.status,
+        required_for_release_candidate=item.required_for_release_candidate,
+        summary=scrub_text(item.summary, workspace_root, out_dir),
+        source=scrub_text(item.source, workspace_root, out_dir),
+        details=dict(sanitize_value(item.details, workspace_root, out_dir)),
+    )
+
+
+def has_required_flow(summary: dict[str, Any], flow_name: str) -> bool:
+    flows = summary.get("flows", {})
+    if not isinstance(flows, dict):
+        return False
+    flow = flows.get(flow_name, {})
+    return isinstance(flow, dict) and flow.get("status") == "passed"
+
+
+def flow_status(summary: dict[str, Any], flow_name: str) -> str:
+    flows = summary.get("flows", {})
+    if not isinstance(flows, dict):
+        return "missing"
+    flow = flows.get(flow_name, {})
+    if isinstance(flow, dict):
+        return str(flow.get("status", "missing"))
+    return str(flow)
+
+
+def sanitized_artifact_refs(summary: dict[str, Any], workspace_root: Path, out_dir: Path) -> list[str]:
+    artifacts = summary.get("artifacts", [])
+    if not isinstance(artifacts, list):
+        return []
+    refs: list[str] = []
+    for artifact in artifacts:
+        artifact_text = str(artifact)
+        if any(name in artifact_text for name in PRIVATE_ARTIFACT_NAMES):
+            continue
+        refs.append(str(sanitize_value(artifact_text, workspace_root, out_dir)))
+    return sorted(dict.fromkeys(refs))
+
+
+def interop_evidence(
+    evidence_id: str,
+    path: Path,
+    required: bool,
+    expected_mode: str,
+    workspace_root: Path,
+    out_dir: Path,
+) -> EvidenceItem:
+    source = display_path(path, workspace_root, out_dir)
+    summary = read_json(path)
+    if summary is None:
+        missing_status = "missing"
+        return EvidenceItem(
+            evidence_id,
+            missing_status,
+            required,
+            f"{expected_mode} interop summary is missing",
+            source,
+            {},
+        )
+
+    sanitized = sanitize_value(summary, workspace_root, out_dir)
+    common_required_flows = [
+        "handshake",
+        "peer_exchange",
+        "chk_cross_fetch",
+        "ssk_cross_fetch",
+        "usk_smoke",
+        "restart_recovery",
+    ]
+    extended_required_flows = ["usk_subscribe_soak", "persistent_request_replay"]
+    required_flows = common_required_flows + (
+        extended_required_flows if expected_mode == "extended" else []
+    )
+    coverage = {flow: flow_status(summary, flow) for flow in required_flows}
+    missing_flows = [flow for flow in required_flows if not has_required_flow(summary, flow)]
+    summary_status = str(summary.get("status", "missing"))
+    summary_mode = str(summary.get("mode", "missing"))
+    mode_matches = summary_mode == expected_mode
+    if summary_status == "success" and not mode_matches:
+        status = "fail" if required else "warn"
+        headline = f"{expected_mode} Hyphanet interop summary has wrong mode"
+    elif summary_status == "success" and not missing_flows:
+        status = "pass"
+        headline = f"{expected_mode} Hyphanet interop passed"
+    elif summary_status == "success":
+        status = "warn" if not required else "fail"
+        headline = f"{expected_mode} Hyphanet interop completed with incomplete required coverage"
+    elif summary_status == "failure":
+        status = "fail"
+        headline = f"{expected_mode} Hyphanet interop failed"
+    else:
+        status = "missing"
+        headline = f"{expected_mode} Hyphanet interop status is unavailable"
+
+    details = {
+        "expectedMode": expected_mode,
+        "mode": sanitized.get("mode"),
+        "modeMatches": mode_matches,
+        "status": sanitized.get("status"),
+        "coverage": coverage,
+        "missingRequiredFlows": missing_flows,
+        "restartRecoveryLevel": sanitized.get("restart_recovery_level"),
+        "restartRecoveryChecks": sanitized.get("restart_recovery_checks", []),
+        "baseline": sanitized.get("baseline", sanitized.get("hyphanet", {})),
+        "artifacts": sanitized_artifact_refs(summary, workspace_root, out_dir),
+    }
+    if expected_mode == "extended":
+        details["extendedCoverage"] = {
+            "uskSubscribeSoak": flow_status(summary, "usk_subscribe_soak"),
+            "persistentRequestReplay": flow_status(summary, "persistent_request_replay"),
+            "opennetOptional": flow_status(summary, "opennet_optional"),
+        }
+    return EvidenceItem(evidence_id, status, required, headline, source, details)
+
+
+def perf_evidence(path: Path, required: bool, workspace_root: Path, out_dir: Path) -> EvidenceItem:
+    source = display_path(path, workspace_root, out_dir)
+    summary = read_json(path)
+    if summary is None:
+        return EvidenceItem(
+            "performance.smoke",
+            "missing",
+            required,
+            "Performance smoke summary is missing",
+            source,
+            {},
+        )
+    sanitized = sanitize_value(summary, workspace_root, out_dir)
+    raw_status = str(summary.get("status", "missing"))
+    summary_mode = str(summary.get("mode", "missing"))
+    expected_mode = "smoke"
+    mode_matches = summary_mode == expected_mode
+    status = (
+        {"success": "pass", "warning": "warn", "failure": "fail"}.get(raw_status, "missing")
+        if mode_matches
+        else ("fail" if required else "warn")
+    )
+    comparison = summary.get("comparison", {})
+    if not isinstance(comparison, dict):
+        comparison = {}
+    details = {
+        "expectedMode": expected_mode,
+        "mode": sanitized.get("mode"),
+        "modeMatches": mode_matches,
+        "status": sanitized.get("status"),
+        "comparison": sanitize_value(comparison, workspace_root, out_dir),
+        "failedMetrics": failed_perf_metrics(summary),
+        "warningMetrics": warning_perf_metrics(summary),
+        "perfReport": display_path(path.parent / "artifacts" / "perf-report.md", workspace_root, out_dir),
+    }
+    if not mode_matches:
+        return EvidenceItem(
+            "performance.smoke",
+            status,
+            required,
+            "Performance smoke summary has wrong mode",
+            source,
+            details,
+        )
+    return EvidenceItem(
+        "performance.smoke",
+        status,
+        required,
+        f"Performance smoke status is {raw_status}",
+        source,
+        details,
+    )
+
+
+def failed_perf_metrics(summary: dict[str, Any]) -> list[str]:
+    metrics = summary.get("metrics", {})
+    if not isinstance(metrics, dict):
+        return []
+    return sorted(name for name, metric in metrics.items() if isinstance(metric, dict) and metric.get("status") == "failed")
+
+
+def warning_perf_metrics(summary: dict[str, Any]) -> list[str]:
+    comparison = summary.get("comparison", {})
+    if not isinstance(comparison, dict):
+        return []
+    names: list[str] = []
+    for group in ("regressions", "warnings"):
+        entries = comparison.get(group, [])
+        if isinstance(entries, list):
+            for entry in entries:
+                if isinstance(entry, dict) and entry.get("metric"):
+                    names.append(str(entry["metric"]))
+    return sorted(dict.fromkeys(names))
+
+
+def app_platform_evidence(
+    path: Path, workspace_root: Path, out_dir: Path, expected_mode: str
+) -> list[EvidenceItem]:
+    source = display_path(path, workspace_root, out_dir)
+    summary = read_json(path)
+    expected_ids = [
+        "app-platform.first-party",
+        "app-platform.devtools-cli",
+        "app-platform.signed-bundles",
+        "catalog.smoke",
+        "app-ui.smoke",
+        "legacy.retirement",
+        "apphost.live",
+    ]
+    if summary is None:
+        return [
+            EvidenceItem(
+                evidence_id,
+                "missing" if evidence_id != "apphost.live" else "skip",
+                evidence_id != "apphost.live",
+                "App-platform smoke summary is missing",
+                source,
+                {},
+            )
+            for evidence_id in expected_ids
+        ]
+    summary_mode = str(summary.get("mode", "missing"))
+    mode_matches = summary_mode == expected_mode
+    if expected_mode == "release-candidate" and not mode_matches:
+        return [
+            EvidenceItem(
+                evidence_id,
+                "fail" if evidence_id != "apphost.live" else "skip",
+                evidence_id != "apphost.live",
+                "App-platform smoke summary has wrong mode",
+                source,
+                {
+                    "expectedMode": expected_mode,
+                    "mode": sanitize_value(summary_mode, workspace_root, out_dir),
+                    "modeMatches": False,
+                    "summaryStatus": sanitize_value(summary.get("status"), workspace_root, out_dir),
+                },
+            )
+            for evidence_id in expected_ids
+        ]
+    evidence = summary.get("evidence", [])
+    if not isinstance(evidence, list):
+        return [
+            EvidenceItem(
+                "app-platform.smoke",
+                "fail",
+                True,
+                "App-platform summary has no evidence list",
+                source,
+                {"summaryStatus": sanitize_value(summary.get("status"), workspace_root, out_dir)},
+            )
+        ]
+    items: list[EvidenceItem] = []
+    seen: set[str] = set()
+    for value in evidence:
+        if not isinstance(value, dict):
+            continue
+        evidence_id = str(value.get("id", "app-platform.unknown"))
+        seen.add(evidence_id)
+        items.append(
+            EvidenceItem(
+                id=evidence_id,
+                status=normalize_evidence_status(str(value.get("status", "missing"))),
+                required_for_release_candidate=bool(value.get("requiredForReleaseCandidate", True)),
+                summary=str(
+                    sanitize_value(value.get("summary", "No summary provided"), workspace_root, out_dir)
+                ),
+                source=str(sanitize_value(value.get("source", source), workspace_root, out_dir)),
+                details=dict(
+                    sanitize_value(value.get("details", {}), workspace_root, out_dir)
+                    if isinstance(value.get("details", {}), dict)
+                    else {}
+                ),
+            )
+        )
+    for evidence_id in expected_ids:
+        if evidence_id not in seen:
+            items.append(
+                EvidenceItem(
+                    evidence_id,
+                    "missing" if evidence_id != "apphost.live" else "skip",
+                    evidence_id != "apphost.live",
+                    f"{evidence_id} was not reported by app-platform smoke",
+                    source,
+                    {},
+                )
+            )
+    return items
+
+
+def command_output(args: list[str], cwd: Path) -> str:
+    try:
+        completed = subprocess.run(
+            args,
+            cwd=str(cwd),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip()
+
+
+def collect_git_metadata(settings: Settings) -> dict[str, str]:
+    if settings.skip_git_metadata:
+        return {}
+    metadata: dict[str, str] = {}
+    sha = command_output(["git", "rev-parse", "HEAD"], settings.workspace_root)
+    branch = command_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], settings.workspace_root)
+    dirty = command_output(["git", "status", "--short"], settings.workspace_root)
+    if sha:
+        metadata["gitCommit"] = sha
+    if branch:
+        metadata["gitBranch"] = branch
+    if dirty:
+        metadata["gitDirty"] = "true"
+    elif sha or branch:
+        metadata["gitDirty"] = "false"
+    return metadata
+
+
+def collect_ci_metadata(env: dict[str, str]) -> dict[str, str]:
+    mappings = {
+        "GITHUB_ACTIONS": "githubActions",
+        "GITHUB_WORKFLOW": "githubWorkflow",
+        "GITHUB_RUN_ID": "githubRunId",
+        "GITHUB_RUN_ATTEMPT": "githubRunAttempt",
+        "GITHUB_REF": "githubRef",
+        "GITHUB_SHA": "githubSha",
+        "RUNNER_OS": "runnerOs",
+    }
+    metadata: dict[str, str] = {}
+    for env_name, key in mappings.items():
+        value = env.get(env_name)
+        if value:
+            metadata[key] = value
+    return metadata
+
+
+def determine_overall_status(mode: str, evidence: list[EvidenceItem]) -> tuple[str, bool]:
+    required_bad = [
+        item
+        for item in evidence
+        if item.required_for_release_candidate and item.status in {"fail", "missing", "skip"}
+        and not item.details.get("waived")
+    ]
+    required_warn = [
+        item
+        for item in evidence
+        if item.required_for_release_candidate and item.status == "warn" and not item.details.get("waived")
+    ]
+    any_warnish = any(item.status in {"warn", "missing", "skip", "fail"} for item in evidence)
+    if mode == "release-candidate":
+        if required_bad:
+            return "fail", False
+        if required_warn or any_warnish:
+            return "warn", True
+        return "pass", True
+    if mode == "nightly":
+        required_fail = [
+            item
+            for item in evidence
+            if item.required_for_release_candidate and item.status == "fail" and not item.details.get("waived")
+        ]
+        if required_fail:
+            return "fail", False
+        if required_bad:
+            return "warn", False
+        if required_warn or any_warnish:
+            return "warn", True
+        return "pass", True
+    if any_warnish:
+        return "warn", not required_bad
+    return "pass", True
+
+
+def evidence_counts(evidence: list[EvidenceItem]) -> dict[str, int]:
+    counts = {status: 0 for status in CERT_STATUSES}
+    for item in evidence:
+        counts[item.status] = counts.get(item.status, 0) + 1
+    return counts
+
+
+def collect_source_artifacts(settings: Settings, out_dir: Path) -> list[str]:
+    artifacts_dir = out_dir / "artifacts"
+    if artifacts_dir.exists():
+        shutil.rmtree(artifacts_dir)
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    source_map = {
+        "interop-smoke-summary.json": settings.interop_smoke_summary,
+        "interop-extended-summary.json": settings.interop_extended_summary,
+        "performance-smoke-summary.json": settings.perf_smoke_summary,
+        "app-platform-smoke-summary.json": settings.app_platform_summary,
+        "interop-smoke-report.md": settings.interop_smoke_summary.parent / "artifacts" / "interop-report.md",
+        "interop-extended-report.md": settings.interop_extended_summary.parent / "artifacts" / "interop-report.md",
+        "performance-smoke-report.md": settings.perf_smoke_summary.parent / "artifacts" / "perf-report.md",
+        "app-platform-smoke-report.md": settings.app_platform_summary.parent / "app-platform-smoke-report.md",
+    }
+    copied: list[str] = []
+    for target_name, source_path in source_map.items():
+        if not source_path.is_file():
+            continue
+        if any(name in str(source_path) for name in PRIVATE_ARTIFACT_NAMES):
+            continue
+        target_path = artifacts_dir / target_name
+        if source_path.suffix == ".json":
+            value = read_json(source_path)
+            if value is None:
+                continue
+            write_json(target_path, sanitize_value(value, settings.workspace_root, out_dir))
+        else:
+            target_path.write_text(
+                scrub_text(source_path.read_text(encoding="utf-8"), settings.workspace_root, out_dir),
+                encoding="utf-8",
+            )
+        copied.append(display_path(target_path, settings.workspace_root, out_dir))
+    return copied
+
+
+def build_summary(settings: Settings, evidence: list[EvidenceItem], copied_artifacts: list[str]) -> dict[str, Any]:
+    status, release_candidate_passed = determine_overall_status(settings.mode, evidence)
+    metadata = {}
+    metadata.update(collect_git_metadata(settings))
+    metadata.update(collect_ci_metadata(os.environ))
+    metadata.update(settings.metadata)
+    sanitized_metadata = sanitize_value(metadata, settings.workspace_root, settings.out_dir)
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "tool": TOOL_NAME,
+        "mode": settings.mode,
+        "status": status,
+        "releaseCandidatePassed": release_candidate_passed,
+        "generatedAt": utc_now(),
+        "workspaceRoot": "<repo>",
+        "summaryPath": display_path(settings.out_dir / SUMMARY_FILE_NAME, settings.workspace_root, settings.out_dir),
+        "reportPath": display_path(settings.out_dir / REPORT_FILE_NAME, settings.workspace_root, settings.out_dir),
+        "artifactsDir": display_path(settings.out_dir / "artifacts", settings.workspace_root, settings.out_dir),
+        "metadata": sanitized_metadata,
+        "waivers": sanitize_value(settings.waivers, settings.workspace_root, settings.out_dir),
+        "counts": evidence_counts(evidence),
+        "evidence": [item.to_json() for item in evidence],
+        "copiedArtifacts": copied_artifacts,
+        "redaction": {
+            "privateArtifactsExcluded": list(PRIVATE_ARTIFACT_NAMES),
+            "secretMaterialRedacted": True,
+            "absolutePathsSanitized": True,
+        },
+    }
+
+
+def render_report(summary: dict[str, Any]) -> str:
+    lines = [
+        "# Release Certification Report",
+        "",
+        f"- Mode: `{summary['mode']}`",
+        f"- Status: `{summary['status']}`",
+        f"- Release-candidate gate: `{'passed' if summary['releaseCandidatePassed'] else 'failed'}`",
+        f"- Generated: `{summary['generatedAt']}`",
+        f"- Summary: `{summary['summaryPath']}`",
+        f"- Artifacts: `{summary['artifactsDir']}`",
+        "",
+        "## Evidence Summary",
+        "",
+        "| Evidence | Status | Required for RC | Source | Summary |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for item in summary["evidence"]:
+        required = "yes" if item["requiredForReleaseCandidate"] else "no"
+        lines.append(
+            "| `{id}` | `{status}` | {required} | `{source}` | {summary_text} |".format(
+                id=item["id"],
+                status=item["status"],
+                required=required,
+                source=item["source"],
+                summary_text=str(item["summary"]).replace("|", "\\|"),
+            )
+        )
+    lines.extend(["", "## Hyphanet Interop", ""])
+    append_detail(lines, summary, "interop.smoke")
+    append_detail(lines, summary, "interop.extended")
+    lines.extend(["", "## Performance Regression", ""])
+    append_detail(lines, summary, "performance.smoke")
+    lines.extend(["", "## App Platform", ""])
+    for evidence_id in (
+        "app-platform.first-party",
+        "app-platform.devtools-cli",
+        "app-platform.signed-bundles",
+        "catalog.smoke",
+        "app-ui.smoke",
+        "apphost.live",
+    ):
+        append_detail(lines, summary, evidence_id)
+    lines.extend(["", "## Legacy Admin Retirement", ""])
+    append_detail(lines, summary, "legacy.retirement")
+    lines.extend(
+        [
+            "",
+            "## Redaction Rules",
+            "",
+            "- Private signing keys, form passwords, app process tokens, browser-session tokens, raw request bodies, and private insert URIs are not included.",
+            "- Local absolute paths are sanitized as `<repo>`, `<workdir>`, `<home>`, or `<path>` placeholders.",
+            "- `artifacts/private-insert-uris.json` is excluded even if an interop summary references it.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def append_detail(lines: list[str], summary: dict[str, Any], evidence_id: str) -> None:
+    item = next((entry for entry in summary["evidence"] if entry["id"] == evidence_id), None)
+    if item is None:
+        return
+    lines.append(f"### `{evidence_id}`")
+    lines.append("")
+    lines.append(f"- Status: `{item['status']}`")
+    lines.append(f"- Source: `{item['source']}`")
+    lines.append(f"- Summary: {item['summary']}")
+    details = item.get("details", {})
+    if details:
+        compact = json.dumps(details, indent=2, sort_keys=True)
+        lines.extend(["", "```json", compact, "```"])
+    lines.append("")
+
+
+def gather_evidence(settings: Settings) -> list[EvidenceItem]:
+    evidence = [
+        interop_evidence(
+            "interop.smoke",
+            settings.interop_smoke_summary,
+            True,
+            "smoke",
+            settings.workspace_root,
+            settings.out_dir,
+        ),
+        interop_evidence(
+            "interop.extended",
+            settings.interop_extended_summary,
+            False,
+            "extended",
+            settings.workspace_root,
+            settings.out_dir,
+        ),
+        perf_evidence(settings.perf_smoke_summary, True, settings.workspace_root, settings.out_dir),
+    ]
+    evidence.extend(
+        app_platform_evidence(
+            settings.app_platform_summary,
+            settings.workspace_root,
+            settings.out_dir,
+            settings.mode,
+        )
+    )
+    return [
+        sanitize_evidence_item(
+            with_waiver(item, settings.waivers, settings.workspace_root, settings.out_dir),
+            settings.workspace_root,
+            settings.out_dir,
+        )
+        for item in evidence
+    ]
+
+
+def run(settings: Settings) -> tuple[dict[str, Any], int]:
+    settings.out_dir.mkdir(parents=True, exist_ok=True)
+    copied = collect_source_artifacts(settings, settings.out_dir)
+    evidence = gather_evidence(settings)
+    summary = build_summary(settings, evidence, copied)
+    write_json(settings.out_dir / SUMMARY_FILE_NAME, summary)
+    report = render_report(summary)
+    write_text(settings.out_dir / REPORT_FILE_NAME, report)
+    exit_code = 1 if summary["status"] == "fail" else 0
+    return summary, exit_code
+
+
+def parse_key_value(values: list[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for value in values:
+        if "=" not in value:
+            raise argparse.ArgumentTypeError(f"Expected key=value, got {value}")
+        key, text = value.split("=", 1)
+        if not key:
+            raise argparse.ArgumentTypeError(f"Expected non-empty key in {value}")
+        result[key] = text
+    return result
+
+
+def settings_from_args(args: argparse.Namespace) -> Settings:
+    workspace_root = args.workspace_root.resolve()
+    out_dir = (workspace_root / args.out_dir).resolve() if not args.out_dir.is_absolute() else args.out_dir.resolve()
+    mode = args.mode or os.environ.get("CRYPTAD_CERT_MODE", "pr")
+    if mode not in MODES:
+        raise SystemExit(f"--mode must be one of {', '.join(MODES)}")
+    return Settings(
+        workspace_root=workspace_root,
+        out_dir=out_dir,
+        mode=mode,
+        interop_smoke_summary=resolve_path(workspace_root, args.interop_smoke_summary),
+        interop_extended_summary=resolve_path(workspace_root, args.interop_extended_summary),
+        perf_smoke_summary=resolve_path(workspace_root, args.perf_smoke_summary),
+        app_platform_summary=resolve_path(workspace_root, args.app_platform_summary),
+        waivers=parse_key_value(args.waive),
+        metadata=parse_key_value(args.metadata),
+        skip_git_metadata=args.skip_git_metadata,
+    )
+
+
+def resolve_path(workspace_root: Path, path: Path) -> Path:
+    return (workspace_root / path).resolve() if not path.is_absolute() else path.resolve()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="Run Python-only self-tests.")
+    parser.add_argument("--workspace-root", type=Path, default=Path.cwd())
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument("--mode", choices=MODES, default=None)
+    parser.add_argument("--interop-smoke-summary", type=Path, default=Path("build/interop-smoke/summary.json"))
+    parser.add_argument("--interop-extended-summary", type=Path, default=Path("build/interop-extended/summary.json"))
+    parser.add_argument("--perf-smoke-summary", type=Path, default=Path("build/perf-smoke/summary.json"))
+    parser.add_argument(
+        "--app-platform-summary",
+        type=Path,
+        default=DEFAULT_OUT_DIR / "app-platform-smoke" / "summary.json",
+    )
+    parser.add_argument("--waive", action="append", default=[], metavar="ID=REASON")
+    parser.add_argument("--metadata", action="append", default=[], metavar="KEY=VALUE")
+    parser.add_argument("--skip-git-metadata", action="store_true")
+    return parser
+
+
+def run_self_test(repo_root: Path) -> None:
+    fixture_dir = repo_root / "tools/release-certification/fixtures"
+    with tempfile.TemporaryDirectory(prefix="cryptad-cert-self-test-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        out_dir = workspace / "build/release-certification"
+        (workspace / "build/interop-smoke").mkdir(parents=True)
+        (workspace / "build/interop-extended").mkdir(parents=True)
+        (workspace / "build/perf-smoke").mkdir(parents=True)
+        (out_dir / "app-platform-smoke").mkdir(parents=True)
+        shutil.copy2(fixture_dir / "self-test-interop-smoke.json", workspace / "build/interop-smoke/summary.json")
+        shutil.copy2(
+            fixture_dir / "self-test-interop-extended.json",
+            workspace / "build/interop-extended/summary.json",
+        )
+        shutil.copy2(fixture_dir / "self-test-perf-smoke.json", workspace / "build/perf-smoke/summary.json")
+        shutil.copy2(
+            fixture_dir / "self-test-app-platform-smoke.json",
+            out_dir / "app-platform-smoke/summary.json",
+        )
+        settings = Settings(
+            workspace_root=workspace.resolve(),
+            out_dir=out_dir.resolve(),
+            mode="release-candidate",
+            interop_smoke_summary=workspace / "build/interop-smoke/summary.json",
+            interop_extended_summary=workspace / "build/interop-extended/summary.json",
+            perf_smoke_summary=workspace / "build/perf-smoke/summary.json",
+            app_platform_summary=out_dir / "app-platform-smoke/summary.json",
+            waivers={},
+            metadata={"selfTest": "true"},
+            skip_git_metadata=True,
+        )
+        summary, exit_code = run(settings)
+        assert exit_code == 0, summary
+        assert summary["status"] in {"pass", "warn"}, summary
+        assert summary["releaseCandidatePassed"] is True, summary
+        report = (out_dir / REPORT_FILE_NAME).read_text(encoding="utf-8")
+        assert "Release Certification Report" in report
+        encoded = json.dumps(summary, sort_keys=True)
+        for forbidden in ("CRYPTAD_APP_TOKEN", "USK@private", str(workspace)):
+            assert forbidden not in encoded, f"self-test leaked {forbidden}"
+        interop_item = next(item for item in summary["evidence"] if item["id"] == "interop.smoke")
+        assert "artifacts/private-insert-uris.json" not in json.dumps(interop_item)
+        wrong_mode_extended = interop_evidence(
+            "interop.extended",
+            settings.interop_smoke_summary,
+            False,
+            "extended",
+            workspace,
+            out_dir,
+        )
+        assert wrong_mode_extended.status == "warn", wrong_mode_extended
+        assert wrong_mode_extended.details["expectedMode"] == "extended", wrong_mode_extended
+        assert wrong_mode_extended.details["mode"] == "smoke", wrong_mode_extended
+        assert wrong_mode_extended.details["modeMatches"] is False, wrong_mode_extended
+
+        missing_extended_flow_path = workspace / "build/interop-extended-missing-flow/summary.json"
+        missing_extended_flow = read_json(settings.interop_extended_summary)
+        assert missing_extended_flow is not None
+        missing_extended_flow["flows"].pop("persistent_request_replay", None)
+        write_json(missing_extended_flow_path, missing_extended_flow)
+        missing_extended_flow_item = interop_evidence(
+            "interop.extended",
+            missing_extended_flow_path,
+            False,
+            "extended",
+            workspace,
+            out_dir,
+        )
+        assert missing_extended_flow_item.status == "warn", missing_extended_flow_item
+        assert "persistent_request_replay" in missing_extended_flow_item.details["missingRequiredFlows"]
+
+        collect_perf_path = workspace / "build/perf-collect/summary.json"
+        collect_perf = read_json(settings.perf_smoke_summary)
+        assert collect_perf is not None
+        collect_perf["mode"] = "collect"
+        collect_perf["status"] = "warning"
+        write_json(collect_perf_path, collect_perf)
+        collect_perf_item = perf_evidence(collect_perf_path, True, workspace, out_dir)
+        assert collect_perf_item.status == "fail", collect_perf_item
+        assert collect_perf_item.details["expectedMode"] == "smoke", collect_perf_item
+        assert collect_perf_item.details["mode"] == "collect", collect_perf_item
+        assert collect_perf_item.details["modeMatches"] is False, collect_perf_item
+        collect_perf_settings = dataclasses.replace(
+            settings,
+            out_dir=(workspace / "build/collect-perf-cert").resolve(),
+            perf_smoke_summary=collect_perf_path,
+        )
+        collect_perf_summary, collect_perf_exit_code = run(collect_perf_settings)
+        assert collect_perf_exit_code == 1, collect_perf_summary
+        assert collect_perf_summary["status"] == "fail", collect_perf_summary
+        assert collect_perf_summary["releaseCandidatePassed"] is False, collect_perf_summary
+
+        pr_app_summary_path = workspace / "build/app-platform-pr/summary.json"
+        pr_app_summary = read_json(settings.app_platform_summary)
+        assert pr_app_summary is not None
+        pr_app_summary["mode"] = "pr"
+        pr_app_summary["status"] = "warn"
+        write_json(pr_app_summary_path, pr_app_summary)
+        pr_app_items = app_platform_evidence(pr_app_summary_path, workspace, out_dir, "release-candidate")
+        assert all(
+            item.status == "fail" for item in pr_app_items if item.required_for_release_candidate
+        ), pr_app_items
+        assert pr_app_items[0].details["expectedMode"] == "release-candidate", pr_app_items
+        assert pr_app_items[0].details["mode"] == "pr", pr_app_items
+        assert pr_app_items[0].details["modeMatches"] is False, pr_app_items
+        pr_app_settings = dataclasses.replace(
+            settings,
+            out_dir=(workspace / "build/pr-app-cert").resolve(),
+            app_platform_summary=pr_app_summary_path,
+        )
+        pr_app_cert_summary, pr_app_exit_code = run(pr_app_settings)
+        assert pr_app_exit_code == 1, pr_app_cert_summary
+        assert pr_app_cert_summary["status"] == "fail", pr_app_cert_summary
+        assert pr_app_cert_summary["releaseCandidatePassed"] is False, pr_app_cert_summary
+
+        stale_artifact = out_dir / "artifacts/stale-from-previous-run.txt"
+        stale_artifact.write_text("old evidence\n", encoding="utf-8")
+        rerun_summary, rerun_exit_code = run(settings)
+        assert rerun_exit_code == 0, rerun_summary
+        assert not stale_artifact.exists(), stale_artifact
+        assert "stale-from-previous-run.txt" not in json.dumps(rerun_summary, sort_keys=True)
+        repo_tmp_path = workspace / "build/tmp-release-certification/release-certification-summary.json"
+        assert (
+            scrub_text(str(repo_tmp_path), workspace, out_dir)
+            == "<repo>/build/tmp-release-certification/release-certification-summary.json"
+        )
+        assert (
+            normalize_redacted_separators(r"<repo>\build\tmp-release-certification\release-certification-summary.json")
+            == "<repo>/build/tmp-release-certification/release-certification-summary.json"
+        )
+        windows_scrubbed = scrub_text(
+            r"keys at D:\release\signing.pem and \\builder\share\certs\catalog.pem",
+            workspace,
+            out_dir,
+        )
+        assert r"D:\release" not in windows_scrubbed, windows_scrubbed
+        assert r"\\builder\share" not in windows_scrubbed, windows_scrubbed
+        assert "<path>/signing.pem" in windows_scrubbed, windows_scrubbed
+        assert "<path>/catalog.pem" in windows_scrubbed, windows_scrubbed
+        file_uri_scrubbed = scrub_text(
+            "metadata file:///home/alice/signing/key.pem file:///D:/keys/catalog.pem",
+            workspace,
+            out_dir,
+        )
+        assert "/home/alice/signing" not in file_uri_scrubbed, file_uri_scrubbed
+        assert "D:/keys" not in file_uri_scrubbed, file_uri_scrubbed
+        assert "file://<path>/key.pem" in file_uri_scrubbed, file_uri_scrubbed
+        assert "file://<path>/catalog.pem" in file_uri_scrubbed, file_uri_scrubbed
+        route_scrubbed = scrub_text(
+            "/apps/install /apps/cert-smoke/runtime /api/v1/diagnostics "
+            "/mnt/secrets/signing/key.pem",
+            workspace,
+            out_dir,
+        )
+        assert "/apps/install" in route_scrubbed, route_scrubbed
+        assert "/apps/cert-smoke/runtime" in route_scrubbed, route_scrubbed
+        assert "/api/v1/diagnostics" in route_scrubbed, route_scrubbed
+        assert "/mnt/secrets/signing/key.pem" not in route_scrubbed, route_scrubbed
+        assert "<path>/key.pem" in route_scrubbed, route_scrubbed
+        signing_metadata = sanitize_value(
+            {
+                "privateKeyPresent": False,
+                "privateKeySource": "missing",
+                "publicKeyPresent": True,
+                "publicKeySource": "environment",
+                "secretMaterialRedacted": True,
+                "privateKey": "actual-secret",
+                "privateKeyFile": "/mnt/secrets/signing/key.pem",
+                "token": "runtime-token",
+                "path": "/apps/cert-smoke/runtime",
+            },
+            workspace,
+            out_dir,
+        )
+        assert signing_metadata["privateKeyPresent"] is False, signing_metadata
+        assert signing_metadata["privateKeySource"] == "missing", signing_metadata
+        assert signing_metadata["publicKeyPresent"] is True, signing_metadata
+        assert signing_metadata["publicKeySource"] == "environment", signing_metadata
+        assert signing_metadata["secretMaterialRedacted"] is True, signing_metadata
+        assert signing_metadata["privateKey"] == "<redacted>", signing_metadata
+        assert signing_metadata["privateKeyFile"] == "<redacted>", signing_metadata
+        assert signing_metadata["token"] == "<redacted>", signing_metadata
+        assert signing_metadata["path"] == "/apps/cert-smoke/runtime", signing_metadata
+        credential_scrubbed = scrub_text(
+            'Authorization: Bearer report-secret\n'
+            'Cookie: session=abc; csrf=def\n'
+            '{"token":"json-secret","authorization":"Bearer json-secret","password":"pw"} '
+            "authorization=Bearer inline-secret "
+            "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64=base64-secret "
+            "privateKeyBase64=key-secret clientSecret=client-secret api_password=api-secret "
+            "privateKeyPresent=false",
+            workspace,
+            out_dir,
+        )
+        for forbidden in (
+            "Bearer report-secret",
+            "session=abc",
+            "csrf=def",
+            "json-secret",
+            '"pw"',
+            "inline-secret",
+            "base64-secret",
+            "key-secret",
+            "client-secret",
+            "api-secret",
+        ):
+            assert forbidden not in credential_scrubbed, credential_scrubbed
+        assert "Authorization: <redacted>" in credential_scrubbed, credential_scrubbed
+        assert "Cookie: <redacted>" in credential_scrubbed, credential_scrubbed
+        assert '"token":"<redacted>"' in credential_scrubbed, credential_scrubbed
+        assert "authorization=<redacted>" in credential_scrubbed, credential_scrubbed
+        assert "privateKeyPresent=false" in credential_scrubbed, credential_scrubbed
+
+        external_out_dir = Path(temp_name) / "external-cert"
+        external_settings = dataclasses.replace(settings, out_dir=external_out_dir.resolve())
+        external_summary, external_exit_code = run(external_settings)
+        assert external_exit_code == 0, external_summary
+        assert external_summary["summaryPath"].startswith("<workdir>/"), external_summary
+        assert external_summary["reportPath"].startswith("<workdir>/"), external_summary
+        assert (external_out_dir / SUMMARY_FILE_NAME).is_file(), external_summary
+        assert str(external_out_dir) not in json.dumps(external_summary, sort_keys=True), external_summary
+
+        missing_settings = dataclasses.replace(
+            settings,
+            out_dir=(workspace / "build/missing-cert").resolve(),
+            interop_smoke_summary=workspace / "build/missing-interop/summary.json",
+        )
+        missing_summary, missing_exit_code = run(missing_settings)
+        assert missing_exit_code == 1, missing_summary
+        assert missing_summary["status"] == "fail", missing_summary
+        assert missing_summary["releaseCandidatePassed"] is False, missing_summary
+
+        malformed_path = workspace / "build/malformed-interop/summary.json"
+        malformed_path.parent.mkdir(parents=True, exist_ok=True)
+        malformed_path.write_text('{"status": "success"', encoding="utf-8")
+        malformed_settings = dataclasses.replace(
+            settings,
+            out_dir=(workspace / "build/malformed-cert").resolve(),
+            interop_smoke_summary=malformed_path,
+        )
+        malformed_summary, malformed_exit_code = run(malformed_settings)
+        assert malformed_exit_code == 1, malformed_summary
+        assert malformed_summary["status"] == "fail", malformed_summary
+        malformed_interop = next(item for item in malformed_summary["evidence"] if item["id"] == "interop.smoke")
+        assert malformed_interop["status"] == "missing", malformed_interop
+        assert (malformed_settings.out_dir / REPORT_FILE_NAME).is_file(), malformed_summary
+        assert not any(
+            artifact.endswith("/interop-smoke-summary.json")
+            for artifact in malformed_summary["copiedArtifacts"]
+        ), malformed_summary
+
+        pr_missing_settings = dataclasses.replace(
+            missing_settings,
+            out_dir=(workspace / "build/pr-missing-cert").resolve(),
+            mode="pr",
+        )
+        pr_missing_summary, pr_missing_exit_code = run(pr_missing_settings)
+        assert pr_missing_exit_code == 0, pr_missing_summary
+        assert pr_missing_summary["status"] == "warn", pr_missing_summary
+        assert pr_missing_summary["releaseCandidatePassed"] is False, pr_missing_summary
+
+        nightly_missing_settings = dataclasses.replace(
+            missing_settings,
+            out_dir=(workspace / "build/nightly-missing-cert").resolve(),
+            mode="nightly",
+        )
+        nightly_missing_summary, nightly_missing_exit_code = run(nightly_missing_settings)
+        assert nightly_missing_exit_code == 0, nightly_missing_summary
+        assert nightly_missing_summary["status"] == "warn", nightly_missing_summary
+        assert nightly_missing_summary["releaseCandidatePassed"] is False, nightly_missing_summary
+
+        failing_perf = read_json(settings.perf_smoke_summary)
+        assert failing_perf is not None
+        failing_perf["status"] = "failure"
+        failing_perf_path = workspace / "build/failing-perf/summary.json"
+        write_json(failing_perf_path, failing_perf)
+        nightly_failing_settings = dataclasses.replace(
+            settings,
+            out_dir=(workspace / "build/nightly-failing-cert").resolve(),
+            mode="nightly",
+            perf_smoke_summary=failing_perf_path,
+        )
+        nightly_failing_summary, nightly_failing_exit_code = run(nightly_failing_settings)
+        assert nightly_failing_exit_code == 1, nightly_failing_summary
+        assert nightly_failing_summary["status"] == "fail", nightly_failing_summary
+        assert nightly_failing_summary["releaseCandidatePassed"] is False, nightly_failing_summary
+
+        waived_settings = dataclasses.replace(
+            missing_settings,
+            out_dir=(workspace / "build/waived-cert").resolve(),
+            waivers={"interop.smoke": "Release manager accepted CI artifact from upstream run."},
+        )
+        waived_summary, waived_exit_code = run(waived_settings)
+        assert waived_exit_code == 0, waived_summary
+        assert waived_summary["status"] == "warn", waived_summary
+        waived_item = next(item for item in waived_summary["evidence"] if item["id"] == "interop.smoke")
+        assert waived_item["details"]["waived"] is True
+
+        sensitive_reason = f"token=hunter2 USK@private/insert /mnt/secrets/signing/key.pem {workspace}/secret"
+        sensitive_waived_settings = dataclasses.replace(
+            missing_settings,
+            out_dir=(workspace / "build/sensitive-waived-cert").resolve(),
+            waivers={"interop.smoke": sensitive_reason},
+        )
+        sensitive_waived_summary, sensitive_waived_exit_code = run(sensitive_waived_settings)
+        assert sensitive_waived_exit_code == 0, sensitive_waived_summary
+        sensitive_report = (
+            sensitive_waived_settings.out_dir / REPORT_FILE_NAME
+        ).read_text(encoding="utf-8")
+        sensitive_encoded = json.dumps(sensitive_waived_summary, sort_keys=True) + sensitive_report
+        for forbidden in ("hunter2", "USK@private", "/mnt/secrets/signing/key.pem", str(workspace)):
+            assert forbidden not in sensitive_encoded, f"waiver reason leaked {forbidden}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.self_test:
+        run_self_test(Path(__file__).resolve().parents[2])
+        print("release-certification self-test passed")
+        return 0
+    settings = settings_from_args(args)
+    summary, exit_code = run(settings)
+    print(f"Release certification {summary['status']}: {settings.out_dir / REPORT_FILE_NAME}")
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release-certification/run-release-certification.sh
+++ b/tools/release-certification/run-release-certification.sh
@@ -112,8 +112,9 @@ if [[ ${#SKIP_GRADLE_ARG[@]} -eq 0 && "$MODE" == "pr" && "${CRYPTAD_CERT_RUN_GRA
   SKIP_GRADLE_ARG=(--skip-gradle)
 fi
 
+rm -f "$APP_SMOKE_SUMMARY" "$APP_SMOKE_OUT_DIR/app-platform-smoke-report.md"
+
 if [[ "$SKIP_APP_SMOKE" != "1" ]]; then
-  rm -f "$APP_SMOKE_SUMMARY" "$APP_SMOKE_OUT_DIR/app-platform-smoke-report.md"
   set +e
   python3 "$ROOT_DIR/tools/release-certification/app_platform_smoke.py" \
     --workspace-root "$ROOT_DIR" \
@@ -126,6 +127,8 @@ if [[ "$SKIP_APP_SMOKE" != "1" ]]; then
   if [[ "$APP_SMOKE_EXIT" -ne 0 ]]; then
     echo "App-platform smoke exited with $APP_SMOKE_EXIT; certification aggregation will record the evidence state." >&2
   fi
+else
+  rm -rf "$APP_SMOKE_OUT_DIR/artifacts"
 fi
 
 exec python3 "$ROOT_DIR/tools/release-certification/release_certification.py" \

--- a/tools/release-certification/run-release-certification.sh
+++ b/tools/release-certification/run-release-certification.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MODE="${CRYPTAD_CERT_MODE:-pr}"
+OUT_DIR="${CRYPTAD_CERT_OUT_DIR:-$ROOT_DIR/build/release-certification}"
+SKIP_APP_SMOKE="${CRYPTAD_CERT_SKIP_APP_SMOKE:-0}"
+SKIP_GRADLE_ARG=()
+LIVE_ARGS=()
+CERT_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      MODE="$2"
+      shift 2
+      ;;
+    --mode=*)
+      MODE="${1#--mode=}"
+      shift
+      ;;
+    --out-dir)
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --out-dir=*)
+      OUT_DIR="${1#--out-dir=}"
+      shift
+      ;;
+    --skip-app-smoke)
+      SKIP_APP_SMOKE=1
+      shift
+      ;;
+    --skip-gradle)
+      SKIP_GRADLE_ARG=(--skip-gradle)
+      shift
+      ;;
+    --live)
+      LIVE_ARGS+=(--live)
+      shift
+      ;;
+    --node-base-url)
+      LIVE_ARGS+=(--node-base-url "$2")
+      shift 2
+      ;;
+    --node-base-url=*)
+      LIVE_ARGS+=(--node-base-url "${1#--node-base-url=}")
+      shift
+      ;;
+    --form-password)
+      echo "--form-password is not supported; set CRYPTAD_CERT_FORM_PASSWORD in the environment." >&2
+      exit 2
+      ;;
+    --form-password=*)
+      echo "--form-password is not supported; set CRYPTAD_CERT_FORM_PASSWORD in the environment." >&2
+      exit 2
+      ;;
+    --waive|--metadata)
+      CERT_ARGS+=("$1" "$2")
+      shift 2
+      ;;
+    --waive=*|--metadata=*)
+      CERT_ARGS+=("$1")
+      shift
+      ;;
+    --skip-git-metadata)
+      CERT_ARGS+=(--skip-git-metadata)
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$MODE" in
+  pr|nightly|release-candidate)
+    ;;
+  *)
+    echo "--mode must be pr, nightly, or release-candidate; got: $MODE" >&2
+    exit 2
+    ;;
+esac
+
+case "$OUT_DIR" in
+  /*)
+    ;;
+  *)
+    OUT_DIR="$ROOT_DIR/$OUT_DIR"
+    ;;
+esac
+
+if ! command -v python3 >/dev/null 2>&1; then
+  mkdir -p "$OUT_DIR"
+  echo "python3 is required." | tee "$OUT_DIR/shell-error.txt" >&2
+  exit 1
+fi
+
+if ! python3 -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; then
+  mkdir -p "$OUT_DIR"
+  python_version="$(python3 -c 'import platform; print(platform.python_version())' 2>/dev/null || echo unknown)"
+  echo "python3 3.10 or newer is required; found ${python_version}." | tee "$OUT_DIR/shell-error.txt" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+APP_SMOKE_OUT_DIR="$OUT_DIR/app-platform-smoke"
+APP_SMOKE_SUMMARY="$APP_SMOKE_OUT_DIR/summary.json"
+
+if [[ ${#SKIP_GRADLE_ARG[@]} -eq 0 && "$MODE" == "pr" && "${CRYPTAD_CERT_RUN_GRADLE:-0}" != "1" ]]; then
+  SKIP_GRADLE_ARG=(--skip-gradle)
+fi
+
+if [[ "$SKIP_APP_SMOKE" != "1" ]]; then
+  rm -f "$APP_SMOKE_SUMMARY" "$APP_SMOKE_OUT_DIR/app-platform-smoke-report.md"
+  set +e
+  python3 "$ROOT_DIR/tools/release-certification/app_platform_smoke.py" \
+    --workspace-root "$ROOT_DIR" \
+    --out-dir "$APP_SMOKE_OUT_DIR" \
+    --mode "$MODE" \
+    "${SKIP_GRADLE_ARG[@]}" \
+    "${LIVE_ARGS[@]}"
+  APP_SMOKE_EXIT=$?
+  set -e
+  if [[ "$APP_SMOKE_EXIT" -ne 0 ]]; then
+    echo "App-platform smoke exited with $APP_SMOKE_EXIT; certification aggregation will record the evidence state." >&2
+  fi
+fi
+
+exec python3 "$ROOT_DIR/tools/release-certification/release_certification.py" \
+  --workspace-root "$ROOT_DIR" \
+  --out-dir "$OUT_DIR" \
+  --mode "$MODE" \
+  --app-platform-summary "$APP_SMOKE_SUMMARY" \
+  "${CERT_ARGS[@]}"


### PR DESCRIPTION
## Summary
- Add the standard-library release certification aggregator with stable Markdown/JSON outputs, evidence ids, mode semantics, waivers, redaction, path sanitization, and self-test fixtures.
- Add the app-platform smoke collector for first-party app staging, static UI/SDK checks, `crypta-app` CLI coverage, signed bundle/catalog evidence, legacy-admin retirement evidence, and optional localhost-only live AppHost lifecycle checks.
- Add the release-certification GitHub Actions workflow plus quick CI self-tests, while keeping existing interop/performance gates intact.
- Update release, interop, performance, app-platform, README, AGENTS, and repo skill documentation for the new certification workflow.

## Test Plan
- [x] `./gradlew spotlessApply`
- [x] `python3 tools/release-certification/release_certification.py --self-test`
- [x] `python3 tools/release-certification/app_platform_smoke.py --self-test`
- [x] `tools/release-certification/run-release-certification.sh --mode pr --skip-gradle --skip-git-metadata` *(local report exits 0 with expected warnings when full gate summaries/signing evidence are not present)*
- [x] `git diff --check origin/develop...HEAD`