### PR TITLE
feat(apps): Isolate app UI origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,9 +249,10 @@ Cryptad now uses a partial multi-project Gradle build.
   lifecycle, per-start launch-token plumbing, sandbox status reporting, data/cache quota checks,
   and bounded process-log handling for local apps.
 - `:platform-app-ui` owns app-owned static UI route helpers under
-  `network.crypta.platform.appui`. It maps static app UI metadata to `/apps/{appId}/`, resolves
-  installed-bundle assets, issues short-lived browser sessions for static app API calls, and
-  enforces traversal, symlink, and content-type boundaries before the HTTP adapter streams files.
+  `network.crypta.platform.appui`. It maps static app UI metadata to isolated per-app loopback
+  origins with `/apps/{appId}/` as a compatibility fallback, resolves installed-bundle assets,
+  issues origin-bound short-lived browser sessions for static app API calls, and enforces
+  traversal, symlink, and content-type boundaries before the HTTP adapter streams files.
 - `:platform-sdk-js` owns the dependency-free browser SDK resource used by app-owned static UI
   bundles. First-party app staging copies this SDK into staged `static/` assets so pages can use
   the same bootstrap, Platform API, mutation, error, and fragment-sanitization helpers.
@@ -366,11 +367,12 @@ catalog signatures, trusted-key configuration, optional app-store metadata, and
 and signed bundle verification remain the trust source.
 
 Installed apps can also declare browser UI ownership with `app.ui.mode` and `app.ui.entry`.
-Static UI bundles open at `/apps/{appId}/`; shell-panel bundles keep existing local links such as
+Static UI bundles prefer isolated loopback origins per app; `/apps/{appId}/` remains a
+compatibility fallback, and shell-panel bundles keep existing local links such as
 `/app/node/#queue`. See [`docs/app-owned-ui.md`](docs/app-owned-ui.md) for the route contract,
-first-party bootstrap JSON, security headers, and static asset boundary. The repo-owned Queue
-Manager and Publisher bundles now stage static UIs at `/apps/queue-manager/static/` and
-`/apps/publisher/static/`, including the browser SDK described in
+origin-bound bootstrap JSON, restricted Platform API CORS behavior, security headers, and static
+asset boundary. The repo-owned Queue Manager and Publisher bundles now stage static UIs that open
+through the isolated app UI path when available, including the browser SDK described in
 [`docs/platform-sdk-js.md`](docs/platform-sdk-js.md).
 
 Production-facing installs reject unsigned bundles by default. To install signed bundles through a
@@ -441,13 +443,14 @@ Phase 3 Platform Primacy makes `:platform-api`, `:platform-web-shell`, and `:pla
 primary local platform path for operator workflows and first-party apps. Legacy HTTP and FCP remain
 compatibility, bridge, debug, and fallback surfaces.
 
-Current Phase 5 app-platform work extends that path with signed catalog sources, Crypta catalog
-transport, app-owned static UI routes, browser sessions for static app API calls, richer catalog
-review metadata, AppHost sandbox/quota visibility, the `crypta-app` developer CLI, and independent
-first-party Queue Manager and Publisher UIs. Installed apps can be launched through `/app/node/`
-shell-panel links or through stable `/apps/{appId}/` routes when the signed bundle declares
-`app.ui.mode=static`. The Web Shell Apps section uses `/api/v1/app-catalogs` metadata to show
-source, license, category, review,
+Phase 5 app-platform work added signed catalog sources, Crypta catalog transport, app-owned static
+UI routes, browser sessions for static app API calls, richer catalog review metadata, AppHost
+sandbox/quota visibility, the `crypta-app` developer CLI, and independent first-party Queue
+Manager and Publisher UIs. Phase 6 starts moving static app UIs onto isolated per-app loopback
+origins while retaining `/apps/{appId}/` as a compatibility fallback. Installed apps can be
+launched through `/app/node/` shell-panel links or through isolated app UI URLs when the signed
+bundle declares `app.ui.mode=static`. The Web Shell Apps section uses `/api/v1/app-catalogs`
+metadata to show source, license, category, review,
 permission-rationale, version-difference, compatibility, and changelog details before install or
 update.
 
@@ -671,7 +674,7 @@ build/cryptad-jlink-image/bin/cryptad-launcher    # Windows: cryptad-launcher.ba
 
 Notes
 - The jlink image includes `bin/cryptad-launcher` which prefers the embedded `bin/java` and uses `lib/*` for classpath.
-- We explicitly include key modules (e.g., `jdk.crypto.ec`, `java.net.http`, `jdk.unsupported`, `java.desktop`) and call `jlink` directly.
+- We explicitly include key modules (e.g., `jdk.crypto.ec`, `jdk.httpserver`, `java.net.http`, `jdk.unsupported`, `java.desktop`) and call `jlink` directly.
 - This does not alter the existing wrapper-based distribution; it is an additional, self-contained runtime option.
 - `bin/cryptad-launcher` and `cryptad-launcher.bat` now auto-detect the embedded runtime: when run from the jlink image they prefer `image/bin/java`; outside the image they fall back to `$JAVA_HOME/bin/java` or `java` on `PATH`.
 
@@ -888,8 +891,9 @@ Root build also includes:
   provider status, enforces positive AppHost-managed data/cache quotas at launch and restart
   boundaries, and bounds managed process logs.
 - `:platform-app-ui`: app-owned static UI route and asset-resolution helpers used by the legacy
-  HTTP admin adapter to serve `/apps/{appId}/` without exposing data/cache/run directories or
-  traversal paths. It also owns browser session issuance and verification for static app API calls.
+  HTTP admin adapter to serve isolated per-app loopback origins and the `/apps/{appId}/`
+  compatibility path without exposing data/cache/run directories or traversal paths. It also owns
+  origin-bound browser session issuance and verification for static app API calls.
 - `:platform-sdk-js`: browser-native SDK resource for app-owned static UI bootstrap, Platform API
   form/JSON helpers, error handling, and conservative legacy-fragment sanitization.
 - `:platform-appdist`: local app distribution tooling for deterministic bundle digests, Ed25519
@@ -981,8 +985,9 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   stop, uninstall, and replace an installed app bundle from a caller-supplied local staged
   directory through `:platform-apphost` and the Platform API v1. Signed local staged bundles are
   supported. Signed local and HTTPS catalog sources can now install or update apps through the
-  same AppHost staged-directory semantics. Static app UI routes are served from the installed
-  bundle under `/apps/{appId}/`; background app-update fetching remains future work.
+  same AppHost staged-directory semantics. Static app UIs are served from the installed bundle on
+  isolated per-app loopback origins when available, with `/apps/{appId}/` retained as a
+  compatibility fallback; background app-update fetching remains future work.
 
 ## Architecture Overview
 

--- a/adapter-http-legacy-admin/gradle/owned-output-patterns.txt
+++ b/adapter-http-legacy-admin/gradle/owned-output-patterns.txt
@@ -3,6 +3,7 @@
 # :adapter-http-legacy-browse owns the concrete browse/FProxy tree.
 
 network/crypta/clients/http/BadRequestException*.class
+network/crypta/clients/http/AppUiLoopbackOriginServer*.class
 network/crypta/clients/http/BookmarkManagerHandle*.class
 network/crypta/clients/http/ChatForumsToadlet*.class
 network/crypta/clients/http/ConfigToadlet*.class

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
@@ -292,12 +292,16 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
       return;
     }
     boolean includeBody = "GET".equals(method);
-    Optional<AppUiOriginBinding> refreshedBinding = refreshBindingForRequest(bindingServer);
-    if (refreshedBinding.isEmpty()) {
-      sendText(exchange, 404, null, "App UI is not available.", includeBody);
+    BindingRefresh refreshed = refreshBindingForRequest(bindingServer);
+    if (refreshed.binding().isEmpty()) {
+      try {
+        sendText(exchange, 404, null, "App UI is not available.", includeBody);
+      } finally {
+        refreshed.stopRetiredServer();
+      }
       return;
     }
-    AppUiOriginBinding binding = refreshedBinding.get();
+    AppUiOriginBinding binding = refreshed.binding().get();
     String adminPath = toAdminAppPath(binding.appId(), exchange.getRequestURI().getRawPath());
     try {
       if (AppUiBootstrapService.isBootstrapRequest(adminPath)) {
@@ -321,17 +325,21 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
     }
   }
 
-  private Optional<AppUiOriginBinding> refreshBindingForRequest(BindingServer bindingServer)
-      throws IOException {
+  private BindingRefresh refreshBindingForRequest(BindingServer bindingServer) throws IOException {
     String appId = bindingServer.binding().appId();
     Optional<InstalledAppSnapshot> snapshot = appHost.describe(appId);
     if (snapshot.isEmpty() || snapshot.get().manifest().uiMode() != AppUiMode.STATIC) {
-      byOrigin.remove(bindingServer.binding().origin());
-      bootstrapNonces.clearApp(appId);
-      return Optional.empty();
+      return retireBindingServerForRequest(appId, bindingServer);
     }
     refreshBinding(bindingServer, snapshot.get());
-    return Optional.of(bindingServer.binding());
+    return BindingRefresh.current(bindingServer.binding());
+  }
+
+  private BindingRefresh retireBindingServerForRequest(String appId, BindingServer bindingServer) {
+    BindingServer retiredServer = byAppId.remove(appId, bindingServer) ? bindingServer : null;
+    byOrigin.remove(bindingServer.binding().origin());
+    bootstrapNonces.clearApp(appId);
+    return BindingRefresh.retired(retiredServer);
   }
 
   private void writeBootstrap(
@@ -634,6 +642,23 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
             attributes.lastModifiedTime().toMillis());
       } catch (IOException e) {
         return UNAVAILABLE;
+      }
+    }
+  }
+
+  /** Result of refreshing a listener binding before serving one loopback request. */
+  private record BindingRefresh(Optional<AppUiOriginBinding> binding, BindingServer retiredServer) {
+    private static BindingRefresh current(AppUiOriginBinding binding) {
+      return new BindingRefresh(Optional.of(binding), null);
+    }
+
+    private static BindingRefresh retired(BindingServer retiredServer) {
+      return new BindingRefresh(Optional.empty(), retiredServer);
+    }
+
+    private void stopRetiredServer() {
+      if (retiredServer != null) {
+        retiredServer.stop();
       }
     }
   }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
@@ -308,7 +308,8 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
     }
     boolean includeBody = "GET".equals(method);
     BindingRefresh refreshed = refreshBindingForRequest(bindingServer);
-    if (refreshed.binding().isEmpty()) {
+    Optional<AppUiOriginBinding> refreshedBinding = refreshed.binding();
+    if (refreshedBinding.isEmpty()) {
       try {
         sendText(exchange, 404, null, "App UI is not available.", includeBody);
       } finally {
@@ -316,7 +317,7 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
       }
       return;
     }
-    AppUiOriginBinding binding = refreshed.binding().get();
+    AppUiOriginBinding binding = refreshedBinding.orElseThrow();
     if (ORIGIN_PROBE_PATH.equals(exchange.getRequestURI().getRawPath())) {
       writeOriginProbe(exchange, binding, includeBody);
       return;
@@ -465,7 +466,7 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
         return Optional.empty();
       }
       return Optional.of(origin.trim());
-    } catch (IllegalArgumentException exception) {
+    } catch (IllegalArgumentException _) {
       return Optional.empty();
     }
   }
@@ -757,7 +758,7 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
             fileKey == null ? null : fileKey.toString(),
             attributes.size(),
             attributes.lastModifiedTime().toMillis());
-      } catch (IOException e) {
+      } catch (IOException _) {
         return UNAVAILABLE;
       }
     }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
@@ -8,6 +8,10 @@ import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
@@ -25,6 +29,7 @@ import network.crypta.platform.api.PlatformApiPaths;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.appui.AppBrowserSessionIssuer;
 import network.crypta.platform.appui.AppStaticAsset;
 import network.crypta.platform.appui.AppStaticAssetException;
@@ -70,6 +75,7 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
   private static final Logger LOG = LoggerFactory.getLogger(AppUiLoopbackOriginServer.class);
   private static final int BACKLOG = 16;
   private static final int BOOTSTRAP_NONCE_BYTES = 32;
+  static final int MAX_BOOTSTRAP_NONCES_PER_APP = 16;
   private static final Duration BOOTSTRAP_NONCE_LIFETIME = Duration.ofHours(1);
 
   /**
@@ -187,7 +193,12 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
     if (!binding.get().isolatedAndActive()) {
       return Optional.ofNullable(binding.get().uiUrl());
     }
-    String nonce = bootstrapNonces.issue(binding.get().appId());
+    BindingServer bindingServer = byAppId.get(binding.get().appId());
+    if (bindingServer == null) {
+      return Optional.empty();
+    }
+    String nonce =
+        bootstrapNonces.issue(binding.get().appId(), bindingServer.snapshotFingerprint());
     return Optional.of(appendBootstrapNonceFragment(binding.get().uiUrl(), nonce));
   }
 
@@ -235,8 +246,9 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
       AppUiOriginBinding binding =
           AppUiOriginBinding.isolatedLoopback(
               snapshot.manifest(), origin, platformApiRoot, shellRoot);
-      BindingServer bindingServer = new BindingServer(server, origin, binding);
-      server.createContext("/", exchange -> handle(exchange, bindingServer.binding()));
+      BindingServer bindingServer =
+          new BindingServer(server, origin, binding, SnapshotFingerprint.from(snapshot));
+      server.createContext("/", exchange -> handle(exchange, bindingServer));
       server.setExecutor(executor);
       server.start();
       byOrigin.put(binding.origin(), binding);
@@ -251,7 +263,12 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
         AppUiOriginBinding.isolatedLoopback(
             snapshot.manifest(), bindingServer.origin(), platformApiRoot, shellRoot);
     AppUiOriginBinding previous = bindingServer.binding();
-    bindingServer.update(refreshed);
+    SnapshotFingerprint previousFingerprint = bindingServer.snapshotFingerprint();
+    SnapshotFingerprint refreshedFingerprint = SnapshotFingerprint.from(snapshot);
+    bindingServer.update(refreshed, refreshedFingerprint);
+    if (!Objects.equals(previousFingerprint, refreshedFingerprint)) {
+      bootstrapNonces.clearApp(snapshot.appId());
+    }
     if (!Objects.equals(previous.origin(), refreshed.origin())) {
       byOrigin.remove(previous.origin());
     }
@@ -268,13 +285,19 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
     bindingServer.stop();
   }
 
-  private void handle(HttpExchange exchange, AppUiOriginBinding binding) throws IOException {
+  private void handle(HttpExchange exchange, BindingServer bindingServer) throws IOException {
     String method = exchange.getRequestMethod();
     if (!"GET".equals(method) && !"HEAD".equals(method)) {
       sendText(exchange, 405, null, "Method not allowed.");
       return;
     }
     boolean includeBody = "GET".equals(method);
+    Optional<AppUiOriginBinding> refreshedBinding = refreshBindingForRequest(bindingServer);
+    if (refreshedBinding.isEmpty()) {
+      sendText(exchange, 404, null, "App UI is not available.", includeBody);
+      return;
+    }
+    AppUiOriginBinding binding = refreshedBinding.get();
     String adminPath = toAdminAppPath(binding.appId(), exchange.getRequestURI().getRawPath());
     try {
       if (AppUiBootstrapService.isBootstrapRequest(adminPath)) {
@@ -296,6 +319,19 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
       int status = exception.statusCode() == 404 ? 404 : 400;
       sendText(exchange, status, null, "App UI path is not valid.", includeBody);
     }
+  }
+
+  private Optional<AppUiOriginBinding> refreshBindingForRequest(BindingServer bindingServer)
+      throws IOException {
+    String appId = bindingServer.binding().appId();
+    Optional<InstalledAppSnapshot> snapshot = appHost.describe(appId);
+    if (snapshot.isEmpty() || snapshot.get().manifest().uiMode() != AppUiMode.STATIC) {
+      byOrigin.remove(bindingServer.binding().origin());
+      bootstrapNonces.clearApp(appId);
+      return Optional.empty();
+    }
+    refreshBinding(bindingServer, snapshot.get());
+    return Optional.of(bindingServer.binding());
   }
 
   private void writeBootstrap(
@@ -353,7 +389,9 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
 
   private boolean validBootstrapProof(AppUiOriginBinding binding, HttpExchange exchange) {
     String nonce = exchange.getRequestHeaders().getFirst(BOOTSTRAP_NONCE_HEADER);
-    return bootstrapNonces.verify(binding.appId(), nonce);
+    BindingServer bindingServer = byAppId.get(binding.appId());
+    return bindingServer != null
+        && bootstrapNonces.verify(binding.appId(), bindingServer.snapshotFingerprint(), nonce);
   }
 
   private static void redirect(HttpExchange exchange, String location, boolean includeBody)
@@ -477,26 +515,35 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
   private static final class BootstrapNonceStore {
     private final SecureRandom random = new SecureRandom();
     private final Map<String, BootstrapNonce> nonces = new ConcurrentHashMap<>();
+    private long nextSequence;
 
-    private synchronized String issue(String appId) {
+    private synchronized String issue(String appId, SnapshotFingerprint snapshotFingerprint) {
       Instant now = Instant.now();
       pruneExpired(now);
+      evictOldestAppNonces(appId);
       String nonce = generateNonce();
       while (nonces.containsKey(nonce)) {
         nonce = generateNonce();
       }
-      nonces.put(nonce, new BootstrapNonce(appId, now.plus(BOOTSTRAP_NONCE_LIFETIME)));
+      nonces.put(
+          nonce,
+          new BootstrapNonce(
+              appId, snapshotFingerprint, nextSequence++, now.plus(BOOTSTRAP_NONCE_LIFETIME)));
       return nonce;
     }
 
-    private synchronized boolean verify(String appId, String nonce) {
+    private synchronized boolean verify(
+        String appId, SnapshotFingerprint snapshotFingerprint, String nonce) {
       if (nonce == null || nonce.isBlank()) {
         return false;
       }
       Instant now = Instant.now();
       pruneExpired(now);
       BootstrapNonce issued = nonces.get(nonce.trim());
-      return issued != null && issued.appId().equals(appId) && issued.expiresAt().isAfter(now);
+      return issued != null
+          && issued.appId().equals(appId)
+          && issued.snapshotFingerprint().equals(snapshotFingerprint)
+          && issued.expiresAt().isAfter(now);
     }
 
     private synchronized void clearApp(String appId) {
@@ -513,24 +560,100 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
       return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 
+    private void evictOldestAppNonces(String appId) {
+      while (countAppNonces(appId) >= MAX_BOOTSTRAP_NONCES_PER_APP) {
+        String oldestNonce = oldestAppNonce(appId);
+        if (oldestNonce == null) {
+          return;
+        }
+        nonces.remove(oldestNonce);
+      }
+    }
+
+    private long countAppNonces(String appId) {
+      return nonces.values().stream().filter(nonce -> nonce.appId().equals(appId)).count();
+    }
+
+    private String oldestAppNonce(String appId) {
+      String oldestNonce = null;
+      long oldestSequence = Long.MAX_VALUE;
+      for (Map.Entry<String, BootstrapNonce> entry : nonces.entrySet()) {
+        BootstrapNonce nonce = entry.getValue();
+        if (nonce.appId().equals(appId) && nonce.sequence() < oldestSequence) {
+          oldestNonce = entry.getKey();
+          oldestSequence = nonce.sequence();
+        }
+      }
+      return oldestNonce;
+    }
+
     private void pruneExpired(Instant now) {
       nonces.entrySet().removeIf(entry -> !entry.getValue().expiresAt().isAfter(now));
     }
   }
 
-  /** Immutable association between a launch proof, its app id, and its expiration time. */
-  private record BootstrapNonce(String appId, Instant expiresAt) {}
+  /**
+   * Immutable association between a launch proof and the installed app snapshot that received it.
+   */
+  private record BootstrapNonce(
+      String appId, SnapshotFingerprint snapshotFingerprint, long sequence, Instant expiresAt) {}
+
+  /**
+   * Internal install-state fingerprint used to keep launch proofs scoped to one app snapshot.
+   *
+   * <p>The manifest is the semantic security boundary for browser-session permissions. Filesystem
+   * identities provide an additional install-generation signal for normal AppHost updates, where
+   * the copied bundle root or manifest file is replaced even if some manifest fields stay the same.
+   */
+  private record SnapshotFingerprint(
+      AppManifest manifest,
+      Path installedRoot,
+      FileIdentity installedRootIdentity,
+      FileIdentity manifestFileIdentity) {
+    private static SnapshotFingerprint from(InstalledAppSnapshot snapshot) {
+      return new SnapshotFingerprint(
+          snapshot.manifest(),
+          snapshot.paths().installedRoot(),
+          FileIdentity.from(snapshot.paths().installedRoot()),
+          FileIdentity.from(snapshot.paths().manifestFile()));
+    }
+  }
+
+  /** Display-free filesystem identity for one installed-bundle path. */
+  private record FileIdentity(String fileKey, long sizeBytes, long lastModifiedMillis) {
+    private static final FileIdentity UNAVAILABLE = new FileIdentity(null, -1L, -1L);
+
+    private static FileIdentity from(Path path) {
+      try {
+        BasicFileAttributes attributes =
+            Files.readAttributes(path, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        Object fileKey = attributes.fileKey();
+        return new FileIdentity(
+            fileKey == null ? null : fileKey.toString(),
+            attributes.size(),
+            attributes.lastModifiedTime().toMillis());
+      } catch (IOException e) {
+        return UNAVAILABLE;
+      }
+    }
+  }
 
   /** Holds the active HTTP listener and the latest app binding advertised for that listener. */
   private static final class BindingServer {
     private final HttpServer server;
     private final AppUiOrigin origin;
     private final AtomicReference<AppUiOriginBinding> binding;
+    private final AtomicReference<SnapshotFingerprint> snapshotFingerprint;
 
-    private BindingServer(HttpServer server, AppUiOrigin origin, AppUiOriginBinding binding) {
+    private BindingServer(
+        HttpServer server,
+        AppUiOrigin origin,
+        AppUiOriginBinding binding,
+        SnapshotFingerprint snapshotFingerprint) {
       this.server = server;
       this.origin = origin;
       this.binding = new AtomicReference<>(binding);
+      this.snapshotFingerprint = new AtomicReference<>(snapshotFingerprint);
     }
 
     private AppUiOrigin origin() {
@@ -541,8 +664,13 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
       return binding.get();
     }
 
-    private void update(AppUiOriginBinding binding) {
+    private SnapshotFingerprint snapshotFingerprint() {
+      return snapshotFingerprint.get();
+    }
+
+    private void update(AppUiOriginBinding binding, SnapshotFingerprint snapshotFingerprint) {
       this.binding.set(binding);
+      this.snapshotFingerprint.set(snapshotFingerprint);
     }
 
     private void stop() {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
@@ -105,6 +105,9 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
   static final String ORIGIN_PROBE_PATH = "/.well-known/cryptad-origin.json";
 
   private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
+  private static final String IPV6_LOOPBACK_HOST = "::1";
+  private static final String IPV6_LOOPBACK_HOST_EXPANDED = "0:0:0:0:0:0:0:1";
+  private static final String LOCALHOST_HOST = "localhost";
   private static final String TEXT_CONTENT_TYPE = "text/plain";
 
   private final AppHost appHost;
@@ -596,7 +599,22 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
   }
 
   private static boolean localAdminHost(String host) {
-    return AppUiOrigin.LOOPBACK_HOST.equals(host) || "localhost".equalsIgnoreCase(host);
+    String normalizedHost = normalizeUriHost(host);
+    return AppUiOrigin.LOOPBACK_HOST.equals(normalizedHost)
+        || LOCALHOST_HOST.equalsIgnoreCase(normalizedHost)
+        || IPV6_LOOPBACK_HOST.equalsIgnoreCase(normalizedHost)
+        || IPV6_LOOPBACK_HOST_EXPANDED.equalsIgnoreCase(normalizedHost);
+  }
+
+  private static String normalizeUriHost(String host) {
+    if (host == null) {
+      return "";
+    }
+    String trimmed = host.trim();
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      return trimmed.substring(1, trimmed.length() - 1);
+    }
+    return trimmed;
   }
 
   private static int effectivePort(URI uri) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
@@ -1,0 +1,562 @@
+package network.crypta.clients.http;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
+import network.crypta.platform.api.PlatformApiPaths;
+import network.crypta.platform.appdist.AppUiMode;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.appui.AppBrowserSessionIssuer;
+import network.crypta.platform.appui.AppStaticAsset;
+import network.crypta.platform.appui.AppStaticAssetException;
+import network.crypta.platform.appui.AppStaticAssetService;
+import network.crypta.platform.appui.AppUiBootstrap;
+import network.crypta.platform.appui.AppUiBootstrapJson;
+import network.crypta.platform.appui.AppUiBootstrapService;
+import network.crypta.platform.appui.AppUiOrigin;
+import network.crypta.platform.appui.AppUiOriginBinding;
+import network.crypta.platform.appui.AppUiOriginRegistry;
+import network.crypta.platform.appui.AppUiPaths;
+import network.crypta.platform.appui.AppUiSecurityHeaders;
+import network.crypta.platform.webshell.routes.WebShellPaths;
+import network.crypta.support.io.FileBucket;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Loopback-only per-app HTTP server for isolated static app UI origins.
+ *
+ * <p>The server allocates one {@code 127.0.0.1:<port>} listener per static app as bindings are
+ * requested. Each listener serves the app at its origin root, but request handling is adapted back
+ * through {@link AppStaticAssetService} and {@link AppUiBootstrapService}. That keeps installed
+ * bundle confinement, path traversal rejection, content-type handling, and browser-session issuance
+ * in the reusable app UI layer.
+ *
+ * <p>This type is owned by the legacy admin HTTP adapter because it must share the operator-facing
+ * admin root, JavaScript policy, and Web Shell launch route. It deliberately binds only to the
+ * advertised IPv4 loopback address so the URL given to the browser matches the socket. Bindings are
+ * lazy and are refreshed against the current {@link InstalledAppSnapshot}; removing or changing an
+ * app invalidates the corresponding origin entry and any launch nonces for that app.
+ *
+ * <p>Bootstrap JSON is guarded by a short-lived launch nonce. The nonce is placed in the Web Shell
+ * launch URL fragment and must be echoed in {@value #BOOTSTRAP_NONCE_HEADER}; ordinary local
+ * processes that can reach the loopback port do not receive a browser-session token without that
+ * launch proof.
+ *
+ * @see AppUiOriginRegistry
+ * @see AppUiOriginBinding
+ */
+final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(AppUiLoopbackOriginServer.class);
+  private static final int BACKLOG = 16;
+  private static final int BOOTSTRAP_NONCE_BYTES = 32;
+  private static final Duration BOOTSTRAP_NONCE_LIFETIME = Duration.ofHours(1);
+
+  /**
+   * Request header that carries the Web Shell launch proof for isolated bootstrap fetches.
+   *
+   * <p>The value is a bearer nonce, not an app browser session. It authorizes issuance of a fresh
+   * browser session only for the app id that received the original launch URL.
+   */
+  static final String BOOTSTRAP_NONCE_HEADER = "X-Crypta-App-Bootstrap-Nonce";
+
+  /**
+   * URL-fragment parameter used to deliver the launch proof to the static app page.
+   *
+   * <p>The fragment keeps the nonce out of the HTTP request line when Web Shell opens the app. The
+   * SDK reads the value in the browser and sends it back through {@link #BOOTSTRAP_NONCE_HEADER}.
+   */
+  static final String BOOTSTRAP_NONCE_FRAGMENT_PARAMETER = "cryptadBootstrapNonce";
+
+  private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
+  private static final String TEXT_CONTENT_TYPE = "text/plain";
+
+  private final AppHost appHost;
+  private final AppStaticAssetService assetService;
+  private final AppUiBootstrapService bootstrapService;
+  private final BootstrapNonceStore bootstrapNonces = new BootstrapNonceStore();
+  private final String platformApiRoot;
+  private final String shellRoot;
+  private final BooleanSupplier javascriptEnabled;
+  private final ExecutorService executor;
+  private final Map<String, BindingServer> byAppId = new ConcurrentHashMap<>();
+  private final Map<String, AppUiOriginBinding> byOrigin = new ConcurrentHashMap<>();
+
+  /**
+   * Creates a loopback-origin registry backed by lazy per-app HTTP listeners.
+   *
+   * <p>The server derives both the Platform API root and Web Shell root from {@code adminRoot}; the
+   * scheme and host therefore follow the configured admin listener instead of assuming plain HTTP.
+   * Static app listeners are not started during construction. They are created on demand by {@link
+   * #bindingForApp(String)} or {@link #launchUrlForApp(String)} and are stopped when {@link
+   * #close()} is called.
+   *
+   * @param appHost source of installed app snapshots and static app metadata.
+   * @param sessionIssuer issuer used for app browser sessions in bootstrap JSON.
+   * @param adminRoot absolute admin origin root, including scheme, host, and port.
+   * @param javascriptEnabled live supplier for the operator's FProxy JavaScript policy.
+   */
+  AppUiLoopbackOriginServer(
+      AppHost appHost,
+      AppBrowserSessionIssuer sessionIssuer,
+      String adminRoot,
+      BooleanSupplier javascriptEnabled) {
+    this.appHost = Objects.requireNonNull(appHost, "appHost");
+    this.assetService = new AppStaticAssetService(appHost);
+    this.bootstrapService = new AppUiBootstrapService(appHost, sessionIssuer);
+    String normalizedAdminRoot = normalizeAdminRoot(adminRoot);
+    this.platformApiRoot = appendRootPath(normalizedAdminRoot, PlatformApiPaths.API_V1_PREFIX);
+    this.shellRoot = appendRootPath(normalizedAdminRoot, WebShellPaths.SHELL_ROOT);
+    this.javascriptEnabled = Objects.requireNonNull(javascriptEnabled, "javascriptEnabled");
+    this.executor = Executors.newCachedThreadPool(new DaemonThreadFactory());
+  }
+
+  /**
+   * Returns an active isolated binding for a static app, creating its listener if necessary.
+   *
+   * <p>Only installed static apps receive loopback origins. Missing apps, process-only apps, and
+   * apps whose snapshot no longer describes static UI remove any stale listener and return empty.
+   * Existing listeners are reused so browser tabs keep a stable origin while the installed snapshot
+   * is refreshed.
+   *
+   * @param appId installed app identifier requested by Web Shell or the API summary path.
+   * @return the current isolated binding, or empty when the app cannot use static UI isolation.
+   */
+  @Override
+  public Optional<AppUiOriginBinding> bindingForApp(String appId) {
+    try {
+      Optional<InstalledAppSnapshot> snapshot = appHost.describe(appId);
+      if (snapshot.isEmpty() || snapshot.get().manifest().uiMode() != AppUiMode.STATIC) {
+        removeBindingServer(appId);
+        return Optional.empty();
+      }
+      BindingServer bindingServer = byAppId.get(snapshot.get().appId());
+      if (bindingServer == null) {
+        bindingServer = createBindingServer(snapshot.get());
+        BindingServer raced = byAppId.putIfAbsent(snapshot.get().appId(), bindingServer);
+        if (raced != null) {
+          byOrigin.remove(bindingServer.binding().origin());
+          bindingServer.stop();
+          bindingServer = raced;
+        }
+      }
+      refreshBinding(bindingServer, snapshot.get());
+      return Optional.of(bindingServer.binding());
+    } catch (IOException | RuntimeException e) {
+      LOG.warn("Failed to provide isolated app UI origin for {}", appId, e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * Builds the browser launch URL for an app and attaches a bootstrap launch proof when isolated.
+   *
+   * <p>The returned URL is safe to hand to Web Shell launch controls. For active isolated bindings,
+   * the URL includes a fragment nonce that is scoped to {@code appId}; for non-isolated fallback
+   * bindings, the binding's UI URL is returned unchanged.
+   *
+   * @param appId installed app identifier selected by the operator.
+   * @return launch URL for the current UI binding, or empty when no binding is available.
+   */
+  @Override
+  public Optional<String> launchUrlForApp(String appId) {
+    Optional<AppUiOriginBinding> binding = bindingForApp(appId);
+    if (binding.isEmpty()) {
+      return Optional.empty();
+    }
+    if (!binding.get().isolatedAndActive()) {
+      return Optional.ofNullable(binding.get().uiUrl());
+    }
+    String nonce = bootstrapNonces.issue(binding.get().appId());
+    return Optional.of(appendBootstrapNonceFragment(binding.get().uiUrl(), nonce));
+  }
+
+  /**
+   * Looks up a registered binding by its browser origin.
+   *
+   * <p>The lookup refreshes the app binding before returning it, so callers do not authenticate
+   * CORS requests against origins that were removed after the map entry was created.
+   *
+   * @param origin browser {@code Origin} header value to validate against current app bindings.
+   * @return current binding for that origin, or empty when the origin is unknown or stale.
+   */
+  @Override
+  public Optional<AppUiOriginBinding> bindingForOrigin(String origin) {
+    if (origin == null || origin.isBlank()) {
+      return Optional.empty();
+    }
+    AppUiOriginBinding binding = byOrigin.get(origin.trim());
+    if (binding == null) {
+      return Optional.empty();
+    }
+    return bindingForApp(binding.appId()).filter(current -> origin.trim().equals(current.origin()));
+  }
+
+  /**
+   * Stops every loopback listener owned by this registry and clears launch nonce state.
+   *
+   * <p>The method is idempotent for normal shutdown paths. It does not stop the admin listener or
+   * invalidate already-issued browser-session tokens; those remain owned by the session store.
+   */
+  @Override
+  public void close() {
+    byAppId.values().forEach(BindingServer::stop);
+    byAppId.clear();
+    byOrigin.clear();
+    bootstrapNonces.clear();
+    executor.shutdownNow();
+  }
+
+  private BindingServer createBindingServer(InstalledAppSnapshot snapshot) {
+    try {
+      HttpServer server =
+          HttpServer.create(new InetSocketAddress(advertisedLoopbackAddress(), 0), BACKLOG);
+      AppUiOrigin origin = AppUiOrigin.loopback(snapshot.appId(), server.getAddress().getPort());
+      AppUiOriginBinding binding =
+          AppUiOriginBinding.isolatedLoopback(
+              snapshot.manifest(), origin, platformApiRoot, shellRoot);
+      BindingServer bindingServer = new BindingServer(server, origin, binding);
+      server.createContext("/", exchange -> handle(exchange, bindingServer.binding()));
+      server.setExecutor(executor);
+      server.start();
+      byOrigin.put(binding.origin(), binding);
+      return bindingServer;
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to start app UI loopback listener.", e);
+    }
+  }
+
+  private void refreshBinding(BindingServer bindingServer, InstalledAppSnapshot snapshot) {
+    AppUiOriginBinding refreshed =
+        AppUiOriginBinding.isolatedLoopback(
+            snapshot.manifest(), bindingServer.origin(), platformApiRoot, shellRoot);
+    AppUiOriginBinding previous = bindingServer.binding();
+    bindingServer.update(refreshed);
+    if (!Objects.equals(previous.origin(), refreshed.origin())) {
+      byOrigin.remove(previous.origin());
+    }
+    byOrigin.put(refreshed.origin(), refreshed);
+  }
+
+  private void removeBindingServer(String appId) {
+    BindingServer bindingServer = byAppId.remove(appId);
+    if (bindingServer == null) {
+      return;
+    }
+    byOrigin.remove(bindingServer.binding().origin());
+    bootstrapNonces.clearApp(appId);
+    bindingServer.stop();
+  }
+
+  private void handle(HttpExchange exchange, AppUiOriginBinding binding) throws IOException {
+    String method = exchange.getRequestMethod();
+    if (!"GET".equals(method) && !"HEAD".equals(method)) {
+      sendText(exchange, 405, null, "Method not allowed.");
+      return;
+    }
+    boolean includeBody = "GET".equals(method);
+    String adminPath = toAdminAppPath(binding.appId(), exchange.getRequestURI().getRawPath());
+    try {
+      if (AppUiBootstrapService.isBootstrapRequest(adminPath)) {
+        writeBootstrap(exchange, binding, adminPath, includeBody);
+        return;
+      }
+      Optional<String> canonicalRootRedirect = assetService.canonicalRootRedirect(adminPath);
+      if (canonicalRootRedirect.isPresent()) {
+        redirect(exchange, toOriginPath(canonicalRootRedirect.get()), includeBody);
+        return;
+      }
+      Optional<AppStaticAsset> asset = assetService.resolve(adminPath);
+      if (asset.isEmpty()) {
+        sendText(exchange, 404, null, "App UI asset not found.", includeBody);
+        return;
+      }
+      writeAsset(exchange, binding, asset.get(), includeBody);
+    } catch (AppStaticAssetException exception) {
+      int status = exception.statusCode() == 404 ? 404 : 400;
+      sendText(exchange, status, null, "App UI path is not valid.", includeBody);
+    }
+  }
+
+  private void writeBootstrap(
+      HttpExchange exchange, AppUiOriginBinding binding, String adminPath, boolean includeBody)
+      throws IOException, AppStaticAssetException {
+    if (!includeBody) {
+      if (bootstrapService.isAvailable(adminPath)) {
+        sendHeaders(exchange, 200, appHeaders(binding), JSON_CONTENT_TYPE, 0L);
+      } else {
+        sendText(exchange, 404, null, "App UI bootstrap not found.", false);
+      }
+      return;
+    }
+    if (!validBootstrapProof(binding, exchange)) {
+      sendText(exchange, 401, appHeaders(binding), "App UI bootstrap launch proof is required.");
+      return;
+    }
+    Optional<AppUiBootstrap> bootstrap =
+        bootstrapService.resolve(adminPath, platformApiRoot, shellRoot, binding);
+    if (bootstrap.isEmpty()) {
+      sendText(exchange, 404, null, "App UI bootstrap not found.");
+      return;
+    }
+    byte[] body = AppUiBootstrapJson.serialize(bootstrap.get()).getBytes(StandardCharsets.UTF_8);
+    sendBytes(exchange, 200, appHeaders(binding), body, JSON_CONTENT_TYPE, true);
+  }
+
+  private void writeAsset(
+      HttpExchange exchange, AppUiOriginBinding binding, AppStaticAsset asset, boolean includeBody)
+      throws IOException {
+    Headers headers = appHeaders(binding);
+    if (!includeBody) {
+      sendOkHeadHeaders(exchange, headers, asset.contentType(), asset.sizeBytes());
+      return;
+    }
+    sendHeaders(exchange, 200, headers, asset.contentType(), asset.sizeBytes());
+    try (FileBucket bucket = new FileBucket(asset.path().toFile(), true, false, false, false);
+        var input = bucket.getInputStream();
+        OutputStream output = exchange.getResponseBody()) {
+      input.transferTo(output);
+    }
+  }
+
+  private Headers appHeaders(AppUiOriginBinding binding) {
+    Headers headers = new Headers();
+    for (Map.Entry<String, String> entry :
+        AppUiSecurityHeaders.headers(
+                javascriptEnabled.getAsBoolean(), binding.platformApiRoot(), binding.shellRoot())
+            .entrySet()) {
+      headers.add(entry.getKey(), entry.getValue());
+    }
+    headers.add("cache-control", "no-store");
+    return headers;
+  }
+
+  private boolean validBootstrapProof(AppUiOriginBinding binding, HttpExchange exchange) {
+    String nonce = exchange.getRequestHeaders().getFirst(BOOTSTRAP_NONCE_HEADER);
+    return bootstrapNonces.verify(binding.appId(), nonce);
+  }
+
+  private static void redirect(HttpExchange exchange, String location, boolean includeBody)
+      throws IOException {
+    Headers headers = new Headers();
+    headers.add("Location", appendRawQuery(location, exchange.getRequestURI().getRawQuery()));
+    if (!includeBody) {
+      sendHeaders(exchange, 302, headers, null, 0L);
+      return;
+    }
+    sendText(exchange, 302, headers, "Redirecting to app UI.");
+  }
+
+  private static void sendText(HttpExchange exchange, int status, Headers headers, String text)
+      throws IOException {
+    sendText(exchange, status, headers, text, true);
+  }
+
+  private static void sendText(
+      HttpExchange exchange, int status, Headers headers, String text, boolean includeBody)
+      throws IOException {
+    sendBytes(
+        exchange,
+        status,
+        headers,
+        text.getBytes(StandardCharsets.UTF_8),
+        TEXT_CONTENT_TYPE,
+        includeBody);
+  }
+
+  private static void sendBytes(
+      HttpExchange exchange,
+      int status,
+      Headers headers,
+      byte[] body,
+      String contentType,
+      boolean includeBody)
+      throws IOException {
+    sendHeaders(exchange, status, headers, contentType, includeBody ? body.length : 0L);
+    if (includeBody) {
+      try (OutputStream output = exchange.getResponseBody()) {
+        output.write(body);
+      }
+    }
+  }
+
+  private static void sendHeaders(
+      HttpExchange exchange, int status, Headers headers, String contentType, long length)
+      throws IOException {
+    Headers responseHeaders = exchange.getResponseHeaders();
+    if (headers != null) {
+      responseHeaders.putAll(headers);
+    }
+    if (contentType != null) {
+      responseHeaders.add("content-type", contentType);
+    }
+    exchange.sendResponseHeaders(status, length);
+  }
+
+  private static void sendOkHeadHeaders(
+      HttpExchange exchange, Headers headers, String contentType, long length) throws IOException {
+    Headers responseHeaders = exchange.getResponseHeaders();
+    if (headers != null) {
+      responseHeaders.putAll(headers);
+    }
+    if (contentType != null) {
+      responseHeaders.add("content-type", contentType);
+    }
+    responseHeaders.set("content-length", Long.toString(length));
+    exchange.sendResponseHeaders(200, -1L);
+  }
+
+  private static String toAdminAppPath(String appId, String rawPath) {
+    String path = rawPath == null || rawPath.isBlank() ? "/" : rawPath;
+    if ("/".equals(path)) {
+      return AppUiPaths.appRoot(appId);
+    }
+    return AppUiPaths.APPS_ROOT + appId + path;
+  }
+
+  private static String toOriginPath(String adminPath) {
+    String remainder = adminPath.substring(AppUiPaths.APPS_ROOT.length());
+    int slash = remainder.indexOf('/');
+    return slash < 0 ? "/" : remainder.substring(slash);
+  }
+
+  private static String appendRawQuery(String path, String rawQuery) {
+    if (rawQuery == null) {
+      return path;
+    }
+    int fragmentIndex = path.indexOf('#');
+    if (fragmentIndex < 0) {
+      return path + "?" + rawQuery;
+    }
+    return path.substring(0, fragmentIndex) + "?" + rawQuery + path.substring(fragmentIndex);
+  }
+
+  private static String normalizeAdminRoot(String adminRoot) {
+    String value = Objects.requireNonNull(adminRoot, "adminRoot").trim();
+    if (value.isEmpty()) {
+      throw new IllegalArgumentException("adminRoot must not be blank");
+    }
+    return value.endsWith("/") ? value : value + "/";
+  }
+
+  private static String appendRootPath(String root, String path) {
+    String relativePath = path.startsWith("/") ? path.substring(1) : path;
+    return root + relativePath;
+  }
+
+  private static InetAddress advertisedLoopbackAddress() throws IOException {
+    return InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+  }
+
+  private static String appendBootstrapNonceFragment(String url, String nonce) {
+    String separator = url.indexOf('#') < 0 ? "#" : "&";
+    return url + separator + BOOTSTRAP_NONCE_FRAGMENT_PARAMETER + "=" + nonce;
+  }
+
+  /** Stores short-lived Web Shell launch proofs keyed by their opaque nonce values. */
+  private static final class BootstrapNonceStore {
+    private final SecureRandom random = new SecureRandom();
+    private final Map<String, BootstrapNonce> nonces = new ConcurrentHashMap<>();
+
+    private synchronized String issue(String appId) {
+      Instant now = Instant.now();
+      pruneExpired(now);
+      String nonce = generateNonce();
+      while (nonces.containsKey(nonce)) {
+        nonce = generateNonce();
+      }
+      nonces.put(nonce, new BootstrapNonce(appId, now.plus(BOOTSTRAP_NONCE_LIFETIME)));
+      return nonce;
+    }
+
+    private synchronized boolean verify(String appId, String nonce) {
+      if (nonce == null || nonce.isBlank()) {
+        return false;
+      }
+      Instant now = Instant.now();
+      pruneExpired(now);
+      BootstrapNonce issued = nonces.get(nonce.trim());
+      return issued != null && issued.appId().equals(appId) && issued.expiresAt().isAfter(now);
+    }
+
+    private synchronized void clearApp(String appId) {
+      nonces.entrySet().removeIf(entry -> entry.getValue().appId().equals(appId));
+    }
+
+    private synchronized void clear() {
+      nonces.clear();
+    }
+
+    private String generateNonce() {
+      byte[] bytes = new byte[BOOTSTRAP_NONCE_BYTES];
+      random.nextBytes(bytes);
+      return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private void pruneExpired(Instant now) {
+      nonces.entrySet().removeIf(entry -> !entry.getValue().expiresAt().isAfter(now));
+    }
+  }
+
+  /** Immutable association between a launch proof, its app id, and its expiration time. */
+  private record BootstrapNonce(String appId, Instant expiresAt) {}
+
+  /** Holds the active HTTP listener and the latest app binding advertised for that listener. */
+  private static final class BindingServer {
+    private final HttpServer server;
+    private final AppUiOrigin origin;
+    private final AtomicReference<AppUiOriginBinding> binding;
+
+    private BindingServer(HttpServer server, AppUiOrigin origin, AppUiOriginBinding binding) {
+      this.server = server;
+      this.origin = origin;
+      this.binding = new AtomicReference<>(binding);
+    }
+
+    private AppUiOrigin origin() {
+      return origin;
+    }
+
+    private AppUiOriginBinding binding() {
+      return binding.get();
+    }
+
+    private void update(AppUiOriginBinding binding) {
+      this.binding.set(binding);
+    }
+
+    private void stop() {
+      server.stop(0);
+    }
+  }
+
+  /** Creates daemon worker threads so loopback app listeners cannot keep node shutdown alive. */
+  private static final class DaemonThreadFactory implements ThreadFactory {
+    @Override
+    public Thread newThread(@NotNull Runnable runnable) {
+      Thread thread = new Thread(runnable, "Cryptad-AppUi-Origin");
+      thread.setDaemon(true);
+      return thread;
+    }
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -16,6 +17,7 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -26,6 +28,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import network.crypta.platform.api.PlatformApiPaths;
+import network.crypta.platform.api.json.PlatformApiJsonWriter;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
@@ -66,7 +69,9 @@ import org.slf4j.LoggerFactory;
  * <p>Bootstrap JSON is guarded by a short-lived launch nonce. The nonce is placed in the Web Shell
  * launch URL fragment and must be echoed in {@value #BOOTSTRAP_NONCE_HEADER}; ordinary local
  * processes that can reach the loopback port do not receive a browser-session token without that
- * launch proof.
+ * launch proof. A separate token-free origin probe allows Web Shell to check whether the current
+ * browser can actually reach the loopback listener before it asks the admin compatibility route for
+ * a nonce-bearing launch redirect.
  *
  * @see AppUiOriginRegistry
  * @see AppUiOriginBinding
@@ -94,6 +99,11 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
    */
   static final String BOOTSTRAP_NONCE_FRAGMENT_PARAMETER = "cryptadBootstrapNonce";
 
+  /**
+   * Token-free metadata endpoint used by Web Shell to confirm browser reachability before launch.
+   */
+  static final String ORIGIN_PROBE_PATH = "/.well-known/cryptad-origin.json";
+
   private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
   private static final String TEXT_CONTENT_TYPE = "text/plain";
 
@@ -101,6 +111,7 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
   private final AppStaticAssetService assetService;
   private final AppUiBootstrapService bootstrapService;
   private final BootstrapNonceStore bootstrapNonces = new BootstrapNonceStore();
+  private final URI adminRootUri;
   private final String platformApiRoot;
   private final String shellRoot;
   private final BooleanSupplier javascriptEnabled;
@@ -131,6 +142,7 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
     this.assetService = new AppStaticAssetService(appHost);
     this.bootstrapService = new AppUiBootstrapService(appHost, sessionIssuer);
     String normalizedAdminRoot = normalizeAdminRoot(adminRoot);
+    this.adminRootUri = parseAdminRoot(normalizedAdminRoot);
     this.platformApiRoot = appendRootPath(normalizedAdminRoot, PlatformApiPaths.API_V1_PREFIX);
     this.shellRoot = appendRootPath(normalizedAdminRoot, WebShellPaths.SHELL_ROOT);
     this.javascriptEnabled = Objects.requireNonNull(javascriptEnabled, "javascriptEnabled");
@@ -302,6 +314,10 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
       return;
     }
     AppUiOriginBinding binding = refreshed.binding().get();
+    if (ORIGIN_PROBE_PATH.equals(exchange.getRequestURI().getRawPath())) {
+      writeOriginProbe(exchange, binding, includeBody);
+      return;
+    }
     String adminPath = toAdminAppPath(binding.appId(), exchange.getRequestURI().getRawPath());
     try {
       if (AppUiBootstrapService.isBootstrapRequest(adminPath)) {
@@ -367,6 +383,22 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
     sendBytes(exchange, 200, appHeaders(binding), body, JSON_CONTENT_TYPE, true);
   }
 
+  private void writeOriginProbe(
+      HttpExchange exchange, AppUiOriginBinding binding, boolean includeBody) throws IOException {
+    Map<String, Object> body = LinkedHashMap.newLinkedHashMap(4);
+    body.put("appId", binding.appId());
+    body.put("uiOrigin", binding.origin());
+    body.put("uiOriginMode", binding.mode().jsonValue());
+    body.put("uiOriginStatus", binding.status().jsonValue());
+    sendBytes(
+        exchange,
+        200,
+        originProbeHeaders(exchange),
+        PlatformApiJsonWriter.write(body).getBytes(StandardCharsets.UTF_8),
+        JSON_CONTENT_TYPE,
+        includeBody);
+  }
+
   private void writeAsset(
       HttpExchange exchange, AppUiOriginBinding binding, AppStaticAsset asset, boolean includeBody)
       throws IOException {
@@ -393,6 +425,46 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
     }
     headers.add("cache-control", "no-store");
     return headers;
+  }
+
+  private Headers originProbeHeaders(HttpExchange exchange) {
+    Headers headers = new Headers();
+    allowedAdminCorsOrigin(exchange)
+        .ifPresent(
+            origin -> {
+              headers.add("access-control-allow-origin", origin);
+              headers.add("vary", "Origin");
+            });
+    headers.add("cache-control", "no-store");
+    return headers;
+  }
+
+  private Optional<String> allowedAdminCorsOrigin(HttpExchange exchange) {
+    String origin = exchange.getRequestHeaders().getFirst("Origin");
+    if (origin == null || origin.isBlank()) {
+      return Optional.empty();
+    }
+    try {
+      URI originUri = URI.create(origin.trim());
+      String rawPath = originUri.getRawPath();
+      if ((rawPath != null && !rawPath.isEmpty())
+          || originUri.getRawQuery() != null
+          || originUri.getRawFragment() != null) {
+        return Optional.empty();
+      }
+      if (!Objects.equals(adminRootUri.getScheme(), originUri.getScheme())) {
+        return Optional.empty();
+      }
+      if (!localAdminHost(originUri.getHost())) {
+        return Optional.empty();
+      }
+      if (effectivePort(originUri) != effectivePort(adminRootUri)) {
+        return Optional.empty();
+      }
+      return Optional.of(origin.trim());
+    } catch (IllegalArgumentException exception) {
+      return Optional.empty();
+    }
   }
 
   private boolean validBootstrapProof(AppUiOriginBinding binding, HttpExchange exchange) {
@@ -505,6 +577,15 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
     return value.endsWith("/") ? value : value + "/";
   }
 
+  private static URI parseAdminRoot(String adminRoot) {
+    URI uri = URI.create(adminRoot);
+    if (uri.getScheme() == null || uri.getHost() == null || effectivePort(uri) < 0) {
+      throw new IllegalArgumentException(
+          "adminRoot must include an HTTP(S) scheme, host, and port");
+    }
+    return uri;
+  }
+
   private static String appendRootPath(String root, String path) {
     String relativePath = path.startsWith("/") ? path.substring(1) : path;
     return root + relativePath;
@@ -512,6 +593,24 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
 
   private static InetAddress advertisedLoopbackAddress() throws IOException {
     return InetAddress.getByAddress(new byte[] {127, 0, 0, 1});
+  }
+
+  private static boolean localAdminHost(String host) {
+    return AppUiOrigin.LOOPBACK_HOST.equals(host) || "localhost".equalsIgnoreCase(host);
+  }
+
+  private static int effectivePort(URI uri) {
+    int explicitPort = uri.getPort();
+    if (explicitPort >= 0) {
+      return explicitPort;
+    }
+    if ("http".equalsIgnoreCase(uri.getScheme())) {
+      return 80;
+    }
+    if ("https".equalsIgnoreCase(uri.getScheme())) {
+      return 443;
+    }
+    return -1;
   }
 
   private static String appendBootstrapNonceFragment(String url, String nonce) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiLoopbackOriginServer.java
@@ -34,6 +34,7 @@ import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.appui.AppBrowserSessionIssuer;
+import network.crypta.platform.appui.AppBrowserSessionStore;
 import network.crypta.platform.appui.AppStaticAsset;
 import network.crypta.platform.appui.AppStaticAssetException;
 import network.crypta.platform.appui.AppStaticAssetService;
@@ -80,8 +81,11 @@ final class AppUiLoopbackOriginServer implements AppUiOriginRegistry, AutoClosea
   private static final Logger LOG = LoggerFactory.getLogger(AppUiLoopbackOriginServer.class);
   private static final int BACKLOG = 16;
   private static final int BOOTSTRAP_NONCE_BYTES = 32;
+  // A launch proof must outlive one browser-session window so long-lived tabs can renew sessions.
+  private static final int BOOTSTRAP_NONCE_SESSION_WINDOWS = 8;
   static final int MAX_BOOTSTRAP_NONCES_PER_APP = 16;
-  private static final Duration BOOTSTRAP_NONCE_LIFETIME = Duration.ofHours(1);
+  static final Duration BOOTSTRAP_NONCE_LIFETIME =
+      AppBrowserSessionStore.DEFAULT_LIFETIME.multipliedBy(BOOTSTRAP_NONCE_SESSION_WINDOWS);
 
   /**
    * Request header that carries the Web Shell launch proof for isolated bootstrap fetches.

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiToadlet.java
@@ -29,13 +29,16 @@ import network.crypta.support.io.FileBucket;
 /**
  * Legacy HTTP bridge for app-owned static browser UI routes.
  *
- * <p>The toadlet preserves the legacy {@code /apps/{appId}/} compatibility route while redirecting
- * app roots to isolated loopback origins when a binding is active. It keeps the legacy HTTP
- * transport details out of the reusable app UI resolver and performs the checks that depend on the
- * current HTTP context, such as full-access authorization, method-specific body handling, redirect
- * responses, and conversion from platform security-header maps into the legacy {@link
- * MultiValueTable} representation. Filesystem confinement, AppHost lookup, manifest-mode filtering,
- * content-type selection, and symlink rejection stay in {@link AppStaticAssetService}.
+ * <p>The toadlet preserves the legacy {@code /apps/{appId}/} compatibility route as an explicit
+ * same-origin fallback. Web Shell can request an isolated launch after proving that the per-app
+ * loopback origin is reachable from the current browser, but ordinary compatibility links stay on
+ * the admin origin so remote, proxied, container-mapped, and tunneled sessions do not receive
+ * client-local {@code 127.0.0.1} redirects. The adapter keeps the legacy HTTP transport details out
+ * of the reusable app UI resolver and performs the checks that depend on the current HTTP context,
+ * such as full-access authorization, method-specific body handling, redirect responses, and
+ * conversion from platform security-header maps into the legacy {@link MultiValueTable}
+ * representation. Filesystem confinement, AppHost lookup, manifest-mode filtering, content-type
+ * selection, and symlink rejection stay in {@link AppStaticAssetService}.
  *
  * <p>Responses use the normal dynamic header path rather than the legacy public static-file helper.
  * The route is stable across app updates, so month-long public caching would otherwise leave
@@ -59,13 +62,16 @@ public final class AppUiToadlet extends Toadlet {
   /** JSON media type used for dynamic first-party static UI bootstrap metadata. */
   private static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
 
+  /** Internal query parameter used by Web Shell after browser-side isolated-origin probing. */
+  private static final String ISOLATED_LAUNCH_PARAMETER = "cryptadIsolatedLaunch";
+
   /** Request-scoped resolver that keeps AppHost and filesystem validation outside this adapter. */
   private final AppStaticAssetService assetService;
 
   /** Request-scoped resolver for the reserved dynamic bootstrap resource. */
   private final AppUiBootstrapService bootstrapService;
 
-  /** Optional registry used to redirect static app roots to isolated loopback origins. */
+  /** Optional registry used for explicit isolated loopback launches. */
   private final AppUiOriginRegistry appUiOriginRegistry;
 
   /**
@@ -202,14 +208,19 @@ public final class AppUiToadlet extends Toadlet {
         return;
       }
       Optional<AppUiOriginBinding> isolatedBinding = isolatedBindingFor(requestPath);
-      if (isolatedBinding.isPresent() && AppUiRoute.parse(requestPath).assetPath() == null) {
+      if (isolatedBinding.isPresent()
+          && AppUiRoute.parse(requestPath).assetPath() == null
+          && isolatedLaunchRequested(uri)) {
         String launchUrl =
             includeBody
                 ? appUiOriginRegistry
                     .launchUrlForApp(isolatedBinding.get().appId())
                     .orElse(isolatedBinding.get().uiUrl())
                 : isolatedBinding.get().uiUrl();
-        writeRedirect(ctx, appendRawQuery(launchUrl, uri.getRawQuery()), includeBody);
+        writeRedirect(
+            ctx,
+            appendRawQuery(launchUrl, rawQueryWithoutIsolatedLaunch(uri.getRawQuery())),
+            includeBody);
         return;
       }
       Optional<String> canonicalRootRedirect = assetService.canonicalRootRedirect(requestPath);
@@ -423,6 +434,59 @@ public final class AppUiToadlet extends Toadlet {
     return appUiOriginRegistry
         .bindingForApp(route.appId())
         .filter(AppUiOriginBinding::isolatedAndActive);
+  }
+
+  private static boolean isolatedLaunchRequested(URI uri) {
+    return rawQueryContainsParameter(uri.getRawQuery(), ISOLATED_LAUNCH_PARAMETER);
+  }
+
+  private static boolean rawQueryContainsParameter(String rawQuery, String expectedParameterName) {
+    if (rawQuery == null || rawQuery.isBlank()) {
+      return false;
+    }
+    int start = 0;
+    while (start <= rawQuery.length()) {
+      int ampersand = rawQuery.indexOf('&', start);
+      String part =
+          ampersand < 0 ? rawQuery.substring(start) : rawQuery.substring(start, ampersand);
+      if (expectedParameterName.equals(parameterName(part))) {
+        return true;
+      }
+      if (ampersand < 0) {
+        return false;
+      }
+      start = ampersand + 1;
+    }
+    return false;
+  }
+
+  private static String rawQueryWithoutIsolatedLaunch(String rawQuery) {
+    if (rawQuery == null || rawQuery.isBlank()) {
+      return null;
+    }
+    StringBuilder kept = new StringBuilder();
+    int start = 0;
+    while (start <= rawQuery.length()) {
+      int ampersand = rawQuery.indexOf('&', start);
+      String part =
+          ampersand < 0 ? rawQuery.substring(start) : rawQuery.substring(start, ampersand);
+      if (!ISOLATED_LAUNCH_PARAMETER.equals(parameterName(part))) {
+        if (!kept.isEmpty()) {
+          kept.append('&');
+        }
+        kept.append(part);
+      }
+      if (ampersand < 0) {
+        break;
+      }
+      start = ampersand + 1;
+    }
+    return kept.isEmpty() ? null : kept.toString();
+  }
+
+  private static String parameterName(String rawQueryPart) {
+    int equals = rawQueryPart.indexOf('=');
+    return equals < 0 ? rawQueryPart : rawQueryPart.substring(0, equals);
   }
 
   private AppUiOriginBinding fallbackBinding(String requestPath) throws AppStaticAssetException {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/AppUiToadlet.java
@@ -16,6 +16,8 @@ import network.crypta.platform.appui.AppStaticAssetService;
 import network.crypta.platform.appui.AppUiBootstrap;
 import network.crypta.platform.appui.AppUiBootstrapJson;
 import network.crypta.platform.appui.AppUiBootstrapService;
+import network.crypta.platform.appui.AppUiOriginBinding;
+import network.crypta.platform.appui.AppUiOriginRegistry;
 import network.crypta.platform.appui.AppUiPaths;
 import network.crypta.platform.appui.AppUiRoute;
 import network.crypta.platform.appui.AppUiSecurityHeaders;
@@ -27,12 +29,13 @@ import network.crypta.support.io.FileBucket;
 /**
  * Legacy HTTP bridge for app-owned static browser UI routes.
  *
- * <p>The toadlet serves installed static app UIs under {@code /apps/{appId}/} while keeping the
- * legacy HTTP transport details out of the reusable app UI resolver. It performs the checks that
- * depend on the current HTTP context, such as full-access authorization, method-specific body
- * handling, redirect responses, and conversion from platform security-header maps into the legacy
- * {@link MultiValueTable} representation. Filesystem confinement, AppHost lookup, manifest-mode
- * filtering, content-type selection, and symlink rejection stay in {@link AppStaticAssetService}.
+ * <p>The toadlet preserves the legacy {@code /apps/{appId}/} compatibility route while redirecting
+ * app roots to isolated loopback origins when a binding is active. It keeps the legacy HTTP
+ * transport details out of the reusable app UI resolver and performs the checks that depend on the
+ * current HTTP context, such as full-access authorization, method-specific body handling, redirect
+ * responses, and conversion from platform security-header maps into the legacy {@link
+ * MultiValueTable} representation. Filesystem confinement, AppHost lookup, manifest-mode filtering,
+ * content-type selection, and symlink rejection stay in {@link AppStaticAssetService}.
  *
  * <p>Responses use the normal dynamic header path rather than the legacy public static-file helper.
  * The route is stable across app updates, so month-long public caching would otherwise leave
@@ -62,6 +65,9 @@ public final class AppUiToadlet extends Toadlet {
   /** Request-scoped resolver for the reserved dynamic bootstrap resource. */
   private final AppUiBootstrapService bootstrapService;
 
+  /** Optional registry used to redirect static app roots to isolated loopback origins. */
+  private final AppUiOriginRegistry appUiOriginRegistry;
+
   /**
    * Creates an app UI toadlet backed by the shared AppHost.
    *
@@ -77,7 +83,17 @@ public final class AppUiToadlet extends Toadlet {
   }
 
   AppUiToadlet(AppHost appHost, AppBrowserSessionIssuer sessionIssuer) {
-    this(new AppStaticAssetService(appHost), new AppUiBootstrapService(appHost, sessionIssuer));
+    this(appHost, sessionIssuer, AppUiOriginRegistry.sameOriginOnly());
+  }
+
+  AppUiToadlet(
+      AppHost appHost,
+      AppBrowserSessionIssuer sessionIssuer,
+      AppUiOriginRegistry appUiOriginRegistry) {
+    this(
+        new AppStaticAssetService(appHost),
+        new AppUiBootstrapService(appHost, sessionIssuer),
+        appUiOriginRegistry);
   }
 
   /**
@@ -101,8 +117,16 @@ public final class AppUiToadlet extends Toadlet {
    * @param bootstrapService resolver used for the reserved bootstrap resource, or {@code null}
    */
   AppUiToadlet(AppStaticAssetService assetService, AppUiBootstrapService bootstrapService) {
+    this(assetService, bootstrapService, AppUiOriginRegistry.sameOriginOnly());
+  }
+
+  AppUiToadlet(
+      AppStaticAssetService assetService,
+      AppUiBootstrapService bootstrapService,
+      AppUiOriginRegistry appUiOriginRegistry) {
     this.assetService = Objects.requireNonNull(assetService, "assetService");
     this.bootstrapService = bootstrapService;
+    this.appUiOriginRegistry = Objects.requireNonNull(appUiOriginRegistry, "appUiOriginRegistry");
   }
 
   /** {@inheritDoc} */
@@ -177,6 +201,17 @@ public final class AppUiToadlet extends Toadlet {
         writeBootstrap(ctx, requestPath, includeBody);
         return;
       }
+      Optional<AppUiOriginBinding> isolatedBinding = isolatedBindingFor(requestPath);
+      if (isolatedBinding.isPresent() && AppUiRoute.parse(requestPath).assetPath() == null) {
+        String launchUrl =
+            includeBody
+                ? appUiOriginRegistry
+                    .launchUrlForApp(isolatedBinding.get().appId())
+                    .orElse(isolatedBinding.get().uiUrl())
+                : isolatedBinding.get().uiUrl();
+        writeRedirect(ctx, appendRawQuery(launchUrl, uri.getRawQuery()), includeBody);
+        return;
+      }
       Optional<String> canonicalRootRedirect = assetService.canonicalRootRedirect(requestPath);
       if (canonicalRootRedirect.isPresent()) {
         writeRedirect(
@@ -201,9 +236,9 @@ public final class AppUiToadlet extends Toadlet {
   /**
    * Writes the reserved dynamic app UI bootstrap resource.
    *
-   * <p>The bootstrap exposes route roots and a browser-scoped app session token for same-origin
-   * first-party static UIs. It deliberately does not expose AppHost launch tokens, local-admin form
-   * passwords, or installed filesystem paths.
+   * <p>The bootstrap exposes fallback route roots and a browser-scoped app session token for
+   * explicit same-origin compatibility loading. It deliberately does not expose AppHost launch
+   * tokens, local-admin form passwords, or installed filesystem paths.
    *
    * @param ctx response context that receives headers and body bytes
    * @param requestPath raw app UI request path
@@ -223,7 +258,10 @@ public final class AppUiToadlet extends Toadlet {
     }
     Optional<AppUiBootstrap> bootstrap =
         bootstrapService.resolve(
-            requestPath, PlatformApiPaths.API_V1_PREFIX, WebShellPaths.SHELL_ROOT);
+            requestPath,
+            PlatformApiPaths.API_V1_PREFIX,
+            WebShellPaths.SHELL_ROOT,
+            fallbackBinding(requestPath));
     if (bootstrap.isEmpty()) {
       sendError(ctx, 404, NOT_FOUND_REASON, BOOTSTRAP_NOT_FOUND_MESSAGE, true);
       return;
@@ -342,7 +380,7 @@ public final class AppUiToadlet extends Toadlet {
   /**
    * Converts platform security headers into the legacy multi-value response table.
    *
-   * @param javascriptEnabled whether app-owned same-origin scripts may execute
+   * @param javascriptEnabled whether app-owned scripts may execute
    * @return response headers for app-owned static UI assets
    */
   private static MultiValueTable<String, String> responseHeaders(boolean javascriptEnabled) {
@@ -369,7 +407,31 @@ public final class AppUiToadlet extends Toadlet {
    * @return path with the original query attached when one was present
    */
   private static String appendRawQuery(String path, String rawQuery) {
-    return rawQuery == null ? path : path + "?" + rawQuery;
+    if (rawQuery == null) {
+      return path;
+    }
+    int fragmentIndex = path.indexOf('#');
+    if (fragmentIndex < 0) {
+      return path + "?" + rawQuery;
+    }
+    return path.substring(0, fragmentIndex) + "?" + rawQuery + path.substring(fragmentIndex);
+  }
+
+  private Optional<AppUiOriginBinding> isolatedBindingFor(String requestPath)
+      throws AppStaticAssetException {
+    AppUiRoute route = AppUiRoute.parse(requestPath);
+    return appUiOriginRegistry
+        .bindingForApp(route.appId())
+        .filter(AppUiOriginBinding::isolatedAndActive);
+  }
+
+  private AppUiOriginBinding fallbackBinding(String requestPath) throws AppStaticAssetException {
+    AppUiRoute route = AppUiRoute.parse(requestPath);
+    return appUiOriginRegistry
+        .bindingForApp(route.appId())
+        .filter(binding -> !binding.isolatedAndActive())
+        .filter(binding -> binding.uiRoot() != null && binding.assetRoot() != null)
+        .orElse(null);
   }
 
   /**

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -9,7 +9,6 @@ import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.appui.AppBrowserSessionStore;
-import network.crypta.platform.appui.AppUiOrigin;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -329,7 +328,7 @@ final class FProxyRegistrar {
         new AppUiLoopbackOriginServer(
             dependencies.appHost(),
             appBrowserSessionStore,
-            server.getURL(AppUiOrigin.LOOPBACK_HOST),
+            server.getLocalAdminURL(),
             server::isFProxyJavascriptEnabled);
     Runtime.getRuntime()
         .addShutdownHook(new Thread(appUiOriginServer::close, "Cryptad-AppUi-Origin-Shutdown"));

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -9,6 +9,7 @@ import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.appui.AppBrowserSessionStore;
+import network.crypta.platform.appui.AppUiOrigin;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.runtime.spi.TransferAccessPort;
@@ -324,7 +325,16 @@ final class FProxyRegistrar {
 
     AppBrowserSessionStore appBrowserSessionStore =
         new AppBrowserSessionStore(dependencies.appHost());
-    AppUiToadlet appUiToadlet = new AppUiToadlet(dependencies.appHost(), appBrowserSessionStore);
+    AppUiLoopbackOriginServer appUiOriginServer =
+        new AppUiLoopbackOriginServer(
+            dependencies.appHost(),
+            appBrowserSessionStore,
+            server.getURL(AppUiOrigin.LOOPBACK_HOST),
+            server::isFProxyJavascriptEnabled);
+    Runtime.getRuntime()
+        .addShutdownHook(new Thread(appUiOriginServer::close, "Cryptad-AppUi-Origin-Shutdown"));
+    AppUiToadlet appUiToadlet =
+        new AppUiToadlet(dependencies.appHost(), appBrowserSessionStore, appUiOriginServer);
     server.register(appUiToadlet, ToadletRegistration.basic(null, appUiToadlet.path(), true, true));
 
     PlatformApiToadlet platformApiToadlet =
@@ -332,7 +342,8 @@ final class FProxyRegistrar {
             runtimePorts,
             dependencies.appHost(),
             dependencies.appCatalogManager(),
-            appBrowserSessionStore);
+            appBrowserSessionStore,
+            appUiOriginServer);
     server.register(
         platformApiToadlet,
         ToadletRegistration.basic(null, PlatformApiToadlet.MOUNT_PATH, true, true));

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -20,6 +20,9 @@ import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppTokenPrincipal;
 import network.crypta.platform.appui.AppBrowserSession;
 import network.crypta.platform.appui.AppBrowserSessionVerifier;
+import network.crypta.platform.appui.AppUiOriginBinding;
+import network.crypta.platform.appui.AppUiOriginMode;
+import network.crypta.platform.appui.AppUiOriginRegistry;
 import network.crypta.runtime.spi.RuntimePorts;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.URLDecoder;
@@ -59,6 +62,20 @@ public final class PlatformApiToadlet extends Toadlet {
   private static final String APP_TOKEN_HEADER = "x-crypta-app-token";
   private static final String APP_SESSION_HEADER = "x-crypta-app-session";
   private static final String AUTHORIZATION_HEADER = "authorization";
+  private static final String ORIGIN_HEADER = "origin";
+  private static final String ACCESS_CONTROL_REQUEST_METHOD_HEADER =
+      "access-control-request-method";
+  private static final String ACCESS_CONTROL_REQUEST_HEADERS_HEADER =
+      "access-control-request-headers";
+  private static final String ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = "Access-Control-Allow-Origin";
+  private static final String ACCESS_CONTROL_ALLOW_METHODS_HEADER = "Access-Control-Allow-Methods";
+  private static final String ACCESS_CONTROL_ALLOW_HEADERS_HEADER = "Access-Control-Allow-Headers";
+  private static final String ACCESS_CONTROL_MAX_AGE_HEADER = "Access-Control-Max-Age";
+  private static final String VARY_HEADER = "Vary";
+  private static final String ALLOWED_CORS_METHODS = "GET, POST, DELETE";
+  private static final String ALLOWED_CORS_HEADERS = "X-Crypta-App-Session, Accept, Content-Type";
+  private static final String CORS_VARY_VALUE =
+      "Origin, Access-Control-Request-Method, Access-Control-Request-Headers";
   private static final String BEARER_PREFIX = "bearer";
   private static final String DELETE_METHOD = "DELETE";
   private static final String ALERTS_SEGMENT = "alerts";
@@ -83,6 +100,9 @@ public final class PlatformApiToadlet extends Toadlet {
   /** Optional verifier used to authenticate browser-originated app sessions. */
   private final AppBrowserSessionVerifier appBrowserSessionVerifier;
 
+  /** Registry of isolated app UI origins allowed to use browser-session CORS. */
+  private final AppUiOriginRegistry appUiOriginRegistry;
+
   /**
    * Creates a platform API toadlet backed by the supplied runtime ports.
    *
@@ -92,7 +112,8 @@ public final class PlatformApiToadlet extends Toadlet {
     this(
         new PlatformApiRouter(runtimePorts, null, null, LegacyAdminUsageRecorder.defaultRecorder()),
         null,
-        null);
+        null,
+        AppUiOriginRegistry.sameOriginOnly());
   }
 
   /**
@@ -106,7 +127,8 @@ public final class PlatformApiToadlet extends Toadlet {
         new PlatformApiRouter(
             runtimePorts, appHost, null, LegacyAdminUsageRecorder.defaultRecorder()),
         appHost,
-        null);
+        null,
+        AppUiOriginRegistry.sameOriginOnly());
   }
 
   /**
@@ -122,7 +144,8 @@ public final class PlatformApiToadlet extends Toadlet {
         new PlatformApiRouter(
             runtimePorts, appHost, appCatalogManager, LegacyAdminUsageRecorder.defaultRecorder()),
         appHost,
-        null);
+        null,
+        AppUiOriginRegistry.sameOriginOnly());
   }
 
   /**
@@ -140,10 +163,39 @@ public final class PlatformApiToadlet extends Toadlet {
       AppCatalogManager appCatalogManager,
       AppBrowserSessionVerifier appBrowserSessionVerifier) {
     this(
-        new PlatformApiRouter(
-            runtimePorts, appHost, appCatalogManager, LegacyAdminUsageRecorder.defaultRecorder()),
+        runtimePorts,
         appHost,
-        appBrowserSessionVerifier);
+        appCatalogManager,
+        appBrowserSessionVerifier,
+        AppUiOriginRegistry.sameOriginOnly());
+  }
+
+  /**
+   * Creates a platform API toadlet backed by runtime ports, AppHost, signed catalogs, browser
+   * sessions, and app UI origin metadata.
+   *
+   * @param runtimePorts detached runtime ports exposed to the platform API leaf
+   * @param appHost detached AppHost exposed through app lifecycle and catalog install routes
+   * @param appCatalogManager signed app-catalog manager exposed through catalog routes
+   * @param appBrowserSessionVerifier verifier shared with the app-owned UI bootstrap route
+   * @param appUiOriginRegistry registry of active isolated app UI origins
+   */
+  public PlatformApiToadlet(
+      RuntimePorts runtimePorts,
+      AppHost appHost,
+      AppCatalogManager appCatalogManager,
+      AppBrowserSessionVerifier appBrowserSessionVerifier,
+      AppUiOriginRegistry appUiOriginRegistry) {
+    this(
+        new PlatformApiRouter(
+            runtimePorts,
+            appHost,
+            appCatalogManager,
+            LegacyAdminUsageRecorder.defaultRecorder(),
+            appUiOriginRegistry),
+        appHost,
+        appBrowserSessionVerifier,
+        appUiOriginRegistry);
   }
 
   /**
@@ -167,10 +219,19 @@ public final class PlatformApiToadlet extends Toadlet {
       PlatformApiRouter router,
       AppHost appHost,
       AppBrowserSessionVerifier appBrowserSessionVerifier) {
+    this(router, appHost, appBrowserSessionVerifier, AppUiOriginRegistry.sameOriginOnly());
+  }
+
+  PlatformApiToadlet(
+      PlatformApiRouter router,
+      AppHost appHost,
+      AppBrowserSessionVerifier appBrowserSessionVerifier,
+      AppUiOriginRegistry appUiOriginRegistry) {
     super();
     this.router = Objects.requireNonNull(router, "router");
     this.appHost = appHost;
     this.appBrowserSessionVerifier = appBrowserSessionVerifier;
+    this.appUiOriginRegistry = Objects.requireNonNull(appUiOriginRegistry, "appUiOriginRegistry");
   }
 
   @Override
@@ -226,6 +287,11 @@ public final class PlatformApiToadlet extends Toadlet {
    */
   public void handleMethodOPTIONS(URI uri, HTTPRequest request, ToadletContext ctx)
       throws ToadletContextClosedException, IOException {
+    CorsRequest cors = CorsRequest.from(request);
+    if (cors.preflight()) {
+      writeCorsPreflightResponse(cors, ctx);
+      return;
+    }
     writePlatformApiResponse("OPTIONS", uri, request, ctx);
   }
 
@@ -345,8 +411,9 @@ public final class PlatformApiToadlet extends Toadlet {
       String method, URI uri, HTTPRequest request, ToadletContext ctx, boolean includeBody)
       throws ToadletContextClosedException, IOException {
     PlatformApiResponse response;
+    CorsRequest cors = CorsRequest.from(request);
     try {
-      response = resolveAndRoutePlatformApiRequest(method, uri, request, ctx);
+      response = resolveAndRoutePlatformApiRequest(method, uri, request, ctx, cors);
     } catch (URLEncodedFormatException _) {
       response =
           PlatformApiResponse.error(
@@ -361,7 +428,7 @@ public final class PlatformApiToadlet extends Toadlet {
     if (response == null) {
       return;
     }
-    writeJsonReply(ctx, response, includeBody);
+    writeJsonReply(ctx, responseWithCors(response, cors), includeBody);
   }
 
   /**
@@ -382,9 +449,9 @@ public final class PlatformApiToadlet extends Toadlet {
    * @throws URLEncodedFormatException if the request path contains malformed percent-encoding
    */
   private PlatformApiResponse resolveAndRoutePlatformApiRequest(
-      String method, URI uri, HTTPRequest request, ToadletContext ctx)
+      String method, URI uri, HTTPRequest request, ToadletContext ctx, CorsRequest cors)
       throws ToadletContextClosedException, IOException, URLEncodedFormatException {
-    PrincipalResolution principalResolution = resolvePrincipal(request);
+    PrincipalResolution principalResolution = resolvePrincipal(request, cors);
     if (principalResolution.failureResponse() != null) {
       return principalResolution.failureResponse();
     }
@@ -706,7 +773,7 @@ public final class PlatformApiToadlet extends Toadlet {
         method, relativeApiPath(requestPath(uri)), queryParameters, principal);
   }
 
-  private PrincipalResolution resolvePrincipal(HTTPRequest request) {
+  private PrincipalResolution resolvePrincipal(HTTPRequest request, CorsRequest cors) {
     String directToken = directAppTokenFromHeader(request);
     if (directToken != null) {
       return authenticateExplicitAppToken(directToken);
@@ -722,7 +789,12 @@ public final class PlatformApiToadlet extends Toadlet {
 
     String browserSessionToken = appSessionFromHeader(request);
     if (browserSessionToken != null) {
-      return authenticateBrowserSession(browserSessionToken);
+      return authenticateBrowserSession(browserSessionToken, cors);
+    }
+    if (cors.fromRegisteredAppOrigin(appUiOriginRegistry)) {
+      cors.allowIfRegistered(cors.origin(), appUiOriginRegistry);
+      return unauthenticatedAppBrowserSession(
+          "App browser session is required for app-origin Platform API requests.");
     }
     return hostOperatorPrincipal();
   }
@@ -789,19 +861,76 @@ public final class PlatformApiToadlet extends Toadlet {
         PlatformApiPrincipal.appToken(principal.appId(), principal.permissions()), null);
   }
 
-  private PrincipalResolution authenticateBrowserSession(String token) {
+  private PrincipalResolution authenticateBrowserSession(String token, CorsRequest cors) {
     if (appBrowserSessionVerifier == null) {
       return unauthenticatedAppBrowserSession("App browser session authentication is unavailable.");
     }
     Optional<AppBrowserSession> session = appBrowserSessionVerifier.verify(token);
+    if (session.isEmpty()) {
+      cors.allowIfRegistered(cors.origin(), appUiOriginRegistry);
+      return unauthenticatedAppBrowserSession("Invalid app browser session.");
+    }
     return session
-        .map(PlatformApiToadlet::appBrowserSessionPrincipal)
+        .map(value -> appBrowserSessionPrincipal(value, cors))
         .orElseGet(() -> unauthenticatedAppBrowserSession("Invalid app browser session."));
   }
 
-  private static PrincipalResolution appBrowserSessionPrincipal(AppBrowserSession session) {
+  private PrincipalResolution appBrowserSessionPrincipal(
+      AppBrowserSession session, CorsRequest cors) {
+    PrincipalResolution originFailure = validateBrowserSessionOrigin(session, cors);
+    if (originFailure != null) {
+      return originFailure;
+    }
+    cors.allowIfRegistered(session.expectedOrigin(), appUiOriginRegistry);
     return new PrincipalResolution(
-        PlatformApiPrincipal.appBrowserSession(session.appId(), session.permissions()), null);
+        PlatformApiPrincipal.appBrowserSession(
+            session.appId(), session.permissions(), session.expectedOrigin(), session.originMode()),
+        null);
+  }
+
+  private PrincipalResolution validateBrowserSessionOrigin(
+      AppBrowserSession session, CorsRequest cors) {
+    if (session.originMode() == AppUiOriginMode.ISOLATED_LOOPBACK) {
+      if (requestOriginDiffersFromSession(session, cors)) {
+        cors.allowIfRegistered(cors.origin(), appUiOriginRegistry);
+        return originMismatch("App browser session origin does not match the request origin.");
+      }
+      Optional<AppUiOriginBinding> binding = appUiOriginRegistry.bindingForOrigin(cors.origin());
+      if (binding.isEmpty()
+          || !binding.get().appId().equals(session.appId())
+          || !binding.get().isolatedAndActive()) {
+        cors.allowIfRegistered(cors.origin(), appUiOriginRegistry);
+        return originMismatch("App browser origin is not currently registered for this app.");
+      }
+      return null;
+    }
+    if (cors.fromRegisteredAppOrigin(appUiOriginRegistry)) {
+      cors.allowIfRegistered(cors.origin(), appUiOriginRegistry);
+      return originMismatch(
+          "Same-origin fallback app browser session cannot be used from an isolated app origin.");
+    }
+    if (requestOriginConflictsWithFallbackSession(session, cors)) {
+      cors.allowIfRegistered(cors.origin(), appUiOriginRegistry);
+      return originMismatch("App browser session origin does not match the request origin.");
+    }
+    return null;
+  }
+
+  private static boolean requestOriginDiffersFromSession(
+      AppBrowserSession session, CorsRequest cors) {
+    return cors.origin() == null || !cors.origin().equals(session.expectedOrigin());
+  }
+
+  private static boolean requestOriginConflictsWithFallbackSession(
+      AppBrowserSession session, CorsRequest cors) {
+    return cors.origin() != null
+        && session.expectedOrigin() != null
+        && requestOriginDiffersFromSession(session, cors);
+  }
+
+  private static PrincipalResolution originMismatch(String message) {
+    return new PrincipalResolution(
+        null, PlatformApiResponse.error(403, "origin_mismatch", message));
   }
 
   private static String directAppTokenFromHeader(HTTPRequest request) {
@@ -966,6 +1095,43 @@ public final class PlatformApiToadlet extends Toadlet {
     return rawPath != null ? rawPath : uri.getPath();
   }
 
+  private void writeCorsPreflightResponse(CorsRequest cors, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    if (!cors.preflightAllowed(appUiOriginRegistry)) {
+      writeJsonReply(
+          ctx,
+          PlatformApiResponse.error(
+              403, "origin_mismatch", "App browser origin is not allowed for Platform API CORS."),
+          true);
+      return;
+    }
+    MultiValueTable<String, String> headers = new MultiValueTable<>();
+    addCorsHeaders(headers, cors.origin());
+    headers.put(ACCESS_CONTROL_MAX_AGE_HEADER, "600");
+    ctx.sendReplyHeaders(204, "No Content", headers, null, 0L, true);
+  }
+
+  private static PlatformApiResponse responseWithCors(
+      PlatformApiResponse response, CorsRequest cors) {
+    if (cors.allowedResponseOrigin() == null) {
+      return response;
+    }
+    LinkedHashMap<String, String> headers =
+        LinkedHashMap.newLinkedHashMap(response.headers().size() + 3);
+    headers.putAll(response.headers());
+    headers.put(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, cors.allowedResponseOrigin());
+    headers.put(VARY_HEADER, "Origin");
+    return new PlatformApiResponse(
+        response.statusCode(), response.reasonPhrase(), headers, response.body());
+  }
+
+  private static void addCorsHeaders(MultiValueTable<String, String> headers, String origin) {
+    headers.put(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER, origin);
+    headers.put(VARY_HEADER, CORS_VARY_VALUE);
+    headers.put(ACCESS_CONTROL_ALLOW_METHODS_HEADER, ALLOWED_CORS_METHODS);
+    headers.put(ACCESS_CONTROL_ALLOW_HEADERS_HEADER, ALLOWED_CORS_HEADERS);
+  }
+
   /**
    * Writes the Platform API response back through the legacy HTTP shell.
    *
@@ -1001,5 +1167,98 @@ public final class PlatformApiToadlet extends Toadlet {
         replyHeaders.headers(),
         replyHeaders.mimeType(),
         body.length);
+  }
+
+  private static final class CorsRequest {
+    private final String origin;
+    private final String requestedMethod;
+    private final String requestedHeaders;
+    private String allowedResponseOrigin;
+
+    private CorsRequest(String origin, String requestedMethod, String requestedHeaders) {
+      this.origin = normalizedHeader(origin);
+      this.requestedMethod = normalizedHeader(requestedMethod);
+      this.requestedHeaders = normalizedHeader(requestedHeaders);
+    }
+
+    private static CorsRequest from(HTTPRequest request) {
+      return new CorsRequest(
+          request.getHeader(ORIGIN_HEADER),
+          request.getHeader(ACCESS_CONTROL_REQUEST_METHOD_HEADER),
+          request.getHeader(ACCESS_CONTROL_REQUEST_HEADERS_HEADER));
+    }
+
+    private String origin() {
+      return origin;
+    }
+
+    private String allowedResponseOrigin() {
+      return allowedResponseOrigin;
+    }
+
+    private boolean preflight() {
+      return origin != null && requestedMethod != null;
+    }
+
+    private boolean preflightAllowed(AppUiOriginRegistry registry) {
+      return registry.isRegisteredOrigin(origin)
+          && allowedCorsMethod(requestedMethod)
+          && allowedCorsHeaders(requestedHeaders);
+    }
+
+    private boolean fromRegisteredAppOrigin(AppUiOriginRegistry registry) {
+      return origin != null && registry.isRegisteredOrigin(origin);
+    }
+
+    private void allowIfRegistered(String expectedOrigin, AppUiOriginRegistry registry) {
+      if (origin == null
+          || !origin.equals(expectedOrigin)
+          || !registry.isRegisteredOrigin(origin)) {
+        return;
+      }
+      allowedResponseOrigin = origin;
+    }
+
+    private static boolean allowedCorsMethod(String method) {
+      return "GET".equalsIgnoreCase(method)
+          || "POST".equalsIgnoreCase(method)
+          || DELETE_METHOD.equalsIgnoreCase(method);
+    }
+
+    private static boolean allowedCorsHeaders(String requestedHeaders) {
+      if (requestedHeaders == null || requestedHeaders.isBlank()) {
+        return true;
+      }
+      int start = 0;
+      while (start <= requestedHeaders.length()) {
+        int comma = requestedHeaders.indexOf(',', start);
+        String normalized =
+            (comma < 0
+                    ? requestedHeaders.substring(start)
+                    : requestedHeaders.substring(start, comma))
+                .trim();
+        if (!normalized.isEmpty() && !allowedCorsHeader(normalized)) {
+          return false;
+        }
+        if (comma < 0) {
+          break;
+        }
+        start = comma + 1;
+      }
+      return true;
+    }
+
+    private static boolean allowedCorsHeader(String header) {
+      return APP_SESSION_HEADER.equalsIgnoreCase(header)
+          || "accept".equalsIgnoreCase(header)
+          || "content-type".equalsIgnoreCase(header);
+    }
+
+    private static String normalizedHeader(String value) {
+      if (value == null || value.isBlank()) {
+        return null;
+      }
+      return value.trim();
+    }
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -10,6 +10,7 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Objects;
+import java.util.StringTokenizer;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import network.crypta.client.filter.HTMLFilterPolicy;
@@ -100,6 +101,14 @@ public final class SimpleToadletServer
   private static final String FILENAME_KEY = "filename";
   private static final String CSS_OVERRIDE_KEY = "CSSOverride";
   private static final String PASSTHROUGH_MAX_SIZE_PROGRESS_KEY = "passthroughMaxSizeProgress";
+  private static final String IPV4_LOOPBACK_HOST = "127.0.0.1";
+  private static final String IPV4_WILDCARD_HOST = "0.0.0.0";
+  private static final String IPV6_LOOPBACK_HOST = "::1";
+  private static final String IPV6_LOOPBACK_HOST_EXPANDED = "0:0:0:0:0:0:0:1";
+  private static final String IPV6_WILDCARD_HOST = "::";
+  private static final String IPV6_WILDCARD_HOST_EXPANDED = "0:0:0:0:0:0:0:0";
+  private static final String IPV6_LOOPBACK_URL_HOST = "[::1]";
+  private static final String LOCALHOST_HOST = "localhost";
 
   // Socket / Binding
   private final int port;
@@ -1998,18 +2007,72 @@ public final class SimpleToadletServer
     return getURL(null);
   }
 
+  String getLocalAdminURL() {
+    return getURL(localAdminUrlHost(bindTo));
+  }
+
   @Override
   public String getURL(String host) {
     StringBuilder sb = new StringBuilder();
     if (ssl) sb.append("https");
     else sb.append("http");
     sb.append("://");
-    if (host == null) host = "127.0.0.1";
+    if (host == null) host = IPV4_LOOPBACK_HOST;
     sb.append(host);
     sb.append(":");
     sb.append(this.port);
     sb.append("/");
     return sb.toString();
+  }
+
+  private static String localAdminUrlHost(String configuredBindTo) {
+    if (configuredBindTo == null || configuredBindTo.isBlank()) {
+      return IPV4_LOOPBACK_HOST;
+    }
+    StringTokenizer hosts = new StringTokenizer(configuredBindTo, ",");
+    boolean localhostBound = false;
+    boolean ipv6LoopbackBound = false;
+    while (hosts.hasMoreTokens()) {
+      String host = hosts.nextToken();
+      String normalizedHost = normalizeBindHost(host);
+      if (isIpv4LocalAdminBindHost(normalizedHost)) {
+        return IPV4_LOOPBACK_HOST;
+      }
+      if (LOCALHOST_HOST.equalsIgnoreCase(normalizedHost)) {
+        localhostBound = true;
+      }
+      if (isIpv6LocalAdminBindHost(normalizedHost)) {
+        ipv6LoopbackBound = true;
+      }
+    }
+    if (localhostBound) {
+      return LOCALHOST_HOST;
+    }
+    if (ipv6LoopbackBound) {
+      return IPV6_LOOPBACK_URL_HOST;
+    }
+    return IPV4_LOOPBACK_HOST;
+  }
+
+  private static String normalizeBindHost(String host) {
+    String trimmed = host == null ? "" : host.trim();
+    if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+      return trimmed.substring(1, trimmed.length() - 1);
+    }
+    return trimmed;
+  }
+
+  private static boolean isIpv4LocalAdminBindHost(String host) {
+    return IPV4_LOOPBACK_HOST.equals(host)
+        || host.startsWith("127.")
+        || IPV4_WILDCARD_HOST.equals(host);
+  }
+
+  private static boolean isIpv6LocalAdminBindHost(String host) {
+    return IPV6_LOOPBACK_HOST.equalsIgnoreCase(host)
+        || IPV6_LOOPBACK_HOST_EXPANDED.equalsIgnoreCase(host)
+        || IPV6_WILDCARD_HOST.equals(host)
+        || IPV6_WILDCARD_HOST_EXPANDED.equalsIgnoreCase(host);
   }
 
   @Override

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
@@ -64,7 +64,29 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class AppUiToadletTest {
+  private static final String ACCEPT_HEADER = "Accept";
+  private static final String ACCESS_CONTROL_ALLOW_ORIGIN_HEADER = "access-control-allow-origin";
+  private static final String ADMIN_ROOT = "http://127.0.0.1:8888/";
+  private static final String APP_BOOTSTRAP_URL =
+      "http://localhost/apps/demo-app/.well-known/cryptad-bootstrap.json";
+  private static final String APP_ID = "demo-app";
+  private static final String APP_ROOT_URL = "http://localhost/apps/demo-app/";
+  private static final String APPLICATION_JSON = "application/json";
+  private static final String BOOTSTRAP_RESOURCE = ".well-known/cryptad-bootstrap.json";
+  private static final String BROWSER_SESSION_TOKEN_FIELD = "browserSessionToken";
+  private static final String BROWSER_SESSION_TOKEN_JSON = "\"browserSessionToken\":\"";
   private static final String CONTENT_SECURITY_POLICY_HEADER = "content-security-policy";
+  private static final String GENERATED_PAGE = "generated-page";
+  private static final String HTML_BODY = "<html></html>";
+  private static final String INDEX_ENTRY = "index.html";
+  private static final String JAVASCRIPT_BODY = "export {};";
+  private static final String JAVASCRIPT_CONTENT_TYPE = "text/javascript; charset=UTF-8";
+  private static final String LOCATION_HEADER = "Location";
+  private static final String NOT_FOUND_REASON = "Not Found";
+  private static final String ORIGIN_HEADER = "Origin";
+  private static final String REDIRECTING_TO_APP_UI = "Redirecting to app UI.";
+  private static final String STATIC_DIRECTORY = "static";
+  private static final String STATIC_ENTRY = "static/index.html";
 
   @Mock private ToadletContext ctx;
   @Mock private ToadletContainer container;
@@ -81,14 +103,14 @@ class AppUiToadletTest {
 
   @Test
   void handleMethodGET_whenRootEntryRequested_expectDeclaredEntryHtml() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("index.html");
+    InstalledAppSnapshot snapshot = staticApp(INDEX_ENTRY);
     Files.createDirectories(snapshot.paths().installedRoot());
-    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), "<html></html>");
+    Files.writeString(snapshot.paths().installedRoot().resolve(INDEX_ENTRY), HTML_BODY);
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
     enableJavascript(true);
 
-    toadlet.handleMethodGET(URI.create("http://localhost/apps/demo-app/"), request, ctx);
+    toadlet.handleMethodGET(URI.create(APP_ROOT_URL), request, ctx);
 
     ReplyCapture reply = captureReply();
     assertEquals(200, reply.statusCode());
@@ -101,25 +123,25 @@ class AppUiToadletTest {
         AppUiSecurityHeaders.CONTENT_SECURITY_POLICY,
         reply.headers().getFirst(CONTENT_SECURITY_POLICY_HEADER));
     assertEquals(13L, reply.length());
-    assertEquals("<html></html>", captureBucketWriteText());
+    assertEquals(HTML_BODY, captureBucketWriteText());
   }
 
   @Test
   void handleMethodGET_whenNestedAppRootRequested_expectRedirectToEntryDirectory()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     AppUiToadlet toadlet = spy(new AppUiToadlet(new InMemoryAppHost(snapshot)));
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
 
-    toadlet.handleMethodGET(URI.create("http://localhost/apps/demo-app/"), request, ctx);
+    toadlet.handleMethodGET(URI.create(APP_ROOT_URL), request, ctx);
 
-    verify(toadlet).writeTemporaryRedirect(ctx, "Redirecting to app UI.", "/apps/demo-app/static/");
+    verify(toadlet).writeTemporaryRedirect(ctx, REDIRECTING_TO_APP_UI, "/apps/demo-app/static/");
   }
 
   @Test
   void handleMethodGET_whenIsolatedOriginActive_expectSameOriginFallbackByDefault()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     AppUiOriginBinding binding = isolatedBinding(snapshot);
     AppUiToadlet toadlet =
         spy(
@@ -132,13 +154,13 @@ class AppUiToadletTest {
     toadlet.handleMethodGET(URI.create("http://localhost/apps/demo-app/?view=queue"), request, ctx);
 
     verify(toadlet)
-        .writeTemporaryRedirect(ctx, "Redirecting to app UI.", "/apps/demo-app/static/?view=queue");
+        .writeTemporaryRedirect(ctx, REDIRECTING_TO_APP_UI, "/apps/demo-app/static/?view=queue");
   }
 
   @Test
   void handleMethodGET_whenIsolatedLaunchRequested_expectRootRedirectToIsolatedLaunchUrl()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     AppUiOriginBinding binding = isolatedBinding(snapshot);
     String launchUrl = binding.uiUrl() + "#cryptadBootstrapNonce=test-nonce";
     AppUiToadlet toadlet =
@@ -155,28 +177,28 @@ class AppUiToadletTest {
         ctx);
 
     String expectedLaunchUrl = binding.uiUrl() + "?view=queue#cryptadBootstrapNonce=test-nonce";
-    verify(toadlet).writeTemporaryRedirect(ctx, "Redirecting to app UI.", expectedLaunchUrl);
+    verify(toadlet).writeTemporaryRedirect(ctx, REDIRECTING_TO_APP_UI, expectedLaunchUrl);
   }
 
   @Test
   void loopbackOrigin_whenBootstrapRequested_expectConfiguredHttpsAdminRootsAndIpv4Origin()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
             appHost, new AppBrowserSessionStore(appHost), "https://127.0.0.1:9443/", () -> true)) {
-      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+      AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
 
       assertTrue(binding.origin().startsWith("http://127.0.0.1:"));
       assertEquals("https://127.0.0.1:9443/api/v1/", binding.platformApiRoot());
       assertEquals("https://127.0.0.1:9443/app/node/", binding.shellRoot());
 
-      String nonce = bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+      String nonce = bootstrapNonceFrom(originServer.launchUrlForApp(APP_ID).orElseThrow());
       HttpResponseCapture response =
           httpGet(
-              binding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              binding.uiRoot() + BOOTSTRAP_RESOURCE,
               Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, nonce));
 
       assertEquals(200, response.statusCode());
@@ -189,158 +211,157 @@ class AppUiToadletTest {
   @Test
   void loopbackOrigin_whenOriginProbeRequestedFromLocalAdminOrigin_expectCorsMetadata()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
-            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
-      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+            appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
 
       String probeUrl = binding.uiRoot() + AppUiLoopbackOriginServer.ORIGIN_PROBE_PATH.substring(1);
       RawHttpResponseCapture response =
           rawHttpGet(
-              probeUrl, Map.of("Origin", "http://localhost:8888", "Accept", "application/json"));
+              probeUrl,
+              Map.of(ORIGIN_HEADER, "http://localhost:8888", ACCEPT_HEADER, APPLICATION_JSON));
       RawHttpResponseCapture ipv6LoopbackResponse =
-          rawHttpGet(probeUrl, Map.of("Origin", "http://[::1]:8888", "Accept", "application/json"));
+          rawHttpGet(
+              probeUrl,
+              Map.of(ORIGIN_HEADER, "http://[::1]:8888", ACCEPT_HEADER, APPLICATION_JSON));
       RawHttpResponseCapture remoteOriginResponse =
           rawHttpGet(
               probeUrl,
-              Map.of("Origin", "http://admin.example:8888", "Accept", "application/json"));
+              Map.of(ORIGIN_HEADER, "http://admin.example:8888", ACCEPT_HEADER, APPLICATION_JSON));
 
       assertEquals(200, response.statusCode());
-      assertEquals("http://localhost:8888", response.header("access-control-allow-origin"));
+      assertEquals("http://localhost:8888", response.header(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER));
       assertEquals(200, ipv6LoopbackResponse.statusCode());
-      assertEquals("http://[::1]:8888", ipv6LoopbackResponse.header("access-control-allow-origin"));
+      assertEquals(
+          "http://[::1]:8888", ipv6LoopbackResponse.header(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER));
       assertTrue(response.body().contains("\"appId\":\"demo-app\""));
       assertTrue(response.body().contains("\"uiOrigin\":\"" + binding.origin() + "\""));
       assertEquals(200, remoteOriginResponse.statusCode());
-      assertNull(remoteOriginResponse.header("access-control-allow-origin"));
+      assertNull(remoteOriginResponse.header(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER));
     }
   }
 
   @Test
   void loopbackOrigin_whenBootstrapRequestedWithoutLaunchProof_expectUnauthorized()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
-            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
-      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+            appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
 
-      HttpResponseCapture response =
-          httpGet(binding.uiRoot() + ".well-known/cryptad-bootstrap.json");
+      HttpResponseCapture response = httpGet(binding.uiRoot() + BOOTSTRAP_RESOURCE);
 
       assertEquals(401, response.statusCode());
-      assertFalse(response.body().contains("browserSessionToken"));
+      assertFalse(response.body().contains(BROWSER_SESSION_TOKEN_FIELD));
     }
   }
 
   @Test
   void loopbackOrigin_whenLaunchProofBelongsToDifferentApp_expectUnauthorized() throws Exception {
-    InstalledAppSnapshot firstApp = staticApp("demo-app", "index.html");
-    InstalledAppSnapshot secondApp = staticApp("other-app", "index.html");
+    InstalledAppSnapshot firstApp = staticApp(APP_ID, INDEX_ENTRY);
+    InstalledAppSnapshot secondApp = staticApp("other-app", INDEX_ENTRY);
     InMemoryAppHost appHost = new InMemoryAppHost(firstApp, secondApp);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
-            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
+            appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> true)) {
       AppUiOriginBinding secondBinding = originServer.bindingForApp("other-app").orElseThrow();
-      String firstNonce =
-          bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+      String firstNonce = bootstrapNonceFrom(originServer.launchUrlForApp(APP_ID).orElseThrow());
 
       HttpResponseCapture response =
           httpGet(
-              secondBinding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              secondBinding.uiRoot() + BOOTSTRAP_RESOURCE,
               Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, firstNonce));
 
       assertEquals(401, response.statusCode());
-      assertFalse(response.body().contains("browserSessionToken"));
+      assertFalse(response.body().contains(BROWSER_SESSION_TOKEN_FIELD));
       assertFalse(response.body().contains("\"appId\":\"other-app\""));
     }
   }
 
   @Test
   void loopbackOrigin_whenAppSnapshotChanges_expectPreviousLaunchProofRejected() throws Exception {
-    InstalledAppSnapshot original = staticApp("index.html");
+    InstalledAppSnapshot original = staticApp(INDEX_ENTRY);
     InMemoryAppHost appHost = new InMemoryAppHost(original);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
-            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
-      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
-      String staleNonce =
-          bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+            appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
+      String staleNonce = bootstrapNonceFrom(originServer.launchUrlForApp(APP_ID).orElseThrow());
 
-      appHost.replace(staticAppWithName("Updated App", "index.html"));
+      appHost.replace(staticAppWithName("Updated App", INDEX_ENTRY));
 
       HttpResponseCapture rejected =
           httpGet(
-              binding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              binding.uiRoot() + BOOTSTRAP_RESOURCE,
               Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, staleNonce));
       assertEquals(401, rejected.statusCode());
-      assertFalse(rejected.body().contains("browserSessionToken"));
+      assertFalse(rejected.body().contains(BROWSER_SESSION_TOKEN_FIELD));
 
-      String currentNonce =
-          bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+      String currentNonce = bootstrapNonceFrom(originServer.launchUrlForApp(APP_ID).orElseThrow());
       HttpResponseCapture accepted =
           httpGet(
-              binding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              binding.uiRoot() + BOOTSTRAP_RESOURCE,
               Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, currentNonce));
       assertEquals(200, accepted.statusCode());
       assertTrue(accepted.body().contains("\"name\":\"Updated App\""));
-      assertTrue(accepted.body().contains("\"browserSessionToken\":\""));
+      assertTrue(accepted.body().contains(BROWSER_SESSION_TOKEN_JSON));
     }
   }
 
   @Test
   void loopbackOrigin_whenManyLaunchProofsIssued_expectOldestLaunchProofEvicted() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("index.html");
+    InstalledAppSnapshot snapshot = staticApp(INDEX_ENTRY);
     InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
-            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
-      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
-      String firstNonce =
-          bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+            appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
+      String firstNonce = bootstrapNonceFrom(originServer.launchUrlForApp(APP_ID).orElseThrow());
       String latestNonce = firstNonce;
       for (int index = 0; index < AppUiLoopbackOriginServer.MAX_BOOTSTRAP_NONCES_PER_APP; index++) {
-        latestNonce = bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+        latestNonce = bootstrapNonceFrom(originServer.launchUrlForApp(APP_ID).orElseThrow());
       }
 
       HttpResponseCapture rejected =
           httpGet(
-              binding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              binding.uiRoot() + BOOTSTRAP_RESOURCE,
               Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, firstNonce));
       assertEquals(401, rejected.statusCode());
-      assertFalse(rejected.body().contains("browserSessionToken"));
+      assertFalse(rejected.body().contains(BROWSER_SESSION_TOKEN_FIELD));
 
       HttpResponseCapture accepted =
           httpGet(
-              binding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              binding.uiRoot() + BOOTSTRAP_RESOURCE,
               Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, latestNonce));
       assertEquals(200, accepted.statusCode());
-      assertTrue(accepted.body().contains("\"browserSessionToken\":\""));
+      assertTrue(accepted.body().contains(BROWSER_SESSION_TOKEN_JSON));
     }
   }
 
   @Test
   void loopbackOrigin_whenStaleTabRequestsRemovedApp_expectLoopbackListenerStopped()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("index.html");
+    InstalledAppSnapshot snapshot = staticApp(INDEX_ENTRY);
     Files.createDirectories(snapshot.paths().installedRoot());
-    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), "<html></html>");
+    Files.writeString(snapshot.paths().installedRoot().resolve(INDEX_ENTRY), HTML_BODY);
     InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
-            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
-      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+            appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
 
-      appHost.remove("demo-app");
+      appHost.remove(APP_ID);
 
       HttpResponseCapture staleTabResponse = httpGet(binding.uiUrl());
       assertEquals(404, staleTabResponse.statusCode());
@@ -352,15 +373,15 @@ class AppUiToadletTest {
 
   @Test
   void loopbackOrigin_whenJavascriptDisabled_expectScriptExecutionBlocked() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("index.html");
+    InstalledAppSnapshot snapshot = staticApp(INDEX_ENTRY);
     Files.createDirectories(snapshot.paths().installedRoot());
-    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), "<html></html>");
+    Files.writeString(snapshot.paths().installedRoot().resolve(INDEX_ENTRY), HTML_BODY);
     InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
-            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> false)) {
-      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+            appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> false)) {
+      AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
 
       HttpResponseCapture response = httpGet(binding.uiUrl());
 
@@ -369,22 +390,22 @@ class AppUiToadletTest {
       assertTrue(contentSecurityPolicy.contains("script-src 'none'"));
       assertFalse(contentSecurityPolicy.contains("script-src 'self'"));
       assertTrue(contentSecurityPolicy.contains("connect-src 'self' http://127.0.0.1:8888"));
-      assertEquals("<html></html>", response.body());
+      assertEquals(HTML_BODY, response.body());
     }
   }
 
   @Test
   void loopbackOrigin_whenHeadAssetRequested_expectAssetLengthWithoutBody() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("index.html");
+    InstalledAppSnapshot snapshot = staticApp(INDEX_ENTRY);
     String body = "<html>demo</html>";
     Files.createDirectories(snapshot.paths().installedRoot());
-    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), body);
+    Files.writeString(snapshot.paths().installedRoot().resolve(INDEX_ENTRY), body);
     InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
-            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
-      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+            appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
 
       HttpResponseCapture response = httpHead(binding.uiUrl());
 
@@ -396,15 +417,15 @@ class AppUiToadletTest {
 
   @Test
   void loopbackOrigin_whenHeadMissingAssetRequested_expectNotFoundWithoutBody() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("index.html");
+    InstalledAppSnapshot snapshot = staticApp(INDEX_ENTRY);
     Files.createDirectories(snapshot.paths().installedRoot());
-    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), "<html></html>");
+    Files.writeString(snapshot.paths().installedRoot().resolve(INDEX_ENTRY), HTML_BODY);
     InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
-            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
-      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+            appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
 
       HttpResponseCapture response = httpHead(binding.uiRoot() + "missing.js");
 
@@ -415,15 +436,15 @@ class AppUiToadletTest {
 
   @Test
   void loopbackOrigin_whenHeadTraversalRequested_expectBadRequestWithoutBody() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("index.html");
+    InstalledAppSnapshot snapshot = staticApp(INDEX_ENTRY);
     Files.createDirectories(snapshot.paths().installedRoot());
-    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), "<html></html>");
+    Files.writeString(snapshot.paths().installedRoot().resolve(INDEX_ENTRY), HTML_BODY);
     InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
 
     try (AppUiLoopbackOriginServer originServer =
         new AppUiLoopbackOriginServer(
-            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
-      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+            appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
 
       HttpResponseCapture response = httpHead(binding.uiRoot() + "%2e%2e/secret");
 
@@ -434,10 +455,9 @@ class AppUiToadletTest {
 
   @Test
   void handleMethodGET_whenJavascriptDisabled_expectScriptExecutionBlocked() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
-    Files.createDirectories(snapshot.paths().installedRoot().resolve("static"));
-    Files.writeString(
-        snapshot.paths().installedRoot().resolve("static/index.html"), "<html></html>");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
+    Files.createDirectories(snapshot.paths().installedRoot().resolve(STATIC_DIRECTORY));
+    Files.writeString(snapshot.paths().installedRoot().resolve(STATIC_ENTRY), HTML_BODY);
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
     enableJavascript(false);
@@ -448,14 +468,14 @@ class AppUiToadletTest {
     assertEquals(
         AppUiSecurityHeaders.JAVASCRIPT_DISABLED_CONTENT_SECURITY_POLICY,
         reply.headers().getFirst(CONTENT_SECURITY_POLICY_HEADER));
-    assertEquals("<html></html>", captureBucketWriteText());
+    assertEquals(HTML_BODY, captureBucketWriteText());
   }
 
   @Test
   void handleMethodGET_whenStaticAssetRequested_expectJavascriptContentType() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
-    Files.createDirectories(snapshot.paths().installedRoot().resolve("static"));
-    Files.writeString(snapshot.paths().installedRoot().resolve("static/app.js"), "export {};");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
+    Files.createDirectories(snapshot.paths().installedRoot().resolve(STATIC_DIRECTORY));
+    Files.writeString(snapshot.paths().installedRoot().resolve("static/app.js"), JAVASCRIPT_BODY);
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
     enableJavascript(true);
@@ -464,23 +484,20 @@ class AppUiToadletTest {
         URI.create("http://localhost/apps/demo-app/static/app.js"), request, ctx);
 
     ReplyCapture reply = captureReply();
-    assertEquals("text/javascript; charset=UTF-8", reply.mimeType());
+    assertEquals(JAVASCRIPT_CONTENT_TYPE, reply.mimeType());
     assertEquals(10L, reply.length());
-    assertEquals("export {};", captureBucketWriteText());
+    assertEquals(JAVASCRIPT_BODY, captureBucketWriteText());
   }
 
   @Test
   void handleMethodGET_whenBootstrapRequested_expectBrowserSessionJsonWithoutHostCredentials()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
     enableJavascript(true);
 
-    toadlet.handleMethodGET(
-        URI.create("http://localhost/apps/demo-app/.well-known/cryptad-bootstrap.json"),
-        request,
-        ctx);
+    toadlet.handleMethodGET(URI.create(APP_BOOTSTRAP_URL), request, ctx);
 
     ReplyCapture reply = captureReply();
     assertEquals(200, reply.statusCode());
@@ -497,7 +514,7 @@ class AppUiToadletTest {
     assertTrue(body.contains("\"uiOriginMode\":\"same-origin-fallback\""));
     assertTrue(body.contains("\"uiOriginStatus\":\"fallback\""));
     assertTrue(body.contains("\"sameOriginFallbackUrl\":\"/apps/demo-app/\""));
-    assertTrue(body.contains("\"browserSessionToken\":\""));
+    assertTrue(body.contains(BROWSER_SESSION_TOKEN_JSON));
     assertTrue(body.contains("\"browserSessionExpiresAt\":\""));
     assertFalse(body.contains("formPassword"));
     assertFalse(body.contains("CRYPTAD_APP_TOKEN"));
@@ -508,7 +525,7 @@ class AppUiToadletTest {
   @Test
   void handleMethodGET_whenIsolatedOriginActiveAndBootstrapRequested_expectFallbackBootstrap()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     AppUiOriginBinding binding = isolatedBinding(snapshot);
     InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
     AppUiToadlet toadlet =
@@ -516,10 +533,7 @@ class AppUiToadletTest {
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
     enableJavascript(true);
 
-    toadlet.handleMethodGET(
-        URI.create("http://localhost/apps/demo-app/.well-known/cryptad-bootstrap.json"),
-        request,
-        ctx);
+    toadlet.handleMethodGET(URI.create(APP_BOOTSTRAP_URL), request, ctx);
 
     ReplyCapture reply = captureReply();
     assertEquals(200, reply.statusCode());
@@ -534,16 +548,13 @@ class AppUiToadletTest {
   @Test
   void handleMethodHEAD_whenBootstrapRequestedForStaticApp_expectHeadersOnlyJson()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     AppBrowserSessionIssuer sessionIssuer = mock(AppBrowserSessionIssuer.class);
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot), sessionIssuer);
     when(ctx.isAllowedFullAccess()).thenReturn(true);
     enableJavascript(true);
 
-    toadlet.handleMethodHEAD(
-        URI.create("http://localhost/apps/demo-app/.well-known/cryptad-bootstrap.json"),
-        request,
-        ctx);
+    toadlet.handleMethodHEAD(URI.create(APP_BOOTSTRAP_URL), request, ctx);
 
     ReplyCapture reply = captureReply();
     assertEquals(200, reply.statusCode());
@@ -560,14 +571,11 @@ class AppUiToadletTest {
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
     when(ctx.isAllowedFullAccess()).thenReturn(true);
 
-    toadlet.handleMethodHEAD(
-        URI.create("http://localhost/apps/demo-app/.well-known/cryptad-bootstrap.json"),
-        request,
-        ctx);
+    toadlet.handleMethodHEAD(URI.create(APP_BOOTSTRAP_URL), request, ctx);
 
     ReplyCapture reply = captureReply();
     assertEquals(404, reply.statusCode());
-    assertEquals("Not Found", reply.reasonPhrase());
+    assertEquals(NOT_FOUND_REASON, reply.reasonPhrase());
     assertEquals(0L, reply.length());
     verifyNoBodyWrites();
   }
@@ -575,8 +583,8 @@ class AppUiToadletTest {
   @Test
   void handleMethodGET_whenCanonicalParentRelativeAssetExistsAtBundleRoot_expectBundleRelativeBody()
       throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
-    Files.createDirectories(snapshot.paths().installedRoot().resolve("static"));
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
+    Files.createDirectories(snapshot.paths().installedRoot().resolve(STATIC_DIRECTORY));
     Files.writeString(snapshot.paths().installedRoot().resolve("static/shared.js"), "nested");
     Files.writeString(snapshot.paths().installedRoot().resolve("shared.js"), "root");
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
@@ -586,16 +594,16 @@ class AppUiToadletTest {
     toadlet.handleMethodGET(URI.create("http://localhost/apps/demo-app/shared.js"), request, ctx);
 
     ReplyCapture reply = captureReply();
-    assertEquals("text/javascript; charset=UTF-8", reply.mimeType());
+    assertEquals(JAVASCRIPT_CONTENT_TYPE, reply.mimeType());
     assertEquals(4L, reply.length());
     assertEquals("root", captureBucketWriteText());
   }
 
   @Test
   void handleMethodHEAD_whenStaticAssetRequested_expectHeadersOnly() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
-    Files.createDirectories(snapshot.paths().installedRoot().resolve("static"));
-    Files.writeString(snapshot.paths().installedRoot().resolve("static/app.js"), "export {};");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
+    Files.createDirectories(snapshot.paths().installedRoot().resolve(STATIC_DIRECTORY));
+    Files.writeString(snapshot.paths().installedRoot().resolve("static/app.js"), JAVASCRIPT_BODY);
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
     when(ctx.isAllowedFullAccess()).thenReturn(true);
     enableJavascript(true);
@@ -604,17 +612,16 @@ class AppUiToadletTest {
         URI.create("http://localhost/apps/demo-app/static/app.js"), request, ctx);
 
     ReplyCapture reply = captureReply();
-    assertEquals("text/javascript; charset=UTF-8", reply.mimeType());
+    assertEquals(JAVASCRIPT_CONTENT_TYPE, reply.mimeType());
     assertEquals(10L, reply.length());
     verifyNoBodyWrites();
   }
 
   @Test
   void handleMethodGET_whenEntryDirectoryRequested_expectDeclaredEntryHtml() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
-    Files.createDirectories(snapshot.paths().installedRoot().resolve("static"));
-    Files.writeString(
-        snapshot.paths().installedRoot().resolve("static/index.html"), "<html></html>");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
+    Files.createDirectories(snapshot.paths().installedRoot().resolve(STATIC_DIRECTORY));
+    Files.writeString(snapshot.paths().installedRoot().resolve(STATIC_ENTRY), HTML_BODY);
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
     enableJavascript(true);
@@ -624,7 +631,7 @@ class AppUiToadletTest {
     ReplyCapture reply = captureReply();
     assertEquals(200, reply.statusCode());
     assertEquals("text/html; charset=UTF-8", reply.mimeType());
-    assertEquals("<html></html>", captureBucketWriteText());
+    assertEquals(HTML_BODY, captureBucketWriteText());
   }
 
   @Test
@@ -637,7 +644,7 @@ class AppUiToadletTest {
     ReplyCapture reply = captureReply();
     assertEquals(302, reply.statusCode());
     assertEquals("Found", reply.reasonPhrase());
-    assertEquals("/apps/demo-app/", reply.headers().getFirst("Location"));
+    assertEquals("/apps/demo-app/", reply.headers().getFirst(LOCATION_HEADER));
     assertEquals(0L, reply.length());
     verifyNoBodyWrites();
   }
@@ -652,13 +659,14 @@ class AppUiToadletTest {
         URI.create("http://localhost/apps/demo-app?view=queue&filter=a%2Fb"), request, ctx);
 
     ReplyCapture reply = captureReply();
-    assertEquals("/apps/demo-app/?view=queue&filter=a%2Fb", reply.headers().getFirst("Location"));
+    assertEquals(
+        "/apps/demo-app/?view=queue&filter=a%2Fb", reply.headers().getFirst(LOCATION_HEADER));
     verifyNoBodyWrites();
   }
 
   @Test
   void handleMethodHEAD_whenNestedAppRootHasQuery_expectRedirectPreservesQuery() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
     when(ctx.isAllowedFullAccess()).thenReturn(true);
 
@@ -667,13 +675,14 @@ class AppUiToadletTest {
 
     ReplyCapture reply = captureReply();
     assertEquals(
-        "/apps/demo-app/static/?view=queue&filter=a%2Fb", reply.headers().getFirst("Location"));
+        "/apps/demo-app/static/?view=queue&filter=a%2Fb",
+        reply.headers().getFirst(LOCATION_HEADER));
     verifyNoBodyWrites();
   }
 
   @Test
   void handleMethodHEAD_whenStaticAssetMissing_expectHeaderOnlyNotFound() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
     when(ctx.isAllowedFullAccess()).thenReturn(true);
 
@@ -682,7 +691,7 @@ class AppUiToadletTest {
 
     ReplyCapture reply = captureReply();
     assertEquals(404, reply.statusCode());
-    assertEquals("Not Found", reply.reasonPhrase());
+    assertEquals(NOT_FOUND_REASON, reply.reasonPhrase());
     assertEquals(0L, reply.length());
     verifyNoBodyWrites();
   }
@@ -708,7 +717,7 @@ class AppUiToadletTest {
     AppUiToadlet toadlet = new AppUiToadlet(appHost);
     when(ctx.isAllowedFullAccess()).thenReturn(false);
 
-    toadlet.handleMethodHEAD(URI.create("http://localhost/apps/demo-app/"), request, ctx);
+    toadlet.handleMethodHEAD(URI.create(APP_ROOT_URL), request, ctx);
 
     ReplyCapture reply = captureReply();
     assertEquals(403, reply.statusCode());
@@ -725,7 +734,7 @@ class AppUiToadletTest {
     AppUiToadlet toadlet = new AppUiToadlet(appHost);
     when(ctx.checkFullAccess(toadlet)).thenReturn(false);
 
-    toadlet.handleMethodGET(URI.create("http://localhost/apps/demo-app/"), request, ctx);
+    toadlet.handleMethodGET(URI.create(APP_ROOT_URL), request, ctx);
 
     verify(ctx).checkFullAccess(toadlet);
     verifyNoInteractions(appHost);
@@ -733,7 +742,7 @@ class AppUiToadletTest {
 
   @Test
   void handleMethodGET_whenTraversalRequested_expectBadRequest() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     AppUiToadlet toadlet = spy(new AppUiToadlet(new InMemoryAppHost(snapshot)));
     StubbedErrorPage errorPage = stubErrorPage(toadlet);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
@@ -743,12 +752,12 @@ class AppUiToadletTest {
 
     assertEquals(400, errorPage.statusCode.get());
     assertEquals("Bad Request", errorPage.reasonPhrase.get());
-    assertEquals("generated-page", errorPage.body.get());
+    assertEquals(GENERATED_PAGE, errorPage.body.get());
   }
 
   @Test
   void handleMethodGET_whenNonEntryDirectoryPathEndsWithSlash_expectNotFound() throws Exception {
-    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);
     AppUiToadlet toadlet = spy(new AppUiToadlet(new InMemoryAppHost(snapshot)));
     StubbedErrorPage errorPage = stubErrorPage(toadlet);
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
@@ -756,8 +765,8 @@ class AppUiToadletTest {
     toadlet.handleMethodGET(URI.create("http://localhost/apps/demo-app/assets/"), request, ctx);
 
     assertEquals(404, errorPage.statusCode.get());
-    assertEquals("Not Found", errorPage.reasonPhrase.get());
-    assertEquals("generated-page", errorPage.body.get());
+    assertEquals(NOT_FOUND_REASON, errorPage.reasonPhrase.get());
+    assertEquals(GENERATED_PAGE, errorPage.body.get());
   }
 
   private StubbedErrorPage stubErrorPage(AppUiToadlet toadlet) throws Exception {
@@ -770,7 +779,7 @@ class AppUiToadletTest {
     when(ctx.getPageMaker()).thenReturn(pageMaker);
     when(pageMaker.getPageNode(anyString(), eq(ctx))).thenReturn(pageNode);
     when(pageNode.getContentNode()).thenReturn(contentNode);
-    when(pageNode.generate()).thenReturn("generated-page");
+    when(pageNode.generate()).thenReturn(GENERATED_PAGE);
     when(pageMaker.getInfobox(anyString(), anyString(), eq(contentNode), isNull(), anyBoolean()))
         .thenReturn(infoboxNode);
     doAnswer(
@@ -920,7 +929,7 @@ class AppUiToadletTest {
     while (System.nanoTime() < deadlineNanos) {
       try {
         httpGet(url);
-      } catch (IOException expected) {
+      } catch (IOException _) {
         return;
       }
       Thread.sleep(25L);
@@ -949,7 +958,7 @@ class AppUiToadletTest {
   }
 
   private InstalledAppSnapshot staticApp(String uiEntry) {
-    return staticApp("demo-app", uiEntry);
+    return staticApp(APP_ID, uiEntry);
   }
 
   private InstalledAppSnapshot staticApp(String appId, String uiEntry) {
@@ -957,7 +966,7 @@ class AppUiToadletTest {
   }
 
   private InstalledAppSnapshot staticAppWithName(String appName, String uiEntry) {
-    return app("demo-app", appName, AppUiMode.STATIC, uiEntry);
+    return app(APP_ID, appName, AppUiMode.STATIC, uiEntry);
   }
 
   private static AppUiOriginBinding isolatedBinding(InstalledAppSnapshot snapshot) {
@@ -988,7 +997,7 @@ class AppUiToadletTest {
   }
 
   private InstalledAppSnapshot shellPanelApp() {
-    return app("demo-app", AppUiMode.SHELL_PANEL, "/app/node/#queue");
+    return app(APP_ID, AppUiMode.SHELL_PANEL, "/app/node/#queue");
   }
 
   private InstalledAppSnapshot app(String appId, AppUiMode uiMode, String uiEntry) {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
@@ -2,6 +2,7 @@ package network.crypta.clients.http;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -22,6 +23,10 @@ import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.appui.AppBrowserSessionIssuer;
+import network.crypta.platform.appui.AppBrowserSessionStore;
+import network.crypta.platform.appui.AppUiOrigin;
+import network.crypta.platform.appui.AppUiOriginBinding;
+import network.crypta.platform.appui.AppUiOriginRegistry;
 import network.crypta.platform.appui.AppUiSecurityHeaders;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.MultiValueTable;
@@ -55,6 +60,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("java:S100")
 class AppUiToadletTest {
+  private static final String CONTENT_SECURITY_POLICY_HEADER = "content-security-policy";
+
   @Mock private ToadletContext ctx;
   @Mock private ToadletContainer container;
   @Mock private HTTPRequest request;
@@ -88,7 +95,7 @@ class AppUiToadletTest {
     assertEquals("no-referrer", reply.headers().getFirst("referrer-policy"));
     assertEquals(
         AppUiSecurityHeaders.CONTENT_SECURITY_POLICY,
-        reply.headers().getFirst("content-security-policy"));
+        reply.headers().getFirst(CONTENT_SECURITY_POLICY_HEADER));
     assertEquals(13L, reply.length());
     assertEquals("<html></html>", captureBucketWriteText());
   }
@@ -106,6 +113,179 @@ class AppUiToadletTest {
   }
 
   @Test
+  void handleMethodGET_whenIsolatedOriginActive_expectRootRedirectToIsolatedLaunchUrl()
+      throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    AppUiOriginBinding binding = isolatedBinding(snapshot);
+    String launchUrl = binding.uiUrl() + "#cryptadBootstrapNonce=test-nonce";
+    AppUiToadlet toadlet =
+        spy(
+            new AppUiToadlet(
+                new InMemoryAppHost(snapshot),
+                mock(AppBrowserSessionIssuer.class),
+                registryWithLaunchUrl(binding, launchUrl)));
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/apps/demo-app/?view=queue"), request, ctx);
+
+    String expectedLaunchUrl = binding.uiUrl() + "?view=queue#cryptadBootstrapNonce=test-nonce";
+    verify(toadlet).writeTemporaryRedirect(ctx, "Redirecting to app UI.", expectedLaunchUrl);
+  }
+
+  @Test
+  void loopbackOrigin_whenBootstrapRequested_expectConfiguredHttpsAdminRootsAndIpv4Origin()
+      throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "https://127.0.0.1:9443/", () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+
+      assertTrue(binding.origin().startsWith("http://127.0.0.1:"));
+      assertEquals("https://127.0.0.1:9443/api/v1/", binding.platformApiRoot());
+      assertEquals("https://127.0.0.1:9443/app/node/", binding.shellRoot());
+
+      String nonce = bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+      HttpResponseCapture response =
+          httpGet(
+              binding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, nonce));
+
+      assertEquals(200, response.statusCode());
+      assertTrue(
+          response.body().contains("\"platformApiRoot\":\"https://127.0.0.1:9443/api/v1/\""));
+      assertTrue(response.body().contains("\"shellRoot\":\"https://127.0.0.1:9443/app/node/\""));
+    }
+  }
+
+  @Test
+  void loopbackOrigin_whenBootstrapRequestedWithoutLaunchProof_expectUnauthorized()
+      throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+
+      HttpResponseCapture response =
+          httpGet(binding.uiRoot() + ".well-known/cryptad-bootstrap.json");
+
+      assertEquals(401, response.statusCode());
+      assertFalse(response.body().contains("browserSessionToken"));
+    }
+  }
+
+  @Test
+  void loopbackOrigin_whenLaunchProofBelongsToDifferentApp_expectUnauthorized() throws Exception {
+    InstalledAppSnapshot firstApp = staticApp("demo-app", "index.html");
+    InstalledAppSnapshot secondApp = staticApp("other-app", "index.html");
+    InMemoryAppHost appHost = new InMemoryAppHost(firstApp, secondApp);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
+      AppUiOriginBinding secondBinding = originServer.bindingForApp("other-app").orElseThrow();
+      String firstNonce =
+          bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+
+      HttpResponseCapture response =
+          httpGet(
+              secondBinding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, firstNonce));
+
+      assertEquals(401, response.statusCode());
+      assertFalse(response.body().contains("browserSessionToken"));
+      assertFalse(response.body().contains("\"appId\":\"other-app\""));
+    }
+  }
+
+  @Test
+  void loopbackOrigin_whenJavascriptDisabled_expectScriptExecutionBlocked() throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("index.html");
+    Files.createDirectories(snapshot.paths().installedRoot());
+    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), "<html></html>");
+    InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> false)) {
+      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+
+      HttpResponseCapture response = httpGet(binding.uiUrl());
+
+      assertEquals(200, response.statusCode());
+      String contentSecurityPolicy = response.contentSecurityPolicy();
+      assertTrue(contentSecurityPolicy.contains("script-src 'none'"));
+      assertFalse(contentSecurityPolicy.contains("script-src 'self'"));
+      assertTrue(contentSecurityPolicy.contains("connect-src 'self' http://127.0.0.1:8888"));
+      assertEquals("<html></html>", response.body());
+    }
+  }
+
+  @Test
+  void loopbackOrigin_whenHeadAssetRequested_expectAssetLengthWithoutBody() throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("index.html");
+    String body = "<html>demo</html>";
+    Files.createDirectories(snapshot.paths().installedRoot());
+    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), body);
+    InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+
+      HttpResponseCapture response = httpHead(binding.uiUrl());
+
+      assertEquals(200, response.statusCode());
+      assertEquals(body.getBytes(StandardCharsets.UTF_8).length, response.contentLength());
+      assertEquals("", response.body());
+    }
+  }
+
+  @Test
+  void loopbackOrigin_whenHeadMissingAssetRequested_expectNotFoundWithoutBody() throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("index.html");
+    Files.createDirectories(snapshot.paths().installedRoot());
+    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), "<html></html>");
+    InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+
+      HttpResponseCapture response = httpHead(binding.uiRoot() + "missing.js");
+
+      assertEquals(404, response.statusCode());
+      assertEquals("", response.body());
+    }
+  }
+
+  @Test
+  void loopbackOrigin_whenHeadTraversalRequested_expectBadRequestWithoutBody() throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("index.html");
+    Files.createDirectories(snapshot.paths().installedRoot());
+    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), "<html></html>");
+    InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+
+      HttpResponseCapture response = httpHead(binding.uiRoot() + "%2e%2e/secret");
+
+      assertEquals(400, response.statusCode());
+      assertEquals("", response.body());
+    }
+  }
+
+  @Test
   void handleMethodGET_whenJavascriptDisabled_expectScriptExecutionBlocked() throws Exception {
     InstalledAppSnapshot snapshot = staticApp("static/index.html");
     Files.createDirectories(snapshot.paths().installedRoot().resolve("static"));
@@ -120,7 +300,7 @@ class AppUiToadletTest {
     ReplyCapture reply = captureReply();
     assertEquals(
         AppUiSecurityHeaders.JAVASCRIPT_DISABLED_CONTENT_SECURITY_POLICY,
-        reply.headers().getFirst("content-security-policy"));
+        reply.headers().getFirst(CONTENT_SECURITY_POLICY_HEADER));
     assertEquals("<html></html>", captureBucketWriteText());
   }
 
@@ -166,12 +346,42 @@ class AppUiToadletTest {
     assertTrue(body.contains("\"assetRoot\":\"/apps/demo-app/static/\""));
     assertTrue(body.contains("\"platformApiRoot\":\"/api/v1/\""));
     assertTrue(body.contains("\"shellRoot\":\"/app/node/\""));
+    assertTrue(body.contains("\"uiOrigin\":null"));
+    assertTrue(body.contains("\"uiOriginMode\":\"same-origin-fallback\""));
+    assertTrue(body.contains("\"uiOriginStatus\":\"fallback\""));
+    assertTrue(body.contains("\"sameOriginFallbackUrl\":\"/apps/demo-app/\""));
     assertTrue(body.contains("\"browserSessionToken\":\""));
     assertTrue(body.contains("\"browserSessionExpiresAt\":\""));
     assertFalse(body.contains("formPassword"));
     assertFalse(body.contains("CRYPTAD_APP_TOKEN"));
     assertFalse(body.contains("launchToken"));
     assertFalse(body.contains(tempDir.toString()));
+  }
+
+  @Test
+  void handleMethodGET_whenIsolatedOriginActiveAndBootstrapRequested_expectFallbackBootstrap()
+      throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    AppUiOriginBinding binding = isolatedBinding(snapshot);
+    InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
+    AppUiToadlet toadlet =
+        new AppUiToadlet(appHost, new AppBrowserSessionStore(appHost), registryWith(binding));
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+    enableJavascript(true);
+
+    toadlet.handleMethodGET(
+        URI.create("http://localhost/apps/demo-app/.well-known/cryptad-bootstrap.json"),
+        request,
+        ctx);
+
+    ReplyCapture reply = captureReply();
+    assertEquals(200, reply.statusCode());
+    String body = captureByteArrayWriteText();
+    assertTrue(body.contains("\"uiRoot\":\"/apps/demo-app/\""));
+    assertTrue(body.contains("\"assetRoot\":\"/apps/demo-app/static/\""));
+    assertTrue(body.contains("\"uiOrigin\":null"));
+    assertTrue(body.contains("\"uiOriginMode\":\"same-origin-fallback\""));
+    assertFalse(body.contains(binding.origin()));
   }
 
   @Test
@@ -199,7 +409,7 @@ class AppUiToadletTest {
 
   @Test
   void handleMethodHEAD_whenBootstrapRequestedForShellPanelApp_expectNotFound() throws Exception {
-    InstalledAppSnapshot snapshot = app(AppUiMode.SHELL_PANEL, "/app/node/#queue");
+    InstalledAppSnapshot snapshot = shellPanelApp();
     AppUiToadlet toadlet = new AppUiToadlet(new InMemoryAppHost(snapshot));
     when(ctx.isAllowedFullAccess()).thenReturn(true);
 
@@ -499,30 +709,110 @@ class AppUiToadletTest {
     verify(ctx, never()).writeData(any(byte[].class), anyInt(), anyInt());
   }
 
-  private InstalledAppSnapshot staticApp(String uiEntry) {
-    return app(AppUiMode.STATIC, uiEntry);
+  private static HttpResponseCapture httpGet(String url) throws IOException {
+    return httpRequest("GET", url, Map.of());
   }
 
-  private InstalledAppSnapshot app(AppUiMode uiMode, String uiEntry) {
+  private static HttpResponseCapture httpGet(String url, Map<String, String> headers)
+      throws IOException {
+    return httpRequest("GET", url, headers);
+  }
+
+  private static HttpResponseCapture httpHead(String url) throws IOException {
+    return httpRequest("HEAD", url, Map.of());
+  }
+
+  private static HttpResponseCapture httpRequest(
+      String method, String url, Map<String, String> headers) throws IOException {
+    HttpURLConnection connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
+    connection.setRequestMethod(method);
+    headers.forEach(connection::setRequestProperty);
+    connection.setConnectTimeout(2000);
+    connection.setReadTimeout(2000);
+    int statusCode = connection.getResponseCode();
+    String body = "";
+    if (!"HEAD".equals(method)) {
+      InputStream stream =
+          statusCode >= 400 ? connection.getErrorStream() : connection.getInputStream();
+      if (stream != null) {
+        try (stream) {
+          body = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        }
+      }
+    }
+    return new HttpResponseCapture(statusCode, connection, body);
+  }
+
+  private static String bootstrapNonceFrom(String launchUrl) {
+    String rawFragment = URI.create(launchUrl).getRawFragment();
+    assertNotNull(rawFragment);
+    String prefix = AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_FRAGMENT_PARAMETER + "=";
+    int start = 0;
+    while (start <= rawFragment.length()) {
+      int ampersand = rawFragment.indexOf('&', start);
+      String part =
+          ampersand < 0 ? rawFragment.substring(start) : rawFragment.substring(start, ampersand);
+      if (part.startsWith(prefix)) {
+        return part.substring(prefix.length());
+      }
+      if (ampersand < 0) {
+        break;
+      }
+      start = ampersand + 1;
+    }
+    throw new AssertionError("Launch URL did not include app bootstrap nonce.");
+  }
+
+  private InstalledAppSnapshot staticApp(String uiEntry) {
+    return staticApp("demo-app", uiEntry);
+  }
+
+  private InstalledAppSnapshot staticApp(String appId, String uiEntry) {
+    return app(appId, AppUiMode.STATIC, uiEntry);
+  }
+
+  private static AppUiOriginBinding isolatedBinding(InstalledAppSnapshot snapshot) {
+    return AppUiOriginBinding.isolatedLoopback(
+        snapshot.manifest(),
+        AppUiOrigin.loopback(snapshot.appId(), 12345),
+        "http://127.0.0.1:8888/api/v1/",
+        "http://127.0.0.1:8888/app/node/");
+  }
+
+  private static AppUiOriginRegistry registryWith(AppUiOriginBinding binding) {
+    return appId -> binding.appId().equals(appId) ? Optional.of(binding) : Optional.empty();
+  }
+
+  private static AppUiOriginRegistry registryWithLaunchUrl(
+      AppUiOriginBinding binding, String launchUrl) {
+    return new AppUiOriginRegistry() {
+      @Override
+      public Optional<AppUiOriginBinding> bindingForApp(String appId) {
+        return binding.appId().equals(appId) ? Optional.of(binding) : Optional.empty();
+      }
+
+      @Override
+      public Optional<String> launchUrlForApp(String appId) {
+        return binding.appId().equals(appId) ? Optional.of(launchUrl) : Optional.empty();
+      }
+    };
+  }
+
+  private InstalledAppSnapshot shellPanelApp() {
+    return app("demo-app", AppUiMode.SHELL_PANEL, "/app/node/#queue");
+  }
+
+  private InstalledAppSnapshot app(String appId, AppUiMode uiMode, String uiEntry) {
     AppManifest manifest =
         new AppManifest(
-            1,
-            "demo-app",
-            "Demo App",
-            "1.0.0",
-            "bin/launch.sh",
-            uiMode,
-            uiEntry,
-            List.of(),
-            null,
-            null);
+            1, appId, "Demo App", "1.0.0", "bin/launch.sh", uiMode, uiEntry, List.of(), null, null);
     InstalledAppPaths paths =
         new InstalledAppPaths(
-            "demo-app",
-            tempDir.resolve("installed/demo-app"),
-            tempDir.resolve("data/demo-app"),
-            tempDir.resolve("cache/demo-app"),
-            tempDir.resolve("run/demo-app"));
+            appId,
+            tempDir.resolve("installed").resolve(appId),
+            tempDir.resolve("data").resolve(appId),
+            tempDir.resolve("cache").resolve(appId),
+            tempDir.resolve("run").resolve(appId));
     return new InstalledAppSnapshot(manifest, paths);
   }
 
@@ -533,6 +823,16 @@ class AppUiToadletTest {
       String mimeType,
       long length,
       boolean forceDisableJavascript) {}
+
+  private record HttpResponseCapture(int statusCode, HttpURLConnection connection, String body) {
+    private String contentSecurityPolicy() {
+      return connection.getHeaderField(CONTENT_SECURITY_POLICY_HEADER);
+    }
+
+    private long contentLength() {
+      return connection.getContentLengthLong();
+    }
+  }
 
   private static final class StubbedErrorPage {
     private final AtomicReference<Integer> statusCode = new AtomicReference<>();

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
@@ -932,24 +932,25 @@ class AppUiToadletTest {
   private static void assertHttpRequestEventuallyFails(String url) throws InterruptedException {
     CountDownLatch failureObserved = new CountDownLatch(1);
     AtomicReference<RuntimeException> unexpectedFailure = new AtomicReference<>();
-    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-    ScheduledFuture<?> scheduledProbe =
-        executor.scheduleWithFixedDelay(
-            () -> probeHttpRequestUntilFails(url, failureObserved, unexpectedFailure),
-            0L,
-            25L,
-            TimeUnit.MILLISECONDS);
-    try {
-      assertTrue(
-          failureObserved.await(2L, TimeUnit.SECONDS),
-          () -> "Expected loopback listener to stop: " + url);
-      RuntimeException failure = unexpectedFailure.get();
-      if (failure != null) {
-        throw failure;
+    try (ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor()) {
+      ScheduledFuture<?> scheduledProbe =
+          executor.scheduleWithFixedDelay(
+              () -> probeHttpRequestUntilFails(url, failureObserved, unexpectedFailure),
+              0L,
+              25L,
+              TimeUnit.MILLISECONDS);
+      try {
+        assertTrue(
+            failureObserved.await(2L, TimeUnit.SECONDS),
+            () -> "Expected loopback listener to stop: " + url);
+        RuntimeException failure = unexpectedFailure.get();
+        if (failure != null) {
+          throw failure;
+        }
+      } finally {
+        scheduledProbe.cancel(true);
+        executor.shutdownNow();
       }
-    } finally {
-      scheduledProbe.cancel(true);
-      executor.shutdownNow();
     }
   }
 

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
@@ -204,6 +204,71 @@ class AppUiToadletTest {
   }
 
   @Test
+  void loopbackOrigin_whenAppSnapshotChanges_expectPreviousLaunchProofRejected() throws Exception {
+    InstalledAppSnapshot original = staticApp("index.html");
+    InMemoryAppHost appHost = new InMemoryAppHost(original);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+      String staleNonce =
+          bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+
+      appHost.replace(staticAppWithName("Updated App", "index.html"));
+
+      HttpResponseCapture rejected =
+          httpGet(
+              binding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, staleNonce));
+      assertEquals(401, rejected.statusCode());
+      assertFalse(rejected.body().contains("browserSessionToken"));
+
+      String currentNonce =
+          bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+      HttpResponseCapture accepted =
+          httpGet(
+              binding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, currentNonce));
+      assertEquals(200, accepted.statusCode());
+      assertTrue(accepted.body().contains("\"name\":\"Updated App\""));
+      assertTrue(accepted.body().contains("\"browserSessionToken\":\""));
+    }
+  }
+
+  @Test
+  void loopbackOrigin_whenManyLaunchProofsIssued_expectOldestLaunchProofEvicted() throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("index.html");
+    InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+      String firstNonce =
+          bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+      String latestNonce = firstNonce;
+      for (int index = 0; index < AppUiLoopbackOriginServer.MAX_BOOTSTRAP_NONCES_PER_APP; index++) {
+        latestNonce = bootstrapNonceFrom(originServer.launchUrlForApp("demo-app").orElseThrow());
+      }
+
+      HttpResponseCapture rejected =
+          httpGet(
+              binding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, firstNonce));
+      assertEquals(401, rejected.statusCode());
+      assertFalse(rejected.body().contains("browserSessionToken"));
+
+      HttpResponseCapture accepted =
+          httpGet(
+              binding.uiRoot() + ".well-known/cryptad-bootstrap.json",
+              Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, latestNonce));
+      assertEquals(200, accepted.statusCode());
+      assertTrue(accepted.body().contains("\"browserSessionToken\":\""));
+    }
+  }
+
+  @Test
   void loopbackOrigin_whenJavascriptDisabled_expectScriptExecutionBlocked() throws Exception {
     InstalledAppSnapshot snapshot = staticApp("index.html");
     Files.createDirectories(snapshot.paths().installedRoot());
@@ -771,6 +836,10 @@ class AppUiToadletTest {
     return app(appId, AppUiMode.STATIC, uiEntry);
   }
 
+  private InstalledAppSnapshot staticAppWithName(String appName, String uiEntry) {
+    return app("demo-app", appName, AppUiMode.STATIC, uiEntry);
+  }
+
   private static AppUiOriginBinding isolatedBinding(InstalledAppSnapshot snapshot) {
     return AppUiOriginBinding.isolatedLoopback(
         snapshot.manifest(),
@@ -803,9 +872,13 @@ class AppUiToadletTest {
   }
 
   private InstalledAppSnapshot app(String appId, AppUiMode uiMode, String uiEntry) {
+    return app(appId, "Demo App", uiMode, uiEntry);
+  }
+
+  private InstalledAppSnapshot app(String appId, String appName, AppUiMode uiMode, String uiEntry) {
     AppManifest manifest =
         new AppManifest(
-            1, appId, "Demo App", "1.0.0", "bin/launch.sh", uiMode, uiEntry, List.of(), null, null);
+            1, appId, appName, "1.0.0", "bin/launch.sh", uiMode, uiEntry, List.of(), null, null);
     InstalledAppPaths paths =
         new InstalledAppPaths(
             appId,
@@ -847,6 +920,10 @@ class AppUiToadletTest {
       for (InstalledAppSnapshot snapshot : snapshots) {
         this.snapshots.put(snapshot.appId(), snapshot);
       }
+    }
+
+    private void replace(InstalledAppSnapshot snapshot) {
+      snapshots.put(snapshot.appId(), snapshot);
     }
 
     @Override

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
@@ -14,6 +14,11 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
@@ -87,6 +92,7 @@ class AppUiToadletTest {
   private static final String REDIRECTING_TO_APP_UI = "Redirecting to app UI.";
   private static final String STATIC_DIRECTORY = "static";
   private static final String STATIC_ENTRY = "static/index.html";
+  private static final String UPDATED_APP_NAME = "Updated App";
 
   @Mock private ToadletContext ctx;
   @Mock private ToadletContainer container;
@@ -234,14 +240,13 @@ class AppUiToadletTest {
               Map.of(ORIGIN_HEADER, "http://admin.example:8888", ACCEPT_HEADER, APPLICATION_JSON));
 
       assertEquals(200, response.statusCode());
-      assertEquals("http://localhost:8888", response.header(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER));
+      assertEquals("http://localhost:8888", response.accessControlAllowOrigin());
       assertEquals(200, ipv6LoopbackResponse.statusCode());
-      assertEquals(
-          "http://[::1]:8888", ipv6LoopbackResponse.header(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER));
+      assertEquals("http://[::1]:8888", ipv6LoopbackResponse.accessControlAllowOrigin());
       assertTrue(response.body().contains("\"appId\":\"demo-app\""));
       assertTrue(response.body().contains("\"uiOrigin\":\"" + binding.origin() + "\""));
       assertEquals(200, remoteOriginResponse.statusCode());
-      assertNull(remoteOriginResponse.header(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER));
+      assertNull(remoteOriginResponse.accessControlAllowOrigin());
     }
   }
 
@@ -297,7 +302,7 @@ class AppUiToadletTest {
       AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
       String staleNonce = bootstrapNonceFrom(originServer.launchUrlForApp(APP_ID).orElseThrow());
 
-      appHost.replace(staticAppWithName("Updated App", INDEX_ENTRY));
+      appHost.replace(updatedStaticApp());
 
       HttpResponseCapture rejected =
           httpGet(
@@ -312,7 +317,7 @@ class AppUiToadletTest {
               binding.uiRoot() + BOOTSTRAP_RESOURCE,
               Map.of(AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_HEADER, currentNonce));
       assertEquals(200, accepted.statusCode());
-      assertTrue(accepted.body().contains("\"name\":\"Updated App\""));
+      assertTrue(accepted.body().contains("\"name\":\"" + UPDATED_APP_NAME + "\""));
       assertTrue(accepted.body().contains(BROWSER_SESSION_TOKEN_JSON));
     }
   }
@@ -361,7 +366,7 @@ class AppUiToadletTest {
             appHost, new AppBrowserSessionStore(appHost), ADMIN_ROOT, () -> true)) {
       AppUiOriginBinding binding = originServer.bindingForApp(APP_ID).orElseThrow();
 
-      appHost.remove(APP_ID);
+      appHost.removeDemoApp();
 
       HttpResponseCapture staleTabResponse = httpGet(binding.uiUrl());
       assertEquals(404, staleTabResponse.statusCode());
@@ -925,16 +930,41 @@ class AppUiToadletTest {
   }
 
   private static void assertHttpRequestEventuallyFails(String url) throws InterruptedException {
-    long deadlineNanos = System.nanoTime() + 2_000_000_000L;
-    while (System.nanoTime() < deadlineNanos) {
-      try {
-        httpGet(url);
-      } catch (IOException _) {
-        return;
+    CountDownLatch failureObserved = new CountDownLatch(1);
+    AtomicReference<RuntimeException> unexpectedFailure = new AtomicReference<>();
+    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    ScheduledFuture<?> scheduledProbe =
+        executor.scheduleWithFixedDelay(
+            () -> probeHttpRequestUntilFails(url, failureObserved, unexpectedFailure),
+            0L,
+            25L,
+            TimeUnit.MILLISECONDS);
+    try {
+      assertTrue(
+          failureObserved.await(2L, TimeUnit.SECONDS),
+          () -> "Expected loopback listener to stop: " + url);
+      RuntimeException failure = unexpectedFailure.get();
+      if (failure != null) {
+        throw failure;
       }
-      Thread.sleep(25L);
+    } finally {
+      scheduledProbe.cancel(true);
+      executor.shutdownNow();
     }
-    throw new AssertionError("Expected loopback listener to stop: " + url);
+  }
+
+  private static void probeHttpRequestUntilFails(
+      String url,
+      CountDownLatch failureObserved,
+      AtomicReference<RuntimeException> unexpectedFailure) {
+    try {
+      httpGet(url);
+    } catch (IOException _) {
+      failureObserved.countDown();
+    } catch (RuntimeException failure) {
+      unexpectedFailure.compareAndSet(null, failure);
+      failureObserved.countDown();
+    }
   }
 
   private static String bootstrapNonceFrom(String launchUrl) {
@@ -965,8 +995,8 @@ class AppUiToadletTest {
     return app(appId, AppUiMode.STATIC, uiEntry);
   }
 
-  private InstalledAppSnapshot staticAppWithName(String appName, String uiEntry) {
-    return app(APP_ID, appName, AppUiMode.STATIC, uiEntry);
+  private InstalledAppSnapshot updatedStaticApp() {
+    return app(APP_ID, UPDATED_APP_NAME, AppUiMode.STATIC, INDEX_ENTRY);
   }
 
   private static AppUiOriginBinding isolatedBinding(InstalledAppSnapshot snapshot) {
@@ -1042,7 +1072,7 @@ class AppUiToadletTest {
       String headerText = headerEnd < 0 ? response : response.substring(0, headerEnd);
       String body = headerEnd < 0 ? "" : response.substring(headerEnd + 4);
       List<String> headerLines = headerText.lines().toList();
-      int statusCode = parseStatusCode(headerLines.get(0));
+      int statusCode = parseStatusCode(headerLines.getFirst());
       Map<String, String> headers = new HashMap<>();
       for (int i = 1; i < headerLines.size(); i++) {
         String headerLine = headerLines.get(i);
@@ -1062,8 +1092,8 @@ class AppUiToadletTest {
       return Integer.parseInt(statusLine.substring(firstSpace + 1, secondSpace));
     }
 
-    private String header(String name) {
-      return headers.get(name.toLowerCase(Locale.ROOT));
+    private String accessControlAllowOrigin() {
+      return headers.get(ACCESS_CONTROL_ALLOW_ORIGIN_HEADER);
     }
   }
 
@@ -1086,8 +1116,8 @@ class AppUiToadletTest {
       snapshots.put(snapshot.appId(), snapshot);
     }
 
-    private void remove(String appId) {
-      snapshots.remove(appId);
+    private void removeDemoApp() {
+      snapshots.remove(APP_ID);
     }
 
     @Override

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
@@ -201,6 +201,8 @@ class AppUiToadletTest {
       RawHttpResponseCapture response =
           rawHttpGet(
               probeUrl, Map.of("Origin", "http://localhost:8888", "Accept", "application/json"));
+      RawHttpResponseCapture ipv6LoopbackResponse =
+          rawHttpGet(probeUrl, Map.of("Origin", "http://[::1]:8888", "Accept", "application/json"));
       RawHttpResponseCapture remoteOriginResponse =
           rawHttpGet(
               probeUrl,
@@ -208,6 +210,8 @@ class AppUiToadletTest {
 
       assertEquals(200, response.statusCode());
       assertEquals("http://localhost:8888", response.header("access-control-allow-origin"));
+      assertEquals(200, ipv6LoopbackResponse.statusCode());
+      assertEquals("http://[::1]:8888", ipv6LoopbackResponse.header("access-control-allow-origin"));
       assertTrue(response.body().contains("\"appId\":\"demo-app\""));
       assertTrue(response.body().contains("\"uiOrigin\":\"" + binding.origin() + "\""));
       assertEquals(200, remoteOriginResponse.statusCode());

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
@@ -269,6 +269,29 @@ class AppUiToadletTest {
   }
 
   @Test
+  void loopbackOrigin_whenStaleTabRequestsRemovedApp_expectLoopbackListenerStopped()
+      throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("index.html");
+    Files.createDirectories(snapshot.paths().installedRoot());
+    Files.writeString(snapshot.paths().installedRoot().resolve("index.html"), "<html></html>");
+    InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+
+      appHost.remove("demo-app");
+
+      HttpResponseCapture staleTabResponse = httpGet(binding.uiUrl());
+      assertEquals(404, staleTabResponse.statusCode());
+      assertEquals("App UI is not available.", staleTabResponse.body());
+      assertHttpRequestEventuallyFails(binding.uiUrl());
+      assertTrue(originServer.bindingForOrigin(binding.origin()).isEmpty());
+    }
+  }
+
+  @Test
   void loopbackOrigin_whenJavascriptDisabled_expectScriptExecutionBlocked() throws Exception {
     InstalledAppSnapshot snapshot = staticApp("index.html");
     Files.createDirectories(snapshot.paths().installedRoot());
@@ -808,6 +831,19 @@ class AppUiToadletTest {
     return new HttpResponseCapture(statusCode, connection, body);
   }
 
+  private static void assertHttpRequestEventuallyFails(String url) throws InterruptedException {
+    long deadlineNanos = System.nanoTime() + 2_000_000_000L;
+    while (System.nanoTime() < deadlineNanos) {
+      try {
+        httpGet(url);
+      } catch (IOException expected) {
+        return;
+      }
+      Thread.sleep(25L);
+    }
+    throw new AssertionError("Expected loopback listener to stop: " + url);
+  }
+
   private static String bootstrapNonceFrom(String launchUrl) {
     String rawFragment = URI.create(launchUrl).getRawFragment();
     assertNotNull(rawFragment);
@@ -924,6 +960,10 @@ class AppUiToadletTest {
 
     private void replace(InstalledAppSnapshot snapshot) {
       snapshots.put(snapshot.appId(), snapshot);
+    }
+
+    private void remove(String appId) {
+      snapshots.remove(appId);
     }
 
     @Override

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
@@ -251,6 +251,14 @@ class AppUiToadletTest {
   }
 
   @Test
+  void loopbackOrigin_whenBrowserSessionExpires_expectLaunchProofStillCoversRenewal() {
+    assertTrue(
+        AppUiLoopbackOriginServer.BOOTSTRAP_NONCE_LIFETIME.compareTo(
+                AppBrowserSessionStore.DEFAULT_LIFETIME)
+            > 0);
+  }
+
+  @Test
   void loopbackOrigin_whenBootstrapRequestedWithoutLaunchProof_expectUnauthorized()
       throws Exception {
     InstalledAppSnapshot snapshot = staticApp(STATIC_ENTRY);

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/AppUiToadletTest.java
@@ -3,12 +3,15 @@ package network.crypta.clients.http;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.Socket;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -42,6 +45,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -113,7 +117,26 @@ class AppUiToadletTest {
   }
 
   @Test
-  void handleMethodGET_whenIsolatedOriginActive_expectRootRedirectToIsolatedLaunchUrl()
+  void handleMethodGET_whenIsolatedOriginActive_expectSameOriginFallbackByDefault()
+      throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    AppUiOriginBinding binding = isolatedBinding(snapshot);
+    AppUiToadlet toadlet =
+        spy(
+            new AppUiToadlet(
+                new InMemoryAppHost(snapshot),
+                mock(AppBrowserSessionIssuer.class),
+                registryWithLaunchUrl(binding, binding.uiUrl() + "#cryptadBootstrapNonce=test")));
+    when(ctx.checkFullAccess(toadlet)).thenReturn(true);
+
+    toadlet.handleMethodGET(URI.create("http://localhost/apps/demo-app/?view=queue"), request, ctx);
+
+    verify(toadlet)
+        .writeTemporaryRedirect(ctx, "Redirecting to app UI.", "/apps/demo-app/static/?view=queue");
+  }
+
+  @Test
+  void handleMethodGET_whenIsolatedLaunchRequested_expectRootRedirectToIsolatedLaunchUrl()
       throws Exception {
     InstalledAppSnapshot snapshot = staticApp("static/index.html");
     AppUiOriginBinding binding = isolatedBinding(snapshot);
@@ -126,7 +149,10 @@ class AppUiToadletTest {
                 registryWithLaunchUrl(binding, launchUrl)));
     when(ctx.checkFullAccess(toadlet)).thenReturn(true);
 
-    toadlet.handleMethodGET(URI.create("http://localhost/apps/demo-app/?view=queue"), request, ctx);
+    toadlet.handleMethodGET(
+        URI.create("http://localhost/apps/demo-app/?cryptadIsolatedLaunch=1&view=queue"),
+        request,
+        ctx);
 
     String expectedLaunchUrl = binding.uiUrl() + "?view=queue#cryptadBootstrapNonce=test-nonce";
     verify(toadlet).writeTemporaryRedirect(ctx, "Redirecting to app UI.", expectedLaunchUrl);
@@ -157,6 +183,35 @@ class AppUiToadletTest {
       assertTrue(
           response.body().contains("\"platformApiRoot\":\"https://127.0.0.1:9443/api/v1/\""));
       assertTrue(response.body().contains("\"shellRoot\":\"https://127.0.0.1:9443/app/node/\""));
+    }
+  }
+
+  @Test
+  void loopbackOrigin_whenOriginProbeRequestedFromLocalAdminOrigin_expectCorsMetadata()
+      throws Exception {
+    InstalledAppSnapshot snapshot = staticApp("static/index.html");
+    InMemoryAppHost appHost = new InMemoryAppHost(snapshot);
+
+    try (AppUiLoopbackOriginServer originServer =
+        new AppUiLoopbackOriginServer(
+            appHost, new AppBrowserSessionStore(appHost), "http://127.0.0.1:8888/", () -> true)) {
+      AppUiOriginBinding binding = originServer.bindingForApp("demo-app").orElseThrow();
+
+      String probeUrl = binding.uiRoot() + AppUiLoopbackOriginServer.ORIGIN_PROBE_PATH.substring(1);
+      RawHttpResponseCapture response =
+          rawHttpGet(
+              probeUrl, Map.of("Origin", "http://localhost:8888", "Accept", "application/json"));
+      RawHttpResponseCapture remoteOriginResponse =
+          rawHttpGet(
+              probeUrl,
+              Map.of("Origin", "http://admin.example:8888", "Accept", "application/json"));
+
+      assertEquals(200, response.statusCode());
+      assertEquals("http://localhost:8888", response.header("access-control-allow-origin"));
+      assertTrue(response.body().contains("\"appId\":\"demo-app\""));
+      assertTrue(response.body().contains("\"uiOrigin\":\"" + binding.origin() + "\""));
+      assertEquals(200, remoteOriginResponse.statusCode());
+      assertNull(remoteOriginResponse.header("access-control-allow-origin"));
     }
   }
 
@@ -810,6 +865,31 @@ class AppUiToadletTest {
     return httpRequest("HEAD", url, Map.of());
   }
 
+  private static RawHttpResponseCapture rawHttpGet(String url, Map<String, String> headers)
+      throws IOException {
+    URI uri = URI.create(url);
+    String target =
+        uri.getRawQuery() == null ? uri.getRawPath() : uri.getRawPath() + "?" + uri.getRawQuery();
+    try (Socket socket = new Socket(uri.getHost(), uri.getPort())) {
+      socket.setSoTimeout(2000);
+      StringBuilder request = new StringBuilder("GET ").append(target).append(" HTTP/1.1\r\n");
+      request
+          .append("Host: ")
+          .append(uri.getHost())
+          .append(':')
+          .append(uri.getPort())
+          .append("\r\n");
+      request.append("Connection: close\r\n");
+      headers.forEach(
+          (name, value) -> request.append(name).append(": ").append(value).append("\r\n"));
+      request.append("\r\n");
+      socket.getOutputStream().write(request.toString().getBytes(StandardCharsets.ISO_8859_1));
+      socket.getOutputStream().flush();
+      return RawHttpResponseCapture.parse(
+          new String(socket.getInputStream().readAllBytes(), StandardCharsets.ISO_8859_1));
+    }
+  }
+
   private static HttpResponseCapture httpRequest(
       String method, String url, Map<String, String> headers) throws IOException {
     HttpURLConnection connection = (HttpURLConnection) URI.create(url).toURL().openConnection();
@@ -940,6 +1020,37 @@ class AppUiToadletTest {
 
     private long contentLength() {
       return connection.getContentLengthLong();
+    }
+  }
+
+  private record RawHttpResponseCapture(int statusCode, Map<String, String> headers, String body) {
+    private static RawHttpResponseCapture parse(String response) {
+      int headerEnd = response.indexOf("\r\n\r\n");
+      String headerText = headerEnd < 0 ? response : response.substring(0, headerEnd);
+      String body = headerEnd < 0 ? "" : response.substring(headerEnd + 4);
+      List<String> headerLines = headerText.lines().toList();
+      int statusCode = parseStatusCode(headerLines.get(0));
+      Map<String, String> headers = new HashMap<>();
+      for (int i = 1; i < headerLines.size(); i++) {
+        String headerLine = headerLines.get(i);
+        int colon = headerLine.indexOf(':');
+        if (colon > 0) {
+          headers.put(
+              headerLine.substring(0, colon).toLowerCase(Locale.ROOT),
+              headerLine.substring(colon + 1).trim());
+        }
+      }
+      return new RawHttpResponseCapture(statusCode, headers, body);
+    }
+
+    private static int parseStatusCode(String statusLine) {
+      int firstSpace = statusLine.indexOf(' ');
+      int secondSpace = statusLine.indexOf(' ', firstSpace + 1);
+      return Integer.parseInt(statusLine.substring(firstSpace + 1, secondSpace));
+    }
+
+    private String header(String name) {
+      return headers.get(name.toLowerCase(Locale.ROOT));
     }
   }
 

--- a/build-logic/src/main/kotlin/cryptad.runtime.gradle.kts
+++ b/build-logic/src/main/kotlin/cryptad.runtime.gradle.kts
@@ -149,6 +149,7 @@ val computeJlinkModules by
         "jdk.localedata",
         "jdk.unsupported",
         "jdk.zipfs",
+        "jdk.httpserver",
         "java.net.http",
         "java.desktop",
       )

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -67,10 +67,11 @@ files, `https:`, and loopback-only `http:` sources. Catalog ZIP extraction drops
 `__MACOSX/**` and AppleDouble `._*` metadata entries before verification; executable app payload
 still has to match the signed bundle digest.
 
-App-owned static UI routes serve files from the immutable installed bundle under `/apps/{appId}/`.
-They do not serve app data, cache, run directories, catalog scratch directories, or caller staging
-paths. Static UI remains same-origin with the local admin UI and Platform API, so external URL
-entries are rejected and route responses use conservative CSP, `nosniff`, no-referrer, and
+App-owned static UI routes serve files from the immutable installed bundle. Static apps prefer a
+distinct loopback-only browser origin per app, with `/apps/{appId}/` retained as a compatibility
+and diagnostics fallback. They do not serve app data, cache, run directories, catalog scratch
+directories, or caller staging paths. External URL entries are rejected, app UI listeners bind only
+to loopback addresses, and route responses use conservative CSP, `nosniff`, no-referrer, and
 non-public no-cache headers.
 
 AppHost process launches are process isolation, not hard sandboxing by default. AppHost starts a
@@ -80,7 +81,8 @@ Platform API authentication. App manifests can request `sandbox.mode=none`,
 `restricted-process`, or `wasm-preview`, and Platform API/Web Shell surfaces report the requested
 mode and actual support level. The default restricted-process provider is best-effort launch
 hygiene, not a container, WASM runtime, seccomp profile, chroot, jail, Windows Job Object policy,
-network isolation, or browser origin isolation.
+network isolation, or browser UI origin isolation. Browser UI origin isolation is provided by the
+app-owned UI loopback listener layer and does not make the child process sandboxed.
 
 AppHost enforces manifest data/cache quotas only when `quota.data.bytes` or `quota.cache.bytes` is
 positive. Missing quota fields and explicit `0` values mean unlimited or no explicit app quota for
@@ -101,13 +103,29 @@ principals are denied by default unless the route is covered by manifest-declare
 as `queue.read`, `queue.write`, or `content.insert`. Invalid or stale `X-Crypta-App-Token` values
 fail authentication, and missing capabilities fail authorization without echoing the token.
 
-App-owned static browser UI uses a separate browser app session. The dynamic bootstrap at
-`/apps/{appId}/.well-known/cryptad-bootstrap.json` returns route metadata, an opaque
-`browserSessionToken`, and an expiry timestamp. Static UI sends that token as
-`X-Crypta-App-Session`; the Platform API treats the request as an app browser principal and applies
-the same manifest capability matrix. Browser sessions are distinct from `CRYPTAD_APP_TOKEN`, are
-bound to one installed static app, and must not be persisted by app JavaScript. Invalid browser
-sessions fail with `401 invalid_app_browser_session`.
+App-owned static browser UI uses a separate browser app session. On isolated app origins, the
+dynamic bootstrap at `/.well-known/cryptad-bootstrap.json` returns route metadata, the absolute
+admin Platform API root, UI origin metadata, an opaque `browserSessionToken`, and an expiry
+timestamp. The compatibility `/apps/{appId}/.well-known/cryptad-bootstrap.json` route remains for
+explicit same-origin fallback. Static UI sends that token as `X-Crypta-App-Session`; the Platform
+API treats the request as an app browser principal and applies the same manifest capability matrix.
+Browser sessions are distinct from `CRYPTAD_APP_TOKEN`, are bound to one installed static app and
+the expected browser origin, and must not be persisted by app JavaScript. Invalid browser sessions
+fail with `401 invalid_app_browser_session`; mismatched isolated origins fail with
+`403 origin_mismatch`.
+
+Isolated bootstrap token issuance also requires an admin/Web Shell launch proof. The Web Shell opens
+static apps through the same-origin compatibility launch route, which redirects to the isolated
+origin with a short-lived nonce in the URL fragment. The SDK echoes that proof as
+`X-Crypta-App-Bootstrap-Nonce` before the loopback server returns a browser-session token. Public
+app-origin URLs and app summaries do not contain this proof and are not enough to mint browser
+sessions.
+
+Platform API CORS for app browsers is restricted to active registered app UI origins. It never uses
+wildcard `Access-Control-Allow-Origin`, never allows cookies or local-admin credentials, and does
+not allow `X-Crypta-App-Token` through app-browser preflight. Requests from registered app origins
+without `X-Crypta-App-Session` fail as app-browser requests and cannot silently fall back to
+host/operator authentication.
 
 Runtime status and process-log Platform API responses must remain token-free and path-free. Log
 tail responses redact the current launch token and obvious `CRYPTAD_APP_TOKEN=...` text before
@@ -122,15 +140,18 @@ distinguish process-token requests from browser-session requests. They must not 
 tokens, raw browser session tokens, query strings, request bodies, form passwords, or filesystem
 paths.
 
-Static UI code still runs in the local admin origin until stronger isolation exists. Browser app
-sessions improve server-side attribution and capability enforcement for SDK/API calls, but they are
-not a browser-enforced origin sandbox. Treat untrusted static UI JavaScript as having local admin
-browser-origin access.
+Static UI code should run on its isolated per-app loopback origin when available. Browser app
+sessions improve server-side attribution and capability enforcement for SDK/API calls, and the
+isolated origin separates app JavaScript from the Web Shell/admin origin. The compatibility
+same-origin `/apps/{appId}/` path is for fallback and diagnostics, not the preferred third-party
+app UI boundary.
 
 Treat a bypass that serves host files, follows symlink escapes, executes JavaScript while the admin
 UI has JavaScript disabled, exposes AppHost launch tokens or browser session tokens to the wrong
-surface, authenticates app browser requests as host/operator requests, bypasses app capability
-checks, or allows bundled UI to exfiltrate operator-entered data off-node as security-relevant.
+surface, binds app UI listeners to wildcard or LAN-visible interfaces, shares one browser origin
+across unrelated static apps, authenticates app browser requests as host/operator requests, bypasses
+app capability checks, or allows bundled UI to exfiltrate operator-entered data off-node as
+security-relevant.
 
 For the detailed runtime boundary, exposed environment variables, restart policy semantics,
 permission matrix, audit model, and remaining limitations, see

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -114,12 +114,14 @@ the expected browser origin, and must not be persisted by app JavaScript. Invali
 fail with `401 invalid_app_browser_session`; mismatched isolated origins fail with
 `403 origin_mismatch`.
 
-Isolated bootstrap token issuance also requires an admin/Web Shell launch proof. The Web Shell opens
-static apps through the same-origin compatibility launch route, which redirects to the isolated
-origin with a short-lived nonce in the URL fragment. The SDK echoes that proof as
-`X-Crypta-App-Bootstrap-Nonce` before the loopback server returns a browser-session token. Public
-app-origin URLs and app summaries do not contain this proof and are not enough to mint browser
-sessions.
+Isolated bootstrap token issuance also requires an admin/Web Shell launch proof. Web Shell first
+checks that the current browser can read a token-free origin probe from the app loopback listener.
+Only then does it send an explicit same-origin compatibility launch request, which redirects to the
+isolated origin with a short-lived nonce in the URL fragment. If the probe is not reachable, such as
+from a remote browser or a single-port tunnel, the compatibility route remains a same-origin
+fallback. The SDK echoes the launch proof as `X-Crypta-App-Bootstrap-Nonce` before the loopback
+server returns a browser-session token. Public app-origin URLs and app summaries do not contain this
+proof and are not enough to mint browser sessions.
 
 Platform API CORS for app browsers is restricted to active registered app UI origins. It never uses
 wildcard `Access-Control-Allow-Origin`, never allows cookies or local-admin credentials, and does

--- a/docs/app-owned-ui.md
+++ b/docs/app-owned-ui.md
@@ -87,10 +87,13 @@ The legacy HTTP admin adapter still mounts static app UI compatibility paths suc
 /apps/{appId}/.well-known/cryptad-bootstrap.json
 ```
 
-When an isolated origin is active, `GET /apps/{appId}/` redirects to the app's isolated UI URL with
-a short-lived bootstrap nonce in the URL fragment. `GET /apps/{appId}` still redirects to
-`/apps/{appId}/` first. Static asset paths under `/apps/{appId}/static/...` remain available as an
-explicit same-origin fallback for compatibility and diagnostics.
+The compatibility route stays same-origin by default, even when an isolated origin is active.
+`GET /apps/{appId}` still redirects to `/apps/{appId}/` first, and the fallback root then serves a
+root entry directly or redirects to the static entry directory. Web Shell opens the isolated path
+only after the browser can read a token-free origin probe from the per-app loopback listener; that
+explicit launch request receives the short-lived bootstrap nonce in the isolated URL fragment.
+Static asset paths under `/apps/{appId}/static/...` remain available as an explicit same-origin
+fallback for compatibility and diagnostics.
 
 When isolation is unavailable or an operator opens the explicit fallback path, a static entry at
 the bundle root can be served directly from `/apps/{appId}/`. For nested entries such as

--- a/docs/app-owned-ui.md
+++ b/docs/app-owned-ui.md
@@ -1,16 +1,18 @@
 # App-owned static UI
 
-This document describes how installed AppHost bundles declare and serve app-owned browser UI under
-`/apps/{appId}/`.
+This document describes how installed AppHost bundles declare and serve app-owned browser UI.
+Static app UIs prefer isolated per-app loopback origins, while the legacy `/apps/{appId}/` route
+remains as a compatibility and diagnostics fallback.
 
 ## Scope
 
 App-owned static UI is a local browser surface for installed apps. Static app pages receive a
 browser-scoped app session for Platform API calls, and the server authorizes those calls with the
-installed app's manifest permissions. This does not add sandboxing, container execution, browser
-origin isolation, or remote protocol changes. The [`CryptaPlatform` JavaScript SDK](platform-sdk-js.md)
-is a browser convenience wrapper around bootstrap and Platform API calls; permission enforcement
-remains server-side.
+installed app's manifest permissions. The preferred Phase 6 path serves each static app from a
+distinct loopback-only browser origin such as `http://127.0.0.1:<appUiPort>/`. This does not add
+process sandboxing, container execution, network isolation, or remote protocol changes. The
+[`CryptaPlatform` JavaScript SDK](platform-sdk-js.md) is a browser convenience wrapper around
+bootstrap and Platform API calls; permission enforcement remains server-side.
 
 The route serves immutable files from the installed app bundle only. It does not serve app data,
 cache, run directories, catalog scratch directories, or caller staging paths.
@@ -39,9 +41,45 @@ External URLs are not supported. Static entries reject absolute paths, Windows d
 empty segments, `.`, `..`, backslashes after normalization, reserved distribution sidecars, ISO
 control characters, and path segments with colons.
 
-## Static route behavior
+## Isolated app origins
 
-The legacy HTTP admin adapter mounts static app UI at app-owned paths such as:
+For static apps, Cryptad allocates a distinct loopback listener per installed app when isolation is
+available. The Web Shell and Platform API remain on the local admin origin, for example:
+
+```text
+http://127.0.0.1:<adminPort>/app/node/
+http://127.0.0.1:<adminPort>/api/v1/
+```
+
+Each static app UI opens on its own local origin:
+
+```text
+http://127.0.0.1:<appUiPort>/
+http://127.0.0.1:<anotherAppUiPort>/
+```
+
+App UI listeners bind only to loopback addresses and do not listen on wildcard or LAN-visible
+interfaces. Distinct ports create distinct browser origins; apps do not share one app-UI origin.
+
+An isolated app origin serves:
+
+```text
+GET /                         -> app entry or canonical entry-directory redirect
+GET /static/...               -> installed bundle static assets
+GET /.well-known/cryptad-bootstrap.json -> dynamic bootstrap JSON
+HEAD variants for those paths
+```
+
+The same installed-bundle confinement, traversal rejection, content-type mapping, no-store dynamic
+bootstrap policy, and static UI security headers apply on isolated origins.
+The bootstrap `GET` additionally requires a short-lived launch proof minted by the admin/Web Shell
+route and echoed by the SDK as `X-Crypta-App-Bootstrap-Nonce`. This keeps public app-origin route
+metadata from being enough for another local caller to mint an app browser-session token. Static
+assets remain readable from the app origin without that proof so the browser can load the page.
+
+## Compatibility route behavior
+
+The legacy HTTP admin adapter still mounts static app UI compatibility paths such as:
 
 ```text
 /apps/{appId}/
@@ -49,19 +87,26 @@ The legacy HTTP admin adapter mounts static app UI at app-owned paths such as:
 /apps/{appId}/.well-known/cryptad-bootstrap.json
 ```
 
-`GET /apps/{appId}/` serves the app's declared static `app.ui.entry` when that entry lives at the
-bundle root. `HEAD` returns the same headers without a body. `GET /apps/{appId}` redirects to
-`/apps/{appId}/`.
+When an isolated origin is active, `GET /apps/{appId}/` redirects to the app's isolated UI URL with
+a short-lived bootstrap nonce in the URL fragment. `GET /apps/{appId}` still redirects to
+`/apps/{appId}/` first. Static asset paths under `/apps/{appId}/static/...` remain available as an
+explicit same-origin fallback for compatibility and diagnostics.
 
-For nested entries such as `static/index.html`, `GET /apps/{appId}/` redirects to the entry
-directory, such as `/apps/{appId}/static/`. That preserves the browser base URL, so a page can use
-normal references such as `./app.js` and `../shared.js`. Explicit paths such as
-`/apps/{appId}/static/app.js` still resolve as bundle-relative paths. All served targets must
-resolve to regular files inside the immutable installed bundle root.
+When isolation is unavailable or an operator opens the explicit fallback path, a static entry at
+the bundle root can be served directly from `/apps/{appId}/`. For nested entries such as
+`static/index.html`, the fallback root redirects to the entry directory, such as
+`/apps/{appId}/static/`. That preserves the browser base URL, so a page can use normal references
+such as `./app.js` and `../shared.js`. Explicit paths such as `/apps/{appId}/static/app.js` still
+resolve as bundle-relative paths. All served targets must resolve to regular files inside the
+immutable installed bundle root.
 
 To preserve the browser base URL for nested entries, Platform API summaries publish `uiUrl` at the
-entry directory when needed. For `app.ui.entry=static/index.html`, `uiUrl` is
-`/apps/{appId}/static/`.
+entry directory when needed. With an isolated binding, `uiUrl` is an absolute app-origin URL such
+as `http://127.0.0.1:<appUiPort>/static/`. Without isolation, fallback summaries use the legacy
+same-origin path such as `/apps/{appId}/static/`.
+The isolated `uiUrl` is public route metadata, not a bearer credential and not the complete launch
+handshake. Web Shell opens isolated apps through the same-origin compatibility launch path so the
+admin adapter can mint a fresh bootstrap nonce before the browser reaches the isolated origin.
 
 Only installed apps with `uiMode=static` are served. Missing app ids, non-static apps, missing
 files, and directories return not found responses. Malformed paths, traversal attempts, encoded
@@ -84,29 +129,40 @@ Referrer-Policy: no-referrer
 If JavaScript is disabled for the legacy admin UI, Cryptad changes the app UI CSP to
 `script-src 'none'` for the same response.
 
+Isolated app-origin responses keep scripts local to the app origin and add `connect-src` for the
+admin Platform API root supplied in bootstrap. They do not allow remote scripts, objects, embeds,
+or `base` rewriting. Frame ancestry is limited to the Web Shell/admin origin when embedding is
+enabled by the host response.
+
 App-owned UI uses stable URLs across reinstall and update operations. Responses are therefore sent
 with non-public no-cache headers instead of the legacy admin adapter's long-lived static cache
 policy.
 
-The route remains same-origin with the local admin UI and Platform API. Static browser UI does not
-receive `CRYPTAD_APP_TOKEN` and cannot authenticate as the app process. Instead, app-owned bootstrap
-issues a browser session token for `X-Crypta-App-Session`. Platform API requests with that header
-become app browser principals and use the same central capability matrix as process app tokens.
-
-This is a server-side authorization boundary, not browser-enforced origin isolation. Same-origin
-JavaScript can still make same-origin requests. Until stronger browser isolation exists, install
-static UI bundles only from sources trusted to run JavaScript in the local admin origin.
+Static browser UI does not receive `CRYPTAD_APP_TOKEN` and cannot authenticate as the app process.
+Instead, app-owned bootstrap issues a browser session token for `X-Crypta-App-Session`. Platform
+API requests with that header become app browser principals and use the same central capability
+matrix as process app tokens.
 
 ## First-party app bootstrap
 
-First-party static app UIs can fetch:
+On an isolated app origin, static app UIs fetch bootstrap from their current origin:
+
+```text
+GET /.well-known/cryptad-bootstrap.json
+X-Crypta-App-Bootstrap-Nonce: <short-lived-launch-proof>
+```
+
+The same-origin compatibility route can also return a fallback bootstrap for explicit fallback UI
+loading:
 
 ```text
 GET /apps/{appId}/.well-known/cryptad-bootstrap.json
 ```
 
-The legacy HTTP admin adapter builds this JSON dynamically after the same full-access check used by
-app UI assets. The path is reserved by the host; it is not read from the installed bundle.
+The host builds this JSON dynamically. The isolated app origin serves it without exposing local
+admin form passwords; the same-origin compatibility route still applies the normal full-access
+check used by legacy app UI assets. The path is reserved by the host; it is not read from the
+installed bundle.
 
 The current payload is deliberately small:
 
@@ -118,15 +174,40 @@ The current payload is deliberately small:
   "assetRoot": "/apps/queue-manager/static/",
   "platformApiRoot": "/api/v1/",
   "shellRoot": "/app/node/",
+  "uiOrigin": null,
+  "uiOriginMode": "same-origin-fallback",
+  "uiOriginStatus": "fallback",
+  "sameOriginFallbackUrl": "/apps/queue-manager/",
+  "browserSessionToken": "<opaque-browser-session-token>",
+  "browserSessionExpiresAt": "2026-04-28T12:00:00Z"
+}
+```
+
+For isolated app origins, `uiRoot`, `assetRoot`, `platformApiRoot`, and `shellRoot` are absolute
+local URLs. For example:
+
+```json
+{
+  "appId": "queue-manager",
+  "uiRoot": "http://127.0.0.1:12345/",
+  "assetRoot": "http://127.0.0.1:12345/static/",
+  "platformApiRoot": "http://127.0.0.1:8888/api/v1/",
+  "shellRoot": "http://127.0.0.1:8888/app/node/",
+  "uiOrigin": "http://127.0.0.1:12345",
+  "uiOriginMode": "isolated-loopback",
+  "uiOriginStatus": "active",
+  "sameOriginFallbackUrl": "/apps/queue-manager/",
   "browserSessionToken": "<opaque-browser-session-token>",
   "browserSessionExpiresAt": "2026-04-28T12:00:00Z"
 }
 ```
 
 `browserSessionToken` is an opaque bearer value generated by the node for the installed static app.
-It is bound to the app id, the installed manifest permissions, the issue time, and an absolute
-expiry. The current in-memory implementation uses a one-hour lifetime and rejects blank, unknown,
-expired, uninstalled-app, non-static-app, or stale manifest sessions.
+It is bound to the app id, the installed manifest permissions, the expected browser origin, the
+origin mode, the issue time, and an absolute expiry. The current in-memory implementation uses a
+one-hour lifetime and rejects blank, unknown, expired, uninstalled-app, non-static-app, or stale
+manifest sessions. Isolated-loopback sessions also reject missing-origin or mismatched-origin
+Platform API calls.
 
 Static app UIs send the token as:
 
@@ -140,6 +221,28 @@ legacy local-admin `formPassword`. The browser session token is not an AppHost p
 token, and apps must not persist it in local storage or session storage. The
 [Platform JavaScript SDK](platform-sdk-js.md) keeps it in memory and adds `X-Crypta-App-Session` to
 Platform API calls.
+
+## Platform API CORS
+
+The Platform API remains on the local admin origin. Isolated app UIs call it cross-origin through
+restricted CORS and `X-Crypta-App-Session`.
+
+Only active registered app UI origins are allowed. Cryptad does not return
+`Access-Control-Allow-Origin: *`, does not allow credentials or cookies for app UI origins, and
+does not allow app process-token headers through CORS preflight. Allowed app-browser request
+headers are limited to:
+
+```text
+X-Crypta-App-Session
+Content-Type
+Accept
+```
+
+Actual app-origin requests must carry `Origin` matching the verified browser session. A session for
+one app cannot authenticate another app's origin. Requests from a registered app origin without
+`X-Crypta-App-Session` fail with `401 invalid_app_browser_session` and do not fall back to
+host/operator Web Shell authentication. Requests with a mismatched origin fail with
+`403 origin_mismatch`.
 
 Queue Manager and Publisher are also the primary replacements for the legacy queue and insert
 admin pages in the current retirement map. The full map is maintained in
@@ -156,7 +259,11 @@ Installed app summaries expose UI metadata:
   "version": "1.0.0",
   "uiMode": "static",
   "uiEntry": "static/index.html",
-  "uiUrl": "/apps/demo-app/static/",
+  "uiUrl": "http://127.0.0.1:12345/static/",
+  "uiOrigin": "http://127.0.0.1:12345",
+  "uiOriginMode": "isolated-loopback",
+  "uiOriginStatus": "active",
+  "sameOriginFallbackUrl": "/apps/demo-app/",
   "running": false
 }
 ```

--- a/docs/app-permissions-and-audit.md
+++ b/docs/app-permissions-and-audit.md
@@ -8,8 +8,8 @@ recent app decisions.
 The app permission boundary applies to local AppHost child processes that authenticate with their
 current launch token and to app-owned static browser UIs that authenticate with browser app
 sessions. It is separate from AppHost sandbox status. Permission checks do not add containers, WASM
-isolation, seccomp, chroot, browser origin isolation, FCP changes, wire-protocol changes, or
-persistent compliance-grade audit storage.
+isolation, seccomp, chroot, FCP changes, wire-protocol changes, or persistent compliance-grade
+audit storage.
 
 Host/operator Web Shell requests keep the existing local-admin model. They do not need app
 permissions, and they are not recorded in the app audit log.
@@ -41,10 +41,24 @@ app summaries, runtime status, process-log responses, audit entries, diagnostic 
 
 ## Browser session authentication
 
-Installed static app UIs fetch `/apps/{appId}/.well-known/cryptad-bootstrap.json` after the normal
-full-access check for app-owned UI routes. The bootstrap contains an opaque `browserSessionToken`
-and a `browserSessionExpiresAt` timestamp. It does not contain `CRYPTAD_APP_TOKEN`, a raw process
-launch token, local-admin `formPassword`, filesystem paths, signing keys, or trusted-key material.
+Installed static app UIs prefer a per-app loopback browser origin and fetch
+`/.well-known/cryptad-bootstrap.json` from that origin. The legacy
+`/apps/{appId}/.well-known/cryptad-bootstrap.json` route remains as an explicit same-origin
+fallback. The bootstrap contains an opaque `browserSessionToken`, `browserSessionExpiresAt`, UI
+origin metadata, and the Platform API root the app should call. It does not contain
+`CRYPTAD_APP_TOKEN`, a raw process launch token, local-admin `formPassword`, filesystem paths,
+signing keys, or trusted-key material.
+
+On isolated origins, bootstrap `GET` must also include the short-lived launch proof minted by the
+admin/Web Shell compatibility launch route:
+
+```text
+X-Crypta-App-Bootstrap-Nonce: <short-lived-launch-proof>
+```
+
+App summaries may publish public `uiUrl` and `uiOrigin` metadata, but they do not publish this
+proof. A caller that only knows another app's loopback port cannot mint that app's browser-session
+token.
 
 Browser apps present the token to Platform API v1 with:
 
@@ -52,10 +66,18 @@ Browser apps present the token to Platform API v1 with:
 X-Crypta-App-Session: <token>
 ```
 
-The session is bound to one installed static app and its manifest permissions. Blank, unknown,
-expired, uninstalled-app, non-static-app, or stale manifest sessions fail with
-`401 invalid_app_browser_session`. The raw browser session token is not recorded in audit,
-diagnostics, summaries, logs, errors, or `toString()` output.
+The session is bound to one installed static app, its manifest permissions, the expected browser
+origin, and the origin mode. Blank, unknown, expired, uninstalled-app, non-static-app, or stale
+manifest sessions fail with `401 invalid_app_browser_session`. Isolated-loopback sessions also
+require an `Origin` header matching the session origin and an active registered app UI origin for
+that app. A mismatch fails with `403 origin_mismatch`. The raw browser session token is not
+recorded in audit, diagnostics, summaries, logs, errors, or `toString()` output.
+
+The Platform API accepts cross-origin app-browser requests only from currently registered app UI
+origins. CORS responses never use wildcard origins, never allow cookies or local-admin
+credentials, and do not allow `X-Crypta-App-Token` through app-browser preflight. Requests from a
+registered app origin without `X-Crypta-App-Session` fail as app-browser authentication failures
+and do not fall back to host/operator Web Shell authentication.
 
 ## App principals
 
@@ -69,6 +91,7 @@ When a browser session authenticates, the Platform API receives a token-free app
 
 - app id;
 - manifest-declared permissions bound to the verified browser session;
+- expected browser origin and origin mode;
 - authentication source `APP_BROWSER_SESSION`.
 
 Neither principal carries the raw credential. The permission list is immutable and sorted before the

--- a/docs/apphost-runtime-hardening.md
+++ b/docs/apphost-runtime-hardening.md
@@ -22,10 +22,11 @@ The current boundary provides:
 - best-effort owner-only permissions on POSIX app data, cache, run, and process-log files;
 - bounded in-session restart attempts when a manifest opts in to `on-failure`.
 
-The current boundary does not provide containers, WASM isolation, seccomp, chroot, jails, Windows
-Job Object restrictions, browser origin isolation, or network isolation by default. A third-party
-app still runs as a local process under the same operating-system user as the daemon unless a future
-provider explicitly reports an enforced sandbox.
+The current process boundary does not provide containers, WASM isolation, seccomp, chroot, jails,
+Windows Job Object restrictions, or network isolation by default. A third-party app still runs as a
+local process under the same operating-system user as the daemon unless a future provider
+explicitly reports an enforced sandbox. Browser UI origin isolation is handled separately by the
+app-owned UI layer with per-app loopback origins; it does not change the AppHost process sandbox.
 
 ## Sandbox policy
 
@@ -91,8 +92,8 @@ permissions, never the token itself. See [app-permissions-and-audit.md](app-perm
 for the capability matrix and audit surface.
 
 Static browser UI uses a separate app browser session issued by the app-owned UI bootstrap route.
-That session is not an AppHost launch token, is not injected into the child process environment,
-and does not change process-token behavior.
+That session is bound to the app id and expected browser origin, is not an AppHost launch token, is
+not injected into the child process environment, and does not change process-token behavior.
 
 AppHost does not inject daemon datastore paths, trusted-key files, catalog roots, signing material,
 or the daemon's current working directory. The child process working directory is the installed app

--- a/docs/phase-3-platform-primacy-closeout.md
+++ b/docs/phase-3-platform-primacy-closeout.md
@@ -171,8 +171,9 @@ Phase 4 candidates were plans, not PR-194 implementation scope. Current status:
 
 - Remote signed app catalogs and verified artifact staging have landed; background update
   scheduling remains future work.
-- App-owned static UI routes have landed for installed static bundles; stronger isolation remains
-  future work.
+- App-owned static UI routes have landed for installed static bundles, and Phase 6 now provides
+  isolated per-app loopback browser origins with `/apps/{appId}/` retained as compatibility
+  fallback.
 - Standalone developer tooling has landed through the `crypta-app` CLI for scaffolding,
   validation, signing, packaging, verification, and catalog authoring.
 - Broader first-party app catalog remains future work.

--- a/docs/platform-api-surface.md
+++ b/docs/platform-api-surface.md
@@ -15,18 +15,22 @@ declared stable remote public API.
 Web Shell v1 is mounted separately at `/app/node/`. Its static assets are served beneath
 `/app/node/static/`, and its bootstrap payload points the browser at the Platform API root.
 
-Installed apps with static browser UI are mounted separately at `/apps/{appId}/`. The Platform API
-continues to own the JSON lifecycle/control plane under `/api/v1/apps`; it only publishes
-`uiMode`, `uiEntry`, and `uiUrl` so shells can open the correct app UI route.
+Installed apps with static browser UI prefer isolated per-app loopback origins, with
+`/apps/{appId}/` retained as a compatibility route. The Platform API continues to own the JSON
+lifecycle/control plane under `/api/v1/apps`; it publishes `uiMode`, `uiEntry`, `uiUrl`,
+`uiOrigin`, `uiOriginMode`, `uiOriginStatus`, and `sameOriginFallbackUrl` so shells can open the
+correct app UI route.
 
-Static first-party app UIs use `/apps/{appId}/.well-known/cryptad-bootstrap.json` for route
-metadata and an opaque browser app session token for Platform API calls. That bootstrap is served
-by the app UI route, not by `/api/v1/apps`, and it does not expose `CRYPTAD_APP_TOKEN`, local-admin
-`formPassword`, or AppHost filesystem paths.
+Static first-party app UIs use `/.well-known/cryptad-bootstrap.json` on their app origin for route
+metadata, origin metadata, and an opaque browser app session token for Platform API calls. The
+compatibility `/apps/{appId}/.well-known/cryptad-bootstrap.json` path can return fallback
+bootstrap metadata. Bootstrap is served by the app UI route, not by `/api/v1/apps`, and it does not
+expose `CRYPTAD_APP_TOKEN`, local-admin `formPassword`, or AppHost filesystem paths.
 
 The [Platform JavaScript SDK](platform-sdk-js.md) is a browser convenience layer over that
-bootstrap and the same-origin Platform API. It does not create a new authority boundary; server-side
-Platform API permission checks and app-origin audit remain authoritative.
+bootstrap and Platform API calls. It does not create the authority boundary; server-side Platform
+API permission checks, origin-bound browser sessions, restricted CORS, and app-origin audit remain
+authoritative.
 
 ## Response contract
 

--- a/docs/platform-sdk-js.md
+++ b/docs/platform-sdk-js.md
@@ -48,11 +48,13 @@ On isolated app origins, bootstrap data comes from the current origin:
 GET /.well-known/cryptad-bootstrap.json
 ```
 
-When Web Shell opens an isolated app, the admin compatibility route adds a short-lived launch proof
-to the app URL fragment. The SDK reads `cryptadBootstrapNonce` from that fragment, keeps it only in
-memory, and sends it to the same-origin bootstrap endpoint as
-`X-Crypta-App-Bootstrap-Nonce`. Directly opening a public isolated `uiUrl` without that launch
-proof can load static assets, but bootstrap will not issue an app browser-session token.
+When Web Shell opens an isolated app, it first checks a token-free origin probe on the app loopback
+listener from the current browser. If that probe is reachable, Web Shell sends an explicit launch
+request through the admin compatibility route, which adds a short-lived launch proof to the app URL
+fragment. The SDK reads `cryptadBootstrapNonce` from that fragment, keeps it only in memory, and
+sends it to the same-origin bootstrap endpoint as `X-Crypta-App-Bootstrap-Nonce`. Directly opening a
+public isolated `uiUrl` without that launch proof can load static assets, but bootstrap will not
+issue an app browser-session token.
 
 On the compatibility route, bootstrap data comes from:
 

--- a/docs/platform-sdk-js.md
+++ b/docs/platform-sdk-js.md
@@ -4,10 +4,11 @@ This document describes the browser-side `CryptaPlatform` SDK for app-owned stat
 
 ## Scope
 
-The SDK is a small, dependency-free JavaScript file for static app pages served under
-`/apps/{appId}/`. It wraps the current same-origin bootstrap and Platform API conventions used by
-first-party apps. It carries the browser app session token issued by app-owned UI bootstrap, but it
-is not the server-side authorization boundary and it is not a sandbox or browser isolation layer.
+The SDK is a small, dependency-free JavaScript file for static app pages served from app-owned UI
+origins. The preferred runtime path is an isolated loopback origin per static app, with
+`/apps/{appId}/` retained as a same-origin compatibility fallback. The SDK carries the browser app
+session token issued by app-owned UI bootstrap, but it is not the server-side authorization
+boundary and it is not an AppHost process sandbox.
 
 Static app bundles should load the staged SDK before app-specific JavaScript:
 
@@ -33,33 +34,49 @@ Call `CryptaPlatform.bootstrap.load()` before using API helpers:
 await CryptaPlatform.bootstrap.load();
 ```
 
-The SDK infers the app id from paths such as `/apps/queue-manager/static/`. Tests and unusual local
-mounts can pass an explicit app id:
+On the same-origin compatibility route, the SDK infers the app id from paths such as
+`/apps/queue-manager/static/`. Isolated app origins normally pass or receive the app id through
+bootstrap, and first-party apps still pass it explicitly:
 
 ```js
 await CryptaPlatform.bootstrap.load({ appId: "queue-manager" });
 ```
 
-Bootstrap data comes from:
+On isolated app origins, bootstrap data comes from the current origin:
+
+```text
+GET /.well-known/cryptad-bootstrap.json
+```
+
+When Web Shell opens an isolated app, the admin compatibility route adds a short-lived launch proof
+to the app URL fragment. The SDK reads `cryptadBootstrapNonce` from that fragment, keeps it only in
+memory, and sends it to the same-origin bootstrap endpoint as
+`X-Crypta-App-Bootstrap-Nonce`. Directly opening a public isolated `uiUrl` without that launch
+proof can load static assets, but bootstrap will not issue an app browser-session token.
+
+On the compatibility route, bootstrap data comes from:
 
 ```text
 GET /apps/{appId}/.well-known/cryptad-bootstrap.json
 ```
 
 The SDK keeps a sanitized in-memory copy of the bootstrap fields used by browser apps: `appId`,
-`name`, `uiRoot`, `assetRoot`, `platformApiRoot`, `shellRoot`, and `browserSessionExpiresAt`.
-It reads `browserSessionToken` into private in-memory state and does not expose it through
+`name`, `uiRoot`, `assetRoot`, `platformApiRoot`, `shellRoot`, `uiOrigin`, `uiOriginMode`,
+`uiOriginStatus`, `sameOriginFallbackUrl`, and `browserSessionExpiresAt`. It reads
+`browserSessionToken` into private in-memory state and does not expose it through
 `CryptaPlatform.bootstrap.current()`. `CryptaPlatform.app.currentId()` returns the current app id
 when it can be inferred or has been loaded.
 
 The SDK does not write the browser session token to `localStorage`, `sessionStorage`, cookies, or
-query strings.
+query strings. It also does not expose the bootstrap launch nonce through public SDK state.
 
 ## Platform API reads
 
-`CryptaPlatform.api.url(path)` builds a same-origin URL beneath the bootstrap `platformApiRoot`,
-falling back to `/api/v1/` when the root is missing or invalid. Invalid roots such as external
-URLs, protocol-relative URLs, and roots with query strings or fragments are ignored.
+`CryptaPlatform.api.url(path)` builds a URL beneath the bootstrap `platformApiRoot`, falling back to
+`/api/v1/` when the root is missing or invalid. Isolated app bootstrap supplies an absolute local
+admin Platform API root such as `http://127.0.0.1:<adminPort>/api/v1/`. Invalid roots such as
+remote URLs, protocol-relative URLs, roots outside `/api/v1/`, and roots with query strings or
+fragments are ignored.
 
 Use `CryptaPlatform.api.get(path, options)` for JSON reads:
 
@@ -80,7 +97,9 @@ const snapshot = await CryptaPlatform.queue.snapshot({
 ```
 
 The SDK sends `Accept: application/json` and `X-Crypta-App-Session` with the in-memory browser
-session token. It normalizes common Platform API error bodies into readable `Error` messages.
+session token. Cross-origin API calls use `credentials: "omit"`; app-owned browser authentication
+uses only the session header, not cookies or local-admin form credentials. The SDK normalizes
+common Platform API error bodies into readable `Error` messages.
 
 ## Mutations
 
@@ -96,9 +115,12 @@ await CryptaPlatform.content.insertDirectory(formData);
 ```
 
 `CryptaPlatform.api.postForm(path, formDataOrParams)` and
-`CryptaPlatform.api.deleteForm(path, formDataOrParams)` are available for other same-origin
+`CryptaPlatform.api.deleteForm(path, formDataOrParams)` are available for other app-browser
 Platform API form mutations. If no browser session token is available, the SDK rejects the call
 before it sends a request.
+When an in-memory browser session is still live, mutation helpers reuse it instead of forcing a new
+bootstrap exchange. This avoids depending on the short-lived isolated-origin launch nonce after the
+app tab is already open.
 
 The helper accepts `FormData`, `URLSearchParams`, arrays of pairs, or plain objects. Non-string
 `FormData` entries such as `File` values are not submitted because the current Platform API bridge
@@ -133,6 +155,10 @@ or stale. The SDK clears the in-memory token and raises an error marked with
 `code="invalid_app_browser_session"` and `sessionRefreshRequired=true`. First-party apps should
 surface that as a reload or session-refresh condition.
 
+`403 origin_mismatch` means the Platform API rejected the browser session because the request
+origin did not match the origin bound into the session. Apps should tell the user to reopen the app
+from Web Shell instead of retrying with stored state.
+
 ## HTML fragments
 
 Some queue endpoints still return legacy HTML fragments in JSON. Use
@@ -155,17 +181,16 @@ HTML.
 
 ## Security boundary
 
-The SDK runs in the same local browser origin as the app-owned UI and Platform API. It preserves
-the current local-admin Web Shell path while making app-owned UI API calls use app browser
-principals. It does not isolate third-party JavaScript or authenticate an app as an AppHost process.
+The SDK runs in the app-owned browser origin. In the preferred Phase 6 path that origin is a
+per-app loopback origin distinct from the Web Shell/admin origin. The Platform API still lives on
+the admin origin and accepts app-browser calls only through restricted CORS plus
+`X-Crypta-App-Session`. The same-origin `/apps/{appId}/` route remains a compatibility fallback,
+not the preferred third-party app UI boundary.
 
 AppHost process launch tokens such as `CRYPTAD_APP_TOKEN` are not exposed to browser apps, SDK
 state, app summaries, or bootstrap JSON. Browser code receives route metadata and an app browser
-session token. Permission enforcement and audit for app-originated API calls remain server-side
-Platform API behavior, not a browser SDK guarantee.
-
-Install static UI bundles only from sources trusted to run JavaScript in the local admin origin
-until stronger browser isolation exists.
+session token bound to the expected app origin. Permission enforcement and audit for
+app-originated API calls remain server-side Platform API behavior, not a browser SDK guarantee.
 
 ## First-party examples
 
@@ -186,5 +211,5 @@ const result = await CryptaPlatform.content.insertFile(formData);
 ```
 
 Both apps keep their own UI state, sort handling, key export behavior, and legacy form filtering.
-The SDK owns only bootstrap, same-origin API transport, mutation form submission, error parsing,
+The SDK owns only bootstrap, app-browser API transport, mutation form submission, error parsing,
 and conservative fragment sanitization.

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiPrincipal.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiPrincipal.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.TreeSet;
+import network.crypta.platform.appui.AppUiOriginMode;
 
 /**
  * Token-free identity attached to one Platform API request.
@@ -24,12 +25,16 @@ import java.util.TreeSet;
  * @param authSource transport-side authentication source that established the identity
  * @param appId normalized app id for app principals, or {@code null} for host/operator principals
  * @param permissions immutable sorted app permissions for app principals
+ * @param expectedOrigin browser origin bound to an app browser principal, or {@code null}
+ * @param originMode origin mode associated with an app browser principal, or {@code null}
  */
 public record PlatformApiPrincipal(
     PlatformApiPrincipalType type,
     PlatformApiAuthSource authSource,
     String appId,
-    List<String> permissions) {
+    List<String> permissions,
+    String expectedOrigin,
+    AppUiOriginMode originMode) {
   /**
    * Creates a validated token-free principal.
    *
@@ -42,14 +47,23 @@ public record PlatformApiPrincipal(
    * @throws NullPointerException if {@code type}, {@code authSource}, or {@code permissions} is
    *     {@code null}, or if a permission element is {@code null}
    */
+  public PlatformApiPrincipal(
+      PlatformApiPrincipalType type,
+      PlatformApiAuthSource authSource,
+      String appId,
+      List<String> permissions) {
+    this(type, authSource, appId, permissions, null, compatibilityOriginMode(type, authSource));
+  }
+
   public PlatformApiPrincipal {
     Objects.requireNonNull(type, "type");
     Objects.requireNonNull(authSource, "authSource");
     permissions = sortedPermissions(permissions);
     if (isAppPrincipalType(type)) {
       appId = validateAppPrincipal(type, authSource, appId);
+      validateAppOriginFields(type, expectedOrigin, originMode);
     } else {
-      validateHostPrincipal(authSource, appId, permissions);
+      validateHostPrincipal(authSource, appId, permissions, expectedOrigin, originMode);
     }
   }
 
@@ -83,7 +97,9 @@ public record PlatformApiPrincipal(
         PlatformApiPrincipalType.APP,
         PlatformApiAuthSource.APP_TOKEN,
         appId,
-        List.copyOf(permissions));
+        List.copyOf(permissions),
+        null,
+        null);
   }
 
   /**
@@ -99,11 +115,30 @@ public record PlatformApiPrincipal(
    */
   public static PlatformApiPrincipal appBrowserSession(
       String appId, Collection<String> permissions) {
+    return appBrowserSession(appId, permissions, null, AppUiOriginMode.SAME_ORIGIN_FALLBACK);
+  }
+
+  /**
+   * Builds an app browser principal from a verified origin-bound browser session identity.
+   *
+   * @param appId normalized app id associated with the verified browser session
+   * @param permissions manifest-declared permissions bound to the browser session
+   * @param expectedOrigin browser origin bound to the verified session
+   * @param originMode origin mode used when the session was issued
+   * @return token-free app browser principal ready for Platform API capability checks
+   */
+  public static PlatformApiPrincipal appBrowserSession(
+      String appId,
+      Collection<String> permissions,
+      String expectedOrigin,
+      AppUiOriginMode originMode) {
     return new PlatformApiPrincipal(
         PlatformApiPrincipalType.APP_BROWSER,
         PlatformApiAuthSource.APP_BROWSER_SESSION,
         appId,
-        List.copyOf(permissions));
+        List.copyOf(permissions),
+        expectedOrigin,
+        originMode);
   }
 
   /**
@@ -151,6 +186,15 @@ public record PlatformApiPrincipal(
     return type == PlatformApiPrincipalType.APP || type == PlatformApiPrincipalType.APP_BROWSER;
   }
 
+  private static AppUiOriginMode compatibilityOriginMode(
+      PlatformApiPrincipalType type, PlatformApiAuthSource authSource) {
+    if (type == PlatformApiPrincipalType.APP_BROWSER
+        && authSource == PlatformApiAuthSource.APP_BROWSER_SESSION) {
+      return AppUiOriginMode.SAME_ORIGIN_FALLBACK;
+    }
+    return null;
+  }
+
   private static String validateAppPrincipal(
       PlatformApiPrincipalType type, PlatformApiAuthSource authSource, String appId) {
     if (appId == null || appId.isBlank()) {
@@ -179,7 +223,11 @@ public record PlatformApiPrincipal(
   }
 
   private static void validateHostPrincipal(
-      PlatformApiAuthSource authSource, String appId, List<String> permissions) {
+      PlatformApiAuthSource authSource,
+      String appId,
+      List<String> permissions,
+      String expectedOrigin,
+      AppUiOriginMode originMode) {
     if (appId != null) {
       throw new IllegalArgumentException("host principal must not carry an app id");
     }
@@ -188,6 +236,26 @@ public record PlatformApiPrincipal(
     }
     if (authSource != PlatformApiAuthSource.HOST_LOCAL) {
       throw new IllegalArgumentException("host principal requires HOST_LOCAL auth source");
+    }
+    if (expectedOrigin != null || originMode != null) {
+      throw new IllegalArgumentException("host principal must not carry browser origin metadata");
+    }
+  }
+
+  private static void validateAppOriginFields(
+      PlatformApiPrincipalType type, String expectedOrigin, AppUiOriginMode originMode) {
+    if (type == PlatformApiPrincipalType.APP) {
+      if (expectedOrigin != null || originMode != null) {
+        throw new IllegalArgumentException(
+            "process app principal must not carry browser origin metadata");
+      }
+      return;
+    }
+    if (originMode == null) {
+      throw new IllegalArgumentException("browser app principal requires an origin mode");
+    }
+    if (expectedOrigin != null && expectedOrigin.isBlank()) {
+      throw new IllegalArgumentException("browser app principal origin must not be blank");
     }
   }
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -17,6 +17,7 @@ import network.crypta.platform.api.updates.UpdatesApiHandler;
 import network.crypta.platform.api.wizard.FirstTimeWizardApiHandler;
 import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.appui.AppUiOriginRegistry;
 import network.crypta.runtime.spi.LegacyAdminUsagePort;
 import network.crypta.runtime.spi.RuntimePorts;
 
@@ -135,7 +136,38 @@ public final class PlatformApiRouter {
       AppHost appHost,
       AppCatalogManager appCatalogManager,
       LegacyAdminUsagePort legacyAdminUsage) {
-    this(runtimePorts, appHost, appCatalogManager, legacyAdminUsage, new AppAuditLog());
+    this(
+        runtimePorts,
+        appHost,
+        appCatalogManager,
+        legacyAdminUsage,
+        new AppAuditLog(),
+        AppUiOriginRegistry.sameOriginOnly());
+  }
+
+  /**
+   * Creates a router backed by runtime ports, AppHost, signed catalogs, diagnostics, and app UI
+   * origin metadata.
+   *
+   * @param runtimePorts detached runtime-port aggregate used to resolve API requests
+   * @param appHost detached AppHost used by app lifecycle and catalog install/update routes
+   * @param appCatalogManager signed catalog manager used by the catalog endpoint family
+   * @param legacyAdminUsage optional process-local legacy admin usage source
+   * @param appUiOriginRegistry registry used to publish isolated app UI launch URLs
+   */
+  public PlatformApiRouter(
+      RuntimePorts runtimePorts,
+      AppHost appHost,
+      AppCatalogManager appCatalogManager,
+      LegacyAdminUsagePort legacyAdminUsage,
+      AppUiOriginRegistry appUiOriginRegistry) {
+    this(
+        runtimePorts,
+        appHost,
+        appCatalogManager,
+        legacyAdminUsage,
+        new AppAuditLog(),
+        appUiOriginRegistry);
   }
 
   PlatformApiRouter(
@@ -144,8 +176,25 @@ public final class PlatformApiRouter {
       AppCatalogManager appCatalogManager,
       LegacyAdminUsagePort legacyAdminUsage,
       AppAuditLog appAuditLog) {
+    this(
+        runtimePorts,
+        appHost,
+        appCatalogManager,
+        legacyAdminUsage,
+        appAuditLog,
+        AppUiOriginRegistry.sameOriginOnly());
+  }
+
+  PlatformApiRouter(
+      RuntimePorts runtimePorts,
+      AppHost appHost,
+      AppCatalogManager appCatalogManager,
+      LegacyAdminUsagePort legacyAdminUsage,
+      AppAuditLog appAuditLog,
+      AppUiOriginRegistry appUiOriginRegistry) {
     Objects.requireNonNull(runtimePorts, "runtimePorts");
     this.appAuditLog = Objects.requireNonNull(appAuditLog, "appAuditLog");
+    Objects.requireNonNull(appUiOriginRegistry, "appUiOriginRegistry");
     nodeApiHandler = new NodeApiHandler(runtimePorts.nodeInfo());
     peersApiHandler = new PeersApiHandler(runtimePorts.peer(), runtimePorts.darknetConnections());
     configApiHandler = new ConfigApiHandler(runtimePorts.config());
@@ -165,7 +214,8 @@ public final class PlatformApiRouter {
             runtimePorts.queueCompletion());
     alertsApiHandler = new AlertsApiHandler(runtimePorts.alertFeed(), runtimePorts.alertMutation());
     diagnosticsApiHandler = new DiagnosticsApiHandler(runtimePorts.diagnostic(), legacyAdminUsage);
-    appsApiHandler = appHost == null ? null : new AppsApiHandler(appHost, this.appAuditLog);
+    appsApiHandler =
+        appHost == null ? null : new AppsApiHandler(appHost, this.appAuditLog, appUiOriginRegistry);
     appCatalogsApiHandler =
         appHost == null || appCatalogManager == null
             ? null

--- a/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
@@ -14,6 +14,7 @@ import network.crypta.platform.api.AppAuditEvent;
 import network.crypta.platform.api.AppAuditLog;
 import network.crypta.platform.api.PlatformApiException;
 import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppBundleVerificationException;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppHostException;
@@ -29,6 +30,8 @@ import network.crypta.platform.apphost.sandbox.AppSandboxException;
 import network.crypta.platform.apphost.sandbox.AppSandboxPolicy;
 import network.crypta.platform.apphost.sandbox.AppSandboxProviders;
 import network.crypta.platform.apphost.sandbox.AppSandboxStatus;
+import network.crypta.platform.appui.AppUiOriginBinding;
+import network.crypta.platform.appui.AppUiOriginRegistry;
 import network.crypta.platform.appui.AppUiPaths;
 
 /**
@@ -83,6 +86,9 @@ public final class AppsApiHandler {
   /** Shared bounded audit log for app-originated Platform API decisions. */
   private final AppAuditLog auditLog;
 
+  /** Optional app UI origin registry used to publish isolated static UI links. */
+  private final AppUiOriginRegistry appUiOriginRegistry;
+
   /**
    * Creates an app-management handler backed by the supplied AppHost.
    *
@@ -104,8 +110,22 @@ public final class AppsApiHandler {
    * @param auditLog bounded process-local app audit log
    */
   public AppsApiHandler(AppHost appHost, AppAuditLog auditLog) {
+    this(appHost, auditLog, AppUiOriginRegistry.sameOriginOnly());
+  }
+
+  /**
+   * Creates an app-management handler backed by the supplied AppHost, audit log, and UI origin
+   * registry.
+   *
+   * @param appHost detached AppHost core used for app lifecycle operations
+   * @param auditLog bounded process-local app audit log
+   * @param appUiOriginRegistry registry used to publish isolated app UI launch URLs
+   */
+  public AppsApiHandler(
+      AppHost appHost, AppAuditLog auditLog, AppUiOriginRegistry appUiOriginRegistry) {
     this.appHost = Objects.requireNonNull(appHost, "appHost");
     this.auditLog = Objects.requireNonNull(auditLog, "auditLog");
+    this.appUiOriginRegistry = Objects.requireNonNull(appUiOriginRegistry, "appUiOriginRegistry");
   }
 
   /**
@@ -542,7 +562,18 @@ public final class AppsApiHandler {
     json.put("version", manifest.appVersion());
     json.put("uiMode", manifest.uiMode().manifestValue());
     json.put("uiEntry", manifest.uiEntry());
-    json.put("uiUrl", AppUiPaths.uiUrl(manifest));
+    AppUiOriginBinding uiOriginBinding = uiOriginBinding(manifest);
+    json.put(
+        "uiUrl", uiOriginBinding == null ? AppUiPaths.uiUrl(manifest) : uiOriginBinding.uiUrl());
+    json.put("uiOrigin", uiOriginBinding == null ? null : uiOriginBinding.origin());
+    json.put("uiOriginMode", uiOriginBinding == null ? null : uiOriginBinding.mode().jsonValue());
+    json.put(
+        "uiOriginStatus", uiOriginBinding == null ? null : uiOriginBinding.status().jsonValue());
+    json.put(
+        "sameOriginFallbackUrl",
+        uiOriginBinding == null
+            ? sameOriginFallbackUrl(manifest)
+            : uiOriginBinding.sameOriginFallbackUrl());
     json.put(FIELD_PERMISSIONS, manifest.permissions());
     json.put(FIELD_QUOTA, quota(manifest, quotaStatus));
     json.put(FIELD_SANDBOX, summarizeSandbox(sandboxStatus(manifest, running)));
@@ -619,6 +650,10 @@ public final class AppsApiHandler {
     json.put("uiMode", "none");
     json.put("uiEntry", null);
     json.put("uiUrl", null);
+    json.put("uiOrigin", null);
+    json.put("uiOriginMode", null);
+    json.put("uiOriginStatus", null);
+    json.put("sameOriginFallbackUrl", null);
     json.put(FIELD_PERMISSIONS, List.of());
     json.put(FIELD_QUOTA, unknownQuota());
     json.put(
@@ -631,6 +666,20 @@ public final class AppsApiHandler {
     json.put(FIELD_RECENT_DENIED_COUNT, auditLog.deniedCountForApp(appId));
     json.put("audit", auditSummary(appId));
     return json;
+  }
+
+  private AppUiOriginBinding uiOriginBinding(AppManifest manifest) {
+    if (manifest.uiMode() != AppUiMode.STATIC) {
+      return null;
+    }
+    return appUiOriginRegistry.bindingForApp(manifest.appId()).orElse(null);
+  }
+
+  private static String sameOriginFallbackUrl(AppManifest manifest) {
+    if (manifest.uiMode() == AppUiMode.STATIC) {
+      return AppUiPaths.appRoot(manifest.appId());
+    }
+    return AppUiPaths.uiUrl(manifest);
   }
 
   private Map<String, Object> auditSummary(String appId) {

--- a/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/apps/AppsApiHandler.java
@@ -669,10 +669,11 @@ public final class AppsApiHandler {
   }
 
   private AppUiOriginBinding uiOriginBinding(AppManifest manifest) {
+    AppUiOriginBinding binding = appUiOriginRegistry.bindingForApp(manifest.appId()).orElse(null);
     if (manifest.uiMode() != AppUiMode.STATIC) {
       return null;
     }
-    return appUiOriginRegistry.bindingForApp(manifest.appId()).orElse(null);
+    return binding;
   }
 
   private static String sameOriginFallbackUrl(AppManifest manifest) {

--- a/platform-api/src/test/java/network/crypta/platform/api/PlatformApiRequestTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/PlatformApiRequestTest.java
@@ -4,9 +4,11 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import network.crypta.platform.appui.AppUiOriginMode;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -51,6 +53,19 @@ class PlatformApiRequestTest {
   }
 
   @Test
+  void appBrowserSession_whenOriginMetadataProvided_expectPrincipalRetainsOriginBinding() {
+    PlatformApiPrincipal principal =
+        PlatformApiPrincipal.appBrowserSession(
+            "demo-app",
+            List.of("queue.read"),
+            "http://127.0.0.1:12345",
+            AppUiOriginMode.ISOLATED_LOOPBACK);
+
+    assertEquals("http://127.0.0.1:12345", principal.expectedOrigin());
+    assertEquals(AppUiOriginMode.ISOLATED_LOOPBACK, principal.originMode());
+  }
+
+  @Test
   void constructor_whenMutableInputsChange_expectRequestKeepsImmutableCopies() {
     ArrayList<String> segments = new ArrayList<>(List.of("queue"));
     ArrayList<String> values = new ArrayList<>(List.of("downloads"));
@@ -67,6 +82,23 @@ class PlatformApiRequestTest {
     Map<String, List<String>> copiedQuery = request.queryParameters();
     List<String> newValue = List.of("value");
     assertThrows(UnsupportedOperationException.class, () -> copiedQuery.put("new", newValue));
+  }
+
+  @Test
+  void constructor_whenFourArgAppBrowserPrincipalUsed_expectSameOriginFallbackMode() {
+    PlatformApiPrincipal principal =
+        new PlatformApiPrincipal(
+            PlatformApiPrincipalType.APP_BROWSER,
+            PlatformApiAuthSource.APP_BROWSER_SESSION,
+            "demo-app",
+            List.of("queue.read"));
+
+    assertEquals(PlatformApiPrincipalType.APP_BROWSER, principal.type());
+    assertEquals(PlatformApiAuthSource.APP_BROWSER_SESSION, principal.authSource());
+    assertEquals("demo-app", principal.appId());
+    assertEquals(List.of("queue.read"), principal.permissions());
+    assertNull(principal.expectedOrigin());
+    assertEquals(AppUiOriginMode.SAME_ORIGIN_FALLBACK, principal.originMode());
   }
 
   @Test
@@ -102,6 +134,16 @@ class PlatformApiRequestTest {
         () ->
             new PlatformApiPrincipal(
                 PlatformApiPrincipalType.APP, PlatformApiAuthSource.APP_TOKEN, " ", permissions));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new PlatformApiPrincipal(
+                PlatformApiPrincipalType.APP,
+                PlatformApiAuthSource.APP_TOKEN,
+                "demo-app",
+                permissions,
+                "http://127.0.0.1:12345",
+                AppUiOriginMode.ISOLATED_LOOPBACK));
   }
 
   @Test

--- a/platform-api/src/test/java/network/crypta/platform/api/apps/AppsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/apps/AppsApiHandlerTest.java
@@ -207,6 +207,37 @@ class AppsApiHandlerTest {
   }
 
   @Test
+  void update_whenUiModeStopsBeingStatic_expectOriginRegistryRefreshesStaleBinding()
+      throws IOException {
+    InstalledAppSnapshot staticSnapshot = snapshot(AppUiMode.STATIC, "static/index.html");
+    AppUiOriginBinding staleBinding =
+        AppUiOriginBinding.isolatedLoopback(
+            staticSnapshot.manifest(),
+            AppUiOrigin.loopback(APP_ID, 12345),
+            "http://127.0.0.1:8888/api/v1/",
+            "http://127.0.0.1:8888/app/node/");
+    RecordingOriginRegistry registry = new RecordingOriginRegistry(staleBinding);
+    InstalledAppSnapshot updatedSnapshot = snapshot(AppUiMode.SHELL_PANEL, SHELL_PANEL_ENTRY);
+    SingleAppHost appHost = new SingleAppHost(updatedSnapshot);
+    appHost.updateResult = updatedSnapshot;
+    AppsApiHandler handler = new AppsApiHandler(appHost, new AppAuditLog(), registry);
+    Path stagedDir = stageApp(tempDir.resolve("staged-shell-panel-update"));
+    Map<String, List<String>> updateParameters =
+        Map.of(STAGED_DIR_PARAMETER, List.of(stagedDir.toString()));
+
+    Map<String, Object> summary = handler.update(APP_ID, updateParameters);
+
+    assertEquals(1, appHost.updateCalls);
+    assertEquals(1, registry.bindingForAppCalls);
+    assertEquals(APP_ID, registry.lastAppId);
+    assertEquals("shell-panel", summary.get(FIELD_UI_MODE));
+    assertEquals(SHELL_PANEL_ENTRY, summary.get(FIELD_UI_URL));
+    assertNull(summary.get("uiOrigin"));
+    assertNull(summary.get("uiOriginMode"));
+    assertNull(summary.get("uiOriginStatus"));
+  }
+
+  @Test
   void get_whenNoUiAppInstalled_expectUiUrlIsNull() {
     AppsApiHandler handler = new AppsApiHandler(new SingleAppHost(snapshot(AppUiMode.NONE, null)));
 
@@ -498,6 +529,23 @@ class AppsApiHandlerTest {
     return appId -> binding.appId().equals(appId) ? Optional.of(binding) : Optional.empty();
   }
 
+  private static final class RecordingOriginRegistry implements AppUiOriginRegistry {
+    private final AppUiOriginBinding binding;
+    private int bindingForAppCalls;
+    private String lastAppId;
+
+    private RecordingOriginRegistry(AppUiOriginBinding binding) {
+      this.binding = binding;
+    }
+
+    @Override
+    public Optional<AppUiOriginBinding> bindingForApp(String appId) {
+      bindingForAppCalls++;
+      lastAppId = appId;
+      return binding.appId().equals(appId) ? Optional.of(binding) : Optional.empty();
+    }
+  }
+
   private static final class ThrowingAppHost implements AppHost {
     private IOException installFailure;
     private IOException updateFailure;
@@ -566,11 +614,13 @@ class AppsApiHandlerTest {
 
   private static final class SingleAppHost implements AppHost {
     private final InstalledAppSnapshot snapshot;
+    private InstalledAppSnapshot updateResult;
     private AppRuntimeStatusSnapshot runtimeStatus;
     private AppProcessLogSnapshot processLog;
     private IOException describeFailure;
     private IOException runtimeStatusFailure;
     private IOException startFailure;
+    private int updateCalls;
     private boolean stopResult;
     private int stopCalls;
 
@@ -584,8 +634,16 @@ class AppsApiHandlerTest {
     }
 
     @Override
-    public InstalledAppSnapshot updateFromDirectory(String appId, Path stagedAppDirectory) {
-      throw new UnsupportedOperationException();
+    public InstalledAppSnapshot updateFromDirectory(String appId, Path stagedAppDirectory)
+        throws IOException {
+      updateCalls++;
+      if (!APP_ID.equals(appId)) {
+        throw new AppHostException("app is not installed: " + appId);
+      }
+      if (updateResult == null) {
+        throw new UnsupportedOperationException();
+      }
+      return updateResult;
     }
 
     @Override

--- a/platform-api/src/test/java/network/crypta/platform/api/apps/AppsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/apps/AppsApiHandlerTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import network.crypta.platform.api.AppAuditLog;
 import network.crypta.platform.api.PlatformApiException;
 import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppBundleVerificationException;
@@ -26,6 +27,9 @@ import network.crypta.platform.apphost.RunningAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.apphost.manifest.AppManifestParser;
 import network.crypta.platform.apphost.sandbox.AppSandboxException;
+import network.crypta.platform.appui.AppUiOrigin;
+import network.crypta.platform.appui.AppUiOriginBinding;
+import network.crypta.platform.appui.AppUiOriginRegistry;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -161,10 +165,33 @@ class AppsApiHandlerTest {
     assertEquals("static", summary.get(FIELD_UI_MODE));
     assertEquals("static/index.html", summary.get(FIELD_UI_ENTRY));
     assertEquals("/apps/demo-app/static/", summary.get(FIELD_UI_URL));
+    assertEquals("/apps/demo-app/", summary.get("sameOriginFallbackUrl"));
     Map<?, ?> sandbox = (Map<?, ?>) summary.get("sandbox");
     assertEquals("none", sandbox.get("mode"));
     assertEquals("none", sandbox.get("supportLevel"));
     assertEquals("no-sandbox", sandbox.get("provider"));
+  }
+
+  @Test
+  void get_whenStaticUiOriginBindingExists_expectIsolatedUiSummaryFields() {
+    InstalledAppSnapshot snapshot = snapshot(AppUiMode.STATIC, "static/index.html");
+    AppUiOriginBinding binding =
+        AppUiOriginBinding.isolatedLoopback(
+            snapshot.manifest(),
+            AppUiOrigin.loopback(APP_ID, 12345),
+            "http://127.0.0.1:8888/api/v1/",
+            "http://127.0.0.1:8888/app/node/");
+    AppsApiHandler handler =
+        new AppsApiHandler(new SingleAppHost(snapshot), new AppAuditLog(), registryWith(binding));
+
+    Map<String, Object> summary = handler.get(APP_ID);
+
+    assertEquals("http://127.0.0.1:12345/static/", summary.get(FIELD_UI_URL));
+    assertEquals("http://127.0.0.1:12345", summary.get("uiOrigin"));
+    assertEquals("isolated-loopback", summary.get("uiOriginMode"));
+    assertEquals("active", summary.get("uiOriginStatus"));
+    assertEquals("/apps/demo-app/", summary.get("sameOriginFallbackUrl"));
+    org.junit.jupiter.api.Assertions.assertFalse(summary.toString().contains(tempDir.toString()));
   }
 
   @Test
@@ -229,8 +256,7 @@ class AppsApiHandlerTest {
   }
 
   @Test
-  void start_whenQuotaStatusReadFailsAfterLaunch_expectManifestOnlyQuotaSummary()
-      throws IOException {
+  void start_whenQuotaStatusReadFailsAfterLaunch_expectManifestOnlyQuotaSummary() {
     SingleAppHost appHost = new SingleAppHost(snapshot(AppUiMode.NONE, null, 4096L, 1024L));
     appHost.runtimeStatusFailure = new IOException("process log unavailable");
     AppsApiHandler handler = new AppsApiHandler(appHost);
@@ -466,6 +492,10 @@ class AppsApiHandlerTest {
             tempDir.resolve("cache").resolve(APP_ID),
             tempDir.resolve("run").resolve(APP_ID));
     return new InstalledAppSnapshot(manifest, paths);
+  }
+
+  private static AppUiOriginRegistry registryWith(AppUiOriginBinding binding) {
+    return appId -> binding.appId().equals(appId) ? Optional.of(binding) : Optional.empty();
   }
 
   private static final class ThrowingAppHost implements AppHost {

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppBrowserSession.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppBrowserSession.java
@@ -32,9 +32,17 @@ import java.util.TreeSet;
  *     issued
  * @param issuedAt UTC timestamp when the session was issued
  * @param expiresAt UTC timestamp after which the session must not authenticate
+ * @param expectedOrigin serialized browser origin this session is bound to, or {@code null} for
+ *     legacy same-origin fallback sessions that still accept missing {@code Origin} headers
+ * @param originMode origin mode used when the session was issued
  */
 public record AppBrowserSession(
-    String appId, List<String> permissions, Instant issuedAt, Instant expiresAt) {
+    String appId,
+    List<String> permissions,
+    Instant issuedAt,
+    Instant expiresAt,
+    String expectedOrigin,
+    AppUiOriginMode originMode) {
   /**
    * Creates a token-free session identity.
    *
@@ -52,18 +60,52 @@ public record AppBrowserSession(
    *     expiry does not come after the issue time
    * @throws NullPointerException if a required field or permission value is {@code null}
    */
+  public AppBrowserSession(
+      String appId, List<String> permissions, Instant issuedAt, Instant expiresAt) {
+    this(appId, permissions, issuedAt, expiresAt, null, AppUiOriginMode.SAME_ORIGIN_FALLBACK);
+  }
+
+  /**
+   * Creates a token-free session identity using one app UI origin binding.
+   *
+   * @param appId app identifier associated with the verified browser session
+   * @param permissions manifest permissions captured when the session was issued
+   * @param issuedAt UTC timestamp when the browser session was issued
+   * @param expiresAt UTC timestamp after which the browser session is invalid
+   * @param binding app UI origin binding used for bootstrap
+   */
+  public AppBrowserSession(
+      String appId,
+      List<String> permissions,
+      Instant issuedAt,
+      Instant expiresAt,
+      AppUiOriginBinding binding) {
+    this(
+        appId,
+        permissions,
+        issuedAt,
+        expiresAt,
+        binding == null ? null : binding.origin(),
+        binding == null ? AppUiOriginMode.SAME_ORIGIN_FALLBACK : binding.mode());
+  }
+
   public AppBrowserSession {
     Objects.requireNonNull(appId, "appId");
     Objects.requireNonNull(issuedAt, "issuedAt");
     Objects.requireNonNull(expiresAt, "expiresAt");
+    Objects.requireNonNull(originMode, "originMode");
     if (appId.isBlank()) {
       throw new IllegalArgumentException("appId must not be blank");
     }
     if (!expiresAt.isAfter(issuedAt)) {
       throw new IllegalArgumentException("expiresAt must be after issuedAt");
     }
+    if (expectedOrigin != null && expectedOrigin.isBlank()) {
+      throw new IllegalArgumentException("expectedOrigin must not be blank");
+    }
     appId = appId.trim();
     permissions = sortedPermissions(permissions);
+    expectedOrigin = expectedOrigin == null ? null : expectedOrigin.trim();
   }
 
   /**

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppBrowserSessionIssuer.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppBrowserSessionIssuer.java
@@ -31,4 +31,19 @@ public interface AppBrowserSessionIssuer {
    * @throws IllegalArgumentException if the snapshot cannot receive a browser UI session
    */
   AppBrowserSessionIssue issue(InstalledAppSnapshot snapshot);
+
+  /**
+   * Issues a browser session for one installed static app snapshot and UI origin binding.
+   *
+   * <p>Implementations that understand origin isolation should bind the verified session metadata
+   * to {@code binding}. The default preserves same-origin fallback behavior for tests and
+   * compatibility implementations.
+   *
+   * @param snapshot installed static app snapshot whose manifest permissions bind the session
+   * @param binding app UI origin binding used for this bootstrap response
+   * @return issued browser session bearer token and absolute expiry metadata
+   */
+  default AppBrowserSessionIssue issue(InstalledAppSnapshot snapshot, AppUiOriginBinding binding) {
+    return issue(snapshot);
+  }
 }

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppBrowserSessionStore.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppBrowserSessionStore.java
@@ -29,10 +29,12 @@ import network.crypta.platform.apphost.manifest.AppManifest;
  * manifest/install fingerprint captured at issue time.
  *
  * <p>This implementation is deliberately process-local and memory-backed. It does not survive node
- * restart, share state across processes, or provide browser origin isolation. All public entry
- * points are synchronized, and capacity trimming uses the access-ordered map to discard the least
- * recently used retained session after expired entries have been pruned. Raw tokens are retained
- * only as map keys and are never returned from verification or included in {@link #toString()}.
+ * restart or share state across processes. Browser origin isolation is supplied by the app UI
+ * origin binding recorded in the session metadata, while this store keeps the opaque token and
+ * verifies that metadata. All public entry points are synchronized, and capacity trimming uses the
+ * access-ordered map to discard the least recently used retained session after expired entries have
+ * been pruned. Raw tokens are retained only as map keys and are never returned from verification or
+ * included in {@link #toString()}.
  *
  * <ul>
  *   <li>{@link #issue(InstalledAppSnapshot)} is called by the app UI bootstrap path.
@@ -134,12 +136,25 @@ public final class AppBrowserSessionStore
    */
   @Override
   public synchronized AppBrowserSessionIssue issue(InstalledAppSnapshot snapshot) {
+    return issue(snapshot, null);
+  }
+
+  /**
+   * Issues a browser session for one installed static app snapshot and origin binding.
+   *
+   * <p>The origin binding becomes part of the token-free verified session metadata. Isolated
+   * loopback sessions therefore authenticate only when the HTTP bridge sees the expected browser
+   * {@code Origin} header.
+   */
+  @Override
+  public synchronized AppBrowserSessionIssue issue(
+      InstalledAppSnapshot snapshot, AppUiOriginBinding binding) {
     InstalledAppSnapshot checkedSnapshot = Objects.requireNonNull(snapshot, "snapshot");
     if (checkedSnapshot.manifest().uiMode() != AppUiMode.STATIC) {
       throw new IllegalArgumentException("browser sessions require static app UI");
     }
     pruneExpired(clock.instant());
-    AppBrowserSession session = newSession(checkedSnapshot.manifest());
+    AppBrowserSession session = newSession(checkedSnapshot.manifest(), binding);
     String token = generateUniqueToken();
     sessions.put(token, new StoredSession(session, manifestBinding(checkedSnapshot)));
     trimToCapacity();
@@ -198,10 +213,10 @@ public final class AppBrowserSessionStore
         + "]";
   }
 
-  private AppBrowserSession newSession(AppManifest manifest) {
+  private AppBrowserSession newSession(AppManifest manifest, AppUiOriginBinding binding) {
     Instant issuedAt = clock.instant();
     return new AppBrowserSession(
-        manifest.appId(), manifest.permissions(), issuedAt, issuedAt.plus(lifetime));
+        manifest.appId(), manifest.permissions(), issuedAt, issuedAt.plus(lifetime), binding);
   }
 
   private String generateUniqueToken() {

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiBootstrap.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiBootstrap.java
@@ -50,6 +50,11 @@ public record AppUiBootstrap(
     String sameOriginFallbackUrl,
     String browserSessionToken,
     Instant browserSessionExpiresAt) {
+  private static final String IPV4_LOOPBACK_HOST = "127.0.0.1";
+  private static final String IPV6_LOOPBACK_HOST = "::1";
+  private static final String IPV6_LOOPBACK_HOST_EXPANDED = "0:0:0:0:0:0:0:1";
+  private static final String LOCALHOST_HOST = "localhost";
+
   /**
    * Reserved bundle-relative route used for dynamic app UI bootstrap JSON.
    *
@@ -309,9 +314,10 @@ public record AppUiBootstrap(
 
   private static boolean hasNonLoopbackHost(String host) {
     String normalizedHost = normalizeBracketedIpv6Host(host);
-    return !"127.0.0.1".equals(normalizedHost)
-        && !"localhost".equalsIgnoreCase(normalizedHost)
-        && !"::1".equals(normalizedHost);
+    return !IPV4_LOOPBACK_HOST.equals(normalizedHost)
+        && !LOCALHOST_HOST.equalsIgnoreCase(normalizedHost)
+        && !IPV6_LOOPBACK_HOST.equalsIgnoreCase(normalizedHost)
+        && !IPV6_LOOPBACK_HOST_EXPANDED.equalsIgnoreCase(normalizedHost);
   }
 
   private static String normalizeBracketedIpv6Host(String host) {

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiBootstrap.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiBootstrap.java
@@ -308,6 +308,16 @@ public record AppUiBootstrap(
   }
 
   private static boolean hasNonLoopbackHost(String host) {
-    return !"127.0.0.1".equals(host) && !"localhost".equalsIgnoreCase(host) && !"::1".equals(host);
+    String normalizedHost = normalizeBracketedIpv6Host(host);
+    return !"127.0.0.1".equals(normalizedHost)
+        && !"localhost".equalsIgnoreCase(normalizedHost)
+        && !"::1".equals(normalizedHost);
+  }
+
+  private static String normalizeBracketedIpv6Host(String host) {
+    if (host != null && host.startsWith("[") && host.endsWith("]")) {
+      return host.substring(1, host.length() - 1);
+    }
+    return host;
   }
 }

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiBootstrap.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiBootstrap.java
@@ -10,11 +10,11 @@ import org.jetbrains.annotations.NotNull;
  * Browser bootstrap metadata for an installed static app UI.
  *
  * <p>This record is the small contract served from the reserved app-owned bootstrap route. A
- * browser page uses it to discover the same-origin roots that are stable for the current node:
- * where the app UI is mounted, where static sibling assets should resolve, where Platform API v1 is
- * mounted, and where the Web Shell lives for fallback navigation. The payload is deliberately
- * route-oriented rather than runtime-oriented. It describes local browser entry points, not the
- * AppHost process launch environment.
+ * browser page uses it to discover the local roots that are stable for the current node: where the
+ * app UI is mounted, where static sibling assets should resolve, where Platform API v1 is mounted,
+ * and where the Web Shell lives for fallback navigation. The payload is deliberately route-oriented
+ * rather than runtime-oriented. It describes local browser entry points, not the AppHost process
+ * launch environment.
  *
  * <p>The payload carries a browser-scoped app session token for Platform API calls from the static
  * app UI. The token is distinct from AppHost launch tokens and local-admin form passwords. It must
@@ -27,6 +27,11 @@ import org.jetbrains.annotations.NotNull;
  * @param assetRoot canonical directory URL for the static entry and sibling assets
  * @param platformApiRoot Platform API v1 root ending in {@code /}
  * @param shellRoot Web Shell root ending in {@code /}
+ * @param uiOrigin serialized browser origin expected for this app UI session, or {@code null} for
+ *     legacy path-only fallback bootstrap
+ * @param uiOriginMode origin-isolation mode used for this bootstrap
+ * @param uiOriginStatus runtime status of the UI origin binding
+ * @param sameOriginFallbackUrl legacy {@code /apps/{appId}/} launch URL retained for compatibility
  * @param browserSessionToken opaque app browser session token for {@code X-Crypta-App-Session}
  * @param browserSessionExpiresAt UTC timestamp after which the browser session must be refreshed
  * @see AppUiBootstrapService
@@ -39,6 +44,10 @@ public record AppUiBootstrap(
     String assetRoot,
     String platformApiRoot,
     String shellRoot,
+    String uiOrigin,
+    String uiOriginMode,
+    String uiOriginStatus,
+    String sameOriginFallbackUrl,
     String browserSessionToken,
     Instant browserSessionExpiresAt) {
   /**
@@ -74,15 +83,48 @@ public record AppUiBootstrap(
       String platformApiRoot,
       String shellRoot,
       AppBrowserSessionIssue browserSession) {
+    return forManifest(manifest, platformApiRoot, shellRoot, browserSession, null);
+  }
+
+  /**
+   * Creates bootstrap metadata for one installed static app manifest and origin binding.
+   *
+   * <p>When an isolated loopback binding is present, URL roots in the returned payload use absolute
+   * loopback/admin URLs so app JavaScript can load bootstrap from its own origin and call Platform
+   * API through restricted CORS. Without a binding, the method preserves the legacy path-only
+   * same-origin bootstrap contract.
+   *
+   * @param manifest installed app manifest currently being served
+   * @param platformApiRoot default Platform API root used when {@code binding} is absent
+   * @param shellRoot default Web Shell root used when {@code binding} is absent
+   * @param browserSession issued app browser session metadata
+   * @param binding app UI origin binding, or {@code null} for compatibility fallback
+   * @return immutable bootstrap metadata ready for deterministic JSON serialization
+   */
+  public static AppUiBootstrap forManifest(
+      AppManifest manifest,
+      String platformApiRoot,
+      String shellRoot,
+      AppBrowserSessionIssue browserSession,
+      AppUiOriginBinding binding) {
     Objects.requireNonNull(manifest, "manifest");
     Objects.requireNonNull(browserSession, "browserSession");
+    AppUiOriginBinding effectiveBinding =
+        binding == null
+            ? AppUiOriginBinding.sameOriginFallback(
+                manifest, platformApiRoot, shellRoot, null, null)
+            : binding;
     return new AppUiBootstrap(
         manifest.appId(),
         manifest.appName(),
-        AppUiPaths.appRoot(manifest.appId()),
-        AppUiPaths.uiUrl(manifest),
-        platformApiRoot,
-        shellRoot,
+        effectiveBinding.uiRoot(),
+        effectiveBinding.assetRoot(),
+        effectiveBinding.platformApiRoot(),
+        effectiveBinding.shellRoot(),
+        effectiveBinding.origin(),
+        effectiveBinding.mode().jsonValue(),
+        effectiveBinding.status().jsonValue(),
+        effectiveBinding.sameOriginFallbackUrl(),
         browserSession.token(),
         browserSession.expiresAt());
   }
@@ -105,15 +147,39 @@ public record AppUiBootstrap(
   /**
    * Creates an immutable bootstrap payload.
    *
-   * <p>Required text fields must be non-blank. Route roots must be same-origin absolute paths that
-   * begin with a single {@code /}, contain no query or fragment, and end with {@code /}. The
-   * browser session token text must be non-blank. The expiry timestamp must be present but is not
-   * required to be in the future at construction time because serializers and tests may inspect
-   * already-expired values.
+   * <p>Required text fields must be non-blank. Route roots must be same-origin fallback paths that
+   * begin with a single {@code /} or absolute local HTTP(S) URLs, contain no query or fragment, and
+   * end with {@code /}. The browser session token text must be non-blank. The expiry timestamp must
+   * be present but is not required to be in the future at construction time because serializers and
+   * tests may inspect already-expired values.
    *
    * @throws NullPointerException if any required field is {@code null}
    * @throws IllegalArgumentException if a required text field is blank or a route root is invalid
    */
+  public AppUiBootstrap(
+      String appId,
+      String name,
+      String uiRoot,
+      String assetRoot,
+      String platformApiRoot,
+      String shellRoot,
+      String browserSessionToken,
+      Instant browserSessionExpiresAt) {
+    this(
+        appId,
+        name,
+        uiRoot,
+        assetRoot,
+        platformApiRoot,
+        shellRoot,
+        null,
+        AppUiOriginMode.SAME_ORIGIN_FALLBACK.jsonValue(),
+        AppUiOriginStatus.FALLBACK.jsonValue(),
+        uiRoot,
+        browserSessionToken,
+        browserSessionExpiresAt);
+  }
+
   public AppUiBootstrap {
     requireText(appId, "appId");
     requireText(name, "name");
@@ -121,6 +187,10 @@ public record AppUiBootstrap(
     requireRootPath(assetRoot, "assetRoot");
     requireRootPath(platformApiRoot, "platformApiRoot");
     requireRootPath(shellRoot, "shellRoot");
+    requireOptionalOrigin(uiOrigin);
+    requireText(uiOriginMode, "uiOriginMode");
+    requireText(uiOriginStatus, "uiOriginStatus");
+    requireOptionalFallbackRootPath(sameOriginFallbackUrl);
     requireText(browserSessionToken, "browserSessionToken");
     Objects.requireNonNull(browserSessionExpiresAt, "browserSessionExpiresAt");
   }
@@ -139,6 +209,14 @@ public record AppUiBootstrap(
         + platformApiRoot
         + ", shellRoot="
         + shellRoot
+        + ", uiOrigin="
+        + uiOrigin
+        + ", uiOriginMode="
+        + uiOriginMode
+        + ", uiOriginStatus="
+        + uiOriginStatus
+        + ", sameOriginFallbackUrl="
+        + sameOriginFallbackUrl
         + ", browserSessionToken=[REDACTED], browserSessionExpiresAt="
         + browserSessionExpiresAt
         + "]";
@@ -154,10 +232,39 @@ public record AppUiBootstrap(
 
   private static void requireRootPath(String value, String label) {
     String path = requireText(value, label);
-    requireSingleLeadingSlash(path, label);
-    requireUriPathOnly(path, label);
+    if (path.startsWith("/")) {
+      requireSingleLeadingSlash(path, label);
+      requireUriPathOnly(path, label);
+    } else {
+      requireAbsoluteLocalRootUrl(path, label);
+    }
     if (!path.endsWith("/")) {
       throw new IllegalArgumentException(label + " must end with '/'");
+    }
+  }
+
+  private static void requireOptionalFallbackRootPath(String value) {
+    if (value != null) {
+      requireRootPath(value, "sameOriginFallbackUrl");
+    }
+  }
+
+  private static void requireOptionalOrigin(String value) {
+    if (value == null) {
+      return;
+    }
+    try {
+      URI uri = URI.create(value);
+      if (hasUnsupportedLocalHttpScheme(uri.getScheme())
+          || hasNonLoopbackHost(uri.getHost())
+          || uri.getPort() <= 0
+          || (uri.getRawPath() != null && !uri.getRawPath().isEmpty())
+          || uri.getRawQuery() != null
+          || uri.getRawFragment() != null) {
+        throw new IllegalArgumentException("uiOrigin must be a local HTTP origin");
+      }
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException("uiOrigin must be a local HTTP origin", exception);
     }
   }
 
@@ -178,5 +285,29 @@ public record AppUiBootstrap(
     } catch (IllegalArgumentException exception) {
       throw new IllegalArgumentException(label + " must be a valid absolute root path", exception);
     }
+  }
+
+  private static void requireAbsoluteLocalRootUrl(String value, String label) {
+    try {
+      URI uri = URI.create(value);
+      if (hasUnsupportedLocalHttpScheme(uri.getScheme())
+          || hasNonLoopbackHost(uri.getHost())
+          || uri.getRawQuery() != null
+          || uri.getRawFragment() != null
+          || uri.getRawPath() == null
+          || uri.getRawPath().isBlank()) {
+        throw new IllegalArgumentException(label + " must be a local absolute root URL");
+      }
+    } catch (IllegalArgumentException exception) {
+      throw new IllegalArgumentException(label + " must be a local absolute root URL", exception);
+    }
+  }
+
+  private static boolean hasUnsupportedLocalHttpScheme(String scheme) {
+    return !"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme);
+  }
+
+  private static boolean hasNonLoopbackHost(String host) {
+    return !"127.0.0.1".equals(host) && !"localhost".equalsIgnoreCase(host) && !"::1".equals(host);
   }
 }

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiBootstrapJson.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiBootstrapJson.java
@@ -58,6 +58,10 @@ public final class AppUiBootstrapJson {
     appendStringField(out, "assetRoot", bootstrap.assetRoot());
     appendStringField(out, "platformApiRoot", bootstrap.platformApiRoot());
     appendStringField(out, "shellRoot", bootstrap.shellRoot());
+    appendNullableStringField(out, "uiOrigin", bootstrap.uiOrigin());
+    appendStringField(out, "uiOriginMode", bootstrap.uiOriginMode());
+    appendStringField(out, "uiOriginStatus", bootstrap.uiOriginStatus());
+    appendNullableStringField(out, "sameOriginFallbackUrl", bootstrap.sameOriginFallbackUrl());
     appendStringField(out, "browserSessionToken", bootstrap.browserSessionToken());
     appendStringField(
         out, "browserSessionExpiresAt", bootstrap.browserSessionExpiresAt().toString());
@@ -66,6 +70,15 @@ public final class AppUiBootstrapJson {
 
   private static void appendStringField(StringBuilder out, String name, String value) {
     appendFieldName(out, name);
+    appendJsonString(out, value);
+  }
+
+  private static void appendNullableStringField(StringBuilder out, String name, String value) {
+    appendFieldName(out, name);
+    if (value == null) {
+      out.append("null");
+      return;
+    }
     appendJsonString(out, value);
   }
 

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiBootstrapService.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiBootstrapService.java
@@ -81,13 +81,37 @@ public final class AppUiBootstrapService {
   public Optional<AppUiBootstrap> resolve(
       String rawRequestPath, String platformApiRoot, String shellRoot)
       throws IOException, AppStaticAssetException {
+    return resolve(rawRequestPath, platformApiRoot, shellRoot, null);
+  }
+
+  /**
+   * Resolves one raw HTTP path to app UI bootstrap metadata using an explicit origin binding.
+   *
+   * <p>Callers use this overload when the bootstrap is being served from an isolated app origin or
+   * when the legacy same-origin route can determine its expected browser origin. The binding is
+   * passed to both the issued browser session and the serialized bootstrap metadata.
+   *
+   * @param rawRequestPath raw URI path such as {@code
+   *     /apps/demo-app/.well-known/cryptad-bootstrap.json}
+   * @param platformApiRoot fallback Platform API root used when {@code binding} is {@code null}
+   * @param shellRoot fallback Web Shell root used when {@code binding} is {@code null}
+   * @param binding app UI origin binding for this bootstrap response, or {@code null}
+   * @return bootstrap metadata, or empty when the path is not the bootstrap resource or the app is
+   *     not an installed static UI app
+   * @throws IOException if AppHost metadata cannot be read for the requested app id
+   * @throws AppStaticAssetException if the raw app UI route path is malformed or unsafe
+   */
+  public Optional<AppUiBootstrap> resolve(
+      String rawRequestPath, String platformApiRoot, String shellRoot, AppUiOriginBinding binding)
+      throws IOException, AppStaticAssetException {
     Optional<InstalledAppSnapshot> snapshot = staticBootstrapSnapshot(rawRequestPath);
     if (snapshot.isEmpty()) {
       return Optional.empty();
     }
-    AppBrowserSessionIssue session = sessionIssuer.issue(snapshot.get());
+    AppBrowserSessionIssue session = sessionIssuer.issue(snapshot.get(), binding);
     return Optional.of(
-        AppUiBootstrap.forManifest(snapshot.get().manifest(), platformApiRoot, shellRoot, session));
+        AppUiBootstrap.forManifest(
+            snapshot.get().manifest(), platformApiRoot, shellRoot, session, binding));
   }
 
   /**

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiOrigin.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiOrigin.java
@@ -1,0 +1,119 @@
+package network.crypta.platform.appui;
+
+import java.net.URI;
+import java.util.Locale;
+import java.util.Objects;
+import network.crypta.platform.apphost.manifest.AppManifest;
+
+/**
+ * Loopback-only browser origin assigned to one installed static app UI.
+ *
+ * <p>Cryptad uses distinct loopback ports to create distinct browser origins without exposing app
+ * UI listeners on wildcard or LAN-visible interfaces. This value stores only the public browser
+ * origin. It does not represent a socket, server lifecycle, or AppHost process sandbox.
+ *
+ * <p>The record is intentionally narrow: it accepts only {@code http://127.0.0.1:<port>} and
+ * rejects paths, remote hosts, wildcard addresses, and HTTPS assumptions. The HTTP adapter owns the
+ * actual listener and can recreate it as apps are installed or removed. Other layers use this value
+ * to compare browser {@code Origin} headers, build root URLs, and serialize safe UI metadata
+ * without leaking filesystem paths or app process credentials.
+ *
+ * @param appId normalized app identifier assigned to this browser origin
+ * @param scheme browser scheme, currently the local {@code http} scheme only
+ * @param host loopback host exposed to the browser, currently {@code 127.0.0.1}
+ * @param port TCP port bound on the advertised loopback interface
+ */
+public record AppUiOrigin(String appId, String scheme, String host, int port) {
+  /** Default IPv4 loopback host used for app UI origins. */
+  public static final String LOOPBACK_HOST = "127.0.0.1";
+
+  /** Local HTTP scheme used for per-app loopback origins. */
+  public static final String LOCAL_HTTP_SCHEME = "http";
+
+  /**
+   * Creates an isolated loopback origin for one installed app.
+   *
+   * <p>This factory is the normal path for the loopback listener allocator. It applies the default
+   * scheme and host before the canonical constructor validates the app id and port range.
+   *
+   * @param appId normalized app identifier that owns the allocated listener
+   * @param port loopback TCP port allocated to the app UI listener
+   * @return validated loopback origin for the supplied app and port
+   */
+  public static AppUiOrigin loopback(String appId, int port) {
+    return new AppUiOrigin(appId, LOCAL_HTTP_SCHEME, LOOPBACK_HOST, port);
+  }
+
+  /**
+   * Parses and validates one serialized origin for the supplied app id.
+   *
+   * <p>The serialized value must be an origin, not a full URL. Paths, queries, and fragments are
+   * rejected so callers do not accidentally authorize more than a scheme, host, and port tuple.
+   *
+   * @param appId normalized app identifier expected to own the serialized origin
+   * @param origin serialized origin such as {@code http://127.0.0.1:12345}
+   * @return validated loopback app origin for the supplied app id
+   * @throws IllegalArgumentException if the origin is not a loopback HTTP origin without path,
+   *     query, or fragment
+   */
+  public static AppUiOrigin parse(String appId, String origin) {
+    Objects.requireNonNull(origin, "origin");
+    URI uri = URI.create(origin);
+    if (uri.getRawPath() != null && !uri.getRawPath().isEmpty()) {
+      throw new IllegalArgumentException("app UI origin must not include a path");
+    }
+    if (uri.getRawQuery() != null || uri.getRawFragment() != null) {
+      throw new IllegalArgumentException("app UI origin must not include query or fragment");
+    }
+    return new AppUiOrigin(appId, uri.getScheme(), uri.getHost(), uri.getPort());
+  }
+
+  /**
+   * Creates a validated loopback origin.
+   *
+   * <p>The constructor normalizes the app id, scheme, and host before enforcing the supported
+   * isolation policy. It is public because records expose their canonical constructor, but callers
+   * should prefer {@link #loopback(String, int)} when allocating a new app UI origin.
+   *
+   * @throws IllegalArgumentException if the app id, scheme, host, or port is not supported for
+   *     app-origin isolation
+   */
+  public AppUiOrigin {
+    appId = AppManifest.normalizeAppId(Objects.requireNonNull(appId, "appId"));
+    scheme = Objects.requireNonNull(scheme, "scheme").toLowerCase(Locale.ROOT);
+    host = Objects.requireNonNull(host, "host").toLowerCase(Locale.ROOT);
+    if (!LOCAL_HTTP_SCHEME.equals(scheme)) {
+      throw new IllegalArgumentException("app UI origins must use http");
+    }
+    if (!LOOPBACK_HOST.equals(host)) {
+      throw new IllegalArgumentException("app UI origins must use 127.0.0.1 loopback");
+    }
+    if (port <= 0 || port > 65535) {
+      throw new IllegalArgumentException("app UI origin port must be in range 1..65535");
+    }
+  }
+
+  /**
+   * Returns the serialized browser origin.
+   *
+   * <p>The result is suitable for exact comparison with a browser {@code Origin} header and for
+   * storing in app-origin registries. It never includes a trailing slash.
+   *
+   * @return origin text without a path, query, or fragment
+   */
+  public String origin() {
+    return scheme + "://" + host + ":" + port;
+  }
+
+  /**
+   * Returns the root URL for this app origin.
+   *
+   * <p>The result is the base URL that Web Shell can open and that app bootstrap JSON can publish
+   * as the UI root. It is derived from {@link #origin()} and always ends in one slash.
+   *
+   * @return browser root URL ending in {@code /}
+   */
+  public String rootUrl() {
+    return origin() + "/";
+  }
+}

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiOriginBinding.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiOriginBinding.java
@@ -1,0 +1,184 @@
+package network.crypta.platform.appui;
+
+import java.util.Objects;
+import network.crypta.platform.appdist.AppUiMode;
+import network.crypta.platform.apphost.manifest.AppManifest;
+
+/**
+ * Browser URL assignment for one installed app UI.
+ *
+ * <p>A binding is the transport-neutral summary shared by bootstrap JSON, app summaries, Web Shell
+ * launch links, and Platform API CORS decisions. It contains only browser-visible route metadata.
+ * It never contains AppHost launch tokens, browser-session tokens, filesystem paths, or local admin
+ * form passwords.
+ *
+ * <p>Bindings describe the route that should be used now, not a permanent installation property.
+ * Static apps normally receive an active isolated-loopback binding with an absolute UI URL on a
+ * per-app port. First-party compatibility paths and degraded environments can receive a same-origin
+ * fallback binding instead. API handlers and Web Shell should prefer {@link #uiUrl()} when {@link
+ * #isolatedAndActive()} is true, while still showing {@link #sameOriginFallbackUrl()} for
+ * diagnostics and explicit compatibility flows.
+ *
+ * @param appId normalized app identifier that owns this browser UI assignment
+ * @param mode origin-isolation mode used for this UI route
+ * @param status runtime status for this assignment at the time it was produced
+ * @param origin serialized app browser origin, or {@code null} for same-origin fallback
+ * @param uiRoot root URL for the app UI, ending in {@code /}
+ * @param assetRoot URL directory where the declared static entry and sibling assets resolve
+ * @param uiUrl public app entry URL for the app entry directory; isolated launch redirects may add
+ *     request-specific proof before opening this URL in a browser
+ * @param platformApiRoot Platform API v1 root exposed to app browser code
+ * @param shellRoot Web Shell/admin UI root exposed for fallback navigation
+ * @param sameOriginFallbackUrl legacy same-origin launch path under {@code /apps/{appId}/}
+ * @param warning optional operator-facing reason when isolation is unavailable or degraded
+ */
+public record AppUiOriginBinding(
+    String appId,
+    AppUiOriginMode mode,
+    AppUiOriginStatus status,
+    String origin,
+    String uiRoot,
+    String assetRoot,
+    String uiUrl,
+    String platformApiRoot,
+    String shellRoot,
+    String sameOriginFallbackUrl,
+    String warning) {
+  /**
+   * Builds an active isolated-loopback binding for one static app manifest.
+   *
+   * <p>The static entry directory becomes both {@code assetRoot} and {@code uiUrl}, so an app whose
+   * entry is {@code static/index.html} opens at {@code /static/} on its isolated origin. Bootstrap
+   * code and sibling assets can then use origin-root or directory-relative paths without exposing
+   * the legacy admin {@code /apps/{appId}/} mount as the preferred route.
+   *
+   * @param manifest installed static app manifest that declares the UI entry point
+   * @param origin per-app loopback origin allocated by the HTTP adapter
+   * @param platformApiRoot absolute admin-origin Platform API root for browser SDK calls
+   * @param shellRoot absolute admin-origin Web Shell root for fallback navigation
+   * @return active isolated-loopback binding safe to expose in app summaries
+   */
+  public static AppUiOriginBinding isolatedLoopback(
+      AppManifest manifest, AppUiOrigin origin, String platformApiRoot, String shellRoot) {
+    Objects.requireNonNull(manifest, "manifest");
+    Objects.requireNonNull(origin, "origin");
+    String root = origin.rootUrl();
+    String entryDirectory = staticEntryDirectory(manifest);
+    String uiUrl =
+        entryDirectory.isEmpty()
+            ? root
+            : root + AppUiPaths.encodeRelativePath(entryDirectory) + "/";
+    return new AppUiOriginBinding(
+        manifest.appId(),
+        AppUiOriginMode.ISOLATED_LOOPBACK,
+        AppUiOriginStatus.ACTIVE,
+        origin.origin(),
+        root,
+        uiUrl,
+        uiUrl,
+        platformApiRoot,
+        shellRoot,
+        AppUiPaths.appRoot(manifest.appId()),
+        null);
+  }
+
+  /**
+   * Builds the legacy same-origin fallback binding for one manifest.
+   *
+   * <p>Fallback bindings preserve Phase 5 app UI behavior for diagnostics and environments where an
+   * isolated listener cannot be started. They should not be treated as the preferred third-party UI
+   * route when an active isolated binding is available.
+   *
+   * @param manifest installed app manifest used to derive legacy app UI paths
+   * @param platformApiRoot Platform API root to expose, usually path-only on the admin origin
+   * @param shellRoot Web Shell root to expose, usually path-only on the admin origin
+   * @param expectedOrigin serialized admin origin when known, otherwise {@code null}
+   * @param warning optional warning or reason shown to operators and diagnostics
+   * @return same-origin fallback binding with legacy UI URLs preserved
+   */
+  public static AppUiOriginBinding sameOriginFallback(
+      AppManifest manifest,
+      String platformApiRoot,
+      String shellRoot,
+      String expectedOrigin,
+      String warning) {
+    Objects.requireNonNull(manifest, "manifest");
+    String uiUrl = AppUiPaths.uiUrl(manifest);
+    return new AppUiOriginBinding(
+        manifest.appId(),
+        AppUiOriginMode.SAME_ORIGIN_FALLBACK,
+        AppUiOriginStatus.FALLBACK,
+        expectedOrigin,
+        manifest.uiMode() == AppUiMode.STATIC ? AppUiPaths.appRoot(manifest.appId()) : uiUrl,
+        uiUrl,
+        uiUrl,
+        platformApiRoot,
+        shellRoot,
+        manifest.uiMode() == AppUiMode.STATIC ? AppUiPaths.appRoot(manifest.appId()) : uiUrl,
+        warning);
+  }
+
+  /**
+   * Builds a binding that reports unavailable browser UI.
+   *
+   * <p>Unsupported bindings are useful for process-only apps or invalid app records that still need
+   * a stable summary shape. All browser-openable URL fields are {@code null}; callers must not
+   * synthesize launch routes from this value.
+   *
+   * @param appId normalized app identifier whose browser UI cannot be opened
+   * @param warning reason for the unavailable UI, suitable for diagnostics
+   * @return unsupported binding with no browser-openable URL
+   */
+  public static AppUiOriginBinding unsupported(String appId, String warning) {
+    return new AppUiOriginBinding(
+        appId,
+        AppUiOriginMode.SAME_ORIGIN_FALLBACK,
+        AppUiOriginStatus.UNSUPPORTED,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        warning);
+  }
+
+  /**
+   * Creates a validated origin binding.
+   *
+   * <p>The canonical constructor normalizes the app id and requires the mode and status enum
+   * values. It intentionally leaves URL cross-field validation to the factories because fallback
+   * and unsupported bindings have different nullable fields than active isolated bindings.
+   *
+   * @throws NullPointerException if required identity or status fields are missing
+   * @throws IllegalArgumentException if required app identity is invalid
+   */
+  public AppUiOriginBinding {
+    appId =
+        network.crypta.platform.apphost.manifest.AppManifest.normalizeAppId(
+            Objects.requireNonNull(appId, "appId"));
+    Objects.requireNonNull(mode, "mode");
+    Objects.requireNonNull(status, "status");
+  }
+
+  /**
+   * Returns whether this binding describes an active isolated app origin.
+   *
+   * <p>Callers use this as the main branch for Web Shell launch behavior and for deciding whether
+   * cross-origin CORS checks should expect an app-specific loopback origin.
+   *
+   * @return {@code true} when the app should be opened on its isolated loopback origin
+   */
+  public boolean isolatedAndActive() {
+    return mode == AppUiOriginMode.ISOLATED_LOOPBACK && status == AppUiOriginStatus.ACTIVE;
+  }
+
+  private static String staticEntryDirectory(AppManifest manifest) {
+    if (manifest.uiMode() != AppUiMode.STATIC || manifest.uiEntry() == null) {
+      return "";
+    }
+    int lastSlash = manifest.uiEntry().lastIndexOf('/');
+    return lastSlash < 0 ? "" : manifest.uiEntry().substring(0, lastSlash);
+  }
+}

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiOriginMode.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiOriginMode.java
@@ -1,0 +1,62 @@
+package network.crypta.platform.appui;
+
+/**
+ * Browser-origin policy used when serving an installed static app UI.
+ *
+ * <p>The mode describes the intended browser trust boundary, not the AppHost process sandbox.
+ * Static app UI code can run either on the legacy local-admin origin for compatibility or on a
+ * loopback-only per-app origin. Platform API authorization remains server-side in both modes.
+ *
+ * <p>Mode values are serialized in bootstrap JSON, app summaries, audit-adjacent diagnostics, and
+ * documentation. They are deliberately stable, lower-case strings because operators may compare
+ * summaries from different nodes or release builds. Runtime availability is reported separately by
+ * {@link AppUiOriginStatus}; a mode says what policy was selected, while a status says whether that
+ * policy is currently active, degraded, unsupported, or stopped.
+ */
+public enum AppUiOriginMode {
+  /**
+   * Legacy compatibility mode where the app UI is served below {@code /apps/{appId}/} on the local
+   * admin origin.
+   *
+   * <p>This mode preserves Phase 5 behavior for first-party compatibility, development, and
+   * diagnostics. It is not the preferred trust boundary for third-party static apps when an
+   * isolated loopback origin can be allocated.
+   */
+  SAME_ORIGIN_FALLBACK("same-origin-fallback"),
+
+  /**
+   * Preferred mode where one static app UI is served from its own loopback HTTP origin.
+   *
+   * <p>Each installed static app receives a distinct browser origin, normally by using a distinct
+   * {@code 127.0.0.1} port. Browser sessions issued in this mode are expected to be bound to that
+   * app id and origin.
+   */
+  ISOLATED_LOOPBACK("isolated-loopback"),
+
+  /**
+   * Strict mode where the static app UI must not fall back to the local-admin origin.
+   *
+   * <p>The current implementation can expose this policy in data models before all callers require
+   * it. A binding using this mode should report a non-active status instead of silently serving the
+   * app on the admin origin when loopback isolation is unavailable.
+   */
+  ISOLATED_LOOPBACK_REQUIRED("isolated-loopback-required");
+
+  private final String jsonValue;
+
+  AppUiOriginMode(String jsonValue) {
+    this.jsonValue = jsonValue;
+  }
+
+  /**
+   * Returns the stable JSON/documentation value for this mode.
+   *
+   * <p>The returned value is the wire-facing spelling. It should be used for JSON summaries and
+   * docs rather than {@link #name()}, which is a Java enum identifier.
+   *
+   * @return lower-case hyphenated mode value
+   */
+  public String jsonValue() {
+    return jsonValue;
+  }
+}

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiOriginRegistry.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiOriginRegistry.java
@@ -1,0 +1,84 @@
+package network.crypta.platform.appui;
+
+import java.util.Optional;
+
+/**
+ * Registry of currently assigned app UI browser origins.
+ *
+ * <p>The interface stays transport-neutral so Platform API summaries, app UI bootstrap, and HTTP
+ * CORS handling can consult the same source without depending on a concrete listener
+ * implementation. Production code may allocate loopback listeners lazily. Tests and compatibility
+ * paths can use {@link #sameOriginOnly()} to preserve the legacy {@code /apps/{appId}/} behavior.
+ *
+ * <p>Implementations are expected to return fresh answers. A binding can disappear when an app is
+ * uninstalled, when a static UI becomes unsupported, or when a loopback listener cannot be kept
+ * alive. Callers should treat returned values as snapshots and re-check this registry before making
+ * security decisions such as CORS approval or origin-bound session verification.
+ */
+public interface AppUiOriginRegistry {
+  /**
+   * Returns the current origin binding for an installed static app when one is available.
+   *
+   * <p>Registries that own listeners may allocate or refresh the listener as part of this lookup.
+   * The returned binding must not contain raw browser-session tokens, process tokens, or filesystem
+   * paths because API summaries may expose it to app processes.
+   *
+   * @param appId normalized app identifier whose UI assignment should be resolved
+   * @return origin binding, or empty when no isolated/fallback binding is registered
+   */
+  Optional<AppUiOriginBinding> bindingForApp(String appId);
+
+  /**
+   * Returns a browser launch URL for one installed static app when one is available.
+   *
+   * <p>The default uses the public URL from {@link #bindingForApp(String)}. Registries that manage
+   * isolated listeners may override this method to mint request-specific launch proof for
+   * full-access Web Shell redirects. Callers must not serialize such launch URLs into app summaries
+   * or other APIs that app processes can read.
+   *
+   * @param appId normalized app identifier selected for browser launch
+   * @return browser launch URL, or empty when no app UI binding is available
+   */
+  default Optional<String> launchUrlForApp(String appId) {
+    return bindingForApp(appId).map(AppUiOriginBinding::uiUrl);
+  }
+
+  /**
+   * Returns the binding currently assigned to one serialized browser origin.
+   *
+   * <p>Platform API CORS handling uses this lookup before allowing app-browser requests from
+   * isolated origins. Implementations should normalize or trim input consistently with the HTTP
+   * adapter but must not match wildcard or remote origins.
+   *
+   * @param origin serialized browser origin from an HTTP {@code Origin} header
+   * @return matching binding, or empty when the origin is not registered
+   */
+  default Optional<AppUiOriginBinding> bindingForOrigin(String origin) {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns whether an HTTP {@code Origin} header names a registered active app UI origin.
+   *
+   * <p>The default accepts only bindings that are both registered and active isolated origins. A
+   * same-origin fallback binding is intentionally not treated as a CORS-approved app origin.
+   *
+   * @param origin serialized browser origin from an app-browser request
+   * @return {@code true} when the origin is currently assigned to an active isolated app UI
+   */
+  default boolean isRegisteredOrigin(String origin) {
+    return bindingForOrigin(origin).filter(AppUiOriginBinding::isolatedAndActive).isPresent();
+  }
+
+  /**
+   * Returns a no-op registry that leaves callers on same-origin compatibility paths.
+   *
+   * <p>This is the correct default for tests and runtime paths that have not installed a loopback
+   * origin server. It never approves an isolated CORS origin and never mints launch proof.
+   *
+   * @return registry with no isolated origin bindings
+   */
+  static AppUiOriginRegistry sameOriginOnly() {
+    return _ -> Optional.empty();
+  }
+}

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiOriginStatus.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiOriginStatus.java
@@ -1,0 +1,66 @@
+package network.crypta.platform.appui;
+
+/**
+ * Runtime status for an app UI browser origin assignment.
+ *
+ * <p>The status is intentionally small and operator-facing. It tells summaries and bootstrap
+ * payloads whether the preferred isolated origin is usable or whether the app is running through a
+ * compatibility path.
+ *
+ * <p>Status values are paired with {@link AppUiOriginMode}. The mode describes the selected policy;
+ * this enum describes the current outcome of trying to serve that policy. Keeping the two concepts
+ * separate lets Web Shell show a stable policy while API callers still detect transient listener
+ * failures, unsupported app UI modes, and explicit same-origin fallback.
+ */
+public enum AppUiOriginStatus {
+  /**
+   * The isolated loopback origin is currently active and browser-openable.
+   *
+   * <p>Bindings with this status can be used for Web Shell launch URLs, CORS origin approval, and
+   * origin-bound browser-session verification.
+   */
+  ACTIVE("active"),
+
+  /**
+   * The app UI is using the legacy same-origin compatibility route.
+   *
+   * <p>Fallback keeps development and diagnostic routes working, but it is not an active isolated
+   * origin and should not be approved as an app CORS origin.
+   */
+  FALLBACK("fallback"),
+
+  /**
+   * Origin isolation could not be provided on this node or for this app.
+   *
+   * <p>This status is appropriate for process-only apps, invalid UI declarations, or environments
+   * where the local loopback listener cannot be allocated. A binding may include a warning string
+   * with the operator-facing reason.
+   */
+  UNSUPPORTED("unsupported"),
+
+  /**
+   * A previously assigned origin is not currently serving requests.
+   *
+   * <p>Stopped indicates a runtime lifecycle state rather than a manifest problem. Callers should
+   * refresh the binding before reusing any launch URL or CORS decision derived from it.
+   */
+  STOPPED("stopped");
+
+  private final String jsonValue;
+
+  AppUiOriginStatus(String jsonValue) {
+    this.jsonValue = jsonValue;
+  }
+
+  /**
+   * Returns the stable JSON/documentation value for this status.
+   *
+   * <p>The returned value is the wire-facing spelling used in app summaries and bootstrap metadata.
+   * It should be preferred over {@link #name()} outside Java-only diagnostics.
+   *
+   * @return lower-case hyphenated status value
+   */
+  public String jsonValue() {
+    return jsonValue;
+  }
+}

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiPaths.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiPaths.java
@@ -82,7 +82,7 @@ public final class AppUiPaths {
     return appRoot(manifest.appId()) + encodeRelativePath(entryDirectory) + "/";
   }
 
-  private static String encodeRelativePath(String relativePath) {
+  static String encodeRelativePath(String relativePath) {
     StringBuilder encoded = new StringBuilder(relativePath.length());
     int start = 0;
     while (start < relativePath.length()) {

--- a/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiSecurityHeaders.java
+++ b/platform-app-ui/src/main/java/network/crypta/platform/appui/AppUiSecurityHeaders.java
@@ -6,17 +6,19 @@ import java.util.Map;
 /**
  * Conservative response headers for app-owned static browser UI.
  *
- * <p>The headers keep static apps inside the same-origin local admin boundary while avoiding remote
+ * <p>The headers keep static app resources local to their serving origin while avoiding remote
  * scripts, object embedding, base tag rewrites, cross-origin form posts, referrer leakage, and MIME
  * sniffing. They are deliberately adapter-neutral: the app UI layer returns lowercase header names
  * and string values, and HTTP bridges convert them into their transport-specific header container.
  *
- * <p>This policy is not a sandbox and does not implement app permissions. It is a defensive default
- * for immutable installed-bundle UI assets until later platform phases add stronger isolation. When
- * the legacy admin surface has JavaScript disabled, the app UI CSP also disables script execution
- * so app-owned routes follow the same operator preference.
+ * <p>This policy is not an AppHost process sandbox and does not implement app permissions. It is a
+ * defensive default for immutable installed-bundle UI assets on both same-origin fallback routes
+ * and isolated loopback origins. When the legacy admin surface has JavaScript disabled, the app UI
+ * CSP also disables script execution so app-owned routes follow the same operator preference.
  */
 public final class AppUiSecurityHeaders {
+  private static final String SELF_SOURCE = "'self'";
+
   /**
    * Content Security Policy applied to static app UI responses when JavaScript is enabled.
    *
@@ -62,18 +64,78 @@ public final class AppUiSecurityHeaders {
    * @return immutable header name/value map suitable for adapter conversion
    */
   public static Map<String, String> headers(boolean javascriptEnabled) {
+    return headers(javascriptEnabled, null, null);
+  }
+
+  /**
+   * Returns app UI security headers for an isolated-origin response.
+   *
+   * <p>The CSP still limits scripts and resources to the app origin by default, but it permits
+   * Platform API fetches to the supplied admin API root and limits framing to the supplied Web
+   * Shell/admin origin. {@code X-Frame-Options} is intentionally omitted when a cross-origin frame
+   * ancestor is configured because the older header cannot express that policy.
+   *
+   * @param javascriptEnabled whether app scripts are allowed to execute
+   * @param platformApiRoot absolute Platform API root, or {@code null} for same-origin only
+   * @param shellRoot absolute Web Shell root, or {@code null} for same-origin frame ancestors
+   * @return immutable header name/value map suitable for adapter conversion
+   */
+  public static Map<String, String> headers(
+      boolean javascriptEnabled, String platformApiRoot, String shellRoot) {
     LinkedHashMap<String, String> headers = LinkedHashMap.newLinkedHashMap(4);
-    headers.put("content-security-policy", contentSecurityPolicy(javascriptEnabled));
+    String frameAncestor = originSource(shellRoot);
+    headers.put(
+        "content-security-policy",
+        contentSecurityPolicy(javascriptEnabled, originSource(platformApiRoot), frameAncestor));
     headers.put("x-content-type-options", "nosniff");
     headers.put("referrer-policy", "no-referrer");
-    headers.put("x-frame-options", "SAMEORIGIN");
+    if (frameAncestor == null) {
+      headers.put("x-frame-options", "SAMEORIGIN");
+    }
     return java.util.Collections.unmodifiableMap(headers);
   }
 
   private static String contentSecurityPolicy(boolean javascriptEnabled) {
-    String scriptSource = javascriptEnabled ? "'self'" : "'none'";
-    return "default-src 'self'; script-src "
+    return contentSecurityPolicy(javascriptEnabled, null, null);
+  }
+
+  private static String contentSecurityPolicy(
+      boolean javascriptEnabled, String platformApiOrigin, String frameAncestor) {
+    String scriptSource = javascriptEnabled ? SELF_SOURCE : "'none'";
+    String connectSource =
+        platformApiOrigin == null ? SELF_SOURCE : SELF_SOURCE + " " + platformApiOrigin;
+    String frameAncestors = frameAncestor == null ? SELF_SOURCE : SELF_SOURCE + " " + frameAncestor;
+    return "default-src "
+        + SELF_SOURCE
+        + "; script-src "
         + scriptSource
-        + "; base-uri 'none'; object-src 'none'; form-action 'self'; frame-ancestors 'self'";
+        + "; connect-src "
+        + connectSource
+        + "; base-uri 'none'; object-src 'none'; form-action "
+        + SELF_SOURCE
+        + "; frame-ancestors "
+        + frameAncestors;
+  }
+
+  private static String originSource(String rootUrl) {
+    if (rootUrl == null || rootUrl.startsWith("/")) {
+      return null;
+    }
+    try {
+      java.net.URI uri = java.net.URI.create(rootUrl);
+      if (uri.getScheme() == null || uri.getHost() == null) {
+        return null;
+      }
+      StringBuilder out = new StringBuilder();
+      out.append(uri.getScheme().toLowerCase(java.util.Locale.ROOT));
+      out.append("://");
+      out.append(uri.getHost().toLowerCase(java.util.Locale.ROOT));
+      if (uri.getPort() > 0) {
+        out.append(':').append(uri.getPort());
+      }
+      return out.toString();
+    } catch (IllegalArgumentException _) {
+      return null;
+    }
   }
 }

--- a/platform-app-ui/src/test/java/network/crypta/platform/appui/AppBrowserSessionStoreTest.java
+++ b/platform-app-ui/src/test/java/network/crypta/platform/appui/AppBrowserSessionStoreTest.java
@@ -62,6 +62,28 @@ class AppBrowserSessionStoreTest {
   }
 
   @Test
+  void issue_whenIsolatedOriginBindingProvided_expectVerifiedSessionKeepsOriginMetadata() {
+    MutableAppHost appHost = new MutableAppHost(staticApp("demo-app", List.of("queue.read")));
+    MutableClock clock = new MutableClock(START);
+    AppBrowserSessionStore store =
+        new AppBrowserSessionStore(appHost, clock, new SecureRandom(), Duration.ofHours(1), 10);
+    InstalledAppSnapshot snapshot = appHost.describeUnchecked("demo-app");
+    AppUiOriginBinding binding =
+        AppUiOriginBinding.isolatedLoopback(
+            snapshot.manifest(),
+            AppUiOrigin.loopback("demo-app", 12345),
+            "http://127.0.0.1:8888/api/v1/",
+            "http://127.0.0.1:8888/app/node/");
+
+    AppBrowserSessionIssue issue = store.issue(snapshot, binding);
+    Optional<AppBrowserSession> verified = store.verify(issue.token());
+
+    assertTrue(verified.isPresent());
+    assertEquals("http://127.0.0.1:12345", verified.orElseThrow().expectedOrigin());
+    assertEquals(AppUiOriginMode.ISOLATED_LOOPBACK, verified.orElseThrow().originMode());
+  }
+
+  @Test
   void verify_whenSessionIsBlankUnknownOrExpired_expectEmpty() {
     MutableAppHost appHost = new MutableAppHost(staticApp("demo-app", List.of("queue.read")));
     MutableClock clock = new MutableClock(START);

--- a/platform-app-ui/src/test/java/network/crypta/platform/appui/AppBrowserSessionTest.java
+++ b/platform-app-ui/src/test/java/network/crypta/platform/appui/AppBrowserSessionTest.java
@@ -32,6 +32,29 @@ class AppBrowserSessionTest {
   }
 
   @Test
+  void constructor_whenOriginBindingProvided_expectExpectedOriginAndModeRetained() {
+    AppUiOriginBinding binding =
+        new AppUiOriginBinding(
+            "demo-app",
+            AppUiOriginMode.ISOLATED_LOOPBACK,
+            AppUiOriginStatus.ACTIVE,
+            "http://127.0.0.1:12345",
+            "http://127.0.0.1:12345/",
+            "http://127.0.0.1:12345/static/",
+            "http://127.0.0.1:12345/static/",
+            "http://127.0.0.1:8888/api/v1/",
+            "http://127.0.0.1:8888/app/node/",
+            "/apps/demo-app/",
+            null);
+
+    AppBrowserSession session =
+        new AppBrowserSession("demo-app", List.of("queue.read"), ISSUED_AT, EXPIRES_AT, binding);
+
+    assertEquals("http://127.0.0.1:12345", session.expectedOrigin());
+    assertEquals(AppUiOriginMode.ISOLATED_LOOPBACK, session.originMode());
+  }
+
+  @Test
   void constructor_whenIdentityOrExpiryInvalid_expectIllegalArgumentException() {
     List<String> permissions = List.of("queue.read");
     List<String> permissionsWithBlankValue = List.of("queue.read", " ");
@@ -45,6 +68,16 @@ class AppBrowserSessionTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> new AppBrowserSession("demo-app", permissions, ISSUED_AT, ISSUED_AT));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new AppBrowserSession(
+                "demo-app",
+                permissions,
+                ISSUED_AT,
+                EXPIRES_AT,
+                " ",
+                AppUiOriginMode.ISOLATED_LOOPBACK));
   }
 
   @Test

--- a/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiBootstrapServiceTest.java
+++ b/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiBootstrapServiceTest.java
@@ -47,6 +47,8 @@ class AppUiBootstrapServiceTest {
     assertEquals("/apps/demo-app/static/", bootstrap.assetRoot());
     assertEquals("/api/v1/", bootstrap.platformApiRoot());
     assertEquals("/app/node/", bootstrap.shellRoot());
+    assertEquals("same-origin-fallback", bootstrap.uiOriginMode());
+    assertEquals("fallback", bootstrap.uiOriginStatus());
     assertEquals("browser-token", bootstrap.browserSessionToken());
     assertEquals(EXPIRES_AT, bootstrap.browserSessionExpiresAt());
   }

--- a/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiBootstrapTest.java
+++ b/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiBootstrapTest.java
@@ -66,6 +66,30 @@ class AppUiBootstrapTest {
   }
 
   @Test
+  void constructor_whenBracketedIpv6LoopbackRootsProvided_expectAccepted() {
+    AppUiBootstrap bootstrap =
+        new AppUiBootstrap(
+            "demo-app",
+            "Demo App",
+            "http://[::1]:12345/",
+            "http://[::1]:12345/static/",
+            "http://[::1]:8888/api/v1/",
+            "http://[::1]:8888/app/node/",
+            "http://[::1]:12345",
+            AppUiOriginMode.ISOLATED_LOOPBACK.jsonValue(),
+            AppUiOriginStatus.ACTIVE.jsonValue(),
+            "/apps/demo-app/",
+            "session-token",
+            EXPIRES_AT);
+
+    assertEquals("http://[::1]:12345/", bootstrap.uiRoot());
+    assertEquals("http://[::1]:12345/static/", bootstrap.assetRoot());
+    assertEquals("http://[::1]:8888/api/v1/", bootstrap.platformApiRoot());
+    assertEquals("http://[::1]:8888/app/node/", bootstrap.shellRoot());
+    assertEquals("http://[::1]:12345", bootstrap.uiOrigin());
+  }
+
+  @Test
   void constructor_whenBlankBrowserSessionTokenProvided_expectIllegalArgumentException() {
     assertThrows(
         IllegalArgumentException.class,

--- a/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiBootstrapTest.java
+++ b/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiBootstrapTest.java
@@ -30,8 +30,39 @@ class AppUiBootstrapTest {
     assertEquals("/apps/demo-app/static/", bootstrap.assetRoot());
     assertEquals("/api/v1/", bootstrap.platformApiRoot());
     assertEquals("/app/node/", bootstrap.shellRoot());
+    assertEquals("same-origin-fallback", bootstrap.uiOriginMode());
+    assertEquals("fallback", bootstrap.uiOriginStatus());
+    assertEquals("/apps/demo-app/", bootstrap.sameOriginFallbackUrl());
     assertEquals("session-token", bootstrap.browserSessionToken());
     assertEquals(EXPIRES_AT, bootstrap.browserSessionExpiresAt());
+  }
+
+  @Test
+  void forManifest_whenIsolatedBindingProvided_expectAbsoluteOriginsAndFallbackRoot() {
+    AppManifest manifest = manifest();
+    AppUiOriginBinding binding =
+        AppUiOriginBinding.isolatedLoopback(
+            manifest,
+            AppUiOrigin.loopback("demo-app", 12345),
+            "http://127.0.0.1:8888/api/v1/",
+            "http://127.0.0.1:8888/app/node/");
+
+    AppUiBootstrap bootstrap =
+        AppUiBootstrap.forManifest(
+            manifest,
+            "/api/v1/",
+            "/app/node/",
+            new AppBrowserSessionIssue("session-token", EXPIRES_AT),
+            binding);
+
+    assertEquals("http://127.0.0.1:12345/", bootstrap.uiRoot());
+    assertEquals("http://127.0.0.1:12345/static/", bootstrap.assetRoot());
+    assertEquals("http://127.0.0.1:8888/api/v1/", bootstrap.platformApiRoot());
+    assertEquals("http://127.0.0.1:8888/app/node/", bootstrap.shellRoot());
+    assertEquals("http://127.0.0.1:12345", bootstrap.uiOrigin());
+    assertEquals("isolated-loopback", bootstrap.uiOriginMode());
+    assertEquals("active", bootstrap.uiOriginStatus());
+    assertEquals("/apps/demo-app/", bootstrap.sameOriginFallbackUrl());
   }
 
   @Test
@@ -88,6 +119,10 @@ class AppUiBootstrapTest {
             + "\"assetRoot\":\"/apps/demo-app/static/\","
             + "\"platformApiRoot\":\"/api/v1/\","
             + "\"shellRoot\":\"/app/node/\","
+            + "\"uiOrigin\":null,"
+            + "\"uiOriginMode\":\"same-origin-fallback\","
+            + "\"uiOriginStatus\":\"fallback\","
+            + "\"sameOriginFallbackUrl\":\"/apps/demo-app/\","
             + "\"browserSessionToken\":\"secret\\u0026value\","
             + "\"browserSessionExpiresAt\":\"2026-04-28T12:00:00Z\"}",
         json);

--- a/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiBootstrapTest.java
+++ b/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiBootstrapTest.java
@@ -90,6 +90,30 @@ class AppUiBootstrapTest {
   }
 
   @Test
+  void constructor_whenExpandedIpv6LoopbackRootsProvided_expectAccepted() {
+    AppUiBootstrap bootstrap =
+        new AppUiBootstrap(
+            "demo-app",
+            "Demo App",
+            "http://[0:0:0:0:0:0:0:1]:12345/",
+            "http://[0:0:0:0:0:0:0:1]:12345/static/",
+            "http://[0:0:0:0:0:0:0:1]:8888/api/v1/",
+            "http://[0:0:0:0:0:0:0:1]:8888/app/node/",
+            "http://[0:0:0:0:0:0:0:1]:12345",
+            AppUiOriginMode.ISOLATED_LOOPBACK.jsonValue(),
+            AppUiOriginStatus.ACTIVE.jsonValue(),
+            "/apps/demo-app/",
+            "session-token",
+            EXPIRES_AT);
+
+    assertEquals("http://[0:0:0:0:0:0:0:1]:12345/", bootstrap.uiRoot());
+    assertEquals("http://[0:0:0:0:0:0:0:1]:12345/static/", bootstrap.assetRoot());
+    assertEquals("http://[0:0:0:0:0:0:0:1]:8888/api/v1/", bootstrap.platformApiRoot());
+    assertEquals("http://[0:0:0:0:0:0:0:1]:8888/app/node/", bootstrap.shellRoot());
+    assertEquals("http://[0:0:0:0:0:0:0:1]:12345", bootstrap.uiOrigin());
+  }
+
+  @Test
   void constructor_whenBlankBrowserSessionTokenProvided_expectIllegalArgumentException() {
     assertThrows(
         IllegalArgumentException.class,

--- a/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiOriginTest.java
+++ b/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiOriginTest.java
@@ -1,0 +1,51 @@
+package network.crypta.platform.appui;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class AppUiOriginTest {
+  @Test
+  void loopback_whenValidPortProvided_expectSerializedLocalOrigin() {
+    AppUiOrigin origin = AppUiOrigin.loopback(" Demo-App ", 12345);
+
+    assertEquals("demo-app", origin.appId());
+    assertEquals("http://127.0.0.1:12345", origin.origin());
+    assertEquals("http://127.0.0.1:12345/", origin.rootUrl());
+  }
+
+  @Test
+  void constructor_whenRemoteOrWildcardHostProvided_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new AppUiOrigin("demo-app", "http", "0.0.0.0", 1));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new AppUiOrigin("demo-app", "http", "example.test", 1));
+  }
+
+  @Test
+  void constructor_whenSchemeOrPortUnsupported_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class, () -> new AppUiOrigin("demo-app", "https", "127.0.0.1", 1));
+    assertThrows(
+        IllegalArgumentException.class, () -> new AppUiOrigin("demo-app", "http", "127.0.0.1", 0));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new AppUiOrigin("demo-app", "http", "127.0.0.1", 65536));
+  }
+
+  @Test
+  void parse_whenOriginHasPathQueryOrFragment_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AppUiOrigin.parse("demo-app", "http://127.0.0.1:12345/static"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AppUiOrigin.parse("demo-app", "http://127.0.0.1:12345?x=1"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> AppUiOrigin.parse("demo-app", "http://127.0.0.1:12345#app"));
+  }
+}

--- a/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiSecurityHeadersTest.java
+++ b/platform-app-ui/src/test/java/network/crypta/platform/appui/AppUiSecurityHeadersTest.java
@@ -9,16 +9,27 @@ class AppUiSecurityHeadersTest {
   @Test
   void headers_whenJavascriptEnabled_expectSameOriginFormAction() {
     assertEquals(
-        "default-src 'self'; script-src 'self'; base-uri 'none'; object-src 'none'; form-action"
-            + " 'self'; frame-ancestors 'self'",
+        "default-src 'self'; script-src 'self'; connect-src 'self'; base-uri 'none'; object-src"
+            + " 'none'; form-action 'self'; frame-ancestors 'self'",
         AppUiSecurityHeaders.headers(true).get("content-security-policy"));
   }
 
   @Test
   void headers_whenJavascriptDisabled_expectSameOriginFormActionAndScriptsBlocked() {
     assertEquals(
-        "default-src 'self'; script-src 'none'; base-uri 'none'; object-src 'none'; form-action"
-            + " 'self'; frame-ancestors 'self'",
+        "default-src 'self'; script-src 'none'; connect-src 'self'; base-uri 'none'; object-src"
+            + " 'none'; form-action 'self'; frame-ancestors 'self'",
         AppUiSecurityHeaders.headers(false).get("content-security-policy"));
+  }
+
+  @Test
+  void headers_whenPlatformApiRootProvided_expectConnectSrcAllowsAdminApiOrigin() {
+    assertEquals(
+        "default-src 'self'; script-src 'self'; connect-src 'self' http://127.0.0.1:8888;"
+            + " base-uri 'none'; object-src 'none'; form-action 'self'; frame-ancestors 'self'"
+            + " http://127.0.0.1:8888",
+        AppUiSecurityHeaders.headers(
+                true, "http://127.0.0.1:8888/api/v1/", "http://127.0.0.1:8888/app/node/")
+            .get("content-security-policy"));
   }
 }

--- a/platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js
+++ b/platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js
@@ -182,7 +182,18 @@
     }
 
     const body = toUrlSearchParams(formDataOrParams);
+    try {
+      return await fetchFormMutation(method, path, body, requestOptions);
+    } catch (error) {
+      if (!shouldRefreshAfterSessionError(error, requestOptions)) {
+        throw error;
+      }
+      await refreshBootstrap(requestOptions);
+      return fetchFormMutation(method, path, body, requestOptions);
+    }
+  }
 
+  async function fetchFormMutation(method, path, body, requestOptions) {
     const headers = appSessionHeaders(requestOptions.headers);
     headers.set("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8");
     const response = await fetch(apiUrl(path), {

--- a/platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js
+++ b/platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js
@@ -342,9 +342,13 @@
 
   function localHttpOrigin(url) {
     const hostname = url.hostname.toLowerCase();
+    const normalizedHostname =
+      hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
     return (
       (url.protocol === "http:" || url.protocol === "https:") &&
-      (hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1")
+      (normalizedHostname === "127.0.0.1" ||
+        normalizedHostname === "localhost" ||
+        normalizedHostname === "::1")
     );
   }
 

--- a/platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js
+++ b/platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js
@@ -348,7 +348,8 @@
       (url.protocol === "http:" || url.protocol === "https:") &&
       (normalizedHostname === "127.0.0.1" ||
         normalizedHostname === "localhost" ||
-        normalizedHostname === "::1")
+        normalizedHostname === "::1" ||
+        normalizedHostname === "0:0:0:0:0:0:0:1")
     );
   }
 

--- a/platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js
+++ b/platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js
@@ -7,6 +7,8 @@
 
   const defaultPlatformApiRoot = "/api/v1/";
   const bootstrapResourcePath = ".well-known/cryptad-bootstrap.json";
+  const bootstrapNonceHeader = "X-Crypta-App-Bootstrap-Nonce";
+  const bootstrapNonceFragmentParameter = "cryptadBootstrapNonce";
   const removedElementSelector =
     "script, style, template, iframe, frame, frameset, object, embed, link, meta, base";
   const urlAttributeNames = new Set(["href", "src", "action", "formaction"]);
@@ -15,36 +17,41 @@
   let currentBootstrap = null;
   let currentAppId = null;
   let currentBrowserSessionToken = "";
+  let currentBootstrapNonce = "";
   let loadingAppId = null;
   let loadingBootstrap = null;
 
   async function loadBootstrap(options) {
     const rawAppId = explicitAppId(options) || inferAppId();
-    if (!rawAppId) {
-      throw new Error("Unable to determine the current Cryptad app id.");
-    }
-    const requestedAppId = normalizeAppId(rawAppId);
+    const requestedAppId = rawAppId ? normalizeAppId(rawAppId) : null;
 
     const force = !!(options && options.force);
-    if (!force && currentBootstrap && currentAppId === requestedAppId) {
+    if (!force && currentBootstrap && bootstrapMatchesRequest(currentBootstrap, requestedAppId)) {
       return copyBootstrap(currentBootstrap);
     }
-    if (!force && loadingBootstrap && loadingAppId === requestedAppId) {
+    if (
+      !force &&
+      loadingBootstrap &&
+      (requestedAppId === null || loadingAppId === requestedAppId)
+    ) {
       return loadingBootstrap.then(copyBootstrap);
     }
 
     loadingAppId = requestedAppId;
-    loadingBootstrap = fetchBootstrap(requestedAppId)
+    const inFlightBootstrap = fetchBootstrap(requestedAppId)
       .then((bootstrap) => {
         currentBootstrap = bootstrap;
-        currentAppId = bootstrap.appId || requestedAppId;
-        return copyBootstrap(bootstrap);
+        currentAppId = bootstrap.appId;
+        return bootstrap;
       })
       .finally(() => {
-        loadingAppId = null;
-        loadingBootstrap = null;
+        if (loadingBootstrap === inFlightBootstrap) {
+          loadingAppId = null;
+          loadingBootstrap = null;
+        }
       });
-    return loadingBootstrap;
+    loadingBootstrap = inFlightBootstrap;
+    return inFlightBootstrap.then(copyBootstrap);
   }
 
   function current() {
@@ -60,25 +67,73 @@
   }
 
   async function fetchBootstrap(appId) {
-    const path = `/apps/${encodeURIComponent(appId)}/${bootstrapResourcePath}`;
-    const response = await fetch(path, { headers: { Accept: "application/json" } });
-    const data = await readJson(response);
-    if (!response.ok) {
-      throw new Error(responseErrorMessage(data, response));
+    const urls = bootstrapUrls(appId);
+    const headers = bootstrapHeaders();
+    let lastResponse = null;
+    let lastData = {};
+    for (let index = 0; index < urls.length; index += 1) {
+      const response = await fetch(urls[index], {
+        headers,
+        credentials: "omit",
+      });
+      const data = await readJson(response);
+      if (response.ok) {
+        return finishBootstrap(appId, data);
+      }
+      lastResponse = response;
+      lastData = data;
+      if (index + 1 >= urls.length) {
+        break;
+      }
     }
+    throw new Error(responseErrorMessage(lastData, lastResponse));
+  }
+
+  function finishBootstrap(appId, data) {
     const bootstrap = sanitizeBootstrap(data);
     const browserSessionToken = sessionTokenFromBootstrap(data);
     if (bootstrap.appId) {
       bootstrap.appId = normalizeAppId(bootstrap.appId);
     }
-    if (bootstrap.appId && bootstrap.appId !== appId) {
+    if (bootstrap.appId && appId && bootstrap.appId !== appId) {
       throw new Error("Bootstrap app id does not match the requested app.");
     }
-    if (!bootstrap.appId) {
+    if (!bootstrap.appId && appId) {
       bootstrap.appId = appId;
+    }
+    if (!bootstrap.appId) {
+      throw new Error("Bootstrap response did not include a Cryptad app id.");
     }
     currentBrowserSessionToken = browserSessionToken;
     return bootstrap;
+  }
+
+  function bootstrapHeaders() {
+    const headers = { Accept: "application/json" };
+    const nonce = bootstrapNonce();
+    if (nonce) {
+      headers[bootstrapNonceHeader] = nonce;
+    }
+    return headers;
+  }
+
+  function bootstrapNonce() {
+    const nonce = bootstrapNonceFromHash(window.location.hash);
+    if (nonce) {
+      currentBootstrapNonce = nonce;
+      return nonce;
+    }
+    return currentBootstrapNonce;
+  }
+
+  function bootstrapNonceFromHash(hash) {
+    const value = typeof hash === "string" ? hash.trim() : "";
+    if (!value || value === "#") {
+      return "";
+    }
+    const params = new URLSearchParams(value.startsWith("#") ? value.substring(1) : value);
+    const nonce = params.get(bootstrapNonceFragmentParameter);
+    return typeof nonce === "string" ? nonce.trim() : "";
   }
 
   async function apiGet(path, options) {
@@ -107,7 +162,7 @@
       method: "GET",
       headers,
       signal: requestOptions.signal,
-      credentials: "same-origin",
+      credentials: "omit",
     });
     return readJsonOrThrow(response);
   }
@@ -135,7 +190,7 @@
       headers,
       body: body.toString(),
       signal: requestOptions.signal,
-      credentials: "same-origin",
+      credentials: "omit",
     });
     return readJsonOrThrow(response);
   }
@@ -145,10 +200,10 @@
       currentBootstrap && currentBootstrap.platformApiRoot,
       defaultPlatformApiRoot
     );
-    const rootUrl = new URL(root, window.location.origin);
+    const rootUrl = new URL(root, window.location.href);
     const url = coerceApiUrl(path, rootUrl);
-    if (url.origin !== window.location.origin || !url.pathname.startsWith(rootUrl.pathname)) {
-      throw new Error("Platform API URL must stay under the same-origin API root.");
+    if (url.origin !== rootUrl.origin || !url.pathname.startsWith(rootUrl.pathname)) {
+      throw new Error("Platform API URL must stay under the bootstrap API root.");
     }
     return url;
   }
@@ -253,24 +308,33 @@
       return new URL(value);
     }
     if (value.startsWith("/")) {
-      return new URL(value, window.location.origin);
+      return new URL(value, rootUrl);
     }
     return new URL(value, rootUrl);
   }
 
   function normalizeLocalRoot(value, fallback) {
-    if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) {
+    if (typeof value !== "string" || !value.trim() || value.trim().startsWith("//")) {
       return fallback;
     }
     try {
-      const url = new URL(value, window.location.origin);
-      if (url.origin !== window.location.origin || url.search || url.hash) {
+      const url = new URL(value.trim(), window.location.href);
+      if (!localHttpOrigin(url) || url.search || url.hash || !url.pathname.startsWith("/api/v1/")) {
         return fallback;
       }
-      return url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;
+      url.pathname = url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;
+      return url.href;
     } catch (error) {
       return fallback;
     }
+  }
+
+  function localHttpOrigin(url) {
+    const hostname = url.hostname.toLowerCase();
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      (hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1")
+    );
   }
 
   function hasScheme(value) {
@@ -373,7 +437,30 @@
     if (options && options.refreshBootstrap === false) {
       return ensureBootstrap(options);
     }
+    if (!(options && options.force) && currentBrowserSessionLive()) {
+      return ensureBootstrap(options);
+    }
     return refreshBootstrap(options);
+  }
+
+  function currentBrowserSessionLive() {
+    if (!currentBootstrap || !currentBrowserSessionToken) {
+      return false;
+    }
+    const expiresAt = browserSessionExpiresAtMillis(currentBootstrap);
+    return expiresAt == null || expiresAt > Date.now();
+  }
+
+  function browserSessionExpiresAtMillis(bootstrap) {
+    const value =
+      bootstrap && typeof bootstrap.browserSessionExpiresAt === "string"
+        ? bootstrap.browserSessionExpiresAt.trim()
+        : "";
+    if (!value) {
+      return null;
+    }
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? null : parsed;
   }
 
   async function readJsonOrThrow(response) {
@@ -405,6 +492,8 @@
     const message =
       code === "invalid_app_browser_session"
         ? "App browser session expired; reload the app UI."
+        : code === "origin_mismatch"
+          ? "App browser session origin mismatch; reopen the app from Web Shell."
         : responseErrorMessage(data, response);
     if (code === "invalid_app_browser_session") {
       currentBrowserSessionToken = "";
@@ -481,6 +570,30 @@
     }
   }
 
+  function bootstrapUrls(appId) {
+    const rootBootstrapUrl = `/${bootstrapResourcePath}`;
+    if (!appId || !legacyAdminAppPath(appId)) {
+      return [rootBootstrapUrl];
+    }
+    return [rootBootstrapUrl, `/apps/${encodeURIComponent(appId)}/${bootstrapResourcePath}`];
+  }
+
+  function bootstrapMatchesRequest(bootstrap, appId) {
+    return !appId || (bootstrap && bootstrap.appId === appId);
+  }
+
+  function legacyAdminAppPath(appId) {
+    const segments = window.location.pathname.split("/");
+    if (segments.length < 3 || segments[1] !== "apps") {
+      return false;
+    }
+    try {
+      return normalizeAppId(decodeURIComponent(segments[2])) === appId;
+    } catch (error) {
+      return false;
+    }
+  }
+
   function normalizeAppId(appId) {
     if (typeof appId !== "string") {
       throw new Error("Cryptad app id must be a string.");
@@ -501,6 +614,10 @@
     copyStringField(source, bootstrap, "assetRoot");
     copyStringField(source, bootstrap, "platformApiRoot");
     copyStringField(source, bootstrap, "shellRoot");
+    copyStringField(source, bootstrap, "uiOrigin");
+    copyStringField(source, bootstrap, "uiOriginMode");
+    copyStringField(source, bootstrap, "uiOriginStatus");
+    copyStringField(source, bootstrap, "sameOriginFallbackUrl");
     copyStringField(source, bootstrap, "browserSessionExpiresAt");
     return bootstrap;
   }

--- a/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkResourceTest.java
+++ b/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkResourceTest.java
@@ -74,6 +74,10 @@ class CryptaPlatformSdkResourceTest {
     assertTrue(script.contains("await refreshBootstrap(requestOptions);"));
     assertTrue(script.contains("return fetchApiGet(path, requestOptions);"));
     assertTrue(script.contains("await refreshBootstrapForMutation(requestOptions);"));
+    assertTrue(script.contains("function fetchFormMutation(method, path, body, requestOptions)"));
+    assertTrue(
+        script.contains("return await fetchFormMutation(method, path, body, requestOptions);"));
+    assertTrue(script.contains("return fetchFormMutation(method, path, body, requestOptions);"));
   }
 
   @Test

--- a/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkResourceTest.java
+++ b/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkResourceTest.java
@@ -15,7 +15,7 @@ class CryptaPlatformSdkResourceTest {
       "/network/crypta/platform/sdk/js/crypta-platform.js";
 
   @Test
-  void classpathResource_whenSdkRequested_expectReadableBrowserScript() throws IOException {
+  void classpathResource_whenSdkRequested_expectPublicBrowserSurface() throws IOException {
     String script = readSdkScript();
 
     assertTrue(script.contains("window.CryptaPlatform"));
@@ -28,13 +28,59 @@ class CryptaPlatformSdkResourceTest {
     assertTrue(script.contains("browserSessionToken"));
     assertTrue(script.contains("X-Crypta-App-Session"));
     assertTrue(script.contains("invalid_app_browser_session"));
+    assertTrue(script.contains("origin_mismatch"));
     assertTrue(script.contains("sessionRefreshRequired"));
+    assertTrue(script.contains("credentials: \"omit\""));
+  }
+
+  @Test
+  void classpathResource_whenBootstrapRequested_expectIsolatedOriginBootstrapFlow()
+      throws IOException {
+    String script = readSdkScript();
+
+    assertTrue(
+        script.contains("const bootstrapResourcePath = \".well-known/cryptad-bootstrap.json\";"));
+    assertTrue(script.contains("const bootstrapNonceHeader = \"X-Crypta-App-Bootstrap-Nonce\";"));
+    assertTrue(
+        script.contains("const bootstrapNonceFragmentParameter = \"cryptadBootstrapNonce\";"));
+    assertTrue(script.contains("function bootstrapHeaders()"));
+    assertTrue(script.contains("headers[bootstrapNonceHeader] = nonce;"));
+    assertTrue(script.contains("function bootstrapNonceFromHash(hash)"));
+    assertTrue(script.contains("function bootstrapUrls(appId)"));
+    assertTrue(script.contains("const rootBootstrapUrl = `/${bootstrapResourcePath}`;"));
+    assertTrue(script.contains("if (!appId || !legacyAdminAppPath(appId))"));
+    assertTrue(script.contains("function legacyAdminAppPath(appId)"));
+    assertTrue(script.contains("if (index + 1 >= urls.length)"));
+    assertTrue(
+        script.contains(
+            "throw new Error(\"Bootstrap response did not include a Cryptad app id.\")"));
+    assertTrue(script.contains("copyStringField(source, bootstrap, \"platformApiRoot\");"));
+    assertTrue(script.contains("copyStringField(source, bootstrap, \"uiOrigin\");"));
+  }
+
+  @Test
+  void classpathResource_whenApiRequested_expectAbsoluteApiRootAndSessionRefreshFlow()
+      throws IOException {
+    String script = readSdkScript();
+
     assertTrue(script.contains("function fetchApiGet"));
+    assertFalse(script.contains("return new URL(value, window.location.origin);"));
+    assertTrue(script.contains("return new URL(value, rootUrl);"));
     assertTrue(script.contains("function refreshBootstrap(options)"));
     assertTrue(script.contains("function refreshBootstrapForMutation"));
+    assertTrue(script.contains("currentBrowserSessionLive()"));
+    assertTrue(script.contains("function browserSessionExpiresAtMillis(bootstrap)"));
+    assertTrue(script.contains("Date.parse(value)"));
     assertTrue(script.contains("await refreshBootstrap(requestOptions);"));
     assertTrue(script.contains("return fetchApiGet(path, requestOptions);"));
     assertTrue(script.contains("await refreshBootstrapForMutation(requestOptions);"));
+  }
+
+  @Test
+  void classpathResource_whenSdkRequested_expectNoHostCredentialsOrPersistentStorage()
+      throws IOException {
+    String script = readSdkScript();
+
     assertFalse(script.contains("formPassword"));
     assertFalse(script.contains("CRYPTAD_APP_TOKEN"));
     assertFalse(script.contains("localStorage"));
@@ -46,15 +92,18 @@ class CryptaPlatformSdkResourceTest {
       throws IOException {
     String script = readSdkScript();
 
-    int requestedNormalization = script.indexOf("const requestedAppId = normalizeAppId(rawAppId);");
+    int requestedNormalization =
+        script.indexOf("const requestedAppId = rawAppId ? normalizeAppId(rawAppId) : null;");
     int fetchWithNormalizedId = script.indexOf("fetchBootstrap(requestedAppId)");
     int bootstrapNormalization =
         script.indexOf("bootstrap.appId = normalizeAppId(bootstrap.appId);");
-    int normalizedComparison = script.indexOf("bootstrap.appId && bootstrap.appId !== appId");
+    int normalizedComparison =
+        script.indexOf("bootstrap.appId && appId && bootstrap.appId !== appId");
 
     assertTrue(script.contains("const appIdPattern = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/;"));
     assertTrue(script.contains("const normalized = appId.trim().toLowerCase();"));
-    assertTrue(script.contains("const requestedAppId = normalizeAppId(rawAppId);"));
+    assertTrue(
+        script.contains("const requestedAppId = rawAppId ? normalizeAppId(rawAppId) : null;"));
     assertTrue(script.contains("bootstrap.appId = normalizeAppId(bootstrap.appId);"));
     assertTrue(requestedNormalization >= 0);
     assertTrue(fetchWithNormalizedId > requestedNormalization);

--- a/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkResourceTest.java
+++ b/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkResourceTest.java
@@ -78,6 +78,10 @@ class CryptaPlatformSdkResourceTest {
     assertTrue(
         script.contains("return await fetchFormMutation(method, path, body, requestOptions);"));
     assertTrue(script.contains("return fetchFormMutation(method, path, body, requestOptions);"));
+    assertTrue(
+        script.contains(
+            "hostname.startsWith(\"[\") && hostname.endsWith(\"]\") ? hostname.slice(1, -1)"));
+    assertTrue(script.contains("normalizedHostname === \"::1\""));
   }
 
   @Test

--- a/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkResourceTest.java
+++ b/platform-sdk-js/src/test/java/network/crypta/platform/sdk/js/CryptaPlatformSdkResourceTest.java
@@ -82,6 +82,7 @@ class CryptaPlatformSdkResourceTest {
         script.contains(
             "hostname.startsWith(\"[\") && hostname.endsWith(\"]\") ? hostname.slice(1, -1)"));
     assertTrue(script.contains("normalizedHostname === \"::1\""));
+    assertTrue(script.contains("normalizedHostname === \"0:0:0:0:0:0:0:1\""));
   }
 
   @Test

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -23,6 +23,8 @@
     wizardSnapshot: null,
   };
   const directDownloadOperation = "create_direct_download";
+  const isolatedLaunchParameter = "cryptadIsolatedLaunch";
+  const isolatedOriginProbePath = "/.well-known/cryptad-origin.json";
   const publisherDefaultCompatibilityMode = "COMPAT_CURRENT";
   const queueState = {
     page: "downloads",
@@ -940,9 +942,9 @@
   }
 
   function appUiHref(app) {
-    const isolatedLaunchHref = isolatedAppUiLaunchHref(app);
-    if (isolatedLaunchHref || isolatedAppUiActive(app)) {
-      return isolatedLaunchHref;
+    const isolatedFallbackHref = isolatedAppUiFallbackHref(app);
+    if (isolatedFallbackHref || isolatedAppUiActive(app)) {
+      return isolatedFallbackHref;
     }
     const explicitHref = normalizeAppUiEntryHref(app.uiUrl, app);
     if (explicitHref) {
@@ -958,10 +960,35 @@
   }
 
   function isolatedAppUiLaunchHref(app) {
+    const fallbackHref = isolatedAppUiFallbackHref(app);
+    if (!fallbackHref) {
+      return null;
+    }
+    const url = new URL(fallbackHref, window.location.origin);
+    url.searchParams.set(isolatedLaunchParameter, "1");
+    return `${url.pathname}${url.search}${url.hash}`;
+  }
+
+  function isolatedAppUiFallbackHref(app) {
     if (!isolatedAppUiActive(app)) {
       return null;
     }
     return normalizeAppUiEntryHref(app.sameOriginFallbackUrl, app);
+  }
+
+  function isolatedAppUiProbeHref(app) {
+    if (!isolatedAppUiActive(app) || typeof app.uiOrigin !== "string" || app.uiOrigin.length === 0) {
+      return null;
+    }
+    try {
+      const url = new URL(isolatedOriginProbePath, app.uiOrigin);
+      if (!allowedAppUiOrigin(url, app)) {
+        return null;
+      }
+      return url.href;
+    } catch (error) {
+      return null;
+    }
   }
 
   function isolatedAppUiActive(app) {
@@ -979,8 +1006,86 @@
     link.className = "button button-secondary";
     link.href = href;
     link.textContent = "Open";
+    const isolatedLaunchHref = isolatedAppUiLaunchHref(app);
+    const isolatedProbeHref = isolatedAppUiProbeHref(app);
+    if (
+      isolatedLaunchHref &&
+      isolatedProbeHref &&
+      typeof app.appId === "string" &&
+      app.appId.length > 0
+    ) {
+      link.dataset.isolatedLaunchHref = isolatedLaunchHref;
+      link.dataset.isolatedProbeHref = isolatedProbeHref;
+      link.dataset.isolatedAppId = app.appId;
+    }
     container.append(link);
     return container;
+  }
+
+  function appUiLaunchClickTarget(event) {
+    if (
+      !(event instanceof MouseEvent) ||
+      event.button !== 0 ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    ) {
+      return null;
+    }
+    const anchor = event.target instanceof Element
+      ? event.target.closest("a[data-isolated-launch-href]")
+      : null;
+    return anchor instanceof HTMLAnchorElement ? anchor : null;
+  }
+
+  async function launchAppUiFromLink(link) {
+    const fallbackHref = link.getAttribute("href") || "";
+    const isolatedLaunchHref = link.dataset.isolatedLaunchHref || "";
+    const probeHref = link.dataset.isolatedProbeHref || "";
+    const expectedAppId = link.dataset.isolatedAppId || "";
+    if (
+      isolatedLaunchHref &&
+      await isolatedAppOriginReachable(probeHref, expectedAppId)
+    ) {
+      window.location.assign(isolatedLaunchHref);
+      return;
+    }
+    window.location.assign(fallbackHref);
+  }
+
+  async function isolatedAppOriginReachable(probeHref, expectedAppId) {
+    if (!probeHref || !expectedAppId) {
+      return false;
+    }
+    const controller = typeof AbortController === "function" ? new AbortController() : null;
+    const timeoutId = controller
+      ? window.setTimeout(() => controller.abort(), 1000)
+      : null;
+    try {
+      const probeOrigin = new URL(probeHref).origin;
+      const response = await fetch(probeHref, {
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+        credentials: "omit",
+        mode: "cors",
+        signal: controller ? controller.signal : undefined,
+      });
+      const data = await response.json().catch(() => ({}));
+      return (
+        response.ok &&
+        data &&
+        data.appId === expectedAppId &&
+        data.uiOrigin === probeOrigin &&
+        data.uiOriginStatus === "active"
+      );
+    } catch (error) {
+      return false;
+    } finally {
+      if (timeoutId != null) {
+        window.clearTimeout(timeoutId);
+      }
+    }
   }
 
   function appSandboxStatus(app, runtime) {
@@ -3665,6 +3770,14 @@
     appsControls.refreshButton.addEventListener("click", () => {
       setAppsStatus("Refreshing installed apps and catalogs.");
       loadAppsSection();
+    });
+    sections.apps.addEventListener("click", async (event) => {
+      const link = appUiLaunchClickTarget(event);
+      if (!link) {
+        return;
+      }
+      event.preventDefault();
+      await launchAppUiFromLink(link);
     });
     sections.apps.addEventListener("submit", async (event) => {
       const form = event.target;

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -378,19 +378,36 @@
     }
   }
 
-  function normalizeAppUiEntryHref(value) {
+  function normalizeAppUiEntryHref(value, app) {
     if (typeof value !== "string" || value.length === 0) {
       return null;
     }
     try {
       const url = new URL(value, shellRootUrl);
-      if (url.origin !== window.location.origin) {
+      if (url.origin !== window.location.origin && !allowedAppUiOrigin(url, app)) {
         return null;
       }
-      return `${url.pathname}${url.search}${url.hash}`;
+      return url.origin === window.location.origin
+        ? `${url.pathname}${url.search}${url.hash}`
+        : url.href;
     } catch (error) {
       return null;
     }
+  }
+
+  function allowedAppUiOrigin(url, app) {
+    if (!app || app.uiOriginMode !== "isolated-loopback" || app.uiOriginStatus !== "active") {
+      return false;
+    }
+    if (typeof app.uiOrigin !== "string" || app.uiOrigin.length === 0) {
+      return false;
+    }
+    const hostname = url.hostname.toLowerCase();
+    return (
+      url.origin === app.uiOrigin &&
+      url.protocol === "http:" &&
+      hostname === "127.0.0.1"
+    );
   }
 
   function normalizeLegacyLinkPath(value) {
@@ -923,14 +940,32 @@
   }
 
   function appUiHref(app) {
-    const explicitHref = normalizeAppUiEntryHref(app.uiUrl);
+    const isolatedLaunchHref = isolatedAppUiLaunchHref(app);
+    if (isolatedLaunchHref || isolatedAppUiActive(app)) {
+      return isolatedLaunchHref;
+    }
+    const explicitHref = normalizeAppUiEntryHref(app.uiUrl, app);
     if (explicitHref) {
       return explicitHref;
     }
-    if (app.uiMode === "static" && typeof app.appId === "string" && app.appId.length > 0) {
-      return normalizeAppUiEntryHref(`/apps/${encodeURIComponent(app.appId)}/`);
+    if (typeof app.uiUrl === "string" && app.uiUrl.length > 0) {
+      return null;
     }
-    return normalizeAppUiEntryHref(app.uiEntry);
+    if (app.uiMode === "static" && typeof app.appId === "string" && app.appId.length > 0) {
+      return normalizeAppUiEntryHref(`/apps/${encodeURIComponent(app.appId)}/`, app);
+    }
+    return normalizeAppUiEntryHref(app.uiEntry, app);
+  }
+
+  function isolatedAppUiLaunchHref(app) {
+    if (!isolatedAppUiActive(app)) {
+      return null;
+    }
+    return normalizeAppUiEntryHref(app.sameOriginFallbackUrl, app);
+  }
+
+  function isolatedAppUiActive(app) {
+    return app && app.uiOriginMode === "isolated-loopback" && app.uiOriginStatus === "active";
   }
 
   function appUiEntryNode(app) {
@@ -1323,6 +1358,11 @@
     if (app.uiUrl || app.uiEntry) {
       pills.append(createPill(app.uiMode === "static" ? "Static UI" : "UI"));
     }
+    if (app.uiOriginMode === "isolated-loopback" && app.uiOriginStatus === "active") {
+      pills.append(createPill("Isolated origin", "is-success"));
+    } else if (app.uiOriginMode === "same-origin-fallback") {
+      pills.append(createPill("UI fallback", "is-warning"));
+    }
     const deniedCount = audit && typeof audit.recentDeniedCount === "number"
       ? audit.recentDeniedCount
       : typeof app.recentDeniedCount === "number"
@@ -1350,6 +1390,10 @@
       ["UI mode", scalar(app.uiMode)],
       ["UI", uiEntryNode || scalar(app.uiUrl)],
       ["UI entry", scalar(app.uiEntry)],
+      ["UI origin mode", scalar(app.uiOriginMode)],
+      ["UI origin status", scalar(app.uiOriginStatus)],
+      ["UI origin", scalar(app.uiOrigin)],
+      ["Same-origin fallback", scalar(app.sameOriginFallbackUrl)],
       ["Sandbox", sandboxLabel(sandbox)],
       ["Sandbox required", sandbox && sandbox.required ? "Yes" : "No"],
       ["Sandbox provider", sandbox ? scalar(sandbox.provider) : "Unavailable"],

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -333,9 +333,18 @@ class WebShellResourcesTest {
     assertTrue(script.contains(": url.href;"));
     assertFalse(appUiEntryHelper.contains("const url = new URL(value, window.location.origin);"));
     assertTrue(script.contains("function appUiHref(app)"));
-    assertTrue(script.contains("const isolatedLaunchHref = isolatedAppUiLaunchHref(app);"));
+    assertTrue(script.contains("const isolatedFallbackHref = isolatedAppUiFallbackHref(app);"));
     assertTrue(script.contains("function isolatedAppUiLaunchHref(app)"));
+    assertTrue(script.contains("url.searchParams.set(isolatedLaunchParameter, \"1\");"));
+    assertTrue(script.contains("function isolatedAppUiFallbackHref(app)"));
     assertTrue(script.contains("return normalizeAppUiEntryHref(app.sameOriginFallbackUrl, app);"));
+    assertTrue(script.contains("function isolatedAppUiProbeHref(app)"));
+    assertTrue(
+        script.contains("async function isolatedAppOriginReachable(probeHref, expectedAppId)"));
+    assertTrue(script.contains("const probeOrigin = new URL(probeHref).origin;"));
+    assertTrue(script.contains("credentials: \"omit\""));
+    assertTrue(script.contains("mode: \"cors\""));
+    assertTrue(script.contains("data.uiOrigin === probeOrigin"));
     assertTrue(script.contains("function isolatedAppUiActive(app)"));
     assertTrue(script.contains("function appSandboxStatus(app, runtime)"));
     assertTrue(script.contains("function sandboxLabel(status)"));

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -312,7 +312,7 @@ class WebShellResourcesTest {
   }
 
   private static void assertAppsMarkersPresent(String script) {
-    int appUiEntryHelperIndex = script.indexOf("function normalizeAppUiEntryHref(value)");
+    int appUiEntryHelperIndex = script.indexOf("function normalizeAppUiEntryHref(value, app)");
     int legacyLinkHelperIndex = script.indexOf("function normalizeLegacyLinkPath(value)");
     String appUiEntryHelper = script.substring(appUiEntryHelperIndex, legacyLinkHelperIndex);
 
@@ -326,11 +326,17 @@ class WebShellResourcesTest {
     assertTrue(script.contains("const appsControls = {"));
     assertTrue(
         script.contains("catalogSourceForm: document.getElementById(\"catalog-source-form\")"));
-    assertTrue(script.contains("function normalizeAppUiEntryHref(value)"));
+    assertTrue(script.contains("function normalizeAppUiEntryHref(value, app)"));
     assertTrue(appUiEntryHelper.contains("const url = new URL(value, shellRootUrl);"));
-    assertTrue(script.contains("return `${url.pathname}${url.search}${url.hash}`;"));
+    assertTrue(script.contains("allowedAppUiOrigin(url, app)"));
+    assertTrue(script.contains("return url.origin === window.location.origin"));
+    assertTrue(script.contains(": url.href;"));
     assertFalse(appUiEntryHelper.contains("const url = new URL(value, window.location.origin);"));
     assertTrue(script.contains("function appUiHref(app)"));
+    assertTrue(script.contains("const isolatedLaunchHref = isolatedAppUiLaunchHref(app);"));
+    assertTrue(script.contains("function isolatedAppUiLaunchHref(app)"));
+    assertTrue(script.contains("return normalizeAppUiEntryHref(app.sameOriginFallbackUrl, app);"));
+    assertTrue(script.contains("function isolatedAppUiActive(app)"));
     assertTrue(script.contains("function appSandboxStatus(app, runtime)"));
     assertTrue(script.contains("function sandboxLabel(status)"));
     assertTrue(script.contains("Unsupported required sandbox"));
@@ -351,10 +357,11 @@ class WebShellResourcesTest {
     assertTrue(script.contains("function appLogsPath(appId, maxBytes)"));
     assertTrue(script.contains("function appAuditPath(appId)"));
     assertTrue(script.contains("async function loadAppRuntimeDetails(app)"));
-    assertTrue(script.contains("const explicitHref = normalizeAppUiEntryHref(app.uiUrl);"));
+    assertTrue(script.contains("const explicitHref = normalizeAppUiEntryHref(app.uiUrl, app);"));
     assertTrue(
         script.contains(
-            "return normalizeAppUiEntryHref(`/apps/${encodeURIComponent(app.appId)}/`);"));
+            "return normalizeAppUiEntryHref(`/apps/${encodeURIComponent(app.appId)}/`, app);"));
+    assertTrue(script.contains("[\"UI origin mode\", scalar(app.uiOriginMode)]"));
     assertTrue(script.contains("function renderAppCard(app)"));
     assertTrue(
         script.contains(

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -24,6 +24,7 @@ import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
+import network.crypta.platform.appui.AppUiOrigin;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
@@ -119,6 +120,7 @@ class FProxyRegistrarTest {
     when(runtimePorts.toadletSymlinks()).thenReturn(toadletSymlinkPort);
     when(runtimePorts.transferAccess()).thenReturn(transferAccess);
     when(toadletSymlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
+    when(server.getURL(AppUiOrigin.LOOPBACK_HOST)).thenReturn("http://127.0.0.1:8888/");
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -24,7 +24,6 @@ import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.apphost.manifest.AppManifest;
-import network.crypta.platform.appui.AppUiOrigin;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.runtime.spi.CoreUpdateActionPort;
 import network.crypta.runtime.spi.DarknetConnectionsPort;
@@ -120,7 +119,7 @@ class FProxyRegistrarTest {
     when(runtimePorts.toadletSymlinks()).thenReturn(toadletSymlinkPort);
     when(runtimePorts.transferAccess()).thenReturn(transferAccess);
     when(toadletSymlinkPort.loadConfiguredSymlinks()).thenReturn(List.of());
-    when(server.getURL(AppUiOrigin.LOOPBACK_HOST)).thenReturn("http://127.0.0.1:8888/");
+    when(server.getLocalAdminURL()).thenReturn("http://127.0.0.1:8888/");
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -17,6 +17,10 @@ import network.crypta.platform.apphost.AppHost;
 import network.crypta.platform.apphost.AppTokenPrincipal;
 import network.crypta.platform.appui.AppBrowserSession;
 import network.crypta.platform.appui.AppBrowserSessionVerifier;
+import network.crypta.platform.appui.AppUiOriginBinding;
+import network.crypta.platform.appui.AppUiOriginMode;
+import network.crypta.platform.appui.AppUiOriginRegistry;
+import network.crypta.platform.appui.AppUiOriginStatus;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.api.Bucket;
@@ -58,6 +62,9 @@ class PlatformApiToadletTest {
     lenient().when(request.getHeader("x-crypta-app-token")).thenReturn(null);
     lenient().when(request.getHeader("x-crypta-app-session")).thenReturn(null);
     lenient().when(request.getHeader("authorization")).thenReturn(null);
+    lenient().when(request.getHeader("origin")).thenReturn(null);
+    lenient().when(request.getHeader("access-control-request-method")).thenReturn(null);
+    lenient().when(request.getHeader("access-control-request-headers")).thenReturn(null);
   }
 
   @Test
@@ -159,6 +166,108 @@ class PlatformApiToadletTest {
         PlatformApiAuthSource.APP_BROWSER_SESSION, captor.getValue().principal().authSource());
     assertEquals("alpha", captor.getValue().principal().appId());
     assertEquals(List.of("queue.read"), captor.getValue().principal().permissions());
+    verify(ctx, never()).isAllowedFullAccess();
+  }
+
+  @Test
+  void handleMethodGET_whenOriginBoundAppSessionMatchesRegisteredOrigin_expectCorsPrincipal()
+      throws Exception {
+    AppUiOriginBinding binding = isolatedBinding("alpha", 12345);
+    toadlet =
+        new PlatformApiToadlet(router, appHost, appBrowserSessionVerifier, registryWith(binding));
+    when(request.getHeader("origin")).thenReturn(binding.origin());
+    when(request.getHeader("x-crypta-app-session")).thenReturn("browser-session");
+    when(appBrowserSessionVerifier.verify("browser-session"))
+        .thenReturn(Optional.of(alphaBrowserSession(List.of("queue.read"), binding.origin())));
+    when(request.getParameterNames()).thenReturn(List.of());
+    when(router.route(any(PlatformApiRequest.class)))
+        .thenReturn(PlatformApiResponse.ok(Map.of("ok", true)));
+
+    toadlet.handleMethodGET(URI.create("http://localhost/api/v1/queue"), request, ctx);
+
+    ArgumentCaptor<PlatformApiRequest> captor = ArgumentCaptor.forClass(PlatformApiRequest.class);
+    verify(router).route(captor.capture());
+    assertEquals(PlatformApiPrincipalType.APP_BROWSER, captor.getValue().principal().type());
+    assertEquals(binding.origin(), captor.getValue().principal().expectedOrigin());
+    assertEquals(AppUiOriginMode.ISOLATED_LOOPBACK, captor.getValue().principal().originMode());
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(binding.origin(), replyHeaders.headers().getFirst("Access-Control-Allow-Origin"));
+    assertEquals("Origin", replyHeaders.headers().getFirst("Vary"));
+    verify(ctx, never()).isAllowedFullAccess();
+  }
+
+  @Test
+  void handleMethodGET_whenOriginBoundAppSessionMismatchesOrigin_expect403WithCors()
+      throws Exception {
+    AppUiOriginBinding alphaBinding = isolatedBinding("alpha", 12345);
+    AppUiOriginBinding betaBinding = isolatedBinding("beta", 12346);
+    toadlet =
+        new PlatformApiToadlet(
+            router, appHost, appBrowserSessionVerifier, registryWith(alphaBinding, betaBinding));
+    when(request.getHeader("origin")).thenReturn(betaBinding.origin());
+    when(request.getHeader("x-crypta-app-session")).thenReturn("browser-session");
+    when(appBrowserSessionVerifier.verify("browser-session"))
+        .thenReturn(Optional.of(alphaBrowserSession(List.of("queue.read"), alphaBinding.origin())));
+
+    toadlet.handleMethodGET(URI.create("http://localhost/api/v1/queue"), request, ctx);
+
+    verifyNoInteractions(router);
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(403, replyHeaders.statusCode());
+    assertEquals(
+        betaBinding.origin(), replyHeaders.headers().getFirst("Access-Control-Allow-Origin"));
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"origin_mismatch\",\"message\":\"App browser session origin does"
+            + " not match the request origin.\"}}",
+        bodyWrite.bodyText());
+    verify(ctx, never()).isAllowedFullAccess();
+  }
+
+  @Test
+  void handleMethodGET_whenFallbackSessionUsedFromRegisteredAppOrigin_expect403WithCors()
+      throws Exception {
+    AppUiOriginBinding binding = isolatedBinding("alpha", 12345);
+    toadlet =
+        new PlatformApiToadlet(router, appHost, appBrowserSessionVerifier, registryWith(binding));
+    when(request.getHeader("origin")).thenReturn(binding.origin());
+    when(request.getHeader("x-crypta-app-session")).thenReturn("browser-session");
+    when(appBrowserSessionVerifier.verify("browser-session"))
+        .thenReturn(Optional.of(alphaBrowserSession(List.of("queue.read"))));
+
+    toadlet.handleMethodGET(URI.create("http://localhost/api/v1/queue"), request, ctx);
+
+    verifyNoInteractions(router);
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(403, replyHeaders.statusCode());
+    assertEquals(binding.origin(), replyHeaders.headers().getFirst("Access-Control-Allow-Origin"));
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"origin_mismatch\",\"message\":\"Same-origin fallback app browser"
+            + " session cannot be used from an isolated app origin.\"}}",
+        bodyWrite.bodyText());
+    verify(ctx, never()).isAllowedFullAccess();
+  }
+
+  @Test
+  void handleMethodGET_whenRegisteredAppOriginOmitsSession_expect401WithoutHostFallback()
+      throws Exception {
+    AppUiOriginBinding binding = isolatedBinding("alpha", 12345);
+    toadlet =
+        new PlatformApiToadlet(router, appHost, appBrowserSessionVerifier, registryWith(binding));
+    when(request.getHeader("origin")).thenReturn(binding.origin());
+
+    toadlet.handleMethodGET(URI.create("http://localhost/api/v1/queue"), request, ctx);
+
+    verifyNoInteractions(router);
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(401, replyHeaders.statusCode());
+    assertEquals(binding.origin(), replyHeaders.headers().getFirst("Access-Control-Allow-Origin"));
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"invalid_app_browser_session\",\"message\":\"App browser session"
+            + " is required for app-origin Platform API requests.\"}}",
+        bodyWrite.bodyText());
     verify(ctx, never()).isAllowedFullAccess();
   }
 
@@ -932,6 +1041,54 @@ End
   }
 
   @Test
+  void handleMethodOPTIONS_whenRegisteredAppOriginPreflightsSessionHeader_expectCors204()
+      throws Exception {
+    AppUiOriginBinding binding = isolatedBinding("alpha", 12345);
+    toadlet =
+        new PlatformApiToadlet(router, appHost, appBrowserSessionVerifier, registryWith(binding));
+    when(request.getHeader("origin")).thenReturn(binding.origin());
+    when(request.getHeader("access-control-request-method")).thenReturn("POST");
+    when(request.getHeader("access-control-request-headers"))
+        .thenReturn("X-Crypta-App-Session, Content-Type");
+
+    toadlet.handleMethodOPTIONS(URI.create("http://localhost/api/v1/queue"), request, ctx);
+
+    verifyNoInteractions(router);
+    ReplyHeadersCapture replyHeaders = captureForcedReplyHeaders();
+    assertEquals(204, replyHeaders.statusCode());
+    assertEquals("No Content", replyHeaders.reasonPhrase());
+    assertEquals(binding.origin(), replyHeaders.headers().getFirst("Access-Control-Allow-Origin"));
+    assertEquals(
+        "GET, POST, DELETE", replyHeaders.headers().getFirst("Access-Control-Allow-Methods"));
+    assertEquals(
+        "X-Crypta-App-Session, Accept, Content-Type",
+        replyHeaders.headers().getFirst("Access-Control-Allow-Headers"));
+    assertEquals("600", replyHeaders.headers().getFirst("Access-Control-Max-Age"));
+    verify(ctx, never()).writeData(any(byte[].class), anyInt(), anyInt());
+  }
+
+  @Test
+  void handleMethodOPTIONS_whenPreflightRequestsAppProcessTokenHeader_expect403() throws Exception {
+    AppUiOriginBinding binding = isolatedBinding("alpha", 12345);
+    toadlet =
+        new PlatformApiToadlet(router, appHost, appBrowserSessionVerifier, registryWith(binding));
+    when(request.getHeader("origin")).thenReturn(binding.origin());
+    when(request.getHeader("access-control-request-method")).thenReturn("POST");
+    when(request.getHeader("access-control-request-headers")).thenReturn("X-Crypta-App-Token");
+
+    toadlet.handleMethodOPTIONS(URI.create("http://localhost/api/v1/queue"), request, ctx);
+
+    verifyNoInteractions(router);
+    ReplyHeadersCapture replyHeaders = captureReplyHeaders();
+    assertEquals(403, replyHeaders.statusCode());
+    BodyWriteCapture bodyWrite = captureBodyWrite();
+    assertEquals(
+        "{\"error\":{\"code\":\"origin_mismatch\",\"message\":\"App browser origin is not allowed"
+            + " for Platform API CORS.\"}}",
+        bodyWrite.bodyText());
+  }
+
+  @Test
   void handleMethodHEAD_whenUnsupportedVerb_expectHeaderOnly405() throws Exception {
     when(ctx.isAllowedFullAccess()).thenReturn(true);
     when(request.getParameterNames()).thenReturn(List.of());
@@ -1069,6 +1226,31 @@ End
         length.getValue());
   }
 
+  private ReplyHeadersCapture captureForcedReplyHeaders() throws Exception {
+    ArgumentCaptor<Integer> statusCode = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<String> reasonPhrase = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<MultiValueTable<String, String>> headers = multiValueTableCaptor();
+    ArgumentCaptor<String> mimeType = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<Long> length = ArgumentCaptor.forClass(Long.class);
+    ArgumentCaptor<Boolean> forceDisableJavascript = ArgumentCaptor.forClass(Boolean.class);
+
+    verify(ctx)
+        .sendReplyHeaders(
+            statusCode.capture(),
+            reasonPhrase.capture(),
+            headers.capture(),
+            mimeType.capture(),
+            length.capture(),
+            forceDisableJavascript.capture());
+
+    return new ReplyHeadersCapture(
+        statusCode.getValue(),
+        reasonPhrase.getValue(),
+        headers.getValue(),
+        mimeType.getValue(),
+        length.getValue());
+  }
+
   @SuppressWarnings("unchecked")
   private static ArgumentCaptor<MultiValueTable<String, String>> multiValueTableCaptor() {
     return (ArgumentCaptor<MultiValueTable<String, String>>)
@@ -1100,6 +1282,50 @@ End
   private static AppBrowserSession alphaBrowserSession(List<String> permissions) {
     Instant issuedAt = Instant.parse("2026-04-28T10:00:00Z");
     return new AppBrowserSession("alpha", permissions, issuedAt, issuedAt.plusSeconds(3600));
+  }
+
+  private static AppBrowserSession alphaBrowserSession(
+      List<String> permissions, String expectedOrigin) {
+    Instant issuedAt = Instant.parse("2026-04-28T10:00:00Z");
+    return new AppBrowserSession(
+        "alpha",
+        permissions,
+        issuedAt,
+        issuedAt.plusSeconds(3600),
+        expectedOrigin,
+        AppUiOriginMode.ISOLATED_LOOPBACK);
+  }
+
+  private static AppUiOriginBinding isolatedBinding(String appId, int port) {
+    String origin = "http://127.0.0.1:" + port;
+    return new AppUiOriginBinding(
+        appId,
+        AppUiOriginMode.ISOLATED_LOOPBACK,
+        AppUiOriginStatus.ACTIVE,
+        origin,
+        origin + "/",
+        origin + "/static/",
+        origin + "/static/",
+        "http://127.0.0.1:8888/api/v1/",
+        "http://127.0.0.1:8888/app/node/",
+        "/apps/" + appId + "/",
+        null);
+  }
+
+  private static AppUiOriginRegistry registryWith(AppUiOriginBinding... bindings) {
+    return new AppUiOriginRegistry() {
+      @Override
+      public Optional<AppUiOriginBinding> bindingForApp(String appId) {
+        return Arrays.stream(bindings).filter(binding -> binding.appId().equals(appId)).findFirst();
+      }
+
+      @Override
+      public Optional<AppUiOriginBinding> bindingForOrigin(String origin) {
+        return Arrays.stream(bindings)
+            .filter(binding -> origin != null && origin.equals(binding.origin()))
+            .findFirst();
+      }
+    };
   }
 
   private record ReplyHeadersCapture(

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -531,6 +531,41 @@ class SimpleToadletServerTest {
   }
 
   @Test
+  void getLocalAdminURL_whenBindToDefault_prefersIpv4Loopback() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+
+    String url = server.getLocalAdminURL();
+
+    assertEquals("http://127.0.0.1:" + SimpleToadletServer.DEFAULT_FPROXY_PORT + "/", url);
+  }
+
+  @Test
+  void getLocalAdminURL_whenBindToIpv6Loopback_usesBracketedIpv6Loopback() throws Exception {
+    Config rootConfig = new Config();
+    SubConfig config = rootConfig.createSubConfig("fproxy");
+    SimpleToadletServer server = newServerWithDefaults(config);
+    config.finishedInitialization();
+    config.set("bindTo", "0:0:0:0:0:0:0:1");
+
+    String url = server.getLocalAdminURL();
+
+    assertEquals("http://[::1]:" + SimpleToadletServer.DEFAULT_FPROXY_PORT + "/", url);
+  }
+
+  @Test
+  void getLocalAdminURL_whenBindToIpv6Wildcard_usesBracketedIpv6Loopback() throws Exception {
+    Config rootConfig = new Config();
+    SubConfig config = rootConfig.createSubConfig("fproxy");
+    SimpleToadletServer server = newServerWithDefaults(config);
+    config.finishedInitialization();
+    config.set("bindTo", "::");
+
+    String url = server.getLocalAdminURL();
+
+    assertEquals("http://[::1]:" + SimpleToadletServer.DEFAULT_FPROXY_PORT + "/", url);
+  }
+
+  @Test
   void allowPosts_whenUsingArrayBucketFactory_returnsFalse() throws Exception {
     SimpleToadletServer server = newServerWithDefaults();
     server.setBucketFactory(new ArrayBucketFactory());

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -3368,13 +3368,17 @@ class PlatformApiRouterTest {
       boolean running,
       Long pid,
       Instant startedAt) {
-    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(15);
+    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(19);
     summary.put("appId", appId);
     summary.put("name", appName);
     summary.put("version", appVersion);
     summary.put("uiMode", uiMode(appUiEntry));
     summary.put("uiEntry", appUiEntry);
     summary.put("uiUrl", uiUrl(appId, appUiEntry));
+    summary.put("uiOrigin", null);
+    summary.put("uiOriginMode", null);
+    summary.put("uiOriginStatus", null);
+    summary.put("sameOriginFallbackUrl", sameOriginFallbackUrl(appId, appUiEntry));
     summary.put("permissions", List.of("network.access", "file.read"));
     summary.put("quota", manifestQuotaSummary(installed ? 0L : null, installed ? 0L : null));
     summary.put("sandbox", sandboxSummary());
@@ -3388,13 +3392,17 @@ class PlatformApiRouterTest {
   }
 
   private static Map<String, Object> unknownSummary() {
-    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(15);
+    LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(19);
     summary.put("appId", APP_ID);
     summary.put("name", null);
     summary.put("version", null);
     summary.put("uiMode", "none");
     summary.put("uiEntry", null);
     summary.put("uiUrl", null);
+    summary.put("uiOrigin", null);
+    summary.put("uiOriginMode", null);
+    summary.put("uiOriginStatus", null);
+    summary.put("sameOriginFallbackUrl", null);
     summary.put("permissions", List.of());
     summary.put("quota", unknownQuotaSummary());
     summary.put("sandbox", sandboxSummary());
@@ -3510,6 +3518,15 @@ class PlatformApiRouterTest {
       case "none" -> null;
       case "shell-panel" -> appUiEntry;
       case "static" -> staticUiUrl(appId, appUiEntry);
+      default -> throw new IllegalArgumentException("unexpected UI mode");
+    };
+  }
+
+  private static String sameOriginFallbackUrl(String appId, String appUiEntry) {
+    return switch (uiMode(appUiEntry)) {
+      case "none" -> null;
+      case "shell-panel" -> appUiEntry;
+      case "static" -> "/apps/" + appId + "/";
       default -> throw new IllegalArgumentException("unexpected UI mode");
     };
   }


### PR DESCRIPTION
## Summary
- Add isolated per-app loopback UI origins for static app-owned browser UIs while keeping `/apps/{appId}/` as a compatibility/fallback route.
- Bind app browser sessions and bootstrap metadata to the expected app origin, with launch proof handling for isolated bootstrap requests.
- Add restricted Platform API CORS handling for registered app origins and prevent app-origin requests from falling back to host/operator auth.
- Update the browser SDK and Web Shell launch path for isolated origins, including stale-session recovery for SDK mutations.
- Document the new Phase 6 app-origin trust boundary and update focused regression coverage.

## How to test
- `./gradlew :platform-app-ui:test :adapter-http-legacy-admin:test :platform-api:test :platform-sdk-js:test :platform-web-shell:test :test --tests '*PlatformApiToadletTest' --tests '*PlatformApiRouterTest' --tests '*FProxyRegistrarTest'`
- `./gradlew spotlessApply`