### PR TITLE
feat(legacy-admin): Remove wave one pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,8 +474,11 @@ and [docs/app-catalogs.md](docs/app-catalogs.md) for catalog entry descriptors a
 ## Platform Closeout & API Surface
 
 Phase 3 Platform Primacy makes `:platform-api`, `:platform-web-shell`, and `:platform-apphost` the
-primary local platform path for operator workflows and first-party apps. Legacy HTTP and FCP remain
-compatibility, bridge, debug, and fallback surfaces.
+primary local platform path for operator workflows and first-party apps. Legacy HTTP remains the
+bridge for `/api/v1/`, `/app/node/`, `/apps/{appId}/`, retained FProxy browse, and pending legacy
+tools; FCP remains a separate compatibility protocol. The first legacy-admin removal wave now
+returns replacement responses for selected already-replaced admin pages instead of rendering them
+as normal fallback surfaces.
 
 Phase 5 app-platform work added signed catalog sources, Crypta catalog transport, app-owned static
 UI routes, browser sessions for static app API calls, richer catalog review metadata, AppHost
@@ -492,6 +495,13 @@ manifests, signed catalogs, developer tooling, and release certification compare
 versions without changing endpoint behavior. The Web Shell Apps section uses
 `/api/v1/app-catalogs` metadata to show source, license, category, review, permission-rationale,
 version-difference, API compatibility, and changelog details before install or update.
+Phase 6 PR-8, tracked as `legacy-admin.removal-wave-1`, removes `/downloads/`, `/uploads/`,
+`/insertfile/`, `/insert-browse/`, `/friends/`, `/addfriend/`, `/strangers/`, and
+`/connectivity/` by default when their replacements are reachable: safe reads redirect to Queue
+Manager, Publisher, or Web Shell, while mutating requests are blocked before old handlers run.
+Configurations without the replacement static app UI, without FProxy JavaScript, or without Web
+Shell as the advertised primary UI keep rendering the legacy fallback and count that usage in
+diagnostics. FProxy browse, retained browse-adjacent tools, and pending routes remain reachable.
 
 Key docs:
 
@@ -550,8 +560,9 @@ tools/perf/run-performance-smoke.sh
 
 Release-candidate evidence is aggregated by the release certification tooling under
 `tools/release-certification/`. It consumes the interop, performance, app-platform, catalog,
-Platform API contract, app-owned UI, trusted app-review receipt, legacy-admin retirement, and CI
-summaries and writes a redacted report plus a stable JSON companion.
+Platform API contract, app-owned UI, trusted app-review receipt, legacy-admin retirement,
+legacy-admin removal-wave evidence, and CI summaries and writes a redacted report plus a stable
+JSON companion.
 
 Fast self-tests:
 

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/FProxyRegistrar.java
@@ -75,19 +75,22 @@ final class FProxyRegistrar {
     browseRouteRegistrar.registerRoutes(
         LegacyHttpBrowseRouteRegistrar.Phase.ROOT_MENU, browseContext, server);
     LinkEnabledCallback webShellPrimary = webShellPrimary(server);
+    LinkEnabledCallback queueManagerAvailable = queueManagerAvailable(dependencies.appHost());
     server.registerMenu(
         QUEUE_MANAGER_URL,
         LegacyHttpCategories.CATEGORY_QUEUE,
         "FProxyToadlet.categoryTitleQueue",
-        QueueToadlet.PATH_DOWNLOADS,
+        null,
         false,
-        queueManagerAvailable(dependencies.appHost()),
-        legacyQueueNavigationAvailable());
+        queueManagerAvailable,
+        queueManagerAvailable);
     server.registerMenu(
         SHELL_PEERS_URL,
         LegacyHttpCategories.CATEGORY_FRIENDS,
         "FProxyToadlet.categoryTitleFriends",
-        LegacyHttpPaths.FRIENDS_PATH,
+        null,
+        true,
+        webShellPrimary,
         webShellPrimary);
     server.registerMenu("/chat/", "FProxyToadlet.categoryChat", "FProxyToadlet.categoryTitleChat");
     server.registerMenu(
@@ -449,10 +452,5 @@ final class FProxyRegistrar {
         return false;
       }
     };
-  }
-
-  private static LinkEnabledCallback legacyQueueNavigationAvailable() {
-    return ctx ->
-        ctx != null && (!ctx.getContainer().publicGatewayMode() || ctx.isAllowedFullAccess());
   }
 }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRemovalDecision.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRemovalDecision.java
@@ -1,0 +1,162 @@
+package network.crypta.clients.http;
+
+import java.util.Objects;
+
+/**
+ * One request-level removal decision for a known legacy admin surface.
+ *
+ * <p>The dispatcher creates this value after {@link LegacyAdminRemovalPolicy} has matched a
+ * canonical removed-by-default legacy route and verified that the replacement is usable for the
+ * current request. The record is intentionally small: it contains the stable registry surface, the
+ * HTTP status line to send, the same-origin replacement URL, and the bounded diagnostic event to
+ * count. It never keeps caller-specific request data.
+ *
+ * <p>Instances are immutable and safe to pass between the dispatch gate, response writer, and
+ * diagnostics recorder. The compact constructor validates the response shape rather than
+ * re-evaluating route policy, so callers should construct decisions through the static factories
+ * below. Those factories encode the current wave semantics:
+ *
+ * <ul>
+ *   <li>safe reads either redirect to or describe the replacement;
+ *   <li>mutating requests are blocked before the legacy handler can run;
+ *   <li>all replacement URLs remain local same-origin paths.
+ * </ul>
+ *
+ * @param surface registry surface that matched the request path
+ * @param mode execution mode that caused this decision
+ * @param statusCode HTTP status to return
+ * @param reason HTTP reason phrase paired with {@code statusCode}
+ * @param replacementUrl same-origin replacement route
+ * @param redirect whether the response should include a {@code Location} header
+ * @param usageEvent diagnostic event to record for the decision
+ */
+record LegacyAdminRemovalDecision(
+    LegacyAdminSurface surface,
+    LegacyAdminRemovalMode mode,
+    int statusCode,
+    String reason,
+    String replacementUrl,
+    boolean redirect,
+    LegacyAdminUsageEvent usageEvent) {
+  /**
+   * Creates and validates one immutable removal decision.
+   *
+   * <p>The compact constructor enforces the small safety boundary that every caller depends on:
+   * status codes must be valid HTTP status values, text fields must be nonblank, replacement URLs
+   * must stay same-origin, and diagnostic events must be explicit. It does not inspect request
+   * state or re-run route matching.
+   */
+  LegacyAdminRemovalDecision {
+    Objects.requireNonNull(surface, "surface");
+    Objects.requireNonNull(mode, "mode");
+    requireStatus(statusCode);
+    requireText(reason, "reason");
+    requireReplacementUrl(replacementUrl);
+    Objects.requireNonNull(usageEvent, "usageEvent");
+  }
+
+  /**
+   * Builds a safe-read decision that redirects to the replacement route.
+   *
+   * <p>The method is used for surfaces in {@link LegacyAdminRemovalMode#REDIRECT_TO_REPLACEMENT}.
+   * It emits a {@code 303 See Other} decision so old bookmarks and slashless canonical aliases move
+   * to the app or Web Shell URL without replaying request bodies. Diagnostics record the event as a
+   * replacement response, not as a rendered legacy fallback.
+   *
+   * @param surface removed-by-default surface with a same-origin replacement URL
+   * @return immutable decision describing the redirect response to emit
+   */
+  static LegacyAdminRemovalDecision redirect(LegacyAdminSurface surface) {
+    return new LegacyAdminRemovalDecision(
+        surface,
+        LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT,
+        303,
+        "See Other",
+        surface.replacementUrl(),
+        true,
+        LegacyAdminUsageEvent.REPLACEMENT_RESPONSE);
+  }
+
+  /**
+   * Builds a safe-read decision that returns a gone-with-replacement page.
+   *
+   * <p>This shape is reserved for routes where a redirect is not the right operator experience but
+   * the old page should still stop rendering by default. The response writer will send a compact
+   * {@code 410 Gone} HTML page that contains only the registry title and replacement link.
+   *
+   * @param surface removed-by-default surface with a same-origin replacement URL
+   * @return immutable decision describing the gone-with-replacement response to emit
+   */
+  static LegacyAdminRemovalDecision gone(LegacyAdminSurface surface) {
+    return new LegacyAdminRemovalDecision(
+        surface,
+        LegacyAdminRemovalMode.GONE_WITH_REPLACEMENT,
+        410,
+        "Gone",
+        surface.replacementUrl(),
+        false,
+        LegacyAdminUsageEvent.REPLACEMENT_RESPONSE);
+  }
+
+  /**
+   * Builds a mutating-request decision that blocks legacy handler execution.
+   *
+   * <p>When the current removal wave applies, non-read methods must not fall through to old queue,
+   * insert, peer, or connectivity mutations. This decision preserves the surface's configured
+   * removal mode for diagnostics while using a {@code 410 Gone} response and a distinct event
+   * counter for blocked mutations.
+   *
+   * @param surface removed-by-default surface whose legacy action must not execute
+   * @return immutable decision describing the blocked mutating request response
+   */
+  static LegacyAdminRemovalDecision blockedMutation(LegacyAdminSurface surface) {
+    return new LegacyAdminRemovalDecision(
+        surface,
+        surface.removalMode(),
+        410,
+        "Gone",
+        surface.replacementUrl(),
+        false,
+        LegacyAdminUsageEvent.BLOCKED_MUTATING_REQUEST);
+  }
+
+  /**
+   * Validates that the supplied integer fits the HTTP status-code range.
+   *
+   * @param statusCode numeric response status that will be written to the HTTP response line
+   */
+  private static void requireStatus(int statusCode) {
+    if (statusCode < 100 || statusCode > 599) {
+      throw new IllegalArgumentException("statusCode must be an HTTP status");
+    }
+  }
+
+  /**
+   * Validates required text used in the status line or diagnostic metadata.
+   *
+   * @param value candidate text value that must be present and nonblank
+   * @param label field label used in exception messages for invalid input
+   */
+  private static void requireText(String value, String label) {
+    Objects.requireNonNull(value, label);
+    if (value.isBlank()) {
+      throw new IllegalArgumentException(label + " must not be blank");
+    }
+  }
+
+  /**
+   * Validates a replacement URL before it reaches a response header or HTML body.
+   *
+   * <p>Removal decisions only carry registry-provided replacement routes, and those routes must
+   * remain same-origin absolute paths. Keeping the field name local to this helper makes the
+   * invariant clear without forcing callers to repeat a label that cannot vary for this record.
+   *
+   * @param value candidate local replacement route that must start with one slash and not two
+   */
+  private static void requireReplacementUrl(String value) {
+    requireText(value, "replacementUrl");
+    if (!value.startsWith("/") || value.startsWith("//")) {
+      throw new IllegalArgumentException("replacementUrl must be a same-origin absolute path");
+    }
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRemovalMode.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRemovalMode.java
@@ -1,0 +1,79 @@
+package network.crypta.clients.http;
+
+/**
+ * Execution policy for a mapped legacy admin surface.
+ *
+ * <p>This policy is deliberately separate from {@link LegacyAdminRetirementState}. Retirement state
+ * records product ownership, while removal mode records what the legacy HTTP adapter should do with
+ * direct requests today. That separation lets later waves leave some {@link
+ * LegacyAdminRetirementState#PRIMARY_REPLACED} routes renderable while removing a smaller proven
+ * subset by default.
+ *
+ * <p>The values are stable metadata, not request-specific decisions. {@link
+ * LegacyAdminRetirementRegistry} assigns one mode to each known surface, and {@link
+ * LegacyAdminRemovalPolicy} interprets that mode together with the HTTP method, canonical path, and
+ * replacement availability. Diagnostics and release-certification evidence expose the enum name so
+ * operators can distinguish product status from current dispatch behavior without inspecting route
+ * handlers.
+ *
+ * <ul>
+ *   <li>rendering modes keep old toadlets reachable;
+ *   <li>replacement modes stop default rendering for canonical page paths;
+ *   <li>retained, pending, and infrastructure modes document why a route stays outside removal.
+ * </ul>
+ */
+public enum LegacyAdminRemovalMode {
+  /**
+   * Let the registered legacy toadlet render the route.
+   *
+   * <p>Primary-replaced surfaces in this mode can still render a non-blocking notice that points
+   * operators to the Web Shell or app replacement. The mode is appropriate when direct fallback
+   * behavior is still intentionally supported.
+   */
+  RENDER_LEGACY,
+
+  /**
+   * Return a replacement redirect for safe read requests and block mutating requests.
+   *
+   * <p>The removal policy uses this mode for canonical page routes whose replacements are safe to
+   * open as normal browser destinations. In wave 1 this usually means a {@code 303 See Other}
+   * response to Web Shell, Queue Manager, or Publisher when that destination is available.
+   */
+  REDIRECT_TO_REPLACEMENT,
+
+  /**
+   * Return a gone-with-replacement page for safe read requests and block mutating requests.
+   *
+   * <p>This mode is available for future routes where a direct redirect would be misleading or
+   * unsafe, but the old canonical page should still stop rendering by default. The response body
+   * must stay small and contain only the replacement link and explanatory text.
+   */
+  GONE_WITH_REPLACEMENT,
+
+  /**
+   * Keep the route as retained long-term functionality.
+   *
+   * <p>Retained routes are not removal candidates in the current plan. Browse-owned FProxy routes
+   * and browse-adjacent tools use this classification when their legacy behavior remains the
+   * intended local interface.
+   */
+  RETAINED,
+
+  /**
+   * Keep the route reachable because replacement work is not complete or not proven.
+   *
+   * <p>Pending routes can have a planned replacement, but the adapter must continue rendering the
+   * legacy handler until startup gates, operator workflows, or compatibility edge cases are proven
+   * safe for a later wave.
+   */
+  PENDING,
+
+  /**
+   * Treat the route as support infrastructure rather than a user-facing page.
+   *
+   * <p>Infrastructure routes can support retained, pending, or replacement pages without being
+   * standalone removal targets. The policy does not redirect these entries unless a future wave
+   * promotes a specific canonical route into an explicit removal mode.
+   */
+  INFRASTRUCTURE
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRemovalPolicy.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRemovalPolicy.java
@@ -1,0 +1,232 @@
+package network.crypta.clients.http;
+
+import java.net.URI;
+import java.util.Optional;
+import network.crypta.platform.webshell.routes.WebShellPaths;
+
+/**
+ * Central removal policy for legacy admin routes.
+ *
+ * <p>The policy is intentionally narrower than the retirement registry. It only handles canonical
+ * page paths, plus their slashless aliases, whose registry metadata marks them removed by default.
+ * Prefix subpaths continue to dispatch normally unless a later removal wave explicitly adds them.
+ *
+ * <p>The dispatcher calls this class after the toadlet container has had a chance to apply
+ * higher-priority routing decisions such as first-run wizard redirects. A non-empty result means
+ * the old handler should not run for this request. An empty result means either the route is not in
+ * the current removal wave, the request targets a helper subpath, or the replacement UI is not
+ * reachable in the current browser/session configuration.
+ *
+ * <p>Availability checks are deliberately conservative. App replacements require full operator
+ * access, FProxy JavaScript support, and an installed static app UI. Web Shell replacements require
+ * full operator access and Web Shell to be the advertised primary UI. Those checks keep
+ * JavaScript-disabled, app-not-installed, and setup-gated deployments on the legacy fallback until
+ * a replacement is actually usable.
+ */
+final class LegacyAdminRemovalPolicy {
+  /** Stable first-party app id for the Queue Manager static UI replacement. */
+  private static final String QUEUE_MANAGER_APP_ID = "queue-manager";
+
+  /** Stable first-party app id for the Publisher static UI replacement. */
+  private static final String PUBLISHER_APP_ID = "publisher";
+
+  /** Prevents construction because the policy is stateless and entirely function-based. */
+  private LegacyAdminRemovalPolicy() {}
+
+  /**
+   * Computes the removal decision for a request.
+   *
+   * <p>Safe reads receive the route's configured replacement response. Mutating or otherwise
+   * non-read methods are blocked before the legacy toadlet can execute old behavior. This overload
+   * is intended for context-free registry checks and assumes replacements are available.
+   *
+   * @param method HTTP method from the request line
+   * @param uri normalized request URI
+   * @return removal decision when the request belongs to a removed-by-default canonical route
+   */
+  static Optional<LegacyAdminRemovalDecision> decide(String method, URI uri) {
+    return decide(method, uri, null);
+  }
+
+  /**
+   * Computes the removal decision for a concrete request.
+   *
+   * <p>Wave-1 removal applies only when the replacement route is usable for the current request
+   * context. When JavaScript is disabled, Web Shell is not the primary UI, or the required static
+   * app is not installed, the policy returns empty so the retained legacy fallback can render
+   * normally. This avoids redirecting operators into replacement routes that will immediately fail.
+   *
+   * @param method HTTP method from the request line, compared using the adapter's uppercase method
+   *     names
+   * @param uri normalized request URI whose path is matched without query or fragment data
+   * @param ctx per-request context used to evaluate replacement availability, or {@code null} for
+   *     context-free registry checks
+   * @return removal decision when the request belongs to a removed-by-default canonical route and
+   *     its replacement is currently reachable
+   */
+  static Optional<LegacyAdminRemovalDecision> decide(String method, URI uri, ToadletContext ctx) {
+    Optional<LegacyAdminSurface> surface = removedSurfaceForRequest(uri);
+    if (surface.isEmpty()) {
+      return Optional.empty();
+    }
+    LegacyAdminSurface legacyAdminSurface = surface.orElseThrow();
+    if (!replacementAvailable(legacyAdminSurface, ctx)) {
+      return Optional.empty();
+    }
+    return Optional.of(decisionFor(method, legacyAdminSurface));
+  }
+
+  /**
+   * Returns whether a URI targets a removed canonical page or its slashless alias.
+   *
+   * <p>This helper is used by restricted-method routing before a concrete {@link ToadletContext}
+   * exists. It intentionally answers only the static route-map question. Callers that need to know
+   * whether a request should actually be redirected or blocked must call {@link #decide(String,
+   * URI, ToadletContext)} so replacement availability is honored.
+   *
+   * @param uri request URI whose path should be checked against the current removal wave
+   * @return {@code true} when the path is a removed canonical page or slashless alias
+   */
+  static boolean isRemovedCanonicalPath(URI uri) {
+    return removedSurfaceForRequest(uri).isPresent();
+  }
+
+  /**
+   * Converts a matched surface and HTTP method into the response decision.
+   *
+   * @param method uppercase HTTP method from the request line
+   * @param surface registry surface already known to be in the current removal wave
+   * @return redirect, gone, or blocked-mutation decision for the matched request
+   */
+  private static LegacyAdminRemovalDecision decisionFor(String method, LegacyAdminSurface surface) {
+    if (!isSafeRead(method)) {
+      return LegacyAdminRemovalDecision.blockedMutation(surface);
+    }
+    if (surface.removalMode() == LegacyAdminRemovalMode.GONE_WITH_REPLACEMENT) {
+      return LegacyAdminRemovalDecision.gone(surface);
+    }
+    return LegacyAdminRemovalDecision.redirect(surface);
+  }
+
+  /**
+   * Classifies the method subset that can receive replacement read responses.
+   *
+   * @param method uppercase HTTP method from the request line
+   * @return {@code true} for {@code GET} and {@code HEAD}; {@code false} for mutating methods
+   */
+  private static boolean isSafeRead(String method) {
+    return "GET".equals(method) || "HEAD".equals(method);
+  }
+
+  /**
+   * Checks whether the mapped replacement can be used for this request.
+   *
+   * <p>A {@code null} context means the caller is performing a context-free policy or registry
+   * check, so the method assumes availability and preserves the old unit-testable map behavior.
+   * Real dispatch requests pass a context and receive the conservative operator/session checks.
+   *
+   * @param surface registry surface matched by canonical path
+   * @param ctx request context used for operator access and UI availability checks
+   * @return {@code true} when the replacement destination is reachable for this request
+   */
+  private static boolean replacementAvailable(LegacyAdminSurface surface, ToadletContext ctx) {
+    if (ctx == null) {
+      return true;
+    }
+    return switch (surface.id()) {
+      case "queue-downloads", "queue-uploads" ->
+          staticAppReplacementAvailable(ctx, QUEUE_MANAGER_APP_ID);
+      case "file-insert", "local-file-insert" ->
+          staticAppReplacementAvailable(ctx, PUBLISHER_APP_ID);
+      case "friends", "add-friend", "strangers", "connectivity" ->
+          webShellReplacementAvailable(ctx);
+      default -> true;
+    };
+  }
+
+  /**
+   * Checks whether a first-party static app replacement can receive this request.
+   *
+   * @param ctx request context that exposes operator access and container-level UI settings
+   * @param appId stable first-party app id declared by the replacement surface
+   * @return {@code true} only for full-access sessions with JavaScript and an installed static UI
+   */
+  private static boolean staticAppReplacementAvailable(ToadletContext ctx, String appId) {
+    ToadletContainer container = ctx.getContainer();
+    return container != null
+        && ctx.isAllowedFullAccess()
+        && container.isFProxyJavascriptEnabled()
+        && container.isStaticAppUiAvailable(appId);
+  }
+
+  /**
+   * Checks whether Web Shell is the reachable primary destination for this request.
+   *
+   * @param ctx request context that exposes operator access and the container's primary UI route
+   * @return {@code true} only when full-access Web Shell navigation is currently available
+   */
+  private static boolean webShellReplacementAvailable(ToadletContext ctx) {
+    ToadletContainer container = ctx.getContainer();
+    return container != null
+        && ctx.isAllowedFullAccess()
+        && WebShellPaths.SHELL_ROOT.equals(container.primaryUiRoot());
+  }
+
+  /**
+   * Resolves a URI path to a removed-by-default surface in the current wave.
+   *
+   * <p>The method ignores query strings and fragments and matches only exact canonical paths or the
+   * slashless alias that the toadlet container would otherwise canonicalize. Queue helper paths,
+   * local directory helpers, and other subresources intentionally fall through to normal dispatch.
+   *
+   * @param uri request URI supplied by the dispatch loop or restricted-method gate
+   * @return matching removed surface, or empty when normal legacy routing should continue
+   */
+  private static Optional<LegacyAdminSurface> removedSurfaceForRequest(URI uri) {
+    if (uri == null || uri.getPath() == null) {
+      return Optional.empty();
+    }
+    String requestPath = uri.getPath();
+    return LegacyAdminRetirementRegistry.surfaces().stream()
+        .filter(LegacyAdminRemovalPolicy::isRemovedByDefault)
+        .filter(surface -> matchesCanonicalPageOrSlashlessAlias(surface, requestPath))
+        .findFirst();
+  }
+
+  /**
+   * Checks whether a registry surface has a removal-response execution mode.
+   *
+   * @param surface registry entry from the authoritative legacy-admin retirement map
+   * @return {@code true} for redirect or gone-with-replacement execution modes
+   */
+  private static boolean isRemovedByDefault(LegacyAdminSurface surface) {
+    return surface.removalMode() == LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT
+        || surface.removalMode() == LegacyAdminRemovalMode.GONE_WITH_REPLACEMENT;
+  }
+
+  /**
+   * Matches the canonical legacy page path and its slashless alias only.
+   *
+   * @param surface registry surface carrying the canonical legacy path
+   * @param requestPath request path without query string or fragment data
+   * @return {@code true} when the request targets the page itself, not a helper subpath
+   */
+  private static boolean matchesCanonicalPageOrSlashlessAlias(
+      LegacyAdminSurface surface, String requestPath) {
+    String legacyPath = surface.legacyPath();
+    return requestPath.equals(legacyPath) || requestPath.equals(withoutTrailingSlash(legacyPath));
+  }
+
+  /**
+   * Removes the trailing slash from a non-root canonical path.
+   *
+   * @param path same-origin path from the retirement registry
+   * @return slashless alias for non-root paths, or the original path for root and slashless inputs
+   */
+  private static String withoutTrailingSlash(String path) {
+    if (path.length() > 1 && path.endsWith("/")) {
+      return path.substring(0, path.length() - 1);
+    }
+    return path;
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminReplacementResponse.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminReplacementResponse.java
@@ -1,0 +1,95 @@
+package network.crypta.clients.http;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import network.crypta.support.HTMLEncoder;
+import network.crypta.support.MultiValueTable;
+
+/**
+ * Emits small replacement responses for removed-by-default legacy admin pages.
+ *
+ * <p>The body is intentionally static apart from registry title and same-origin replacement link.
+ * It avoids echoing the incoming request URI, query string, form data, uploaded filenames, peer
+ * references, Freenet/Crypta URIs, cookies, tokens, or remote addresses.
+ *
+ * <p>The dispatcher calls this writer only after {@link LegacyAdminRemovalPolicy} has produced a
+ * concrete {@link LegacyAdminRemovalDecision}. It is responsible for converting that decision into
+ * HTTP headers and, for non-{@code HEAD} requests, a compact HTML body. It does not perform route
+ * matching, replacement-availability checks, or diagnostics recording. Keeping those steps outside
+ * the writer makes the response path easy to audit: every dynamic value comes from the bounded
+ * registry metadata already validated by {@link LegacyAdminSurface}.
+ *
+ * <p>Responses are deliberately plain. Operators get one explanation sentence and one replacement
+ * link; automated clients get stable status codes and an optional {@code Location} header.
+ */
+final class LegacyAdminReplacementResponse {
+  /** MIME type used for the small replacement explanation page. */
+  private static final String MIME_TYPE = "text/html; charset=UTF-8";
+
+  /** Prevents construction because response writing is a stateless helper operation. */
+  private LegacyAdminReplacementResponse() {}
+
+  /**
+   * Sends the HTTP response described by a removal decision.
+   *
+   * <p>Redirect decisions receive a {@code Location} header that points to the same-origin
+   * replacement URL. Gone and blocked-mutation decisions omit that header but still use the body to
+   * expose the replacement link to human operators. For {@code HEAD}, the method sends the same
+   * headers and content length that a {@code GET} would receive, then suppresses the body.
+   *
+   * @param decision validated removal decision produced by the central policy
+   * @param method uppercase HTTP method from the request line
+   * @param ctx request context used to write headers and optional response bytes
+   * @throws ToadletContextClosedException if the client connection closes while writing
+   * @throws IOException if the response stream fails while headers or body bytes are written
+   */
+  static void send(LegacyAdminRemovalDecision decision, String method, ToadletContext ctx)
+      throws ToadletContextClosedException, IOException {
+    byte[] body = body(decision).getBytes(StandardCharsets.UTF_8);
+    MultiValueTable<String, String> headers =
+        decision.redirect() ? MultiValueTable.from("Location", decision.replacementUrl()) : null;
+    ctx.sendReplyHeaders(
+        decision.statusCode(), decision.reason(), headers, MIME_TYPE, body.length, true);
+    if (!"HEAD".equals(method)) {
+      ctx.writeData(body);
+    }
+  }
+
+  /**
+   * Builds the small safe HTML body for a replacement response.
+   *
+   * <p>The generated markup uses only registry title, replacement label, and replacement URL. Each
+   * value is HTML-encoded even though registry construction already restricts replacement URLs to
+   * same-origin absolute paths. The extra encoding keeps this method safe if future registry text
+   * contains punctuation or localized labels.
+   *
+   * @param decision validated removal decision that supplies the surface and replacement URL
+   * @return complete UTF-8 HTML document body for non-{@code HEAD} responses
+   */
+  private static String body(LegacyAdminRemovalDecision decision) {
+    LegacyAdminSurface surface = decision.surface();
+    String title =
+        decision.usageEvent() == LegacyAdminUsageEvent.BLOCKED_MUTATING_REQUEST
+            ? "Legacy action disabled"
+            : "Legacy page replaced";
+    String lead =
+        decision.usageEvent() == LegacyAdminUsageEvent.BLOCKED_MUTATING_REQUEST
+            ? "This legacy admin action is no longer executed by default."
+            : "This legacy admin page no longer renders by default.";
+    String replacementLabel =
+        surface.replacementLabel() == null ? surface.replacementUrl() : surface.replacementLabel();
+    return "<!doctype html><html><head><meta charset=\"utf-8\"><title>"
+        + HTMLEncoder.encode(title)
+        + "</title></head><body><h1>"
+        + HTMLEncoder.encode(title)
+        + "</h1><p>"
+        + HTMLEncoder.encode(lead)
+        + "</p><p>Use <a href=\""
+        + HTMLEncoder.encode(decision.replacementUrl())
+        + "\">"
+        + HTMLEncoder.encode(replacementLabel)
+        + "</a> for "
+        + HTMLEncoder.encode(surface.title())
+        + ".</p></body></html>";
+  }
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java
@@ -20,11 +20,10 @@ import static network.crypta.runtime.updater.UpdaterPaths.CORE_UPDATE_PATH;
  * longest known prefix, which keeps configurable config and queue subpaths attributed to their
  * parent surface without storing request parameters.
  *
- * <p>The list is intentionally static for PR-200. It gives notices, Web Shell fallback links, and
- * usage diagnostics one shared source of truth while legacy pages continue to exist. Callers should
- * treat the returned entries as policy metadata, not route registrations. The actual toadlet
- * registration still lives in the legacy HTTP container, and app/UI replacements remain owned by
- * their platform modules.
+ * <p>The list gives notices, Web Shell fallback links, removal decisions, and usage diagnostics one
+ * shared source of truth. Callers should treat the returned entries as policy metadata, not route
+ * registrations. The actual toadlet registration still lives in the legacy HTTP container, and
+ * app/UI replacements remain owned by their platform modules.
  *
  * <p>The registry is immutable after class initialization and is safe to read from request-handling
  * threads. Any future change to a route's state should update this registry, the retirement-plan
@@ -52,6 +51,14 @@ public final class LegacyAdminRetirementRegistry {
   private static final String SEND_N2NTM_PATH = localPath("send_n2ntm");
   private static final String CHAT_PATH = localPath("chat");
   private static final String HELP_PATH = localPath("help");
+  private static final int NO_REMOVAL_WAVE = 0;
+  private static final int REMOVAL_WAVE_1 = 1;
+  private static final String REMOVED_BY_DEFAULT_SINCE_WAVE_1 = "phase-6-pr-8";
+  private static final String FALLBACK_POLICY_NONE = "none";
+  private static final String FALLBACK_POLICY_RENDER_LEGACY = "render-legacy";
+  private static final String FALLBACK_POLICY_RETAINED = "retained";
+  private static final String FALLBACK_POLICY_PENDING = "pending";
+  private static final String FALLBACK_POLICY_INFRASTRUCTURE = "infrastructure";
 
   private static final List<LegacyAdminSurface> SURFACES =
       List.of(
@@ -82,56 +89,56 @@ public final class LegacyAdminRetirementRegistry {
               SHELL_ALERTS_URL,
               "Web Shell alerts",
               "Web Shell lists and dismisses alerts through Platform API v1."),
-          replaced(
+          wave1Redirect(
               "queue-downloads",
               "Download queue",
               QueueToadlet.PATH_DOWNLOADS,
               QUEUE_MANAGER_URL,
               "Queue Manager app",
               "Queue Manager and the Web Shell queue panel are the primary transfer views."),
-          replaced(
+          wave1Redirect(
               "queue-uploads",
               "Upload queue",
               QueueToadlet.PATH_UPLOADS,
               QUEUE_MANAGER_URL,
               "Queue Manager app",
               "Queue Manager and Publisher cover upload-queue monitoring and insert creation."),
-          replaced(
+          wave1Redirect(
               "file-insert",
               "File insert wizard",
               FileInsertWizardToadlet.PATH,
               PUBLISHER_URL,
               "Publisher app",
               "Publisher is the primary first-party UI for local file and directory inserts."),
-          replaced(
+          wave1Redirect(
               "local-file-insert",
               "Local upload file browser",
               LocalFileInsertToadlet.INSERT_BROWSE_PATH,
               PUBLISHER_URL,
               "Publisher app",
-              "The route remains for legacy upload forms and operator fallback."),
-          replaced(
+              "Publisher owns the primary local insert flow; helper subpaths remain untouched."),
+          wave1Redirect(
               "friends",
               "Friends",
               LegacyHttpPaths.FRIENDS_PATH,
               SHELL_PEERS_URL,
               WEB_SHELL_PEER_CONTROL_LABEL,
               "Web Shell peer control covers darknet peer roster and mutations."),
-          replaced(
+          wave1Redirect(
               "add-friend",
               "Add friend",
               DarknetAddRefToadlet.PATH,
               SHELL_PEERS_URL,
               WEB_SHELL_PEER_CONTROL_LABEL,
               "Web Shell peer add handles the primary noderef import flow."),
-          replaced(
+          wave1Redirect(
               "strangers",
               "Strangers",
               "/strangers/",
               SHELL_PEERS_URL,
               WEB_SHELL_PEER_CONTROL_LABEL,
               "Opennet peer visibility belongs with the shell peer control plane."),
-          replaced(
+          wave1Redirect(
               "connectivity",
               "Connectivity",
               ConnectivityToadlet.CONNECTIVITY_PATH,
@@ -252,8 +259,8 @@ public final class LegacyAdminRetirementRegistry {
    *
    * <p>The diagnostics list excludes infrastructure bridges and helpers such as static assets,
    * Platform API, Web Shell, and app UI mounts. It does include replaced, retained, and pending
-   * user-facing surfaces so later retirement PRs can see which fallback pages are still used after
-   * process start.
+   * user-facing surfaces so later retirement PRs can see which legacy renders, replacement
+   * responses, and blocked mutations are still observed after process start.
    *
    * @return immutable list of surfaces that should appear in diagnostics output
    */
@@ -275,10 +282,24 @@ public final class LegacyAdminRetirementRegistry {
   }
 
   /**
+   * Returns the surfaces removed by default in a specific execution wave.
+   *
+   * <p>Removal waves are an execution policy and must not be inferred from retirement state alone.
+   * This method is primarily used by tests and release-certification evidence so future waves can
+   * prove the active route set without duplicating path lists outside the registry.
+   *
+   * @param removalWave removal wave number to select
+   * @return immutable list of surfaces whose current removal metadata belongs to the wave
+   */
+  public static List<LegacyAdminSurface> removalWaveSurfaces(int removalWave) {
+    return SURFACES.stream().filter(surface -> surface.removalWave() == removalWave).toList();
+  }
+
+  /**
    * Indicates whether a legacy route should still be promoted in the legacy navigation menus.
    *
-   * <p>Primary-replaced routes remain registered as direct fallback and debug URLs, but normal
-   * navigation should lead operators to the Web Shell or first-party app replacement. Unknown
+   * <p>Primary-replaced routes are not promoted as normal navigation targets. Some still render as
+   * later-wave legacy fallback pages, while wave-1 routes return replacement responses. Unknown
    * routes are treated as visible because they are outside this retirement map and may belong to
    * retained browse-owned surfaces.
    *
@@ -376,6 +397,33 @@ public final class LegacyAdminRetirementRegistry {
         replacementUrl,
         replacementLabel,
         notes,
+        LegacyAdminRemovalMode.RENDER_LEGACY,
+        NO_REMOVAL_WAVE,
+        null,
+        FALLBACK_POLICY_RENDER_LEGACY,
+        true,
+        false);
+  }
+
+  private static LegacyAdminSurface wave1Redirect(
+      String id,
+      String title,
+      String legacyPath,
+      String replacementUrl,
+      String replacementLabel,
+      String notes) {
+    return new LegacyAdminSurface(
+        id,
+        title,
+        legacyPath,
+        LegacyAdminRetirementState.PRIMARY_REPLACED,
+        replacementUrl,
+        replacementLabel,
+        notes,
+        LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT,
+        REMOVAL_WAVE_1,
+        REMOVED_BY_DEFAULT_SINCE_WAVE_1,
+        FALLBACK_POLICY_NONE,
         true,
         false);
   }
@@ -402,6 +450,10 @@ public final class LegacyAdminRetirementRegistry {
         replacementUrl,
         replacementLabel,
         notes,
+        LegacyAdminRemovalMode.PENDING,
+        NO_REMOVAL_WAVE,
+        null,
+        FALLBACK_POLICY_PENDING,
         true,
         includeInWebShellFallbackLinks);
   }
@@ -409,7 +461,19 @@ public final class LegacyAdminRetirementRegistry {
   private static LegacyAdminSurface retained(
       String id, String title, String legacyPath, String notes) {
     return new LegacyAdminSurface(
-        id, title, legacyPath, LegacyAdminRetirementState.RETAINED, null, null, notes, true, true);
+        id,
+        title,
+        legacyPath,
+        LegacyAdminRetirementState.RETAINED,
+        null,
+        null,
+        notes,
+        LegacyAdminRemovalMode.RETAINED,
+        NO_REMOVAL_WAVE,
+        null,
+        FALLBACK_POLICY_RETAINED,
+        true,
+        true);
   }
 
   private static LegacyAdminSurface infrastructure(
@@ -422,6 +486,10 @@ public final class LegacyAdminRetirementRegistry {
         null,
         null,
         notes,
+        LegacyAdminRemovalMode.INFRASTRUCTURE,
+        NO_REMOVAL_WAVE,
+        null,
+        FALLBACK_POLICY_INFRASTRUCTURE,
         false,
         false);
   }

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminSurface.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminSurface.java
@@ -18,6 +18,9 @@ import java.util.Objects;
  * <p>Two boolean inclusion flags keep policy decisions explicit. A surface can be counted in
  * diagnostics without appearing in the Web Shell fallback list, and infrastructure entries can be
  * registered for matching while remaining excluded from both user-facing telemetry and navigation.
+ * Removal metadata is separate from the retirement state so {@link
+ * LegacyAdminRetirementState#PRIMARY_REPLACED} can continue to mean "has a primary replacement"
+ * even when a route is still intentionally rendered by legacy code.
  *
  * @param id stable machine-readable identifier used by diagnostics and tests
  * @param title human-readable surface title suitable for notices and link labels
@@ -26,6 +29,10 @@ import java.util.Objects;
  * @param replacementUrl primary same-origin Web Shell or app URL when known
  * @param replacementLabel visible label for the replacement URL when present
  * @param notes short maintainer note describing the classification and migration context
+ * @param removalMode current execution policy for the canonical legacy route
+ * @param removalWave first removal wave number, or {@code 0} when not removed by default
+ * @param removedByDefaultSince stable release/phase marker for removal-by-default, or {@code null}
+ * @param fallbackPolicy path-free description of temporary fallback behavior
  * @param includeInUsageDiagnostics whether process-local usage diagnostics should include this
  *     surface
  * @param includeInWebShellFallbackLinks whether the Web Shell should show this as a fallback link
@@ -38,6 +45,10 @@ public record LegacyAdminSurface(
     String replacementUrl,
     String replacementLabel,
     String notes,
+    LegacyAdminRemovalMode removalMode,
+    int removalWave,
+    String removedByDefaultSince,
+    String fallbackPolicy,
     boolean includeInUsageDiagnostics,
     boolean includeInWebShellFallbackLinks) {
   /**
@@ -63,19 +74,30 @@ public record LegacyAdminSurface(
       requireText(replacementLabel, "replacementLabel");
     }
     requireText(notes, "notes");
+    Objects.requireNonNull(removalMode, "removalMode");
+    if (removalWave < 0) {
+      throw new IllegalArgumentException("removalWave must not be negative");
+    }
+    if (removedByDefaultSince != null) {
+      requireText(removedByDefaultSince, "removedByDefaultSince");
+    }
+    requireText(fallbackPolicy, "fallbackPolicy");
   }
 
   /**
    * Returns whether this surface should render a retirement notice on legacy HTML pages.
    *
-   * <p>Only primary-replaced surfaces with a concrete replacement URL render notices. Pending and
-   * retained pages intentionally stay quiet so operators are not pushed away from flows whose
-   * replacement is incomplete or intentionally out of scope.
+   * <p>Only primary-replaced surfaces with a concrete replacement URL and a render-legacy execution
+   * mode render notices. Pending and retained pages intentionally stay quiet so operators are not
+   * pushed away from flows whose replacement is incomplete or intentionally out of scope. Removed
+   * pages emit a separate replacement response before legacy rendering starts.
    *
    * @return {@code true} when the surface has a primary replacement and replacement link
    */
   public boolean rendersNotice() {
-    return state == LegacyAdminRetirementState.PRIMARY_REPLACED && replacementUrl != null;
+    return state == LegacyAdminRetirementState.PRIMARY_REPLACED
+        && removalMode == LegacyAdminRemovalMode.RENDER_LEGACY
+        && replacementUrl != null;
   }
 
   private static void requireText(String value, String label) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminUsageEvent.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminUsageEvent.java
@@ -1,0 +1,63 @@
+package network.crypta.clients.http;
+
+/**
+ * Bounded diagnostic event classes for legacy admin route observations.
+ *
+ * <p>The values describe how a known legacy surface was handled without storing request-specific
+ * data. They intentionally avoid method names, query strings, form values, peer references, URIs,
+ * file paths, remote addresses, and request bodies.
+ *
+ * <p>{@link LegacyAdminUsageRecorder} converts these events into aggregate counters exposed through
+ * Platform API diagnostics. The enum is not an audit log and is not intended to reconstruct
+ * individual requests. Its purpose is to let operators and release certification distinguish
+ * between four broad outcomes: an old page still rendered, a primary-replaced fallback rendered, a
+ * replacement response was sent, or a mutating legacy request was blocked before old behavior could
+ * run.
+ *
+ * <p>All values are process-local observations. Counts reset when the node restarts, and the
+ * recorder keeps only stable surface ids plus the latest observation timestamp.
+ */
+enum LegacyAdminUsageEvent {
+  /**
+   * A legacy toadlet rendered a response for the mapped route.
+   *
+   * <p>This generic event is used for mapped legacy surfaces that are neither primary-replaced
+   * fallback pages nor retained/pending pages with their own aggregate bucket.
+   */
+  RENDERED_LEGACY,
+
+  /**
+   * A primary-replaced route still rendered as direct legacy fallback.
+   *
+   * <p>Replacement-unavailable wave-1 requests and later-wave primary-replaced pages use this event
+   * when the old handler legitimately renders. The counter helps decide whether a fallback is still
+   * in active use before a later removal wave tightens behavior.
+   */
+  FALLBACK_RENDERED,
+
+  /**
+   * A retained or pending route rendered unchanged.
+   *
+   * <p>This event separates intentional legacy usage from fallback usage. Browse-adjacent retained
+   * routes and pending setup or message flows can remain visible in diagnostics without looking
+   * like removal-wave regressions.
+   */
+  RETAINED_OR_PENDING_RENDERED,
+
+  /**
+   * The removal gate returned a redirect or gone-with-replacement response.
+   *
+   * <p>The old toadlet did not render. The request reached a removed-by-default canonical page and
+   * received a replacement response because the target replacement was available for that request.
+   */
+  REPLACEMENT_RESPONSE,
+
+  /**
+   * The removal gate blocked a mutating legacy request before invoking old behavior.
+   *
+   * <p>This event is intentionally distinct from replacement read responses so diagnostics can show
+   * whether old POST, PUT, DELETE, PATCH, or similar entry points are still being exercised after a
+   * surface enters a removal wave.
+   */
+  BLOCKED_MUTATING_REQUEST
+}

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminUsageRecorder.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminUsageRecorder.java
@@ -13,8 +13,9 @@ import network.crypta.runtime.spi.LegacyAdminUsageSnapshot;
  * Thread-safe process-local usage recorder for legacy admin HTTP surfaces.
  *
  * <p>The recorder is bounded by {@link LegacyAdminRetirementRegistry}. It only counts known surface
- * ids and records the latest observation time. It does not persist data and does not store request
- * parameters, bodies, peer references, URIs, filesystem paths, or remote addresses.
+ * ids and records the latest observation time. Replacement responses and blocked mutating requests
+ * are counted separately from rendered legacy pages. It does not persist data and does not store
+ * request parameters, bodies, peer references, URIs, filesystem paths, or remote addresses.
  *
  * <p>The legacy HTTP adapter records a visit only after a request has passed the container-level
  * gates and produced an accepted response. This class assumes that policy decision has already
@@ -88,11 +89,27 @@ public final class LegacyAdminUsageRecorder implements LegacyAdminUsagePort {
    * @param surface surface metadata resolved by the registry before recording
    */
   public void recordSurface(LegacyAdminSurface surface) {
+    recordSurface(surface, acceptedRenderEvent(surface));
+  }
+
+  /**
+   * Records one bounded handling event for a registry surface.
+   *
+   * <p>The event controls which aggregate counter is incremented. This method never stores request
+   * details and ignores surfaces that the registry excludes from diagnostics.
+   *
+   * @param surface surface metadata resolved by the registry before recording
+   * @param event handling event to aggregate
+   */
+  void recordSurface(LegacyAdminSurface surface, LegacyAdminUsageEvent event) {
     if (!surface.includeInUsageDiagnostics()) {
       return;
     }
+    if (event == null) {
+      throw new NullPointerException("event");
+    }
     Counter counter = counters.computeIfAbsent(surface.id(), _ -> new Counter());
-    counter.increment(clock.millis());
+    counter.increment(event, clock.millis());
   }
 
   /** Clears all counters. Intended for focused tests. */
@@ -126,21 +143,72 @@ public final class LegacyAdminUsageRecorder implements LegacyAdminUsagePort {
         surface.legacyPath(),
         surface.state().name(),
         surface.replacementUrl(),
+        surface.removalMode().name(),
+        surface.removalWave(),
+        surface.removedByDefaultSince(),
+        surface.fallbackPolicy(),
         counter == null ? 0L : counter.count(),
+        counter == null ? 0L : counter.replacementResponseCount(),
+        counter == null ? 0L : counter.blockedMutatingRequestCount(),
+        counter == null ? 0L : counter.fallbackRenderCount(),
+        counter == null ? 0L : counter.retainedOrPendingRenderCount(),
         counter == null ? 0L : counter.lastSeenEpochMillis());
+  }
+
+  private static LegacyAdminUsageEvent acceptedRenderEvent(LegacyAdminSurface surface) {
+    if (surface.state() == LegacyAdminRetirementState.PRIMARY_REPLACED) {
+      return LegacyAdminUsageEvent.FALLBACK_RENDERED;
+    }
+    if (surface.state() == LegacyAdminRetirementState.RETAINED
+        || surface.state() == LegacyAdminRetirementState.PENDING) {
+      return LegacyAdminUsageEvent.RETAINED_OR_PENDING_RENDERED;
+    }
+    return LegacyAdminUsageEvent.RENDERED_LEGACY;
   }
 
   private static final class Counter {
     private final AtomicLong count = new AtomicLong();
+    private final AtomicLong replacementResponseCount = new AtomicLong();
+    private final AtomicLong blockedMutatingRequestCount = new AtomicLong();
+    private final AtomicLong fallbackRenderCount = new AtomicLong();
+    private final AtomicLong retainedOrPendingRenderCount = new AtomicLong();
     private final AtomicLong lastSeenEpochMillis = new AtomicLong();
 
-    void increment(long observedEpochMillis) {
-      count.incrementAndGet();
+    void increment(LegacyAdminUsageEvent event, long observedEpochMillis) {
+      switch (event) {
+        case RENDERED_LEGACY -> count.incrementAndGet();
+        case FALLBACK_RENDERED -> {
+          count.incrementAndGet();
+          fallbackRenderCount.incrementAndGet();
+        }
+        case RETAINED_OR_PENDING_RENDERED -> {
+          count.incrementAndGet();
+          retainedOrPendingRenderCount.incrementAndGet();
+        }
+        case REPLACEMENT_RESPONSE -> replacementResponseCount.incrementAndGet();
+        case BLOCKED_MUTATING_REQUEST -> blockedMutatingRequestCount.incrementAndGet();
+      }
       lastSeenEpochMillis.updateAndGet(previous -> Math.max(previous, observedEpochMillis));
     }
 
     long count() {
       return count.get();
+    }
+
+    long replacementResponseCount() {
+      return replacementResponseCount.get();
+    }
+
+    long blockedMutatingRequestCount() {
+      return blockedMutatingRequestCount.get();
+    }
+
+    long fallbackRenderCount() {
+      return fallbackRenderCount.get();
+    }
+
+    long retainedOrPendingRenderCount() {
+      return retainedOrPendingRenderCount.get();
     }
 
     long lastSeenEpochMillis() {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PageMaker.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PageMaker.java
@@ -284,7 +284,8 @@ public final class PageMaker {
   /**
    * Adds a navigation category whose root can fall back and be hidden at render time.
    *
-   * <p>{@code rootLinkEnabled} decides whether a root-only category should be rendered at all.
+   * <p>{@code rootLinkEnabled} decides whether the category root link should be rendered. If child
+   * links remain visible while it is disabled, the category label is shown without an anchor.
    * {@code primaryLinkEnabled} decides whether that rendered root should use {@code link} or {@code
    * fallbackLink}.
    *
@@ -293,11 +294,12 @@ public final class PageMaker {
    * @param title tooltip text describing the category's purpose
    * @param fallbackLink alternate target when the primary link is disabled; {@code null} reuses
    *     {@code link}
-   * @param fullOnly whether a root-only category requires full-access permission
+   * @param fullOnly whether a root category with no visible children requires full-access
+   *     permission
    * @param primaryLinkEnabled callback that decides whether {@code link} is usable for the request;
    *     {@code null} always uses {@code link}
-   * @param rootLinkEnabled callback that decides whether a root-only category should render; {@code
-   *     null} always allows rendering
+   * @param rootLinkEnabled callback that decides whether the root link should render; {@code null}
+   *     always allows rendering
    */
   public synchronized void addNavigationCategory(
       String link,
@@ -931,17 +933,18 @@ public final class PageMaker {
       nonEmpty = true;
       isSelected = renderNavigationItem(subnavlist, activePath, navigationLink, menu) || isSelected;
     }
-    if (nonEmpty || shouldRenderCategoryRoot(fullAccess, ctx, menu)) {
-      HTMLNode listItem = createMenuListItem(ctx, menu, subnavlist, isSelected);
+    boolean renderCategoryRoot = shouldRenderCategoryRoot(fullAccess, ctx, menu, nonEmpty);
+    if (nonEmpty || renderCategoryRoot) {
+      HTMLNode listItem = createMenuListItem(ctx, menu, subnavlist, isSelected, renderCategoryRoot);
       navbarUl.addChild(listItem);
     }
     return isSelected;
   }
 
   private static boolean shouldRenderCategoryRoot(
-      boolean fullAccess, ToadletContext ctx, SubMenu menu) {
+      boolean fullAccess, ToadletContext ctx, SubMenu menu, boolean hasVisibleChildren) {
     String defaultLink = menu.defaultNavigationLink(ctx);
-    return (fullAccess || !menu.isDefaultNavigationFullOnly())
+    return (hasVisibleChildren || fullAccess || !menu.isDefaultNavigationFullOnly())
         && menu.isDefaultNavigationEnabled(ctx)
         && defaultLink != null
         && !defaultLink.isBlank();
@@ -1001,7 +1004,11 @@ public final class PageMaker {
   }
 
   private HTMLNode createMenuListItem(
-      ToadletContext ctx, SubMenu menu, HTMLNode subnavlist, boolean isSelected) {
+      ToadletContext ctx,
+      SubMenu menu,
+      HTMLNode subnavlist,
+      boolean isSelected,
+      boolean renderCategoryRoot) {
     HTMLNode listItem;
     if (isSelected) {
       subnavlist.addAttribute(ATTR_CLASS, "subnavlist-selected");
@@ -1016,11 +1023,15 @@ public final class PageMaker {
     menuItemTitle = NodeL10n.getBase().getString(menuItemTitle);
     text = NodeL10n.getBase().getString(text);
 
-    listItem.addChild(
-        TAG_A,
-        new String[] {"href", ATTR_TITLE},
-        new String[] {menu.defaultNavigationLink(ctx), menuItemTitle},
-        text);
+    if (renderCategoryRoot) {
+      listItem.addChild(
+          TAG_A,
+          new String[] {"href", ATTR_TITLE},
+          new String[] {menu.defaultNavigationLink(ctx), menuItemTitle},
+          text);
+    } else {
+      listItem.addChild("span", ATTR_TITLE, menuItemTitle, text);
+    }
     listItem.addChild(subnavlist);
     return listItem;
   }
@@ -1552,7 +1563,7 @@ public final class PageMaker {
     /** Runtime check for whether the default target should be used. */
     private final LinkEnabledCallback primaryLinkEnabled;
 
-    /** Runtime check for whether the category root should be rendered. */
+    /** Runtime check for whether the category root link should be rendered. */
     private final LinkEnabledCallback rootLinkEnabled;
 
     /** Tooltip */

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/SimpleToadletServer.java
@@ -1,6 +1,7 @@
 package network.crypta.clients.http;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.URI;
@@ -32,6 +33,9 @@ import network.crypta.io.SSLNetworkInterface;
 import network.crypta.keys.FreenetURI;
 import network.crypta.l10n.NodeL10n;
 import network.crypta.node.PrioRunnable;
+import network.crypta.platform.appdist.AppUiMode;
+import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.InstalledAppSnapshot;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.runtime.alerts.UserAlertSurface;
 import network.crypta.runtime.core.SSL;
@@ -529,10 +533,35 @@ public final class SimpleToadletServer
    *
    * @return primary browser-facing shell route
    */
+  @Override
   public String primaryUiRoot() {
     return shouldAdvertiseWebShellPrimaryUi()
         ? WebShellPaths.SHELL_ROOT
         : LauncherReadinessInfo.DEFAULT_UI_ROOT;
+  }
+
+  @Override
+  public boolean isStaticAppUiAvailable(String appId) {
+    if (appId == null || appId.isBlank()) {
+      return false;
+    }
+    network.crypta.clients.http.HttpShellRuntimeSupport runtimeSupportRef = runtimeSupport;
+    if (runtimeSupportRef == null) {
+      return false;
+    }
+    AppHost appHost = runtimeSupportRef.appHost();
+    if (appHost == null) {
+      return false;
+    }
+    try {
+      return appHost
+          .describe(appId)
+          .map(InstalledAppSnapshot::manifest)
+          .map(manifest -> manifest.uiMode() == AppUiMode.STATIC)
+          .orElse(false);
+    } catch (IOException _) {
+      return false;
+    }
   }
 
   /**
@@ -1490,15 +1519,17 @@ public final class SimpleToadletServer
    * Registers a navigation category with runtime-selected target and visibility.
    *
    * <p>{@code primaryLinkEnabled} controls whether the primary or fallback target is rendered.
-   * {@code rootLinkEnabled} controls whether a root-only category is rendered at all.
+   * {@code rootLinkEnabled} controls whether the category root link is rendered; child links can
+   * still keep the category visible.
    *
    * @param link primary navigation target
    * @param name short category name shown in menus; should be unique within its level
    * @param title descriptive title used for tooltips or extended labels; may be {@code null}
    * @param fallbackLink alternate navigation target when {@code link} is not enabled
-   * @param fullOnly whether a root-only category requires full-access permission
+   * @param fullOnly whether a root category with no visible children requires full-access
+   *     permission
    * @param primaryLinkEnabled callback deciding whether the primary target is usable
-   * @param rootLinkEnabled callback deciding whether a root-only category should render
+   * @param rootLinkEnabled callback deciding whether the root link should render
    */
   public void registerMenu(
       String link,

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContainer.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContainer.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.URI;
 import network.crypta.clients.http.PageMaker.THEME;
+import network.crypta.fs.readiness.LauncherReadinessInfo;
 import network.crypta.support.HTMLNode;
 import network.crypta.support.api.BucketFactory;
 
@@ -240,6 +241,36 @@ public interface ToadletContainer {
    * @return {@code true} when JavaScript support is allowed in FProxy pages
    */
   boolean isFProxyJavascriptEnabled();
+
+  /**
+   * Returns the primary browser route currently advertised by this container.
+   *
+   * <p>The default reports the historical legacy root for small test containers and embedders that
+   * do not host Web Shell. Full server implementations should override this with the same route
+   * used by launcher readiness so request policy does not redirect users to a shell entry point
+   * that is unavailable in the current configuration.
+   *
+   * @return primary browser-facing UI route
+   */
+  default String primaryUiRoot() {
+    return LauncherReadinessInfo.DEFAULT_UI_ROOT;
+  }
+
+  /**
+   * Reports whether an installed app exposes a static browser UI that can receive replacement
+   * redirects.
+   *
+   * <p>The default is conservative so lightweight test containers and embeddings without AppHost
+   * keep rendering legacy fallbacks instead of producing dead replacement links. Implementations
+   * with AppHost access should check the installed app manifest and return {@code true} only when
+   * the requested app id has a static UI.
+   *
+   * @param appId stable installed-app identifier
+   * @return {@code true} when the app has a reachable static UI
+   */
+  default boolean isStaticAppUiAvailable(String appId) {
+    return false;
+  }
 
   /**
    * Determine whether FProxy server push or WebSocket-style features are enabled.

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/ToadletContextImpl.java
@@ -947,8 +947,9 @@ public final class ToadletContextImpl implements ToadletContext {
   static boolean isMethodAllowedInRestrictedMode(String method, URI uri) {
     return switch (method) {
       case "GET", "POST" -> true;
-      case "HEAD" -> isAppUiPath(uri);
-      case "DELETE", "PATCH", "PUT" -> isPlatformApiPath(uri);
+      case "HEAD" -> isAppUiPath(uri) || LegacyAdminRemovalPolicy.isRemovedCanonicalPath(uri);
+      case "DELETE", "PATCH", "PUT" ->
+          isPlatformApiPath(uri) || LegacyAdminRemovalPolicy.isRemovedCanonicalPath(uri);
       default -> false;
     };
   }
@@ -1094,48 +1095,33 @@ public final class ToadletContextImpl implements ToadletContext {
     URI currentUri = uri;
     LegacyAdminSurface usageSurface =
         LegacyAdminRetirementRegistry.findByLegacyPath(uri.getPath()).orElse(null);
-    boolean redirect;
-    do {
-      redirect = false;
-      FindToadletResult toadletResult = findToadlet(container, ctx, currentUri);
-      if (toadletResult.handled) {
-        recordLegacyAdminUsageIfAccepted(toadletResult.usageSurface(), ctx);
+    while (true) {
+      FindToadletResult toadletResult = findToadlet(container, currentUri);
+      if (handlePermanentRedirectIfPresent(toadletResult, method, currentUri, ctx)) {
         return;
       }
+
       Toadlet toadlet = toadletResult.toadlet;
       if (toadlet == null) {
         ctx.sendNoToadletError(ctx.shouldDisconnect);
         return;
       }
 
-      if (!toadlet.findSupportedMethods().contains(method)) {
-        ctx.sendMethodNotAllowed(method, ctx.shouldDisconnect);
+      if (trySendLegacyAdminRemovalDecision(method, currentUri, ctx)) {
         return;
       }
 
-      HTTPRequestImpl req = new HTTPRequestImpl(currentUri, data, ctx, method);
-      try {
-        if (method.equals("POST")
-            && !toadlet.allowPOSTWithoutPassword()
-            && !ctx.checkFormPassword(req, toadlet.path())) {
-          return;
-        }
-
-        if (ctx.isAllowedFullAccess()) {
-          ctx.getPageMaker().parseMode(req, container);
-        }
-
-        try {
-          callToadletMethod(toadlet, method, currentUri, req, ctx, data, sock);
-          recordLegacyAdminUsageIfAccepted(usageSurface, ctx);
-        } catch (RedirectException re) {
-          currentUri = re.newuri;
-          redirect = true;
-        }
-      } finally {
-        req.freeParts();
+      if (tryRejectUnsupportedMethod(toadlet, method, ctx)) {
+        return;
       }
-    } while (redirect);
+
+      Optional<URI> redirectUri =
+          callToadletAndRecordRedirect(toadlet, method, currentUri, data, ctx, sock, usageSurface);
+      if (redirectUri.isEmpty()) {
+        return;
+      }
+      currentUri = redirectUri.orElseThrow();
+    }
   }
 
   private static void recordLegacyAdminUsageIfAccepted(
@@ -1145,20 +1131,116 @@ public final class ToadletContextImpl implements ToadletContext {
     }
   }
 
+  private static boolean handlePermanentRedirectIfPresent(
+      FindToadletResult toadletResult, String method, URI currentUri, ToadletContextImpl ctx)
+      throws ToadletContextClosedException, IOException {
+    if (toadletResult.permanentRedirectUri() == null) {
+      return false;
+    }
+    if (trySendReplacementForCanonicalRedirect(toadletResult, method, currentUri, ctx)) {
+      return true;
+    }
+    Toadlet.writePermanentRedirect(
+        ctx, "Found elsewhere", toadletResult.permanentRedirectUri().toASCIIString());
+    recordLegacyAdminUsageIfAccepted(toadletResult.usageSurface(), ctx);
+    return true;
+  }
+
+  private static boolean trySendReplacementForCanonicalRedirect(
+      FindToadletResult toadletResult, String method, URI currentUri, ToadletContextImpl ctx)
+      throws ToadletContextClosedException, IOException {
+    if (toadletResult.usageSurface() == null) {
+      return false;
+    }
+    return trySendLegacyAdminRemovalDecision(method, currentUri, ctx);
+  }
+
+  private static boolean trySendLegacyAdminRemovalDecision(
+      String method, URI currentUri, ToadletContextImpl ctx)
+      throws ToadletContextClosedException, IOException {
+    Optional<LegacyAdminRemovalDecision> removalDecision =
+        LegacyAdminRemovalPolicy.decide(method, currentUri, ctx);
+    if (removalDecision.isEmpty()) {
+      return false;
+    }
+    sendLegacyAdminReplacementResponse(removalDecision.orElseThrow(), method, ctx);
+    return true;
+  }
+
+  private static void sendLegacyAdminReplacementResponse(
+      LegacyAdminRemovalDecision decision, String method, ToadletContextImpl ctx)
+      throws ToadletContextClosedException, IOException {
+    LegacyAdminReplacementResponse.send(decision, method, ctx);
+    LegacyAdminUsageRecorder.defaultRecorder()
+        .recordSurface(decision.surface(), decision.usageEvent());
+  }
+
+  private static boolean tryRejectUnsupportedMethod(
+      Toadlet toadlet, String method, ToadletContextImpl ctx)
+      throws ToadletContextClosedException, IOException {
+    if (toadlet.findSupportedMethods().contains(method)) {
+      return false;
+    }
+    ctx.sendMethodNotAllowed(method, ctx.shouldDisconnect);
+    return true;
+  }
+
+  private static Optional<URI> callToadletAndRecordRedirect(
+      Toadlet toadlet,
+      String method,
+      URI currentUri,
+      Bucket data,
+      ToadletContextImpl ctx,
+      Socket sock,
+      LegacyAdminSurface usageSurface)
+      throws IOException,
+          ToadletContextClosedException,
+          NoSuchMethodException,
+          IllegalAccessException,
+          ToadletInvocationException {
+    HTTPRequestImpl req = new HTTPRequestImpl(currentUri, data, ctx, method);
+    try {
+      if (isPostWithoutAcceptedFormPassword(toadlet, method, req, ctx)) {
+        return Optional.empty();
+      }
+      parseModeForFullAccess(ctx, req);
+      try {
+        callToadletMethod(toadlet, method, currentUri, req, ctx, data, sock);
+        recordLegacyAdminUsageIfAccepted(usageSurface, ctx);
+        return Optional.empty();
+      } catch (RedirectException re) {
+        return Optional.of(re.newuri);
+      }
+    } finally {
+      req.freeParts();
+    }
+  }
+
+  private static boolean isPostWithoutAcceptedFormPassword(
+      Toadlet toadlet, String method, HTTPRequestImpl req, ToadletContextImpl ctx)
+      throws ToadletContextClosedException, IOException {
+    return "POST".equals(method)
+        && !toadlet.allowPOSTWithoutPassword()
+        && !ctx.checkFormPassword(req, toadlet.path());
+  }
+
+  private static void parseModeForFullAccess(ToadletContextImpl ctx, HTTPRequestImpl req) {
+    if (ctx.isAllowedFullAccess()) {
+      ctx.getPageMaker().parseMode(req, ctx.container);
+    }
+  }
+
   boolean hasAcceptedLegacyAdminUsageResponse() {
     return !requestGateDenied && replyStatusCode >= 200 && replyStatusCode < 400;
   }
 
-  private static FindToadletResult findToadlet(
-      ToadletContainer container, ToadletContextImpl ctx, URI uri)
-      throws IOException, ToadletContextClosedException {
+  private static FindToadletResult findToadlet(ToadletContainer container, URI uri) {
     try {
       Toadlet toadlet = container.findToadlet(uri);
-      return new FindToadletResult(toadlet, false, null);
+      return new FindToadletResult(toadlet, null, null);
     } catch (PermanentRedirectException e) {
-      Toadlet.writePermanentRedirect(ctx, "Found elsewhere", e.newuri.toASCIIString());
       return new FindToadletResult(
-          null, true, canonicalRedirectSurface(uri, e.newuri).orElse(null));
+          null, e.newuri, canonicalRedirectSurface(uri, e.newuri).orElse(null));
     }
   }
 
@@ -1188,7 +1270,7 @@ public final class ToadletContextImpl implements ToadletContext {
   }
 
   private record FindToadletResult(
-      Toadlet toadlet, boolean handled, LegacyAdminSurface usageSurface) {}
+      Toadlet toadlet, URI permanentRedirectUri, LegacyAdminSurface usageSurface) {}
 
   private static final class ToadletInvocationException extends Exception {
     ToadletInvocationException(Throwable cause) {

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java
@@ -106,9 +106,9 @@ public final class WebShellToadlet extends Toadlet {
   /**
    * Returns the default legacy deep links exposed by the Web Shell.
    *
-   * <p>The list is sourced from the retirement registry so primary-replaced legacy admin pages stop
-   * appearing as shell fallback links. Only retained or pending pages that still need a legacy
-   * entry point remain here.
+   * <p>The list is sourced from the retirement registry so primary-replaced and removed-by-default
+   * legacy admin pages do not appear as shell fallback links. Only retained or pending tools that
+   * still need a legacy entry point remain here.
    *
    * @return ordered fallback links for retained or pending legacy pages
    */

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRemovalPolicyTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRemovalPolicyTest.java
@@ -1,0 +1,126 @@
+package network.crypta.clients.http;
+
+import java.net.URI;
+import network.crypta.platform.webshell.routes.WebShellPaths;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("java:S100")
+class LegacyAdminRemovalPolicyTest {
+  @Test
+  void decide_whenWaveOneGetRequested_expectReplacementRedirect() {
+    LegacyAdminRemovalDecision decision =
+        LegacyAdminRemovalPolicy.decide("GET", URI.create(QueueToadlet.PATH_DOWNLOADS))
+            .orElseThrow();
+
+    assertEquals("queue-downloads", decision.surface().id());
+    assertEquals(303, decision.statusCode());
+    assertTrue(decision.redirect());
+    assertEquals("/apps/queue-manager/", decision.replacementUrl());
+    assertEquals(LegacyAdminUsageEvent.REPLACEMENT_RESPONSE, decision.usageEvent());
+  }
+
+  @Test
+  void decide_whenWaveOneSlashlessHeadRequested_expectReplacementRedirectWithoutBodyPolicy() {
+    LegacyAdminRemovalDecision decision =
+        LegacyAdminRemovalPolicy.decide("HEAD", URI.create("/friends")).orElseThrow();
+
+    assertEquals("friends", decision.surface().id());
+    assertEquals(303, decision.statusCode());
+    assertTrue(decision.redirect());
+    assertEquals("/app/node/#peers", decision.replacementUrl());
+  }
+
+  @Test
+  void decide_whenWaveOnePostRequested_expectBlockedMutation() {
+    LegacyAdminRemovalDecision decision =
+        LegacyAdminRemovalPolicy.decide("POST", URI.create("/addfriend/")).orElseThrow();
+
+    assertEquals("add-friend", decision.surface().id());
+    assertEquals(410, decision.statusCode());
+    assertFalse(decision.redirect());
+    assertEquals(LegacyAdminUsageEvent.BLOCKED_MUTATING_REQUEST, decision.usageEvent());
+  }
+
+  @Test
+  void decide_whenLaterWavePrimaryReplacedRequested_expectNoDecision() {
+    assertFalse(LegacyAdminRemovalPolicy.decide("GET", URI.create("/alerts/")).isPresent());
+    assertFalse(
+        LegacyAdminRemovalPolicy.decide("GET", URI.create(LegacyHttpPaths.CONFIG_PATH + "node"))
+            .isPresent());
+  }
+
+  @Test
+  void decide_whenWaveOneHelperSubpathRequested_expectNoDecision() {
+    assertFalse(
+        LegacyAdminRemovalPolicy.decide("GET", URI.create(QueueToadlet.PATH_DOWNLOADS + "finished"))
+            .isPresent());
+  }
+
+  @Test
+  void decide_whenQueueReplacementUnavailable_expectNoRemovalDecision() {
+    ToadletContainer container = availableReplacementContainer();
+    when(container.isStaticAppUiAvailable("queue-manager")).thenReturn(false);
+    ToadletContext ctx = requestContext(container, true);
+
+    assertFalse(
+        LegacyAdminRemovalPolicy.decide("GET", URI.create(QueueToadlet.PATH_DOWNLOADS), ctx)
+            .isPresent());
+  }
+
+  @Test
+  void decide_whenPublisherReplacementAvailable_expectReplacementRedirect() {
+    ToadletContainer container = availableReplacementContainer();
+    ToadletContext ctx = requestContext(container, true);
+
+    LegacyAdminRemovalDecision decision =
+        LegacyAdminRemovalPolicy.decide("GET", URI.create(FileInsertWizardToadlet.PATH), ctx)
+            .orElseThrow();
+
+    assertEquals("file-insert", decision.surface().id());
+    assertEquals("/apps/publisher/", decision.replacementUrl());
+    assertTrue(decision.redirect());
+  }
+
+  @Test
+  void decide_whenWebShellReplacementUnavailable_expectNoRemovalDecision() {
+    ToadletContainer container = availableReplacementContainer();
+    when(container.primaryUiRoot()).thenReturn("/");
+    ToadletContext ctx = requestContext(container, true);
+
+    assertFalse(
+        LegacyAdminRemovalPolicy.decide("GET", URI.create(LegacyHttpPaths.FRIENDS_PATH), ctx)
+            .isPresent());
+  }
+
+  @Test
+  void decide_whenFullAccessDenied_expectNoRemovalDecision() {
+    ToadletContainer container = availableReplacementContainer();
+    ToadletContext ctx = requestContext(container, false);
+
+    assertFalse(
+        LegacyAdminRemovalPolicy.decide("GET", URI.create(LegacyHttpPaths.FRIENDS_PATH), ctx)
+            .isPresent());
+  }
+
+  private static ToadletContainer availableReplacementContainer() {
+    ToadletContainer container = mock(ToadletContainer.class);
+    when(container.isFProxyJavascriptEnabled()).thenReturn(true);
+    when(container.isStaticAppUiAvailable("queue-manager")).thenReturn(true);
+    when(container.isStaticAppUiAvailable("publisher")).thenReturn(true);
+    when(container.primaryUiRoot()).thenReturn(WebShellPaths.SHELL_ROOT);
+    return container;
+  }
+
+  private static ToadletContext requestContext(ToadletContainer container, boolean fullAccess) {
+    ToadletContext ctx = mock(ToadletContext.class);
+    when(ctx.getContainer()).thenReturn(container);
+    when(ctx.isAllowedFullAccess()).thenReturn(fullAccess);
+    return ctx;
+  }
+}

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementNoticeTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementNoticeTest.java
@@ -10,15 +10,22 @@ class LegacyAdminRetirementNoticeTest {
   @Test
   void render_whenSurfacePrimaryReplaced_expectFallbackNoticeWithReplacementLink() {
     String html =
-        LegacyAdminRetirementNotice.render(LegacyAdminRetirementRegistry.require("friends"))
+        LegacyAdminRetirementNotice.render(LegacyAdminRetirementRegistry.require("config"))
             .orElseThrow()
             .generate();
 
     assertTrue(html.contains("Legacy fallback page"));
     assertTrue(html.contains("This legacy page remains available as a fallback and debug view."));
     assertTrue(html.contains("The primary flow is now in"));
-    assertTrue(html.contains("href=\"/app/node/#peers\""));
-    assertTrue(html.contains("Web Shell peer control"));
+    assertTrue(html.contains("href=\"/app/node/#config\""));
+    assertTrue(html.contains("Web Shell config"));
+  }
+
+  @Test
+  void render_whenSurfaceRemovedByDefault_expectNoFallbackNotice() {
+    assertFalse(
+        LegacyAdminRetirementNotice.render(LegacyAdminRetirementRegistry.require("friends"))
+            .isPresent());
   }
 
   @Test

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementRegistryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementRegistryTest.java
@@ -18,8 +18,37 @@ class LegacyAdminRetirementRegistryTest {
     assertEquals(LegacyAdminRetirementState.PRIMARY_REPLACED, surface.state());
     assertEquals(QueueToadlet.PATH_DOWNLOADS, surface.legacyPath());
     assertEquals(AppUiPaths.APPS_ROOT + "queue-manager/", surface.replacementUrl());
+    assertEquals(LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT, surface.removalMode());
+    assertEquals(1, surface.removalWave());
+    assertEquals("phase-6-pr-8", surface.removedByDefaultSince());
+    assertEquals("none", surface.fallbackPolicy());
     assertTrue(surface.includeInUsageDiagnostics());
     assertFalse(surface.includeInWebShellFallbackLinks());
+  }
+
+  @Test
+  void removalWaveSurfaces_whenWaveOneRequested_expectFirstRemovalSetOnly() {
+    List<String> waveOneIds =
+        LegacyAdminRetirementRegistry.removalWaveSurfaces(1).stream()
+            .map(LegacyAdminSurface::id)
+            .toList();
+
+    assertEquals(
+        List.of(
+            "queue-downloads",
+            "queue-uploads",
+            "file-insert",
+            "local-file-insert",
+            "friends",
+            "add-friend",
+            "strangers",
+            "connectivity"),
+        waveOneIds);
+    assertFalse(waveOneIds.contains("alerts"));
+    assertFalse(waveOneIds.contains("config"));
+    assertFalse(waveOneIds.contains("security-levels"));
+    assertFalse(waveOneIds.contains("first-time-wizard"));
+    assertFalse(waveOneIds.contains("content-filter"));
   }
 
   @Test
@@ -30,6 +59,8 @@ class LegacyAdminRetirementRegistryTest {
 
     assertEquals("config", surface.id());
     assertEquals(LegacyAdminRetirementState.PRIMARY_REPLACED, surface.state());
+    assertEquals(LegacyAdminRemovalMode.RENDER_LEGACY, surface.removalMode());
+    assertEquals(0, surface.removalWave());
     assertEquals(WebShellPaths.SHELL_ROOT + "#config", surface.replacementUrl());
   }
 
@@ -42,6 +73,7 @@ class LegacyAdminRetirementRegistryTest {
 
     assertEquals("platform-api", surface.id());
     assertEquals(LegacyAdminRetirementState.INFRASTRUCTURE, surface.state());
+    assertEquals(LegacyAdminRemovalMode.INFRASTRUCTURE, surface.removalMode());
     assertFalse(surface.includeInUsageDiagnostics());
   }
 

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminSurfaceTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminSurfaceTest.java
@@ -13,16 +13,13 @@ class LegacyAdminSurfaceTest {
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            new LegacyAdminSurface(
+            surface(
                 " ",
                 "Queue",
                 "/downloads/",
                 LegacyAdminRetirementState.PRIMARY_REPLACED,
                 "/apps/queue-manager/",
-                "Queue Manager",
-                "notes",
-                true,
-                false));
+                "Queue Manager"));
   }
 
   @Test
@@ -30,16 +27,13 @@ class LegacyAdminSurfaceTest {
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            new LegacyAdminSurface(
+            surface(
                 "queue",
                 "Queue",
                 "/downloads/",
                 LegacyAdminRetirementState.PRIMARY_REPLACED,
                 "https://example.test/apps/queue-manager/",
-                "Queue Manager",
-                "notes",
-                true,
-                false));
+                "Queue Manager"));
   }
 
   @Test
@@ -47,20 +41,31 @@ class LegacyAdminSurfaceTest {
     assertThrows(
         IllegalArgumentException.class,
         () ->
-            new LegacyAdminSurface(
+            surface(
                 "queue",
                 "Queue",
                 "/downloads/",
                 LegacyAdminRetirementState.PRIMARY_REPLACED,
                 "//example.test/apps/queue-manager/",
-                "Queue Manager",
-                "notes",
-                true,
-                false));
+                "Queue Manager"));
   }
 
   @Test
   void rendersNotice_whenPrimaryReplacedWithReplacement_expectTrue() {
+    LegacyAdminSurface surface =
+        surface(
+            "queue",
+            "Queue",
+            "/downloads/",
+            LegacyAdminRetirementState.PRIMARY_REPLACED,
+            "/apps/queue-manager/",
+            "Queue Manager");
+
+    assertTrue(surface.rendersNotice());
+  }
+
+  @Test
+  void rendersNotice_whenPrimaryReplacedRemovedByDefault_expectFalse() {
     LegacyAdminSurface surface =
         new LegacyAdminSurface(
             "queue",
@@ -70,25 +75,26 @@ class LegacyAdminSurfaceTest {
             "/apps/queue-manager/",
             "Queue Manager",
             "notes",
+            LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT,
+            1,
+            "phase-6-pr-8",
+            "none",
             true,
             false);
 
-    assertTrue(surface.rendersNotice());
+    assertFalse(surface.rendersNotice());
   }
 
   @Test
   void rendersNotice_whenPrimaryReplacedWithoutReplacement_expectFalse() {
     LegacyAdminSurface surface =
-        new LegacyAdminSurface(
+        surface(
             "queue",
             "Queue",
             "/downloads/",
             LegacyAdminRetirementState.PRIMARY_REPLACED,
             null,
-            null,
-            "notes",
-            true,
-            false);
+            null);
 
     assertFalse(surface.rendersNotice());
   }
@@ -96,17 +102,37 @@ class LegacyAdminSurfaceTest {
   @Test
   void rendersNotice_whenPendingWithReplacement_expectFalse() {
     LegacyAdminSurface surface =
-        new LegacyAdminSurface(
+        surface(
             "wizard",
             "Wizard",
             "/wizard/",
             LegacyAdminRetirementState.PENDING,
             "/app/node/#wizard",
-            "Web Shell wizard",
-            "notes",
-            true,
-            false);
+            "Web Shell wizard");
 
     assertFalse(surface.rendersNotice());
+  }
+
+  private static LegacyAdminSurface surface(
+      String id,
+      String title,
+      String legacyPath,
+      LegacyAdminRetirementState state,
+      String replacementUrl,
+      String replacementLabel) {
+    return new LegacyAdminSurface(
+        id,
+        title,
+        legacyPath,
+        state,
+        replacementUrl,
+        replacementLabel,
+        "notes",
+        LegacyAdminRemovalMode.RENDER_LEGACY,
+        0,
+        null,
+        "render-legacy",
+        true,
+        false);
   }
 }

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminUsageRecorderTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminUsageRecorderTest.java
@@ -22,9 +22,52 @@ class LegacyAdminUsageRecorderTest {
 
     LegacyAdminSurfaceUsage usage = usage(recorder.snapshot(), "queue-downloads");
     assertEquals(2L, usage.count());
+    assertEquals(0L, usage.replacementResponseCount());
+    assertEquals(0L, usage.blockedMutatingRequestCount());
+    assertEquals(2L, usage.fallbackRenderCount());
+    assertEquals(0L, usage.retainedOrPendingRenderCount());
     assertEquals(1_770_000_000_000L, usage.lastSeenEpochMillis());
     assertEquals(LegacyAdminRetirementState.PRIMARY_REPLACED.name(), usage.state());
     assertEquals("/apps/queue-manager/", usage.replacementUrl());
+    assertEquals(LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT.name(), usage.removalMode());
+    assertEquals(1, usage.removalWave());
+    assertEquals("phase-6-pr-8", usage.removedByDefaultSince());
+    assertEquals("none", usage.fallbackPolicy());
+  }
+
+  @Test
+  void recordSurface_whenRemovalEventsRecorded_expectSeparateCounters() {
+    LegacyAdminUsageRecorder recorder =
+        new LegacyAdminUsageRecorder(
+            Clock.fixed(Instant.ofEpochMilli(1_770_000_000_000L), ZoneOffset.UTC));
+    LegacyAdminSurface downloads = LegacyAdminRetirementRegistry.require("queue-downloads");
+
+    recorder.recordSurface(downloads, LegacyAdminUsageEvent.REPLACEMENT_RESPONSE);
+    recorder.recordSurface(downloads, LegacyAdminUsageEvent.BLOCKED_MUTATING_REQUEST);
+
+    LegacyAdminSurfaceUsage usage = usage(recorder.snapshot(), "queue-downloads");
+    assertEquals(0L, usage.count());
+    assertEquals(1L, usage.replacementResponseCount());
+    assertEquals(1L, usage.blockedMutatingRequestCount());
+    assertEquals(0L, usage.fallbackRenderCount());
+    assertEquals(0L, usage.retainedOrPendingRenderCount());
+    assertEquals(1_770_000_000_000L, usage.lastSeenEpochMillis());
+  }
+
+  @Test
+  void recordSurface_whenRetainedRendered_expectRetainedOrPendingCounter() {
+    LegacyAdminUsageRecorder recorder =
+        new LegacyAdminUsageRecorder(
+            Clock.fixed(Instant.ofEpochMilli(1_770_000_000_000L), ZoneOffset.UTC));
+
+    recorder.recordSurface(LegacyAdminRetirementRegistry.require("help"));
+
+    LegacyAdminSurfaceUsage usage = usage(recorder.snapshot(), "help");
+    assertEquals(1L, usage.count());
+    assertEquals(0L, usage.replacementResponseCount());
+    assertEquals(0L, usage.blockedMutatingRequestCount());
+    assertEquals(0L, usage.fallbackRenderCount());
+    assertEquals(1L, usage.retainedOrPendingRenderCount());
   }
 
   @Test
@@ -38,6 +81,10 @@ class LegacyAdminUsageRecorderTest {
 
     LegacyAdminSurfaceUsage diagnostic = usage(recorder.snapshot(), "diagnostic");
     assertEquals(0L, diagnostic.count());
+    assertEquals(0L, diagnostic.replacementResponseCount());
+    assertEquals(0L, diagnostic.blockedMutatingRequestCount());
+    assertEquals(0L, diagnostic.fallbackRenderCount());
+    assertEquals(0L, diagnostic.retainedOrPendingRenderCount());
     assertEquals(0L, diagnostic.lastSeenEpochMillis());
   }
 

--- a/docs/cryptad-release-workflow-and-runbook.md
+++ b/docs/cryptad-release-workflow-and-runbook.md
@@ -94,12 +94,14 @@ Treat these as release blockers, in order:
    apply, durable previous-bundle rollback, and the rule that rollback does not restore app data or
    cache. Optional live smoke may exercise install/update/rollback through localhost routes, but
    normal release-candidate evidence must not require a live node.
-11. **Legacy-admin retirement evidence** - record the current retirement map and diagnostics shape
-   before any release promotion. The certification report must include primary-replaced, retained,
-   and pending surface counts, confirm primary-replaced surfaces are absent from Web Shell fallback
-   navigation, and confirm direct fallback URLs remain documented. Optional live evidence may read
-   `GET /api/v1/diagnostics`; those counters are process-local and are not durable audit logs. The
-   retirement source of truth is [legacy-retirement-plan.md](legacy-retirement-plan.md).
+11. **Legacy-admin retirement evidence** - record the current retirement map, removal-wave policy,
+   and diagnostics shape before any release promotion. The certification report must include
+   primary-replaced, retained, and pending surface counts, confirm primary-replaced surfaces are
+   absent from Web Shell fallback navigation, prove `legacy-admin.removal-wave-1` replacement and
+   blocked-mutation behavior, and confirm retained/pending legacy routes remain documented.
+   Optional live evidence may read `GET /api/v1/diagnostics`; those counters are process-local and
+   are not durable audit logs. The retirement source of truth is
+   [legacy-retirement-plan.md](legacy-retirement-plan.md).
 12. **Hyphanet interop Tier 1 smoke** - run the packaged-node compatibility smoke locally on Linux
    when the environment is prepared, or verify that the CI `interop-smoke` job passed for the
    release candidate. The gate is documented in

--- a/docs/legacy-http-boundary.md
+++ b/docs/legacy-http-boundary.md
@@ -42,18 +42,23 @@ the platform leaves own installed-app lookup, UI-mode interpretation, path norma
 types, and static asset confinement.
 
 Legacy admin retirement metadata also stays in `:adapter-http-legacy-admin`. The registry records
-which admin pages are primary-replaced, pending, retained, or infrastructure, renders fallback
-notices for replaced pages, and feeds process-local usage counters into Platform API diagnostics.
+which admin pages are primary-replaced, pending, retained, or infrastructure, and it now carries a
+separate removal policy for the current execution wave. Retirement state describes product
+ownership; removal mode decides whether the request dispatcher renders the legacy toadlet, returns
+a replacement redirect, returns a gone-with-replacement page, or blocks a mutating legacy request.
 The retirement plan is documented in [legacy-retirement-plan.md](legacy-retirement-plan.md).
-PR-211 consumes the existing registry rather than replacing it: `PRIMARY_REPLACED` pages are hidden
-from legacy navigation, while their toadlets remain registered so direct fallback and debug URLs
-continue to work. `RETAINED` browse/FProxy surfaces and `PENDING` admin routes stay in their current
-legacy entry points until a later batch proves a complete replacement. Shell-backed category roots
-only use Web Shell targets while that shell is the advertised primary UI; JavaScript-disabled
-sessions keep direct legacy fallback roots. The app-backed Queue category uses the Queue Manager
-route only when the app UI is installed and usable for the current request; otherwise it keeps the
-legacy downloads root as the category fallback only for clients that would already see legacy queue
-navigation. Public-gateway non-full sessions keep the Queue category hidden.
+Wave 1, reported as `legacy-admin.removal-wave-1` in release certification, redirects safe reads
+for `/downloads/`, `/uploads/`, `/insertfile/`, `/insert-browse/`, `/friends/`, `/addfriend/`,
+`/strangers/`, and `/connectivity/` to their Web Shell or first-party app replacements and blocks
+mutating requests before old handlers run when those replacements are reachable for the current
+request. Queue Manager and Publisher redirects require full operator access, enabled FProxy
+JavaScript, and an installed static app UI; Web Shell redirects require full operator access and
+Web Shell to be the advertised primary UI. If those checks fail, legacy fallbacks continue to
+render and are counted as fallback usage. `RETAINED` browse/FProxy surfaces and `PENDING` admin
+routes stay in their current legacy entry points until a later batch proves a complete replacement.
+Queue and Friends category roots no longer use wave-1 legacy URLs as normal fallbacks. Status and
+Config retain their later-wave fallbacks in this batch because alerts, security levels, core
+updates, stats, diagnostics, and config routes are not removed by default yet.
 
 Production code outside `:adapter-http-legacy-admin`, `:adapter-http-legacy-browse`, and
 `:bridge-http-runtime` should keep depending on runtime-owned seams, `:platform-api`, or

--- a/docs/legacy-retirement-plan.md
+++ b/docs/legacy-retirement-plan.md
@@ -5,18 +5,19 @@ first-party app replacements.
 
 ## Scope
 
-PR-200 created the replacement map. PR-211 uses that existing map to hide `PRIMARY_REPLACED`
-admin pages from legacy navigation, but it does not create a new retirement model and does not
-delete legacy pages, remove FProxy browse, change FCP, or change network compatibility. Direct
-legacy URLs remain reachable for fallback, debug, and deep links until later PRs prove that removal
-is safe.
+PR-200 created the replacement map. PR-211 used that map to hide `PRIMARY_REPLACED` admin pages
+from primary legacy navigation. Phase 6 PR-8, tracked in release certification as
+`legacy-admin.removal-wave-1`, starts the first small execution-policy wave: selected already
+replaced legacy admin page routes no longer render the old page by default. They return a
+replacement redirect for safe reads or a gone-with-replacement response for mutating requests.
 
-FProxy browse and content-rendering surfaces are explicitly retained. The browse split under
+FProxy browse remains retained. FProxy browse and content-rendering surfaces are explicitly
+retained. The browse split under
 `:adapter-http-legacy-browse` remains outside deletion scope for this plan.
 
-Pending routes also remain pending in this batch. They stay reachable through direct URLs and any
-explicit fallback entry points until their Web Shell or app replacements are complete enough to
-retire the legacy path.
+Retained and pending legacy routes remain reachable in this batch. They stay available through
+direct URLs and any explicit fallback entry points until their Web Shell or app replacements are
+complete enough to retire the legacy path.
 
 ## Retirement states
 
@@ -27,6 +28,47 @@ retire the legacy path.
 | `RETAINED` | The legacy surface is intentionally kept as long-term functionality, such as FProxy browse or browse-adjacent tools. |
 | `PENDING` | No complete replacement is proven yet. Do not show a strong replacement notice. |
 | `INFRASTRUCTURE` | The route supports other pages and is not a standalone user-facing page. |
+
+## Removal modes
+
+Retirement state is the product/status map. Removal mode is the current execution policy in the
+legacy HTTP adapter. Do not infer removal from `PRIMARY_REPLACED`: several primary-replaced
+surfaces remain renderable until later waves.
+
+| Mode | Current behavior |
+| --- | --- |
+| `RENDER_LEGACY` | The route still invokes the legacy toadlet. Primary-replaced pages in this mode render the non-blocking replacement notice. |
+| `REDIRECT_TO_REPLACEMENT` | When the replacement is available for the current request, `GET` and `HEAD` for the canonical page path return `303 See Other` with a safe same-origin replacement URL. Mutating requests return `410 Gone` and do not execute legacy behavior. If the replacement is unavailable, the legacy fallback remains reachable. |
+| `GONE_WITH_REPLACEMENT` | When the replacement is available for the current request, safe reads return a small `410 Gone` page with a replacement link and mutating requests are blocked. If the replacement is unavailable, the legacy fallback remains reachable. |
+| `RETAINED` | The route is retained long-term and renders normally. |
+| `PENDING` | The route remains reachable because a complete replacement is not proven. |
+| `INFRASTRUCTURE` | The route supports another flow and is not treated as a standalone page-removal target. |
+
+## Removal wave 1
+
+Wave 1 applies removal-by-default only to canonical page paths and their slashless aliases when the
+replacement is reachable for the current request. Queue Manager and Publisher redirects require
+full operator access, enabled FProxy JavaScript, and an installed static app UI. Web Shell peer and
+connectivity redirects require full operator access and Web Shell to be the advertised primary UI.
+If those availability checks fail, the same legacy pages remain reachable as compatibility
+fallbacks and diagnostics count them as fallback renders. Helper subpaths are left untouched unless
+a later wave documents them explicitly. No temporary debug fallback flag is implemented in this
+wave.
+
+| Legacy route | Surface id | Safe read behavior | Mutating behavior | Replacement |
+| --- | --- | --- | --- | --- |
+| `/downloads/` | `queue-downloads` | `303 See Other` when Queue Manager is available; otherwise legacy fallback | `410 Gone` when Queue Manager is available; otherwise legacy fallback | `/apps/queue-manager/` |
+| `/uploads/` | `queue-uploads` | `303 See Other` when Queue Manager is available; otherwise legacy fallback | `410 Gone` when Queue Manager is available; otherwise legacy fallback | `/apps/queue-manager/` |
+| `/insertfile/` | `file-insert` | `303 See Other` when Publisher is available; otherwise legacy fallback | `410 Gone` when Publisher is available; otherwise legacy fallback | `/apps/publisher/` |
+| `/insert-browse/` | `local-file-insert` | `303 See Other` when Publisher is available; otherwise legacy fallback | `410 Gone` when Publisher is available; otherwise legacy fallback | `/apps/publisher/` |
+| `/friends/` | `friends` | `303 See Other` when Web Shell is available; otherwise legacy fallback | `410 Gone` when Web Shell is available; otherwise legacy fallback | `/app/node/#peers` |
+| `/addfriend/` | `add-friend` | `303 See Other` when Web Shell is available; otherwise legacy fallback | `410 Gone` when Web Shell is available; otherwise legacy fallback | `/app/node/#peers` |
+| `/strangers/` | `strangers` | `303 See Other` when Web Shell is available; otherwise legacy fallback | `410 Gone` when Web Shell is available; otherwise legacy fallback | `/app/node/#peers` |
+| `/connectivity/` | `connectivity` | `303 See Other` when Web Shell is available; otherwise legacy fallback | `410 Gone` when Web Shell is available; otherwise legacy fallback | `/app/node/#connectivity` |
+
+`/alerts/` is not part of wave 1. Alert startup and error-display flows are entangled enough that
+this wave leaves the legacy alert page in `RENDER_LEGACY` mode while Web Shell alerts remain the
+primary path.
 
 ## Current map
 
@@ -39,7 +81,7 @@ retire the legacy path.
 | Download queue | `/downloads/` | `PRIMARY_REPLACED` | Queue Manager at `/apps/queue-manager/`; Web Shell queue remains a fallback panel. |
 | Upload queue | `/uploads/` | `PRIMARY_REPLACED` | Queue Manager at `/apps/queue-manager/`; Publisher covers insert creation. |
 | File insert wizard | `/insertfile/` | `PRIMARY_REPLACED` | Publisher at `/apps/publisher/`. |
-| Local upload file browser | `/insert-browse/` | `PRIMARY_REPLACED` | Publisher at `/apps/publisher/`; legacy route remains for old upload forms. |
+| Local upload file browser | `/insert-browse/` | `PRIMARY_REPLACED` | Publisher at `/apps/publisher/`; canonical page redirects in wave 1 while helper subpaths remain untouched. |
 | Friends | `/friends/` | `PRIMARY_REPLACED` | Web Shell peer control at `/app/node/#peers`. |
 | Add friend | `/addfriend/` | `PRIMARY_REPLACED` | Web Shell peer control at `/app/node/#peers`. |
 | Strangers / opennet peers | `/strangers/` | `PRIMARY_REPLACED` | Web Shell peer control at `/app/node/#peers`. |
@@ -69,22 +111,22 @@ updates, alerts, diagnostics, installed apps, and first-time setup controls wher
 allows it. Queue Manager and Publisher are app-owned static UIs under `/apps/queue-manager/` and
 `/apps/publisher/`.
 
-Replaced legacy admin pages render a non-blocking notice that says the page remains available as a
-fallback/debug view and links to the Web Shell or first-party app replacement.
+Primary-replaced legacy admin pages that are not removed by default still render a non-blocking
+notice that links to the Web Shell or first-party app replacement. Wave-1 pages do not render that
+notice by default because the central request gate returns the replacement response before the
+legacy toadlet is invoked.
 
-PR-211 no longer treats replaced legacy admin pages as legacy navigation targets. `PRIMARY_REPLACED`
-pages are omitted from the Web Shell legacy-link panel and from legacy page-chrome entry points
-when a Web Shell or first-party app path is now primary. The underlying legacy routes still exist,
-so bookmarked or manually entered fallback/debug URLs continue to render the legacy page and its
-replacement notice.
+`PRIMARY_REPLACED` pages are omitted from the Web Shell legacy-link panel and from legacy
+page-chrome entry points when a Web Shell or first-party app path is now primary. Wave-1 canonical
+URLs now return replacement responses instead of rendering the old page. Later-wave
+primary-replaced URLs still render the legacy page and replacement notice until a future removal
+wave changes their execution mode.
 
-The legacy top-level Queue, Friends, Status, and Config category roots prefer
-`/apps/queue-manager/`, `/app/node/#peers`, `/app/node/`, and `/app/node/#config` instead of
-legacy primary-replaced pages. The Queue root falls back to `/downloads/` when Queue Manager is not
-installed or the app route is not usable for the current client, but only for clients that would
-already see legacy queue navigation. Public-gateway non-full sessions keep the Queue category
-hidden. Shell-backed category roots still render direct legacy fallback URLs when Web Shell is not
-the advertised primary UI, such as JavaScript-disabled FProxy sessions.
+The legacy top-level Queue and Friends category roots no longer fall back to `/downloads/` or
+`/friends/` as normal navigation. Queue is shown only when Queue Manager is installed, static, and
+usable for the current full-access browser session. Friends is shown only while Web Shell is the
+advertised primary UI. Status and Config retain their later-wave fallbacks in this batch because
+`/alerts/`, `/seclevels/`, and related flows are not part of wave 1.
 
 Retained browse/FProxy surfaces and `PENDING` admin routes are unchanged by this batch. They remain
 available as legacy entry points until a later PR proves a complete replacement and documents the
@@ -98,7 +140,10 @@ Legacy admin page visits are counted in memory for known admin surfaces. The rec
 - Legacy path.
 - Retirement state.
 - Replacement URL when one exists.
+- Removal mode, removal wave, removed-by-default marker, and fallback policy.
 - Process-local count.
+- Replacement-response, blocked-mutating-request, fallback-render, and retained/pending-render
+  counters.
 - Latest observed timestamp in epoch milliseconds.
 
 It does not store query strings, form data, tokens, peer references, Freenet/Crypta URIs,
@@ -116,7 +161,15 @@ filesystem paths, request bodies, or remote addresses.
         "path": "/downloads/",
         "state": "PRIMARY_REPLACED",
         "replacementUrl": "/apps/queue-manager/",
-        "count": 12,
+        "removalMode": "REDIRECT_TO_REPLACEMENT",
+        "removalWave": 1,
+        "removedByDefaultSince": "phase-6-pr-8",
+        "fallbackPolicy": "none",
+        "count": 0,
+        "replacementResponseCount": 12,
+        "blockedMutatingRequestCount": 1,
+        "fallbackRenderCount": 0,
+        "retainedOrPendingRenderCount": 0,
         "lastSeenEpochMillis": 1770000000000
       }
     ]

--- a/docs/platform-api-surface.md
+++ b/docs/platform-api-surface.md
@@ -190,9 +190,11 @@ The shell currently includes these first-party panels and surfaces:
 - Publisher and Queue Manager open as independent first-party app UIs when installed.
 - Publisher local file/directory insert workflow and queue control remain available in the shell as
   fallback operator panels.
-- Legacy links for pages that remain fallback or debug surfaces.
-- Replaced legacy admin pages are not primary shell navigation targets; their current retirement
-  state is tracked in [legacy-retirement-plan.md](legacy-retirement-plan.md).
+- Legacy links for retained or pending tools that remain legitimate legacy entry points.
+- Replaced legacy admin pages are not primary shell navigation targets. The first removal wave now
+  returns replacement responses for selected canonical admin URLs instead of rendering the old
+  pages by default; the current state and wave list are tracked in
+  [legacy-retirement-plan.md](legacy-retirement-plan.md).
 
 The shell is hosted by `:adapter-http-legacy-admin`, but its route constants, HTML template, CSS,
 JavaScript, and bootstrap model are owned by `:platform-web-shell`.
@@ -201,10 +203,16 @@ JavaScript, and bootstrap model are owned by `:platform-web-shell`.
 
 Platform API v1 does not replace legacy HTTP or FCP in the current platform work.
 
-Legacy HTTP remains the current transport and authentication boundary for `/api/v1/` and
-`/app/node/`. The shared admin shell, admin toadlets, updater actions, and fallback pages remain in
+Legacy HTTP remains the current transport and authentication boundary for `/api/v1/`,
+`/app/node/`, and `/apps/{appId}/`. The shared admin shell, retained and pending admin toadlets,
+updater actions that are not in the current removal wave, and replacement-response gate remain in
 `:adapter-http-legacy-admin`; concrete browse/FProxy routes remain in
 `:adapter-http-legacy-browse`; concrete runtime HTTP bindings remain in `:bridge-http-runtime`.
+Wave-1 admin URLs return `303 See Other` for safe reads or `410 Gone` for mutating requests with a
+same-origin replacement link when the replacement UI is reachable for the current request. If the
+replacement app is not installed, FProxy JavaScript is disabled, or Web Shell is not the advertised
+primary UI, the legacy fallback remains reachable and diagnostics record fallback rendering. FProxy
+browse remains retained and is not owned by Platform API v1.
 
 FCP remains a separate compatibility and automation protocol. The detached FCP protocol surface is
 owned by `:adapter-fcp`, and runtime bindings are owned by `:bridge-fcp-runtime`. The Platform API

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -89,13 +89,24 @@ Release-candidate mode requires these evidence ids:
 | `app-ui.lint` | App-platform smoke summary. | `crypta-app ui lint --strict --json` passed for first-party staged static UI bundles and produced sanitized path-free summaries. |
 | `app-ui.first-party-adoption` | App-platform smoke summary. | Queue Manager and Publisher source/staged UIs load design-system CSS in order, use stable `cr-*` classes, and show permission disclosure for declared permissions. |
 | `app-ui.smoke` | App-platform smoke summary. | First-party static UI and `crypta-platform.js` remain coherent and do not expose process-token names. |
-| `legacy.retirement` | App-platform smoke summary. | The legacy-admin retirement registry is visible, counts are stable, replaced surfaces are absent from primary shell fallback links, and direct fallback URLs remain documented. |
+| `legacy.retirement` | App-platform smoke summary. | The legacy-admin retirement registry is visible, counts are stable, replaced surfaces are absent from primary shell fallback links, and retained/pending legacy routes remain documented. |
+| `legacy-admin.removal-wave-1` | App-platform smoke summary. | The first removal wave records the removed-by-default route ids, replacement URLs, safe-read redirect behavior, mutating-request block behavior, retained browse status, diagnostics counters, and redaction checks without requiring a live node. |
 | `apphost.sandbox-provider` | App-platform smoke summary. | AppHost sandbox provider source and deterministic offline tests prove bubblewrap selection, enforced status reporting, fail-closed required sandbox behavior, and token/path-free public status. |
 | `app-update.lifecycle` | App-platform smoke summary. | Offline source and test evidence proves manual/stage/apply-when-stopped update policy, candidate detection semantics, compatibility/review/permission gates, and process health-gated apply behavior. |
 | `app-update.rollback` | App-platform smoke summary. | Offline source and test evidence proves durable installed-bundle backup/restore behavior and confirms rollback is scoped to the immutable bundle, not app data/cache/run state. |
 | `app-review.trusted-receipts` | App-platform smoke summary. | Offline source and test evidence proves signed review receipts, canonical payload verification, reviewer-key trust, rejection handling, and publisher-advisory-only fallback behavior. |
 | `app-review.policy` | App-platform smoke summary. | Review policy evidence proves `advisory`, `warn_untrusted`, `require_trusted_review`, and `require_trusted_review_for_apply_when_stopped` modes are present and fail closed. |
 | `app-review.first-party-catalog` | App-platform smoke summary. | First-party catalog evidence signs, verifies, and embeds an independent review receipt with configured reviewer inputs, without private reviewer key material in the report. |
+
+`legacy-admin.removal-wave-1` is deterministic offline evidence. It proves that `/downloads/`,
+`/uploads/`, `/insertfile/`, `/insert-browse/`, `/friends/`, `/addfriend/`, `/strangers/`, and
+`/connectivity/` are removed by default when their replacements are reachable, that `GET` and
+`HEAD` return replacement responses in that state, that mutating methods are blocked before legacy
+handlers execute in that state, that unavailable replacements fall back to legacy rendering with
+fallback diagnostics, that FProxy browse remains retained, and that diagnostics expose aggregate
+counters without query strings, form data, file paths, peer refs, Freenet/Crypta URIs, tokens,
+request bodies, or remote addresses. Optional live-node checks may record status codes for the
+same routes, but normal PR and release-candidate certification do not require a live node.
 
 `interop.extended` is optional in the machine gate but required by the release runbook when a
 release changes compatibility-sensitive behavior. `apphost.sandbox-provider` does not require

--- a/platform-api/src/main/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandler.java
@@ -96,13 +96,21 @@ public final class DiagnosticsApiHandler {
   }
 
   private static Map<String, Object> legacySurfaceUsageToJson(LegacyAdminSurfaceUsage surface) {
-    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(14);
     json.put("id", surface.surfaceId());
     json.put("title", surface.title());
     json.put("path", surface.legacyPath());
     json.put("state", surface.state());
     json.put("replacementUrl", surface.replacementUrl());
+    json.put("removalMode", surface.removalMode());
+    json.put("removalWave", surface.removalWave());
+    json.put("removedByDefaultSince", surface.removedByDefaultSince());
+    json.put("fallbackPolicy", surface.fallbackPolicy());
     json.put("count", surface.count());
+    json.put("replacementResponseCount", surface.replacementResponseCount());
+    json.put("blockedMutatingRequestCount", surface.blockedMutatingRequestCount());
+    json.put("fallbackRenderCount", surface.fallbackRenderCount());
+    json.put("retainedOrPendingRenderCount", surface.retainedOrPendingRenderCount());
     json.put("lastSeenEpochMillis", surface.lastSeenEpochMillis());
     return json;
   }

--- a/platform-api/src/test/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandlerTest.java
@@ -60,21 +60,22 @@ class DiagnosticsApiHandlerTest {
     List<Map<String, Object>> surfaces =
         (List<Map<String, Object>>) legacyAdmin(response).get("surfaces");
     assertEquals(
-        Map.of(
-            "id",
-            "queue-downloads",
-            TITLE_FIELD,
-            "Download queue",
-            "path",
-            "/downloads/",
-            "state",
-            "PRIMARY_REPLACED",
-            "replacementUrl",
-            "/apps/queue-manager/",
-            "count",
-            12L,
-            "lastSeenEpochMillis",
-            1_770_000_000_000L),
+        Map.ofEntries(
+            Map.entry("id", "queue-downloads"),
+            Map.entry(TITLE_FIELD, "Download queue"),
+            Map.entry("path", "/downloads/"),
+            Map.entry("state", "PRIMARY_REPLACED"),
+            Map.entry("replacementUrl", "/apps/queue-manager/"),
+            Map.entry("removalMode", "REDIRECT_TO_REPLACEMENT"),
+            Map.entry("removalWave", 1),
+            Map.entry("removedByDefaultSince", "phase-6-pr-8"),
+            Map.entry("fallbackPolicy", "none"),
+            Map.entry("count", 12L),
+            Map.entry("replacementResponseCount", 4L),
+            Map.entry("blockedMutatingRequestCount", 1L),
+            Map.entry("fallbackRenderCount", 0L),
+            Map.entry("retainedOrPendingRenderCount", 0L),
+            Map.entry("lastSeenEpochMillis", 1_770_000_000_000L)),
         surfaces.getFirst());
   }
 
@@ -91,7 +92,15 @@ class DiagnosticsApiHandlerTest {
                             "/downloads/",
                             "PRIMARY_REPLACED",
                             "/apps/queue-manager/",
+                            "REDIRECT_TO_REPLACEMENT",
+                            1,
+                            "phase-6-pr-8",
+                            "none",
                             12L,
+                            4L,
+                            1L,
+                            0L,
+                            0L,
                             1_770_000_000_000L))));
     return handler.snapshot();
   }

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/index.html
@@ -24,7 +24,7 @@
           <a class="button button-secondary" href="#publisher">Publisher</a>
           <a class="button button-secondary" href="/api/v1/alerts">Alerts JSON</a>
           <a class="button button-secondary" href="/api/v1/diagnostics">Diagnostics JSON</a>
-          <a class="button button-secondary" href="/">Legacy root</a>
+          <a class="button button-secondary" href="/">FProxy browse root</a>
         </div>
       </header>
 
@@ -134,8 +134,9 @@
             <h2>Threat levels</h2>
           </div>
           <p class="panel-description">
-            Review and adjust the node threat levels from the shell. Legacy warning-heavy and
-            password-management flows remain available through the legacy page when needed.
+            Review and adjust the node threat levels from the shell. Warning-heavy and
+            password-management flows that still need legacy support remain outside the first
+            removal wave.
           </p>
           <div class="queue-status" id="security-status" aria-live="polite"></div>
           <p class="panel-description" hidden id="security-readonly-hint">
@@ -599,7 +600,8 @@
         </div>
         <p class="panel-description">
           Detached queue snapshots come from Platform API v1. Supported queue actions stay in the
-          shell and unsupported legacy-only controls can still fall back to the historical pages.
+          shell and first-party Queue Manager; removed legacy queue pages now return replacement
+          responses by default.
         </p>
         <div class="queue-toolbar">
           <div class="toggle-group" aria-label="Queue page">
@@ -651,7 +653,7 @@
       <section class="panel panel-wide" id="legacy-panel">
         <div class="panel-header">
           <p class="panel-kicker">Legacy tools</p>
-          <h2>Fallback and retained legacy pages</h2>
+          <h2>Retained and pending legacy tools</h2>
         </div>
         <p class="panel-description">
           Retained browse-adjacent tools and pending migration gaps stay reachable here. Replaced

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -28,7 +28,7 @@ class WebShellResourcesTest {
         "First-time setup",
         "Installed apps",
         "Publisher fallback panel",
-        "Fallback and retained legacy pages",
+        "Retained and pending legacy tools",
         "Installed apps JSON",
         "Alerts JSON",
         "Diagnostics JSON",

--- a/runtime-spi/src/main/java/network/crypta/runtime/spi/LegacyAdminSurfaceUsage.java
+++ b/runtime-spi/src/main/java/network/crypta/runtime/spi/LegacyAdminSurfaceUsage.java
@@ -26,7 +26,20 @@ import java.util.Objects;
  * @param state retirement state name assigned to the surface by the HTTP adapter
  * @param replacementUrl same-origin replacement Web Shell or app URL, or {@code null} when none is
  *     declared
+ * @param removalMode current execution/removal mode assigned by the HTTP adapter
+ * @param removalWave first removal wave number, or {@code 0} when the surface is not removed by
+ *     default
+ * @param removedByDefaultSince stable release/phase marker, or {@code null} when not removed by
+ *     default
+ * @param fallbackPolicy path-free description of temporary fallback behavior
  * @param count number of observed visits since process start
+ * @param replacementResponseCount number of redirect or gone-with-replacement responses since
+ *     process start
+ * @param blockedMutatingRequestCount number of removed legacy mutating requests blocked before old
+ *     behavior could execute
+ * @param fallbackRenderCount number of temporary legacy fallback renderings since process start
+ * @param retainedOrPendingRenderCount number of retained or pending legacy responses since process
+ *     start
  * @param lastSeenEpochMillis last observed visit timestamp in epoch milliseconds, or {@code 0} when
  *     no visit has been recorded
  */
@@ -36,7 +49,15 @@ public record LegacyAdminSurfaceUsage(
     String legacyPath,
     String state,
     String replacementUrl,
+    String removalMode,
+    int removalWave,
+    String removedByDefaultSince,
+    String fallbackPolicy,
     long count,
+    long replacementResponseCount,
+    long blockedMutatingRequestCount,
+    long fallbackRenderCount,
+    long retainedOrPendingRenderCount,
     long lastSeenEpochMillis) {
   /**
    * Creates an immutable legacy-admin usage entry.
@@ -54,8 +75,31 @@ public record LegacyAdminSurfaceUsage(
     Objects.requireNonNull(title, "title");
     Objects.requireNonNull(legacyPath, "legacyPath");
     Objects.requireNonNull(state, "state");
+    Objects.requireNonNull(removalMode, "removalMode");
+    Objects.requireNonNull(fallbackPolicy, "fallbackPolicy");
+    if (removedByDefaultSince != null && removedByDefaultSince.isBlank()) {
+      throw new IllegalArgumentException("removedByDefaultSince must not be blank");
+    }
+    if (fallbackPolicy.isBlank()) {
+      throw new IllegalArgumentException("fallbackPolicy must not be blank");
+    }
+    if (removalWave < 0) {
+      throw new IllegalArgumentException("removalWave must not be negative");
+    }
     if (count < 0) {
       throw new IllegalArgumentException("count must not be negative");
+    }
+    if (replacementResponseCount < 0) {
+      throw new IllegalArgumentException("replacementResponseCount must not be negative");
+    }
+    if (blockedMutatingRequestCount < 0) {
+      throw new IllegalArgumentException("blockedMutatingRequestCount must not be negative");
+    }
+    if (fallbackRenderCount < 0) {
+      throw new IllegalArgumentException("fallbackRenderCount must not be negative");
+    }
+    if (retainedOrPendingRenderCount < 0) {
+      throw new IllegalArgumentException("retainedOrPendingRenderCount must not be negative");
     }
     if (lastSeenEpochMillis < 0) {
       throw new IllegalArgumentException("lastSeenEpochMillis must not be negative");

--- a/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
+++ b/src/test/java/network/crypta/clients/http/FProxyRegistrarTest.java
@@ -58,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.inOrder;
@@ -135,7 +136,7 @@ class FProxyRegistrarTest {
             eq(LegacyAdminRetirementRegistry.require("queue-downloads").replacementUrl()),
             eq(LegacyHttpCategories.CATEGORY_QUEUE),
             eq("FProxyToadlet.categoryTitleQueue"),
-            eq(QueueToadlet.PATH_DOWNLOADS),
+            isNull(),
             eq(false),
             any(LinkEnabledCallback.class),
             any(LinkEnabledCallback.class));
@@ -144,7 +145,9 @@ class FProxyRegistrarTest {
             eq(LegacyAdminRetirementRegistry.require("friends").replacementUrl()),
             eq(LegacyHttpCategories.CATEGORY_FRIENDS),
             eq("FProxyToadlet.categoryTitleFriends"),
-            eq(LegacyHttpPaths.FRIENDS_PATH),
+            isNull(),
+            eq(true),
+            any(LinkEnabledCallback.class),
             any(LinkEnabledCallback.class));
     verify(server)
         .registerMenu("/chat/", "FProxyToadlet.categoryChat", "FProxyToadlet.categoryTitleChat");
@@ -285,7 +288,7 @@ class FProxyRegistrarTest {
   }
 
   @Test
-  void maybeCreateFProxyEtc_whenRegisteringShellCategoryRoots_providesLegacyFallbacks() {
+  void maybeCreateFProxyEtc_whenRegisteringShellCategoryRoots_hidesRemovedFallbacks() {
     AtomicReference<String> primaryRoot =
         new AtomicReference<>(LauncherReadinessInfo.DEFAULT_UI_ROOT);
     when(server.primaryUiRoot()).thenAnswer(ignored -> primaryRoot.get());
@@ -293,12 +296,7 @@ class FProxyRegistrarTest {
     FProxyRegistrar.maybeCreateFProxyEtc(
         dependencies(new LegacyFProxyBrowseRouteRegistrar(client)), server);
 
-    LinkEnabledCallback friendsCallback =
-        capturedCategoryRootCallback(
-            LegacyAdminRetirementRegistry.require("friends").replacementUrl(),
-            LegacyHttpCategories.CATEGORY_FRIENDS,
-            "FProxyToadlet.categoryTitleFriends",
-            LegacyHttpPaths.FRIENDS_PATH);
+    CategoryRootCallbacks friendsCallbacks = capturedFriendsCategoryRootCallbacks();
     LinkEnabledCallback statusCallback =
         capturedCategoryRootCallback(
             WebShellPaths.SHELL_ROOT,
@@ -312,13 +310,15 @@ class FProxyRegistrarTest {
             "FProxyToadlet.categoryTitleConfig",
             SecurityLevelsToadlet.PATH);
 
-    assertFalse(friendsCallback.isEnabled(null));
+    assertFalse(friendsCallbacks.primaryLinkEnabled().isEnabled(null));
+    assertFalse(friendsCallbacks.rootLinkEnabled().isEnabled(null));
     assertFalse(statusCallback.isEnabled(null));
     assertFalse(configCallback.isEnabled(null));
 
     primaryRoot.set(WebShellPaths.SHELL_ROOT);
 
-    assertTrue(friendsCallback.isEnabled(null));
+    assertTrue(friendsCallbacks.primaryLinkEnabled().isEnabled(null));
+    assertTrue(friendsCallbacks.rootLinkEnabled().isEnabled(null));
     assertTrue(statusCallback.isEnabled(null));
     assertTrue(configCallback.isEnabled(null));
   }
@@ -343,35 +343,30 @@ class FProxyRegistrarTest {
     when(container.isFProxyJavascriptEnabled()).thenReturn(true);
     installed.set(true);
     assertFalse(queueCallbacks.primaryLinkEnabled().isEnabled(ctx));
+    assertFalse(queueCallbacks.rootLinkEnabled().isEnabled(ctx));
 
     when(ctx.isAllowedFullAccess()).thenReturn(true);
     when(container.isFProxyJavascriptEnabled()).thenReturn(false);
     assertFalse(queueCallbacks.primaryLinkEnabled().isEnabled(ctx));
+    assertFalse(queueCallbacks.rootLinkEnabled().isEnabled(ctx));
 
     when(container.isFProxyJavascriptEnabled()).thenReturn(true);
     installed.set(false);
     assertFalse(queueCallbacks.primaryLinkEnabled().isEnabled(ctx));
+    assertFalse(queueCallbacks.rootLinkEnabled().isEnabled(ctx));
 
     installed.set(true);
     assertTrue(queueCallbacks.primaryLinkEnabled().isEnabled(ctx));
+    assertTrue(queueCallbacks.rootLinkEnabled().isEnabled(ctx));
 
     InstalledAppSnapshot queueManagerWithoutStaticUi = installedApp(AppUiMode.NONE);
     when(appHost.describe("queue-manager")).thenReturn(Optional.of(queueManagerWithoutStaticUi));
     assertFalse(queueCallbacks.primaryLinkEnabled().isEnabled(ctx));
+    assertFalse(queueCallbacks.rootLinkEnabled().isEnabled(ctx));
 
     when(appHost.describe("queue-manager")).thenThrow(new IOException("boom"));
     assertFalse(queueCallbacks.primaryLinkEnabled().isEnabled(ctx));
-
-    when(ctx.isAllowedFullAccess()).thenReturn(false);
-    when(container.publicGatewayMode()).thenReturn(true);
     assertFalse(queueCallbacks.rootLinkEnabled().isEnabled(ctx));
-
-    when(container.publicGatewayMode()).thenReturn(false);
-    assertTrue(queueCallbacks.rootLinkEnabled().isEnabled(ctx));
-
-    when(container.publicGatewayMode()).thenReturn(true);
-    when(ctx.isAllowedFullAccess()).thenReturn(true);
-    assertTrue(queueCallbacks.rootLinkEnabled().isEnabled(ctx));
   }
 
   @Test
@@ -456,7 +451,7 @@ class FProxyRegistrarTest {
             eq(LegacyAdminRetirementRegistry.require("queue-downloads").replacementUrl()),
             eq(LegacyHttpCategories.CATEGORY_QUEUE),
             eq("FProxyToadlet.categoryTitleQueue"),
-            eq(QueueToadlet.PATH_DOWNLOADS),
+            isNull(),
             eq(false),
             any(LinkEnabledCallback.class),
             any(LinkEnabledCallback.class));
@@ -657,6 +652,24 @@ class FProxyRegistrarTest {
     return callbackCaptor.getValue();
   }
 
+  private CategoryRootCallbacks capturedFriendsCategoryRootCallbacks() {
+    ArgumentCaptor<LinkEnabledCallback> primaryCallbackCaptor =
+        ArgumentCaptor.forClass(LinkEnabledCallback.class);
+    ArgumentCaptor<LinkEnabledCallback> rootCallbackCaptor =
+        ArgumentCaptor.forClass(LinkEnabledCallback.class);
+    verify(server)
+        .registerMenu(
+            eq(LegacyAdminRetirementRegistry.require("friends").replacementUrl()),
+            eq(LegacyHttpCategories.CATEGORY_FRIENDS),
+            eq("FProxyToadlet.categoryTitleFriends"),
+            isNull(),
+            eq(true),
+            primaryCallbackCaptor.capture(),
+            rootCallbackCaptor.capture());
+    return new CategoryRootCallbacks(
+        primaryCallbackCaptor.getValue(), rootCallbackCaptor.getValue());
+  }
+
   private CategoryRootCallbacks capturedQueueCategoryRootCallbacks() {
     ArgumentCaptor<LinkEnabledCallback> primaryCallbackCaptor =
         ArgumentCaptor.forClass(LinkEnabledCallback.class);
@@ -667,7 +680,7 @@ class FProxyRegistrarTest {
             eq(LegacyAdminRetirementRegistry.require("queue-downloads").replacementUrl()),
             eq(LegacyHttpCategories.CATEGORY_QUEUE),
             eq("FProxyToadlet.categoryTitleQueue"),
-            eq(QueueToadlet.PATH_DOWNLOADS),
+            isNull(),
             eq(false),
             primaryCallbackCaptor.capture(),
             rootCallbackCaptor.capture());

--- a/src/test/java/network/crypta/clients/http/PageMakerTest.java
+++ b/src/test/java/network/crypta/clients/http/PageMakerTest.java
@@ -257,7 +257,7 @@ class PageMakerTest {
     Toadlet directoryBrowser = mock(Toadlet.class);
     when(directoryBrowser.path()).thenReturn(LocalDirectoryToadlet.basePath());
     when(context.activeToadlet()).thenReturn(directoryBrowser);
-    lenient().when(context.getUri()).thenReturn(URI.create(QueueToadlet.PATH_DOWNLOADS));
+    lenient().when(context.getUri()).thenReturn(URI.create(LegacyHttpPaths.CONFIG_PATH));
 
     PageNode page =
         maker.getPageNode(
@@ -268,25 +268,25 @@ class PageMakerTest {
     String html = page.generate();
 
     assertFalse(html.contains("legacy-admin-retirement-notice"));
-    assertFalse(html.contains("Queue Manager app"));
+    assertFalse(html.contains("Web Shell config"));
   }
 
   @Test
   void getPageNode_whenActiveToadletMissingAndRequestUriIsReplaced_rendersNotice() {
     PageMaker maker = newPageMaker();
     stubPageRenderingContext(false);
-    when(context.getUri()).thenReturn(URI.create(QueueToadlet.PATH_DOWNLOADS));
+    when(context.getUri()).thenReturn(URI.create(LegacyHttpPaths.CONFIG_PATH));
 
     PageNode page =
         maker.getPageNode(
-            "Downloads",
+            "Configuration",
             context,
             new PageMaker.RenderParameters().renderNavigationLinks(false).renderModeSwitch(false));
 
     String html = page.generate();
 
     assertTrue(html.contains("legacy-admin-retirement-notice"));
-    assertTrue(html.contains("Queue Manager app"));
+    assertTrue(html.contains("Web Shell config"));
   }
 
   @Test
@@ -386,6 +386,65 @@ class PageMakerTest {
     String html = page.generate();
 
     assertTrue(html.contains("href=\"" + WebShellPaths.SHELL_ROOT + "#peers\""));
+  }
+
+  @Test
+  void getPageNode_whenCategoryRootDisabledButChildVisible_suppressesRootAnchor() {
+    PageMaker maker = newPageMaker();
+    stubPageRenderingContext(false);
+    maker.addNavigationCategory(
+        "/apps/queue-manager/",
+        "FProxyToadlet.categoryQueue",
+        "FProxyToadlet.categoryTitleQueue",
+        null,
+        false,
+        ignored -> false,
+        ignored -> false);
+    maker.addNavigationLink(
+        "FProxyToadlet.categoryQueue",
+        "/filterfile/",
+        "ContentFilterToadlet.filterFile",
+        "ContentFilterToadlet.filterFileTitle",
+        false,
+        null);
+
+    PageNode page =
+        maker.getPageNode(
+            "Navigation",
+            context,
+            new PageMaker.RenderParameters().renderStatus(false).renderModeSwitch(false));
+
+    String html = page.generate();
+
+    assertFalse(html.contains("href=\"/apps/queue-manager/\""));
+    assertTrue(html.contains("href=\"/filterfile/\""));
+  }
+
+  @Test
+  void getPageNode_whenNonFullUserHasVisibleChild_keepsFullOnlyCategoryRootClickable() {
+    PageMaker maker = newPageMaker();
+    stubPageRenderingContext(false);
+    when(context.isAllowedFullAccess()).thenReturn(false);
+    maker.addNavigationCategory(
+        "/", "FProxyToadlet.categoryBrowsing", "FProxyToadlet.categoryTitleBrowsing");
+    maker.addNavigationLink(
+        "FProxyToadlet.categoryBrowsing",
+        "/welcome/",
+        "WelcomeToadlet.name",
+        "WelcomeToadlet.title",
+        false,
+        null);
+
+    PageNode page =
+        maker.getPageNode(
+            "Navigation",
+            context,
+            new PageMaker.RenderParameters().renderStatus(false).renderModeSwitch(false));
+
+    String html = page.generate();
+
+    assertTrue(html.contains("href=\"/\""));
+    assertTrue(html.contains("href=\"/welcome/\""));
   }
 
   @Test

--- a/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
+++ b/src/test/java/network/crypta/clients/http/SimpleToadletServerTest.java
@@ -1,9 +1,11 @@
 package network.crypta.clients.http;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.URI;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -21,7 +23,10 @@ import network.crypta.io.NetworkInterface;
 import network.crypta.io.SSLNetworkInterface;
 import network.crypta.node.NodeClientCore;
 import network.crypta.node.RequestStarter;
+import network.crypta.platform.appdist.AppUiMode;
 import network.crypta.platform.apphost.AppHost;
+import network.crypta.platform.apphost.InstalledAppSnapshot;
+import network.crypta.platform.apphost.manifest.AppManifest;
 import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.runtime.alerts.UserAlertManager;
 import network.crypta.runtime.alerts.UserAlertSurface;
@@ -155,6 +160,55 @@ class SimpleToadletServerTest {
     config.set("hasCompletedWizard", true);
 
     assertEquals(WebShellPaths.SHELL_ROOT, server.primaryUiRoot());
+  }
+
+  @Test
+  void isStaticAppUiAvailable_whenRuntimeSupportUnavailable_returnsFalse() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+
+    assertFalse(server.isStaticAppUiAvailable("queue-manager"));
+  }
+
+  @Test
+  void isStaticAppUiAvailable_whenStaticAppInstalled_returnsTrue() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    AppHost appHost = mock(AppHost.class);
+    InstalledAppSnapshot queueManager = installedApp(AppUiMode.STATIC);
+    when(appHost.describe("queue-manager")).thenReturn(Optional.of(queueManager));
+    server.setRuntimeSupport(runtimeSupportWith(appHost));
+
+    assertTrue(server.isStaticAppUiAvailable("queue-manager"));
+  }
+
+  @Test
+  void isStaticAppUiAvailable_whenAppMissing_returnsFalse() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    AppHost appHost = mock(AppHost.class);
+    when(appHost.describe("queue-manager")).thenReturn(Optional.empty());
+    server.setRuntimeSupport(runtimeSupportWith(appHost));
+
+    assertFalse(server.isStaticAppUiAvailable("queue-manager"));
+  }
+
+  @Test
+  void isStaticAppUiAvailable_whenAppHasNoStaticUi_returnsFalse() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    AppHost appHost = mock(AppHost.class);
+    InstalledAppSnapshot queueManager = installedApp(AppUiMode.NONE);
+    when(appHost.describe("queue-manager")).thenReturn(Optional.of(queueManager));
+    server.setRuntimeSupport(runtimeSupportWith(appHost));
+
+    assertFalse(server.isStaticAppUiAvailable("queue-manager"));
+  }
+
+  @Test
+  void isStaticAppUiAvailable_whenDescribeFails_returnsFalse() throws Exception {
+    SimpleToadletServer server = newServerWithDefaults();
+    AppHost appHost = mock(AppHost.class);
+    when(appHost.describe("queue-manager")).thenThrow(new IOException("manifest unavailable"));
+    server.setRuntimeSupport(runtimeSupportWith(appHost));
+
+    assertFalse(server.isStaticAppUiAvailable("queue-manager"));
   }
 
   @Test
@@ -638,6 +692,20 @@ class SimpleToadletServerTest {
           .thenReturn(iface);
       return new SimpleToadletServer(config, bucketFactory, executor);
     }
+  }
+
+  private static HttpShellRuntimeSupport runtimeSupportWith(AppHost appHost) {
+    HttpShellRuntimeSupport runtimeSupport = mock(HttpShellRuntimeSupport.class);
+    when(runtimeSupport.appHost()).thenReturn(appHost);
+    return runtimeSupport;
+  }
+
+  private static InstalledAppSnapshot installedApp(AppUiMode uiMode) {
+    InstalledAppSnapshot snapshot = mock(InstalledAppSnapshot.class);
+    AppManifest manifest = mock(AppManifest.class);
+    when(snapshot.manifest()).thenReturn(manifest);
+    when(manifest.uiMode()).thenReturn(uiMode);
+    return snapshot;
   }
 
   private static class DummyToadlet extends Toadlet {

--- a/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
+++ b/src/test/java/network/crypta/clients/http/ToadletContextImplTest.java
@@ -17,7 +17,9 @@ import java.util.Locale;
 import java.util.Map;
 import network.crypta.clients.http.bookmark.BookmarkManager;
 import network.crypta.platform.api.PlatformApiPaths;
+import network.crypta.platform.webshell.routes.WebShellPaths;
 import network.crypta.runtime.alerts.UserAlertSurface;
+import network.crypta.runtime.spi.LegacyAdminSurfaceUsage;
 import network.crypta.support.MultiValueTable;
 import network.crypta.support.SimpleReadOnlyArrayBucket;
 import network.crypta.support.api.BucketFactory;
@@ -42,6 +44,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ToadletContextImplTest {
   private static final String QUEUE_DOWNLOADS_SURFACE_ID = "queue-downloads";
+  private static final String FRIENDS_SURFACE_ID = "friends";
+  private static final String QUEUE_MANAGER_APP_ID = "queue-manager";
+  private static final String CONFIG_SURFACE_ID = "config";
   private static final String WRONG_FORM_PASSWORD_BODY = "formPassword=wrong&confirm=true";
 
   @Mock private BucketFactory bucketFactory;
@@ -137,16 +142,23 @@ class ToadletContextImplTest {
 
   @Test
   void isMethodAllowedInRestrictedMode_whenDeleteTargetsNonPlatformRoute_returnsFalse() {
-    URI uri = URI.create("http://localhost/downloads/");
+    URI uri = URI.create("http://localhost/chat/");
 
     assertFalse(ToadletContextImpl.isMethodAllowedInRestrictedMode("DELETE", uri));
   }
 
   @Test
   void isMethodAllowedInRestrictedMode_whenPutTargetsNonPlatformRoute_returnsFalse() {
-    URI uri = URI.create("http://localhost/downloads/");
+    URI uri = URI.create("http://localhost/chat/");
 
     assertFalse(ToadletContextImpl.isMethodAllowedInRestrictedMode("PUT", uri));
+  }
+
+  @Test
+  void isMethodAllowedInRestrictedMode_whenMutatingMethodTargetsRemovedRoute_returnsTrue() {
+    URI uri = URI.create("http://localhost/downloads/");
+
+    assertTrue(ToadletContextImpl.isMethodAllowedInRestrictedMode("DELETE", uri));
   }
 
   @Test
@@ -212,12 +224,14 @@ class ToadletContextImplTest {
   @Test
   void handle_whenLegacyGetAccepted_recordsLegacyAdminUsage() throws Exception {
     try (var _ = clearedLegacyAdminUsage()) {
-      configureDispatch(new DispatchTestToadlet(QueueToadlet.PATH_DOWNLOADS, 200));
-      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+      configureDispatch(new DispatchTestToadlet(LegacyHttpPaths.CONFIG_PATH, 200));
+      Socket socket = new FakeSocket(rawGetRequest(LegacyHttpPaths.CONFIG_PATH), outputStream);
 
       ToadletContextImpl.handle(socket, newRequestServices());
 
-      assertEquals(1L, queueDownloadsUsageCount());
+      LegacyAdminSurfaceUsage usage = usage(CONFIG_SURFACE_ID);
+      assertEquals(1L, usage.count());
+      assertEquals(1L, usage.fallbackRenderCount());
     }
   }
 
@@ -225,12 +239,12 @@ class ToadletContextImplTest {
   void handle_whenSlashlessLegacyRequestGetsCanonicalRedirect_recordsLegacyAdminUsage()
       throws Exception {
     try (var _ = clearedLegacyAdminUsage()) {
-      configurePermanentRedirect(URI.create(QueueToadlet.PATH_DOWNLOADS));
-      Socket socket = new FakeSocket(rawSlashlessDownloadsGetRequest(), outputStream);
+      configurePermanentRedirect(URI.create(LegacyHttpPaths.CONFIG_PATH));
+      Socket socket = new FakeSocket(rawGetRequest("/config"), outputStream);
 
       ToadletContextImpl.handle(socket, newRequestServices());
 
-      assertEquals(1L, queueDownloadsUsageCount());
+      assertEquals(1L, usage(CONFIG_SURFACE_ID).count());
       assertEquals(
           "301",
           parseHeaders(outputStream.toString(StandardCharsets.UTF_8)).get("__status").getFirst());
@@ -242,11 +256,11 @@ class ToadletContextImplTest {
       throws Exception {
     try (var _ = clearedLegacyAdminUsage()) {
       configurePermanentRedirect(URI.create(FirstTimeWizardToadlet.TOADLET_URL));
-      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+      Socket socket = new FakeSocket(rawGetRequest(LegacyHttpPaths.CONFIG_PATH), outputStream);
 
       ToadletContextImpl.handle(socket, newRequestServices());
 
-      assertEquals(0L, queueDownloadsUsageCount());
+      assertEquals(0L, usage(CONFIG_SURFACE_ID).count());
       assertEquals(
           "301",
           parseHeaders(outputStream.toString(StandardCharsets.UTF_8)).get("__status").getFirst());
@@ -256,39 +270,219 @@ class ToadletContextImplTest {
   @Test
   void handle_whenLegacyRequestRedirectsToHelper_recordsOriginalLegacySurface() throws Exception {
     try (var _ = clearedLegacyAdminUsage()) {
-      URI helperUri = URI.create(LocalDirectoryToadlet.basePath() + QueueToadlet.PATH_DOWNLOADS);
+      URI helperUri = URI.create(LocalDirectoryToadlet.basePath() + LegacyHttpPaths.CONFIG_PATH);
       configureRedirectDispatch(
-          new RedirectingToadlet(QueueToadlet.PATH_DOWNLOADS, helperUri),
+          new RedirectingToadlet(LegacyHttpPaths.CONFIG_PATH, helperUri),
           new DispatchTestToadlet(LocalDirectoryToadlet.basePath(), 200));
-      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+      Socket socket = new FakeSocket(rawGetRequest(LegacyHttpPaths.CONFIG_PATH), outputStream);
 
       ToadletContextImpl.handle(socket, newRequestServices());
 
-      assertEquals(1L, queueDownloadsUsageCount());
+      assertEquals(1L, usage(CONFIG_SURFACE_ID).count());
     }
   }
 
   @Test
   void handle_whenPostFormPasswordDenied_doesNotRecordLegacyAdminUsage() throws Exception {
     try (var _ = clearedLegacyAdminUsage()) {
+      configureDispatch(new DispatchTestToadlet(LegacyHttpPaths.CONFIG_PATH, 200));
+      Socket socket = new FakeSocket(rawDeniedConfigPostRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      assertEquals(0L, usage(CONFIG_SURFACE_ID).count());
+    }
+  }
+
+  @Test
+  void handle_whenRemovedLegacyGetRequested_redirectsToReplacementAndRecordsEvent()
+      throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureQueueManagerReplacementAvailable();
+      configureDispatch(new DispatchTestToadlet(QueueToadlet.PATH_DOWNLOADS, 200));
+      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      Map<String, List<String>> headers =
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
+      LegacyAdminSurfaceUsage usage = usage(QUEUE_DOWNLOADS_SURFACE_ID);
+      assertEquals("303", headers.get("__status").getFirst());
+      assertEquals("/apps/queue-manager/", headers.get("location").getFirst());
+      assertEquals(0L, usage.count());
+      assertEquals(1L, usage.replacementResponseCount());
+      assertEquals(0L, usage.blockedMutatingRequestCount());
+    }
+  }
+
+  @Test
+  void handle_whenWizardGateRedirectsRemovedLegacyGet_honorsWizardRedirect() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configurePermanentRedirect(URI.create(FirstTimeWizardToadlet.TOADLET_URL));
+      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      Map<String, List<String>> headers =
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
+      assertEquals("301", headers.get("__status").getFirst());
+      assertEquals(FirstTimeWizardToadlet.TOADLET_URL, headers.get("location").getFirst());
+      assertEquals(0L, usage(QUEUE_DOWNLOADS_SURFACE_ID).replacementResponseCount());
+      assertEquals(0L, usage(QUEUE_DOWNLOADS_SURFACE_ID).blockedMutatingRequestCount());
+    }
+  }
+
+  @Test
+  void handle_whenWizardGateRedirectsRemovedLegacyPost_honorsWizardRedirect() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configurePermanentRedirect(URI.create(FirstTimeWizardToadlet.TOADLET_URL));
+      Socket socket = new FakeSocket(rawDeniedDownloadsPostRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      Map<String, List<String>> headers =
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
+      assertEquals("301", headers.get("__status").getFirst());
+      assertEquals(FirstTimeWizardToadlet.TOADLET_URL, headers.get("location").getFirst());
+      assertEquals(0L, usage(QUEUE_DOWNLOADS_SURFACE_ID).replacementResponseCount());
+      assertEquals(0L, usage(QUEUE_DOWNLOADS_SURFACE_ID).blockedMutatingRequestCount());
+    }
+  }
+
+  @Test
+  void handle_whenRemovedLegacySlashlessCanonicalRedirect_redirectsToReplacement()
+      throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureQueueManagerReplacementAvailable();
+      configurePermanentRedirect(URI.create(QueueToadlet.PATH_DOWNLOADS));
+      Socket socket = new FakeSocket(rawGetRequest("/downloads"), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      Map<String, List<String>> headers =
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
+      assertEquals("303", headers.get("__status").getFirst());
+      assertEquals("/apps/queue-manager/", headers.get("location").getFirst());
+      assertEquals(1L, usage(QUEUE_DOWNLOADS_SURFACE_ID).replacementResponseCount());
+    }
+  }
+
+  @Test
+  void handle_whenRemovedLegacyPostRequested_blocksMutationAndRecordsEvent() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureQueueManagerReplacementAvailable();
       configureDispatch(new DispatchTestToadlet(QueueToadlet.PATH_DOWNLOADS, 200));
       Socket socket = new FakeSocket(rawDeniedDownloadsPostRequest(), outputStream);
 
       ToadletContextImpl.handle(socket, newRequestServices());
 
-      assertEquals(0L, queueDownloadsUsageCount());
+      Map<String, List<String>> headers =
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
+      LegacyAdminSurfaceUsage usage = usage(QUEUE_DOWNLOADS_SURFACE_ID);
+      assertEquals("410", headers.get("__status").getFirst());
+      assertEquals(0L, usage.count());
+      assertEquals(0L, usage.replacementResponseCount());
+      assertEquals(1L, usage.blockedMutatingRequestCount());
+    }
+  }
+
+  @Test
+  void handle_whenRemovedLegacyHeadRequested_redirectsWithoutBody() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureQueueManagerReplacementAvailable();
+      configureDispatch(new DispatchTestToadlet(QueueToadlet.PATH_DOWNLOADS, 200));
+      Socket socket = new FakeSocket(rawDownloadsHeadRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      String rawResponse = outputStream.toString(StandardCharsets.UTF_8);
+      Map<String, List<String>> headers = parseHeaders(rawResponse);
+      assertEquals("303", headers.get("__status").getFirst());
+      assertEquals("/apps/queue-manager/", headers.get("location").getFirst());
+      assertFalse(rawResponse.contains("Legacy page replaced"));
+      assertEquals(1L, usage(QUEUE_DOWNLOADS_SURFACE_ID).replacementResponseCount());
+    }
+  }
+
+  @Test
+  void handle_whenStaticAppReplacementUnavailable_rendersLegacyFallback() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureQueueManagerReplacementUnavailable();
+      configureDispatch(new DispatchTestToadlet(QueueToadlet.PATH_DOWNLOADS, 200));
+      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      Map<String, List<String>> headers =
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
+      LegacyAdminSurfaceUsage usage = usage(QUEUE_DOWNLOADS_SURFACE_ID);
+      assertEquals("200", headers.get("__status").getFirst());
+      assertEquals(1L, usage.count());
+      assertEquals(1L, usage.fallbackRenderCount());
+      assertEquals(0L, usage.replacementResponseCount());
+      assertEquals(0L, usage.blockedMutatingRequestCount());
+    }
+  }
+
+  @Test
+  void handle_whenWebShellReplacementUnavailable_rendersLegacyFallback() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureWebShellReplacementUnavailable();
+      configureDispatch(new DispatchTestToadlet(LegacyHttpPaths.FRIENDS_PATH, 200));
+      Socket socket = new FakeSocket(rawGetRequest(LegacyHttpPaths.FRIENDS_PATH), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      Map<String, List<String>> headers =
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8));
+      LegacyAdminSurfaceUsage usage = usage(FRIENDS_SURFACE_ID);
+      assertEquals("200", headers.get("__status").getFirst());
+      assertEquals(1L, usage.count());
+      assertEquals(1L, usage.fallbackRenderCount());
+      assertEquals(0L, usage.replacementResponseCount());
+      assertEquals(0L, usage.blockedMutatingRequestCount());
+    }
+  }
+
+  @Test
+  void handle_whenBrowseRootRequested_doesNotApplyRemovalPolicy() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureDispatch(new DispatchTestToadlet("/", 200));
+      Socket socket = new FakeSocket(rawGetRequest("/"), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      assertEquals(
+          "200",
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8)).get("__status").getFirst());
+      assertEquals(0L, usage(QUEUE_DOWNLOADS_SURFACE_ID).replacementResponseCount());
+    }
+  }
+
+  @Test
+  void handle_whenPendingWizardRequested_doesNotApplyRemovalPolicy() throws Exception {
+    try (var _ = clearedLegacyAdminUsage()) {
+      configureDispatch(new DispatchTestToadlet(FirstTimeWizardToadlet.TOADLET_URL, 200));
+      Socket socket =
+          new FakeSocket(rawGetRequest(FirstTimeWizardToadlet.TOADLET_URL), outputStream);
+
+      ToadletContextImpl.handle(socket, newRequestServices());
+
+      assertEquals(
+          "200",
+          parseHeaders(outputStream.toString(StandardCharsets.UTF_8)).get("__status").getFirst());
     }
   }
 
   @Test
   void handle_whenFullAccessDenied_doesNotRecordLegacyAdminUsage() throws Exception {
     try (var _ = clearedLegacyAdminUsage()) {
-      configureDispatch(new FullAccessCheckingToadlet(QueueToadlet.PATH_DOWNLOADS));
-      Socket socket = new FakeSocket(rawDownloadsGetRequest(), outputStream);
+      configureDispatch(new FullAccessCheckingToadlet(LegacyHttpPaths.CONFIG_PATH));
+      Socket socket = new FakeSocket(rawGetRequest(LegacyHttpPaths.CONFIG_PATH), outputStream);
 
       ToadletContextImpl.handle(socket, newRequestServices());
 
-      assertEquals(0L, queueDownloadsUsageCount());
+      assertEquals(0L, usage(CONFIG_SURFACE_ID).count());
     }
   }
 
@@ -460,6 +654,32 @@ class ToadletContextImplTest {
     return new ToadletRequestServices(container, pageMaker, alertManager, bookmarkManager);
   }
 
+  private void configureQueueManagerReplacementAvailable() {
+    org.mockito.Mockito.when(
+            container.isAllowedFullAccess(org.mockito.ArgumentMatchers.any(InetAddress.class)))
+        .thenReturn(true);
+    org.mockito.Mockito.when(container.isFProxyJavascriptEnabled()).thenReturn(true);
+    org.mockito.Mockito.when(container.isStaticAppUiAvailable(QUEUE_MANAGER_APP_ID))
+        .thenReturn(true);
+  }
+
+  private void configureQueueManagerReplacementUnavailable() {
+    org.mockito.Mockito.when(
+            container.isAllowedFullAccess(org.mockito.ArgumentMatchers.any(InetAddress.class)))
+        .thenReturn(true);
+    org.mockito.Mockito.when(container.isFProxyJavascriptEnabled()).thenReturn(true);
+    org.mockito.Mockito.when(container.isStaticAppUiAvailable(QUEUE_MANAGER_APP_ID))
+        .thenReturn(false);
+  }
+
+  private void configureWebShellReplacementUnavailable() {
+    org.mockito.Mockito.when(
+            container.isAllowedFullAccess(org.mockito.ArgumentMatchers.any(InetAddress.class)))
+        .thenReturn(true);
+    org.mockito.Mockito.when(container.primaryUiRoot())
+        .thenReturn(WebShellPaths.SHELL_ROOT + "off");
+  }
+
   private void configureDispatch(Toadlet toadlet) throws Exception {
     org.mockito.Mockito.when(container.getBucketFactory()).thenReturn(new ArrayBucketFactory());
     org.mockito.Mockito.when(container.allowPosts()).thenReturn(true);
@@ -495,12 +715,13 @@ class ToadletContextImplTest {
     return rawGetRequest(QueueToadlet.PATH_DOWNLOADS);
   }
 
-  private static byte[] rawSlashlessDownloadsGetRequest() {
-    return rawGetRequest("/downloads");
-  }
-
   private static byte[] rawGetRequest(String path) {
     return ("GET " + path + " HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .getBytes(StandardCharsets.US_ASCII);
+  }
+
+  private static byte[] rawDownloadsHeadRequest() {
+    return ("HEAD " + QueueToadlet.PATH_DOWNLOADS + " HTTP/1.1\r\nHost: localhost\r\n\r\n")
         .getBytes(StandardCharsets.US_ASCII);
   }
 
@@ -515,12 +736,22 @@ class ToadletContextImplTest {
         .getBytes(StandardCharsets.US_ASCII);
   }
 
-  private static long queueDownloadsUsageCount() {
+  private static byte[] rawDeniedConfigPostRequest() {
+    return ("POST "
+            + LegacyHttpPaths.CONFIG_PATH
+            + " HTTP/1.1\r\nHost: localhost\r\nContent-Type: "
+            + "application/x-www-form-urlencoded; charset=UTF-8\r\nContent-Length: "
+            + WRONG_FORM_PASSWORD_BODY.length()
+            + "\r\n\r\n"
+            + WRONG_FORM_PASSWORD_BODY)
+        .getBytes(StandardCharsets.US_ASCII);
+  }
+
+  private static LegacyAdminSurfaceUsage usage(String surfaceId) {
     return LegacyAdminUsageRecorder.defaultRecorder().snapshot().surfaces().stream()
-        .filter(surface -> surface.surfaceId().equals(QUEUE_DOWNLOADS_SURFACE_ID))
+        .filter(surface -> surface.surfaceId().equals(surfaceId))
         .findFirst()
-        .orElseThrow()
-        .count();
+        .orElseThrow();
   }
 
   private static LegacyAdminUsageScope clearedLegacyAdminUsage() {

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -372,7 +372,15 @@ class PlatformApiRouterTest {
                             "/downloads/",
                             "PRIMARY_REPLACED",
                             "/apps/queue-manager/",
+                            "REDIRECT_TO_REPLACEMENT",
+                            1,
+                            "phase-6-pr-8",
+                            "none",
                             3L,
+                            2L,
+                            1L,
+                            0L,
+                            0L,
                             1_770_000_000_000L))));
     when(diagnosticPort.snapshot()).thenReturn(new DiagnosticReportSnapshot(List.of()));
 
@@ -384,7 +392,11 @@ class PlatformApiRouterTest {
         "{\"sectionCount\":0,\"sections\":[],\"plainTextExport\":\"\",\"legacyAdmin\":{\"surfaces\""
             + ":[{\"id\":\"queue-downloads\",\"title\":\"Download queue\",\"path\":\"/downloads/\","
             + "\"state\":\"PRIMARY_REPLACED\",\"replacementUrl\":\"/apps/queue-manager/\","
-            + "\"count\":3,\"lastSeenEpochMillis\":1770000000000}]}}",
+            + "\"removalMode\":\"REDIRECT_TO_REPLACEMENT\",\"removalWave\":1,"
+            + "\"removedByDefaultSince\":\"phase-6-pr-8\",\"fallbackPolicy\":\"none\","
+            + "\"count\":3,\"replacementResponseCount\":2,"
+            + "\"blockedMutatingRequestCount\":1,\"fallbackRenderCount\":0,"
+            + "\"retainedOrPendingRenderCount\":0,\"lastSeenEpochMillis\":1770000000000}]}}",
         response.body());
   }
 

--- a/src/test/java/network/crypta/runtime/spi/LegacyAdminUsageSnapshotTest.java
+++ b/src/test/java/network/crypta/runtime/spi/LegacyAdminUsageSnapshotTest.java
@@ -45,9 +45,70 @@ class LegacyAdminUsageSnapshotTest {
   }
 
   @Test
+  void surfaceUsageConstructor_whenRemovalWaveNegative_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new LegacyAdminSurfaceUsage(
+                "queue-downloads",
+                "Download queue",
+                "/downloads/",
+                "PRIMARY_REPLACED",
+                "/apps/queue-manager/",
+                "REDIRECT_TO_REPLACEMENT",
+                -1,
+                "phase-6-pr-8",
+                "none",
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L));
+  }
+
+  @Test
+  void surfaceUsageConstructor_whenEventCounterNegative_expectIllegalArgumentException() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            new LegacyAdminSurfaceUsage(
+                "queue-downloads",
+                "Download queue",
+                "/downloads/",
+                "PRIMARY_REPLACED",
+                "/apps/queue-manager/",
+                "REDIRECT_TO_REPLACEMENT",
+                1,
+                "phase-6-pr-8",
+                "none",
+                0L,
+                -1L,
+                0L,
+                0L,
+                0L,
+                0L));
+  }
+
+  @Test
   void surfaceUsageConstructor_whenReplacementUrlNull_expectAccepted() {
     LegacyAdminSurfaceUsage usage =
-        new LegacyAdminSurfaceUsage("help", "Help", "/help/", "RETAINED", null, 0L, 0L);
+        new LegacyAdminSurfaceUsage(
+            "help",
+            "Help",
+            "/help/",
+            "RETAINED",
+            null,
+            "RETAINED",
+            0,
+            null,
+            "retained",
+            0L,
+            0L,
+            0L,
+            0L,
+            0L,
+            0L);
 
     assertEquals("help", usage.surfaceId());
     assertNull(usage.replacementUrl());
@@ -61,7 +122,15 @@ class LegacyAdminUsageSnapshotTest {
         "/downloads/",
         "PRIMARY_REPLACED",
         "/apps/queue-manager/",
+        "REDIRECT_TO_REPLACEMENT",
+        1,
+        "phase-6-pr-8",
+        "none",
         count,
+        0L,
+        0L,
+        0L,
+        0L,
         lastSeenEpochMillis);
   }
 }

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -38,6 +38,16 @@ DEFAULT_OUT_DIR = Path("build/release-certification/app-platform-smoke")
 SUMMARY_FILE_NAME = "summary.json"
 REPORT_FILE_NAME = "app-platform-smoke-report.md"
 APP_IDS = ("queue-manager", "publisher")
+LEGACY_REMOVAL_WAVE_ONE_IDS = (
+    "queue-downloads",
+    "queue-uploads",
+    "file-insert",
+    "local-file-insert",
+    "friends",
+    "add-friend",
+    "strangers",
+    "connectivity",
+)
 APP_UI_DESIGN_SYSTEM_DOC = Path("docs/app-ui-design-system.md")
 APP_VAULT_DOC = Path("docs/app-secret-and-identity-vault.md")
 APP_VAULT_CAPABILITIES = (
@@ -1942,7 +1952,7 @@ def legacy_counts_from_registry_text(text: str) -> dict[str, int]:
     end = text.index("private static final Map", start)
     block = text[start:end]
     return {
-        "PRIMARY_REPLACED": len(re.findall(r"\n\s+replaced\(", block)),
+        "PRIMARY_REPLACED": len(re.findall(r"\n\s+(?:replaced|wave1Redirect)\(", block)),
         "PENDING": len(re.findall(r"\n\s+pendingWizard\(", block)) + len(re.findall(r"\n\s+pending\(", block)),
         "RETAINED": len(re.findall(r"\n\s+retained\(", block)),
         "INFRASTRUCTURE": len(re.findall(r"\n\s+infrastructure\(", block)),
@@ -1976,12 +1986,8 @@ def legacy_fallback_link_checks(text: str) -> dict[str, bool]:
     fallback_body = java_method_body(text, "webShellFallbackSurfaces")
     replaced_body = java_method_body(text, "replaced")
     navigation_body = java_method_body(text, "shouldPromoteInLegacyNavigation")
-    replaced_marks_no_fallback = bool(
-        re.search(
-            r"LegacyAdminRetirementState\.PRIMARY_REPLACED\b.*?,\s*true\s*,\s*false\s*\)\s*;",
-            replaced_body,
-            re.DOTALL,
-        )
+    replaced_marks_no_fallback = "FALLBACK_POLICY_RENDER_LEGACY" in replaced_body and bool(
+        re.search(r",\s*true\s*,\s*false\s*\)\s*;", replaced_body, re.DOTALL)
     )
     fallback_filters_include_flag = bool(
         re.search(r"\.filter\s*\(\s*LegacyAdminSurface::includeInWebShellFallbackLinks\s*\)", fallback_body)
@@ -2031,18 +2037,117 @@ def collect_legacy_evidence(settings: Settings) -> EvidenceItem:
             "primaryReplacedAbsentFromPrimaryNavigation"
         ]
         docs_text = re.sub(r"\s+", " ", docs.read_text(encoding="utf-8")) if docs.is_file() else ""
-        details["fallbackDirectUrlsRemainDocumented"] = "Direct legacy URLs remain reachable" in docs_text
+        details["retainedPendingRoutesDocumented"] = (
+            "retained and pending legacy routes remain reachable" in docs_text.lower()
+        )
         if counts["PRIMARY_REPLACED"] < 1:
             errors.append("No PRIMARY_REPLACED surfaces were found")
         if not details["primaryReplacedAbsentFromFallbackLinks"]:
             errors.append("PRIMARY_REPLACED surfaces may still appear in Web Shell fallback links")
         if not details["primaryReplacedAbsentFromPrimaryNavigation"]:
             errors.append("PRIMARY_REPLACED surfaces may still appear in primary legacy navigation")
-        if not details["fallbackDirectUrlsRemainDocumented"]:
-            errors.append("Legacy fallback/direct URL behavior is not documented")
+        if not details["retainedPendingRoutesDocumented"]:
+            errors.append("Retained/pending legacy route behavior is not documented")
     if errors:
         return EvidenceItem("legacy.retirement", "fail", True, "Legacy-admin retirement evidence is incomplete.", source, {"errors": errors, **details})
     return EvidenceItem("legacy.retirement", "pass", True, "Legacy-admin retirement map is visible and stable.", source, details)
+
+
+def legacy_removal_wave_one_ids(registry_text: str) -> list[str]:
+    return re.findall(r"\n\s+wave1Redirect\(\s*\"([^\"]+)\"", registry_text)
+
+
+def collect_legacy_removal_wave_one_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    root = settings.workspace_root
+    files = {
+        "registry": root / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java",
+        "policy": root / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRemovalPolicy.java",
+        "response": root / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminReplacementResponse.java",
+        "recorder": root / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminUsageRecorder.java",
+        "usageDto": root / "runtime-spi/src/main/java/network/crypta/runtime/spi/LegacyAdminSurfaceUsage.java",
+        "diagnostics": root / "platform-api/src/main/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandler.java",
+        "docs": root / "docs/legacy-retirement-plan.md",
+    }
+    text: dict[str, str] = {}
+    missing = []
+    for key, path in files.items():
+        if not path.is_file():
+            missing.append(key)
+            text[key] = ""
+        else:
+            text[key] = path.read_text(encoding="utf-8")
+
+    wave_ids = legacy_removal_wave_one_ids(text["registry"])
+    checks = {
+        "waveOneIdsMatch": wave_ids == list(LEGACY_REMOVAL_WAVE_ONE_IDS),
+        "redirectModeDeclared": "LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT" in text["registry"],
+        "canonicalOnlyPolicy": "matchesCanonicalPageOrSlashlessAlias" in text["policy"],
+        "safeReadRedirects": "GET" in text["policy"] and "HEAD" in text["policy"] and "redirect(" in text["policy"],
+        "mutatingRequestsBlocked": "BLOCKED_MUTATING_REQUEST" in text["policy"] or "blockedMutation" in text["policy"],
+        "replacementAvailabilityGate": "replacementAvailable" in text["policy"]
+        and "isStaticAppUiAvailable" in text["policy"]
+        and "primaryUiRoot" in text["policy"],
+        "replacementResponsesRecorded": "REPLACEMENT_RESPONSE" in text["recorder"] or "REPLACEMENT_RESPONSE" in text["policy"],
+        "diagnosticsCarriesReplacementCounter": "replacementResponseCount" in text["diagnostics"] and "replacementResponseCount" in text["usageDto"],
+        "diagnosticsCarriesBlockedCounter": "blockedMutatingRequestCount" in text["diagnostics"] and "blockedMutatingRequestCount" in text["usageDto"],
+        "diagnosticsCarriesFallbackCounter": "fallbackRenderCount" in text["diagnostics"] and "fallbackRenderCount" in text["usageDto"],
+        "docsDescribeWave": "legacy-admin.removal-wave-1" in text["docs"],
+        "docsDescribeAvailabilityFallback": "replacement is reachable" in text["docs"]
+        or "replacement is unavailable" in text["docs"],
+        "docsRetainBrowse": "FProxy browse remains retained" in text["docs"],
+        "liveNodeNotRequired": True,
+    }
+    redaction = {
+        "queryStringsExcluded": True,
+        "requestBodiesExcluded": True,
+        "formPasswordsExcluded": True,
+        "remoteAddressesExcluded": True,
+        "tokensExcluded": True,
+        "privateUrisExcluded": True,
+        "localPathsExcluded": True,
+    }
+    details = {
+        "removedByDefaultRouteIds": wave_ids,
+        "expectedRouteIds": list(LEGACY_REMOVAL_WAVE_ONE_IDS),
+        "replacementUrls": {
+            "queue-downloads": "/apps/queue-manager/",
+            "queue-uploads": "/apps/queue-manager/",
+            "file-insert": "/apps/publisher/",
+            "local-file-insert": "/apps/publisher/",
+            "friends": "/app/node/#peers",
+            "add-friend": "/app/node/#peers",
+            "strangers": "/app/node/#peers",
+            "connectivity": "/app/node/#connectivity",
+        },
+        "statusBehavior": {
+            "safeRead": "303 See Other when replacement is available; legacy fallback when unavailable",
+            "mutating": "410 Gone when replacement is available; legacy fallback when unavailable",
+        },
+        "liveNodeRequired": False,
+        "checks": checks,
+        "redaction": redaction,
+        "missingSources": missing,
+    }
+    errors = [name for name, passed in checks.items() if not passed]
+    errors.extend(f"missing {name}" for name in missing)
+    if errors:
+        return EvidenceItem(
+            "legacy-admin.removal-wave-1",
+            "fail",
+            True,
+            "Legacy-admin removal wave 1 evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "legacy-admin.removal-wave-1",
+        "pass",
+        True,
+        "Legacy-admin removal wave 1 replacement behavior is documented and observable.",
+        source,
+        details,
+    )
 
 
 def collect_sandbox_provider_evidence(settings: Settings) -> EvidenceItem:
@@ -2466,6 +2571,17 @@ def diagnostics_body_summary(body: Any) -> dict[str, Any]:
                 if isinstance(surface, dict) and isinstance(surface.get("count"), int)
             ]
             summary["legacyAdminTotalCount"] = sum(counts)
+            for output_key, field_name in (
+                ("legacyAdminReplacementResponseTotal", "replacementResponseCount"),
+                ("legacyAdminBlockedMutatingRequestTotal", "blockedMutatingRequestCount"),
+                ("legacyAdminFallbackRenderTotal", "fallbackRenderCount"),
+                ("legacyAdminRetainedOrPendingRenderTotal", "retainedOrPendingRenderCount"),
+            ):
+                summary[output_key] = sum(
+                    surface.get(field_name)
+                    for surface in surfaces
+                    if isinstance(surface, dict) and isinstance(surface.get(field_name), int)
+                )
     if not summary:
         summary["diagnosticsBodyReceived"] = True
     return summary
@@ -2631,6 +2747,7 @@ def run(settings: Settings) -> tuple[dict[str, Any], int]:
         collect_app_ui_first_party_adoption_evidence(settings),
         collect_app_ui_evidence(settings),
         collect_legacy_evidence(settings),
+        collect_legacy_removal_wave_one_evidence(settings),
         collect_sandbox_provider_evidence(settings),
         collect_app_update_lifecycle_evidence(settings),
         collect_app_update_rollback_evidence(settings),
@@ -2699,7 +2816,7 @@ def run_self_test(repo_root: Path) -> None:
     registry_text = registry_fixture.read_text(encoding="utf-8")
     counts = legacy_counts_from_registry_text(registry_text)
     assert counts == {
-        "PRIMARY_REPLACED": 2,
+        "PRIMARY_REPLACED": 9,
         "PENDING": 2,
         "RETAINED": 1,
         "INFRASTRUCTURE": 1,
@@ -3064,6 +3181,8 @@ def run_self_test(repo_root: Path) -> None:
         evidence_by_id = {item["id"]: item for item in summary["evidence"]}
         assert evidence_by_id["app-platform.first-party"]["status"] == "pass"
         assert evidence_by_id["app-platform.devtools-cli"]["status"] == "pass"
+        assert evidence_by_id["legacy-admin.removal-wave-1"]["status"] == "pass"
+        assert evidence_by_id["legacy-admin.removal-wave-1"]["requiredForReleaseCandidate"] is True
         contract_item = evidence_by_id["platform-api.contract"]
         assert contract_item["status"] == "pass", contract_item
         vault_item = evidence_by_id["app-vault.capabilities"]
@@ -3385,8 +3504,26 @@ def run_self_test(repo_root: Path) -> None:
                     ],
                     "legacyAdmin": {
                         "surfaces": [
-                            {"id": "queue", "path": "/queue/", "state": "PRIMARY_REPLACED", "count": 3},
-                            {"id": "stats", "path": "/stats/", "state": "PENDING", "count": 2},
+                            {
+                                "id": "queue",
+                                "path": "/queue/",
+                                "state": "PRIMARY_REPLACED",
+                                "count": 3,
+                                "replacementResponseCount": 2,
+                                "blockedMutatingRequestCount": 1,
+                                "fallbackRenderCount": 0,
+                                "retainedOrPendingRenderCount": 0,
+                            },
+                            {
+                                "id": "stats",
+                                "path": "/stats/",
+                                "state": "PENDING",
+                                "count": 2,
+                                "replacementResponseCount": 0,
+                                "blockedMutatingRequestCount": 0,
+                                "fallbackRenderCount": 0,
+                                "retainedOrPendingRenderCount": 2,
+                            },
                         ]
                     },
                 }
@@ -3405,6 +3542,10 @@ def run_self_test(repo_root: Path) -> None:
             "sectionCount": 2,
             "legacyAdminSurfaceCount": 2,
             "legacyAdminTotalCount": 5,
+            "legacyAdminReplacementResponseTotal": 2,
+            "legacyAdminBlockedMutatingRequestTotal": 1,
+            "legacyAdminFallbackRenderTotal": 0,
+            "legacyAdminRetainedOrPendingRenderTotal": 2,
         }, diagnostics_step
         assert "body" not in diagnostics_step, diagnostics_step
         live_success_encoded = json.dumps(live_success_item.to_json(), sort_keys=True)
@@ -3487,7 +3628,43 @@ def make_self_test_workspace(workspace: Path) -> None:
     registry.write_text((Path(__file__).parent / "fixtures" / "self-test-legacy-registry.java-fragment").read_text(encoding="utf-8"), encoding="utf-8")
     docs = workspace / "docs/legacy-retirement-plan.md"
     docs.parent.mkdir(parents=True, exist_ok=True)
-    docs.write_text("Direct legacy URLs remain reachable for fallback.\n", encoding="utf-8")
+    docs.write_text(
+        "legacy-admin.removal-wave-1 documents that removed routes return replacement responses "
+        "when the replacement is reachable and render legacy fallback when the replacement is unavailable. "
+        "FProxy browse remains retained, and retained and pending legacy routes remain reachable.\n",
+        encoding="utf-8",
+    )
+    legacy_admin_dir = workspace / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http"
+    (legacy_admin_dir / "LegacyAdminRemovalPolicy.java").write_text(
+        'class LegacyAdminRemovalPolicy { boolean matchesCanonicalPageOrSlashlessAlias; '
+        'boolean replacementAvailable; boolean isStaticAppUiAvailable; boolean primaryUiRoot; '
+        'String m = "GET HEAD"; Object d = LegacyAdminRemovalDecision.redirect(null); '
+        'Object b = LegacyAdminRemovalDecision.blockedMutation(null); }\n',
+        encoding="utf-8",
+    )
+    (legacy_admin_dir / "LegacyAdminReplacementResponse.java").write_text(
+        'class LegacyAdminReplacementResponse { String link = "replacementUrl"; }\n',
+        encoding="utf-8",
+    )
+    (legacy_admin_dir / "LegacyAdminUsageRecorder.java").write_text(
+        "class LegacyAdminUsageRecorder { Object a = LegacyAdminUsageEvent.REPLACEMENT_RESPONSE; }\n",
+        encoding="utf-8",
+    )
+    usage_dto = workspace / "runtime-spi/src/main/java/network/crypta/runtime/spi/LegacyAdminSurfaceUsage.java"
+    usage_dto.parent.mkdir(parents=True, exist_ok=True)
+    usage_dto.write_text(
+        "record LegacyAdminSurfaceUsage(long replacementResponseCount, "
+        "long blockedMutatingRequestCount, long fallbackRenderCount, "
+        "long retainedOrPendingRenderCount) {}\n",
+        encoding="utf-8",
+    )
+    diagnostics_handler = workspace / "platform-api/src/main/java/network/crypta/platform/api/diagnostics/DiagnosticsApiHandler.java"
+    diagnostics_handler.parent.mkdir(parents=True, exist_ok=True)
+    diagnostics_handler.write_text(
+        "class DiagnosticsApiHandler { String a = \"replacementResponseCount "
+        "blockedMutatingRequestCount fallbackRenderCount retainedOrPendingRenderCount\"; }\n",
+        encoding="utf-8",
+    )
     app_vault_doc = workspace / APP_VAULT_DOC
     app_vault_doc.write_text(
         "The app secret and identity vault defines vault.secrets.read, vault.secrets.write, "

--- a/tools/release-certification/fixtures/self-test-app-platform-smoke.json
+++ b/tools/release-certification/fixtures/self-test-app-platform-smoke.json
@@ -217,6 +217,29 @@
     },
     {
       "details": {
+        "removedByDefaultRouteIds": [
+          "queue-downloads",
+          "queue-uploads",
+          "file-insert",
+          "local-file-insert",
+          "friends",
+          "add-friend",
+          "strangers",
+          "connectivity"
+        ],
+        "statusBehavior": {
+          "mutating": "410 Gone when replacement is available; legacy fallback when unavailable",
+          "safeRead": "303 See Other when replacement is available; legacy fallback when unavailable"
+        }
+      },
+      "id": "legacy-admin.removal-wave-1",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Legacy-admin removal wave 1 replacement behavior is documented and observable."
+    },
+    {
+      "details": {
         "fixtureBacked": true,
         "hostBubblewrapProbe": {
           "enabled": false

--- a/tools/release-certification/fixtures/self-test-legacy-registry.java-fragment
+++ b/tools/release-certification/fixtures/self-test-legacy-registry.java-fragment
@@ -3,7 +3,14 @@ final class LegacyAdminRetirementRegistry {
       List.of(
           infrastructure("web-shell", "Web Shell", "/app/node/", "Shell."),
           replaced("alerts", "Alerts", "/alerts/", "/app/node/#alerts", "Shell alerts", "Done."),
-          replaced("downloads", "Downloads", "/downloads/", "/apps/queue-manager/", "Queue Manager", "Done."),
+          wave1Redirect("queue-downloads", "Downloads", "/downloads/", "/apps/queue-manager/", "Queue Manager", "Done."),
+          wave1Redirect("queue-uploads", "Uploads", "/uploads/", "/apps/queue-manager/", "Queue Manager", "Done."),
+          wave1Redirect("file-insert", "Insert file", "/insertfile/", "/apps/publisher/", "Publisher", "Done."),
+          wave1Redirect("local-file-insert", "Insert browse", "/insert-browse/", "/apps/publisher/", "Publisher", "Done."),
+          wave1Redirect("friends", "Friends", "/friends/", "/app/node/#peers", "Peers", "Done."),
+          wave1Redirect("add-friend", "Add friend", "/addfriend/", "/app/node/#peers", "Peers", "Done."),
+          wave1Redirect("strangers", "Strangers", "/strangers/", "/app/node/#peers", "Peers", "Done."),
+          wave1Redirect("connectivity", "Connectivity", "/connectivity/", "/app/node/#connectivity", "Connectivity", "Done."),
           pendingWizard("first-time-wizard", "First-time wizard", "/wizard/", "Pending."),
           pending("node-to-node-message", "N2NTM", "/send_n2ntm/", null, null, "Pending.", true),
           retained("help", "Help", "/help/", "Retained."));
@@ -35,6 +42,33 @@ final class LegacyAdminRetirementRegistry {
         replacementUrl,
         replacementLabel,
         notes,
+        LegacyAdminRemovalMode.RENDER_LEGACY,
+        0,
+        null,
+        FALLBACK_POLICY_RENDER_LEGACY,
+        true,
+        false);
+  }
+
+  private static LegacyAdminSurface wave1Redirect(
+      String id,
+      String title,
+      String legacyPath,
+      String replacementUrl,
+      String replacementLabel,
+      String notes) {
+    return new LegacyAdminSurface(
+        id,
+        title,
+        legacyPath,
+        LegacyAdminRetirementState.PRIMARY_REPLACED,
+        replacementUrl,
+        replacementLabel,
+        notes,
+        LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT,
+        1,
+        "phase-6-pr-8",
+        "none",
         true,
         false);
   }

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -582,6 +582,7 @@ def app_platform_evidence(
         "app-ui.first-party-adoption",
         "app-ui.smoke",
         "legacy.retirement",
+        "legacy-admin.removal-wave-1",
         "apphost.sandbox-provider",
         "app-update.lifecycle",
         "app-update.rollback",
@@ -892,6 +893,7 @@ def render_report(summary: dict[str, Any]) -> str:
         append_detail(lines, summary, evidence_id)
     lines.extend(["", "## Legacy Admin Retirement", ""])
     append_detail(lines, summary, "legacy.retirement")
+    append_detail(lines, summary, "legacy-admin.removal-wave-1")
     lines.extend(
         [
             "",
@@ -1071,6 +1073,8 @@ def run_self_test(repo_root: Path) -> None:
         assert evidence_by_id["app-update.rollback"]["requiredForReleaseCandidate"] is True
         assert evidence_by_id["app-vault.capabilities"]["status"] == "pass", evidence_by_id
         assert evidence_by_id["app-vault.capabilities"]["requiredForReleaseCandidate"] is True
+        assert evidence_by_id["legacy-admin.removal-wave-1"]["status"] == "pass", evidence_by_id
+        assert evidence_by_id["legacy-admin.removal-wave-1"]["requiredForReleaseCandidate"] is True
         optional_skip_status, optional_skip_release_passed = determine_overall_status(
             "release-candidate",
             [


### PR DESCRIPTION
## Summary

- Add the `legacy-admin.removal-wave-1` execution policy for the first batch of already-replaced legacy admin routes.
- Redirect safe reads for `/downloads/`, `/uploads/`, `/insertfile/`, `/insert-browse/`, `/friends/`, `/addfriend/`, `/strangers/`, and `/connectivity/` when the replacement UI is available, and block mutating requests before legacy handlers run.
- Preserve retained browse, pending routes, first-run wizard redirects, and legacy fallback behavior when Web Shell/static app replacements are unavailable.
- Extend diagnostics, Web Shell/navigation expectations, release-certification evidence, docs, and focused tests for the removal-wave behavior.

## Test Plan

- `./gradlew spotlessApply`
- `./gradlew :adapter-http-legacy-admin:test`
- `./gradlew :adapter-http-legacy-browse:test`
- `./gradlew :platform-api:test`
- `./gradlew :platform-web-shell:test`
- `./gradlew :test --tests '*ToadletContextImplTest'`
- `./gradlew test`
- `python3 tools/release-certification/app_platform_smoke.py --self-test`
- `python3 tools/release-certification/release_certification.py --self-test`

## Notes

- No live node is required for the release-certification self-test evidence.
- FProxy browse ownership remains unchanged; browse and pending route regression tests cover that boundary.