### PR TITLE
fix(apphost): Confirm root handoffs before restart

### DIFF
--- a/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
+++ b/platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java
@@ -1225,7 +1225,7 @@ public final class LocalProcessAppHost implements AppHost {
     if (runningProcess == null) {
       return null;
     }
-    RunningProcess refreshedRunningProcess = runningProcess.refresh();
+    RunningProcess refreshedRunningProcess = refreshRunningProcess(runningProcess);
     if (refreshedRunningProcess == null) {
       refreshedRunningProcess = recoverTrackedRunningProcess(runningProcess);
     }
@@ -1242,7 +1242,7 @@ public final class LocalProcessAppHost implements AppHost {
 
   private StartupAcceptance acceptStartupRunningProcess(
       String appId, RunningProcess runningProcess, CompletableFuture<Void> exitCleanup) {
-    RunningProcess refreshedRunningProcess = runningProcess.refresh();
+    RunningProcess refreshedRunningProcess = refreshRunningProcess(runningProcess);
     if (refreshedRunningProcess == null) {
       refreshedRunningProcess = recoverTrackedRunningProcess(runningProcess);
     }
@@ -1259,6 +1259,16 @@ public final class LocalProcessAppHost implements AppHost {
       }
     }
     return StartupAcceptance.failed();
+  }
+
+  private RunningProcess refreshRunningProcess(RunningProcess runningProcess) {
+    return runningProcess.refresh(timing.trackedProcessPostExitCaptureGracePeriod());
+  }
+
+  private RunningProcess refreshRunningProcessFromTree(
+      RunningProcess runningProcess, List<ProcessHandle> processTree) {
+    return runningProcess.tryWithProcessTree(
+        processTree, timing.trackedProcessPostExitCaptureGracePeriod());
   }
 
   private boolean startupRestartScheduled(String appId, RunningProcess runningProcess) {
@@ -1830,6 +1840,8 @@ public final class LocalProcessAppHost implements AppHost {
       refreshObservedProcessTree(appId, process);
       TimeUnit.NANOSECONDS.sleep(timing.startupProcessPollInterval().toNanos());
     }
+    TimeUnit.NANOSECONDS.sleep(timing.startupProcessPollInterval().toNanos());
+    refreshObservedProcessTree(appId, process);
   }
 
   private void capturePostExitProcessTree(
@@ -1872,7 +1884,7 @@ public final class LocalProcessAppHost implements AppHost {
           if (activeProcess.process() != process) {
             return activeProcess;
           }
-          RunningProcess refreshed = activeProcess.refresh();
+          RunningProcess refreshed = refreshRunningProcess(activeProcess);
           if (refreshed == null) {
             refreshed = recoverTrackedRunningProcess(activeProcess);
           }
@@ -2614,7 +2626,7 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private boolean preserveRunningState(String appId, RunningProcess runningProcess) {
-    RunningProcess refreshedRunningProcess = runningProcess.refresh();
+    RunningProcess refreshedRunningProcess = refreshRunningProcess(runningProcess);
     if (refreshedRunningProcess == null) {
       runningApps.remove(appId, runningProcess);
       return false;
@@ -2625,7 +2637,8 @@ public final class LocalProcessAppHost implements AppHost {
 
   private RunningProcess trackRunningProcessForStop(String appId, RunningProcess runningProcess) {
     List<ProcessHandle> processTree = runningProcess.processTree();
-    RunningProcess trackedRunningProcess = runningProcess.tryWithProcessTree(processTree);
+    RunningProcess trackedRunningProcess =
+        refreshRunningProcessFromTree(runningProcess, processTree);
     if (trackedRunningProcess == null) {
       if (runningApps.remove(appId, runningProcess)) {
         recordProcessExit(
@@ -2645,7 +2658,7 @@ public final class LocalProcessAppHost implements AppHost {
   }
 
   private RunningProcess refreshTrackedRunningProcess(String appId, RunningProcess runningProcess) {
-    RunningProcess refreshedRunningProcess = runningProcess.refresh();
+    RunningProcess refreshedRunningProcess = refreshRunningProcess(runningProcess);
     if (refreshedRunningProcess == null) {
       refreshedRunningProcess = recoverTrackedRunningProcess(runningProcess);
     }
@@ -2688,7 +2701,7 @@ public final class LocalProcessAppHost implements AppHost {
     if (recoveredHandles.isEmpty()) {
       return null;
     }
-    return runningProcess.tryWithProcessTree(recoveredHandles);
+    return refreshRunningProcessFromTree(runningProcess, recoveredHandles);
   }
 
   private List<ProcessHandle> recoverTrackedProcesses(
@@ -3420,13 +3433,15 @@ public final class LocalProcessAppHost implements AppHost {
 
   @SuppressWarnings("ClassCanBeRecord")
   private static final class RunningProcess {
+    private static final long NO_ROOT_HANDOFF_CANDIDATE = -1L;
+
     private final Process process;
     private final RunningAppSnapshot snapshot;
     private final CompletableFuture<Void> exitCleanup;
     private final List<ProcessHandle> trackedHandles;
     private final int restartCount;
     private final int currentRestartAttempt;
-    private final boolean representativeProcessHandoff;
+    private final RootHandoffState rootHandoffState;
 
     private RunningProcess(
         Process process,
@@ -3436,13 +3451,31 @@ public final class LocalProcessAppHost implements AppHost {
         int restartCount,
         int currentRestartAttempt,
         boolean representativeProcessHandoff) {
+      this(
+          process,
+          snapshot,
+          exitCleanup,
+          trackedHandles,
+          restartCount,
+          currentRestartAttempt,
+          new RootHandoffState(representativeProcessHandoff, NO_ROOT_HANDOFF_CANDIDATE));
+    }
+
+    private RunningProcess(
+        Process process,
+        RunningAppSnapshot snapshot,
+        CompletableFuture<Void> exitCleanup,
+        List<ProcessHandle> trackedHandles,
+        int restartCount,
+        int currentRestartAttempt,
+        RootHandoffState rootHandoffState) {
       this.process = Objects.requireNonNull(process, "process");
       this.snapshot = Objects.requireNonNull(snapshot, "snapshot");
       this.exitCleanup = Objects.requireNonNull(exitCleanup, "exitCleanup");
       this.trackedHandles = List.copyOf(Objects.requireNonNull(trackedHandles, "trackedHandles"));
       this.restartCount = restartCount;
       this.currentRestartAttempt = currentRestartAttempt;
-      this.representativeProcessHandoff = representativeProcessHandoff;
+      this.rootHandoffState = Objects.requireNonNull(rootHandoffState, "rootHandoffState");
     }
 
     private Process process() {
@@ -3466,11 +3499,11 @@ public final class LocalProcessAppHost implements AppHost {
     }
 
     private boolean isRepresentativeProcessHandoff() {
-      return representativeProcessHandoff;
+      return rootHandoffState.confirmed();
     }
 
     private RunningProcess withObservedRootHandoff() {
-      if (representativeProcessHandoff
+      if (isRepresentativeProcessHandoff()
           || !hasTrackedDescendant()
           || isEffectivelyAlive(process.toHandle())) {
         return this;
@@ -3500,23 +3533,25 @@ public final class LocalProcessAppHost implements AppHost {
       return deduplicateHandles(seedHandles);
     }
 
-    private RunningProcess refresh() {
+    private RunningProcess refresh(Duration rootHandoffConfirmationGrace) {
       List<ProcessHandle> currentProcessTree = aliveHandles(processTree());
       if (currentProcessTree.isEmpty()) {
         return null;
       }
-      return tryWithAliveProcessTree(currentProcessTree);
+      return tryWithAliveProcessTree(currentProcessTree, rootHandoffConfirmationGrace);
     }
 
-    private RunningProcess tryWithProcessTree(List<ProcessHandle> newProcessTree) {
+    private RunningProcess tryWithProcessTree(
+        List<ProcessHandle> newProcessTree, Duration rootHandoffConfirmationGrace) {
       List<ProcessHandle> aliveProcessTree = aliveHandles(newProcessTree);
       if (aliveProcessTree.isEmpty()) {
         return null;
       }
-      return tryWithAliveProcessTree(aliveProcessTree);
+      return tryWithAliveProcessTree(aliveProcessTree, rootHandoffConfirmationGrace);
     }
 
-    private RunningProcess tryWithAliveProcessTree(List<ProcessHandle> aliveProcessTree) {
+    private RunningProcess tryWithAliveProcessTree(
+        List<ProcessHandle> aliveProcessTree, Duration rootHandoffConfirmationGrace) {
       boolean rootProcessExited = rootProcessExited(aliveProcessTree);
       if (!rootProcessExited && !isEffectivelyAlive(process.toHandle())) {
         aliveProcessTree = withoutRootProcess(aliveProcessTree);
@@ -3525,8 +3560,8 @@ public final class LocalProcessAppHost implements AppHost {
         }
         rootProcessExited = true;
       }
-      boolean updatedRepresentativeProcessHandoff =
-          representativeProcessHandoff || rootProcessExited;
+      RootHandoffState updatedRootHandoffState =
+          rootHandoffState(rootProcessExited, rootHandoffConfirmationGrace);
       long updatedPid = representativePid(aliveProcessTree, snapshot.pid(), false);
       RunningAppSnapshot updatedSnapshot =
           updatedPid == snapshot.pid()
@@ -3540,7 +3575,7 @@ public final class LocalProcessAppHost implements AppHost {
                   snapshot.sandboxStatus());
       if (trackedHandlePids().equals(handlePids(aliveProcessTree))
           && updatedPid == snapshot.pid()
-          && updatedRepresentativeProcessHandoff == representativeProcessHandoff) {
+          && updatedRootHandoffState.equals(rootHandoffState)) {
         return this;
       }
       return new RunningProcess(
@@ -3550,7 +3585,33 @@ public final class LocalProcessAppHost implements AppHost {
           aliveProcessTree,
           restartCount,
           currentRestartAttempt,
-          updatedRepresentativeProcessHandoff);
+          updatedRootHandoffState);
+    }
+
+    private RootHandoffState rootHandoffState(
+        boolean rootProcessExited, Duration rootHandoffConfirmationGrace) {
+      if (isRepresentativeProcessHandoff()) {
+        return new RootHandoffState(true, NO_ROOT_HANDOFF_CANDIDATE);
+      }
+      if (!rootProcessExited) {
+        return new RootHandoffState(false, NO_ROOT_HANDOFF_CANDIDATE);
+      }
+      // A clean wrapper can briefly leave stale descendant handles while it reaps a child.
+      // Confirm the handoff only after the existing post-exit capture grace keeps seeing it.
+      long candidateAtNanos = rootHandoffState.candidateAtNanos();
+      long nowNanos = System.nanoTime();
+      if (candidateAtNanos == NO_ROOT_HANDOFF_CANDIDATE) {
+        candidateAtNanos = nowNanos;
+      }
+      if (rootHandoffCandidateExpired(candidateAtNanos, rootHandoffConfirmationGrace, nowNanos)) {
+        return new RootHandoffState(true, NO_ROOT_HANDOFF_CANDIDATE);
+      }
+      return new RootHandoffState(false, candidateAtNanos);
+    }
+
+    private static boolean rootHandoffCandidateExpired(
+        long candidateAtNanos, Duration rootHandoffConfirmationGrace, long nowNanos) {
+      return nowNanos - candidateAtNanos >= rootHandoffConfirmationGrace.toNanos();
     }
 
     private boolean rootProcessExited(List<ProcessHandle> aliveProcessTree) {
@@ -3575,5 +3636,7 @@ public final class LocalProcessAppHost implements AppHost {
     private static List<Long> handlePids(List<ProcessHandle> processHandles) {
       return processHandles.stream().map(ProcessHandle::pid).sorted().toList();
     }
+
+    private record RootHandoffState(boolean confirmed, long candidateAtNanos) {}
   }
 }

--- a/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
+++ b/platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.LockSupport;
@@ -82,6 +83,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1806,6 +1808,65 @@ class LocalProcessAppHostTest {
     assertEquals(0, status.restartCount());
     assertEquals("1\n", Files.readString(runCountFile, StandardCharsets.UTF_8));
     assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+  }
+
+  @Test
+  void restartPolicy_whenCleanRootExitLeavesTransientChildHandle_expectNoFailureRestart()
+      throws IOException, ReflectiveOperationException {
+    LocalProcessAppHost host = allowUnsignedHost();
+    Path stagedApp = stageInstalledRunnerApp(IMMEDIATE_CRASH_SCRIPT);
+    appendOnFailureRestartPolicy(stagedApp, 10);
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    Process process = new CleanExitedProcessWithTransientChild(101L, 102L, 2);
+    RunningAppSnapshot snapshot =
+        new RunningAppSnapshot(
+            installation.manifest(),
+            installation.paths(),
+            DEFAULT_TOKEN,
+            process.pid(),
+            Instant.now());
+    injectRunningProcess(
+        host, RUNNER_APP_ID, snapshot, process, CompletableFuture.completedFuture(null));
+
+    AppRuntimeStatusSnapshot runningStatus = host.runtimeStatus(RUNNER_APP_ID);
+    assertEquals(AppRuntimeState.RUNNING, runningStatus.state());
+    AppRuntimeStatusSnapshot status = waitForRuntimeState(host, AppRuntimeState.EXITED);
+
+    assertEquals(0, status.lastExitCode());
+    assertEquals(0, status.currentRestartAttempt());
+    assertEquals(0, status.restartCount());
+    assertTrue(host.status(RUNNER_APP_ID).isEmpty());
+  }
+
+  @Test
+  void restartPolicy_whenObservedHandoffChildExitsAfterGrace_expectUnknownExitRestarts()
+      throws IOException, ReflectiveOperationException {
+    AppEnv appEnv = new AppEnv();
+    Assumptions.assumeFalse(appEnv.isWindows());
+    LocalProcessAppHost host = allowUnsignedHost();
+    Path stagedApp = stageInstalledRunnerApp(WORKING_DIRECTORY_AND_TOKEN_LOG_SCRIPT);
+    appendOnFailureRestartPolicy(stagedApp, 10);
+    InstalledAppSnapshot installation = host.installFromDirectory(stagedApp);
+    ControlledProcessHandle childHandle = new ControlledProcessHandle(102L);
+    Process process = new CleanExitedProcessWithTransientChild(101L, childHandle);
+    RunningAppSnapshot snapshot =
+        new RunningAppSnapshot(
+            installation.manifest(),
+            installation.paths(),
+            DEFAULT_TOKEN,
+            process.pid(),
+            Instant.now());
+    injectRunningProcess(
+        host, RUNNER_APP_ID, snapshot, process, CompletableFuture.completedFuture(null));
+
+    invokeCapturePostExitProcessTreeHandoff(host, process);
+    childHandle.markExited();
+
+    AppRuntimeStatusSnapshot restartedStatus = waitForRunnerRestarted(host);
+    assertNull(restartedStatus.lastExitCode());
+    assertEquals(1, restartedStatus.currentRestartAttempt());
+    assertEquals(1, restartedStatus.restartCount());
+    assertTrue(host.stop(RUNNER_APP_ID));
   }
 
   @Test
@@ -3675,6 +3736,16 @@ class LocalProcessAppHostTest {
     return (boolean) preserveRunningState.invoke(host, RUNNER_APP_ID, runningProcess);
   }
 
+  @SuppressWarnings("java:S3011")
+  private static void invokeCapturePostExitProcessTreeHandoff(
+      LocalProcessAppHost host, Process process) throws ReflectiveOperationException {
+    Method capturePostExitProcessTreeHandoff =
+        LocalProcessAppHost.class.getDeclaredMethod(
+            "capturePostExitProcessTreeHandoff", String.class, Process.class);
+    capturePostExitProcessTreeHandoff.setAccessible(true);
+    capturePostExitProcessTreeHandoff.invoke(host, RUNNER_APP_ID, process);
+  }
+
   private static void invokeParseRunnerTokenTrackedProcesses(Process process)
       throws ReflectiveOperationException, IOException {
     MethodHandle parseTokenTrackedProcesses =
@@ -3957,6 +4028,21 @@ class LocalProcessAppHostTest {
       pausePolling("interrupted while waiting for app runtime state: " + RUNNER_APP_ID);
     }
     throw new AssertionError("timed out waiting for app runtime state: " + RUNNER_APP_ID);
+  }
+
+  private static AppRuntimeStatusSnapshot waitForRunnerRestarted(AppHost host) throws IOException {
+    long deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos();
+    AppRuntimeStatusSnapshot lastStatus = null;
+    while (System.nanoTime() < deadline) {
+      AppRuntimeStatusSnapshot status = host.runtimeStatus(RUNNER_APP_ID);
+      lastStatus = status;
+      if (status.state() == AppRuntimeState.RUNNING && status.currentRestartAttempt() == 1) {
+        return status;
+      }
+      pausePolling("interrupted while waiting for app runtime restart: " + RUNNER_APP_ID);
+    }
+    throw new AssertionError(
+        "timed out waiting for app runtime restart: " + RUNNER_APP_ID + " last=" + lastStatus);
   }
 
   private static AppRuntimeStatusSnapshot waitForCrashedInactiveSandboxStatus(AppHost host)
@@ -4730,6 +4816,179 @@ class LocalProcessAppHostTest {
     }
   }
 
+  private static final class CleanExitedProcessWithTransientChild extends Process {
+    private final long pid;
+    private final ProcessHandle handle;
+
+    private CleanExitedProcessWithTransientChild(
+        long pid, long childPid, int childAliveChecksBeforeExit) {
+      this(pid, new FadingProcessHandle(childPid, childAliveChecksBeforeExit));
+    }
+
+    private CleanExitedProcessWithTransientChild(long pid, ProcessHandle childHandle) {
+      this.pid = pid;
+      this.handle = new CleanExitedProcessWithTransientChildHandle(childHandle);
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+      return OutputStream.nullOutputStream();
+    }
+
+    @Override
+    public InputStream getInputStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public InputStream getErrorStream() {
+      return InputStream.nullInputStream();
+    }
+
+    @Override
+    public int waitFor() {
+      return 0;
+    }
+
+    @Override
+    public boolean waitFor(long timeout, TimeUnit unit) {
+      return true;
+    }
+
+    @Override
+    public int exitValue() {
+      return 0;
+    }
+
+    @Override
+    public void destroy() {
+      // Intentionally blank: this fake process already exits.
+    }
+
+    @Override
+    public Process destroyForcibly() {
+      return this;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return false;
+    }
+
+    @Override
+    public long pid() {
+      return pid;
+    }
+
+    @Override
+    public ProcessHandle toHandle() {
+      return handle;
+    }
+
+    private final class CleanExitedProcessWithTransientChildHandle implements ProcessHandle {
+      private final ProcessHandle childHandle;
+
+      private CleanExitedProcessWithTransientChildHandle(ProcessHandle childHandle) {
+        this.childHandle = childHandle;
+      }
+
+      @Override
+      public long pid() {
+        return pid;
+      }
+
+      @Override
+      public Info info() {
+        return new Info() {
+          @Override
+          public java.util.Optional<String> command() {
+            return java.util.Optional.empty();
+          }
+
+          @Override
+          public java.util.Optional<String> commandLine() {
+            return java.util.Optional.empty();
+          }
+
+          @Override
+          public java.util.Optional<String[]> arguments() {
+            return java.util.Optional.empty();
+          }
+
+          @Override
+          public java.util.Optional<Instant> startInstant() {
+            return java.util.Optional.empty();
+          }
+
+          @Override
+          public java.util.Optional<Duration> totalCpuDuration() {
+            return java.util.Optional.empty();
+          }
+
+          @Override
+          public java.util.Optional<String> user() {
+            return java.util.Optional.empty();
+          }
+        };
+      }
+
+      @Override
+      public CompletableFuture<ProcessHandle> onExit() {
+        return CompletableFuture.completedFuture(this);
+      }
+
+      @Override
+      public boolean supportsNormalTermination() {
+        return true;
+      }
+
+      @Override
+      public boolean destroy() {
+        return true;
+      }
+
+      @Override
+      public boolean destroyForcibly() {
+        return true;
+      }
+
+      @Override
+      public boolean isAlive() {
+        return false;
+      }
+
+      @Override
+      public java.util.Optional<ProcessHandle> parent() {
+        return java.util.Optional.empty();
+      }
+
+      @Override
+      public java.util.stream.Stream<ProcessHandle> children() {
+        return java.util.stream.Stream.of(childHandle);
+      }
+
+      @Override
+      public java.util.stream.Stream<ProcessHandle> descendants() {
+        return children();
+      }
+
+      @Override
+      public int compareTo(ProcessHandle other) {
+        return Long.compare(pid, other.pid());
+      }
+
+      @Override
+      public boolean equals(Object other) {
+        return other instanceof ProcessHandle otherHandle && pid == otherHandle.pid();
+      }
+
+      @Override
+      public int hashCode() {
+        return Long.hashCode(pid);
+      }
+    }
+  }
+
   private static final class ExitedProcess extends Process {
     private final long pid;
     private final ProcessHandle handle;
@@ -5251,6 +5510,114 @@ class LocalProcessAppHostTest {
     public boolean isAlive() {
       int checksRemaining = remainingAliveChecks.getAndUpdate(current -> Math.max(0, current - 1));
       return checksRemaining > 0;
+    }
+
+    @Override
+    public java.util.Optional<ProcessHandle> parent() {
+      return java.util.Optional.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> children() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public java.util.stream.Stream<ProcessHandle> descendants() {
+      return java.util.stream.Stream.empty();
+    }
+
+    @Override
+    public int compareTo(ProcessHandle other) {
+      return Long.compare(pid, other.pid());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof ProcessHandle handle && pid == handle.pid();
+    }
+
+    @Override
+    public int hashCode() {
+      return Long.hashCode(pid);
+    }
+  }
+
+  private static final class ControlledProcessHandle implements ProcessHandle {
+    private final long pid;
+    private final AtomicBoolean alive = new AtomicBoolean(true);
+
+    private ControlledProcessHandle(long pid) {
+      this.pid = pid;
+    }
+
+    private void markExited() {
+      alive.set(false);
+    }
+
+    @Override
+    public long pid() {
+      return pid;
+    }
+
+    @Override
+    public Info info() {
+      return new Info() {
+        @Override
+        public java.util.Optional<String> command() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String> commandLine() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String[]> arguments() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<Instant> startInstant() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<Duration> totalCpuDuration() {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public java.util.Optional<String> user() {
+          return java.util.Optional.empty();
+        }
+      };
+    }
+
+    @Override
+    public CompletableFuture<ProcessHandle> onExit() {
+      return CompletableFuture.completedFuture(this);
+    }
+
+    @Override
+    public boolean supportsNormalTermination() {
+      return true;
+    }
+
+    @Override
+    public boolean destroy() {
+      return true;
+    }
+
+    @Override
+    public boolean destroyForcibly() {
+      return true;
+    }
+
+    @Override
+    public boolean isAlive() {
+      return alive.get();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Delay AppHost root-handoff confirmation until a descendant remains observable through the post-exit capture grace period.
- Preserve clean wrapper exits with transient descendant handles so `ON_FAILURE` apps do not restart incorrectly.
- Add regression coverage for transient clean child handles and confirmed handoff failures, including Windows-safe handling for the POSIX restart scenario.
- Clean up the touched AppHost test helpers to remove the reported Sonar findings.

## How to test
- `./gradlew spotlessApply`
- `./gradlew :platform-apphost:test --tests network.crypta.platform.apphost.runtime.LocalProcessAppHostTest.restartPolicy_whenObservedHandoffChildExitsAfterGrace_expectUnknownExitRestarts --tests network.crypta.platform.apphost.runtime.LocalProcessAppHostTest.restartPolicy_whenCleanRootExitLeavesTransientChildHandle_expectNoFailureRestart`
- `./gradlew :platform-apphost:test`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=platform-apphost/src/main/java/network/crypta/platform/apphost/runtime/LocalProcessAppHost.java`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=platform-apphost/src/test/java/network/crypta/platform/apphost/runtime/LocalProcessAppHostTest.java`
- `git diff --check`