### PR TITLE
feat(platform-devtools): Add developer beta toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,9 @@ legacy advisory `review` object.
 First-party apps can keep using `:apps:queue-manager`, `:apps:publisher`, and
 `:apps:site-publisher` `stageApp`, `signApp`, and `verifyApp` tasks. See
 [docs/app-dev-cli.md](docs/app-dev-cli.md) for the standalone CLI flow and
-[docs/app-catalogs.md](docs/app-catalogs.md) for catalog entry descriptors and verification.
+[docs/app-catalogs.md](docs/app-catalogs.md) for catalog entry descriptors and verification. The
+PR-225 beta toolkit sidecar walkthrough is in
+[docs/developer-beta-toolkit.md](docs/developer-beta-toolkit.md).
 
 ## Platform Closeout & API Surface
 

--- a/docs/app-catalogs.md
+++ b/docs/app-catalogs.md
@@ -26,6 +26,12 @@ authenticates the extracted app bundle. A review receipt signature independently
 review evidence from a reviewer key that the local node trusts for app review. Legacy
 `review.status` and `review.note` catalog metadata remains publisher-advisory only.
 
+For third-party app authors, `crypta-app catalog entry` can generate the descriptor input for
+`catalog create`, and `crypta-app publish-usk --dry-run` can produce an offline publication
+checklist for a signed catalog. Those helpers do not change the runtime trust layers described
+here; they only reduce hand-authored descriptor and publication-plan mistakes. See
+[developer-beta-toolkit.md](developer-beta-toolkit.md).
+
 ## Catalog files
 
 A catalog source points at `cryptad-app-catalog.properties`. The matching signature is read from

--- a/docs/app-dev-cli.md
+++ b/docs/app-dev-cli.md
@@ -10,12 +10,17 @@ projects. The command works on a staged bundle directory containing `cryptad-app
 launch files, and optional `static/` assets. The scaffold is a standalone staged bundle directory,
 not a new Gradle subproject.
 
-The CLI is offline filesystem tooling. It does not provide hot reload or a daemon-side install
-command. Install and update flows still go through the Platform API or signed catalog source
-handling described in [app-catalogs.md](app-catalogs.md).
+The signing, packing, validation, and catalog commands are offline filesystem tooling. The beta
+toolkit adds a local mock development server for static app UI iteration, but it is not hot reload
+and it is not a daemon-side install command. Install and update flows still go through the Platform
+API or signed catalog source handling described in [app-catalogs.md](app-catalogs.md).
 
 First-party repo apps can keep using their existing Gradle tasks. See
 [First-party Gradle workflow](#first-party-gradle-workflow).
+
+For the PR-225 beta sidecar workflow, including `init --template queue-dashboard`, the mock
+development server, strict beta test wrapper, local key generation, and `publish-usk --dry-run`,
+see [developer-beta-toolkit.md](developer-beta-toolkit.md).
 
 ## Build and run the command
 
@@ -51,6 +56,7 @@ crypta-app init \
   --app-id <app-id> \
   --name <display-name> \
   --version <version> \
+  [--template static-basic|queue-dashboard|publisher|vault-profile] \
   [--ui-mode static|shell-panel|none] \
   [--permission <capability>] \
   [--overwrite]
@@ -101,6 +107,17 @@ supported `cr-*` vocabulary, local-resource rules, and permission-disclosure gui
 scaffold is created with `--ui-mode none`, no browser UI is declared. If it uses
 `--ui-mode shell-panel`, the manifest points at a shell-panel entry instead of an app-owned static
 route.
+
+`--template` defaults to `static-basic`, which preserves the minimal static scaffold. The beta
+templates `queue-dashboard`, `publisher`, and `vault-profile` are static-only examples that vendor
+the same SDK and design-system assets, declare the permissions they demonstrate, and include visible
+permission disclosure. They are intended as staged bundles for app authors, not new Gradle
+subprojects. The `publisher` template uses the same `sourcePath`, `insertUri`, and `identifier`
+form fields accepted by `/api/v1/queue/inserts/file`; it does not read local files through browser
+file inputs. The `vault-profile` template sets `api.experimentalCapabilitiesAccepted=true` because
+the current vault capabilities are experimental. See
+[developer-beta-toolkit.md](developer-beta-toolkit.md) for the complete mock-dev, offline-test,
+signing, catalog, and dry-run publication flow.
 
 A static scaffold should produce a manifest with fields like:
 
@@ -501,6 +518,9 @@ operator flow.
 
 ## Related docs
 
+- [developer-beta-toolkit.md](developer-beta-toolkit.md) gives the PR-225 beta toolkit walkthrough
+  for queue-dashboard scaffolding, mock dev runs, strict tests, key generation, signing, cataloging,
+  and dry-run USK publication.
 - [app-distribution.md](app-distribution.md) describes the signed bundle sidecars, manifest fields,
   and first-party Gradle tasks.
 - [app-ui-design-system.md](app-ui-design-system.md) describes canonical app UI assets and

--- a/docs/app-permissions-and-audit.md
+++ b/docs/app-permissions-and-audit.md
@@ -79,6 +79,12 @@ credentials, and do not allow `X-Crypta-App-Token` through app-browser preflight
 registered app origin without `X-Crypta-App-Session` fail as app-browser authentication failures
 and do not fall back to host/operator Web Shell authentication.
 
+The `crypta-app dev` beta mock server intentionally mirrors the browser-session header shape for
+local template development: bootstrap returns a mock browser session, and mock `/api/v1/...` routes
+return `401 invalid_app_browser_session` when the `X-Crypta-App-Session` value is missing or wrong.
+That local session is not a real AppHost process token and does not install or authorize an app on
+a live node. See [developer-beta-toolkit.md](developer-beta-toolkit.md).
+
 ## App principals
 
 When a process token authenticates, the Platform API receives a token-free app principal:

--- a/docs/app-ui-design-system.md
+++ b/docs/app-ui-design-system.md
@@ -39,6 +39,12 @@ Static app JavaScript should still load the browser SDK before app code:
 <script type="module" src="./app.js"></script>
 ```
 
+The `crypta-app init --template` beta templates vendor these assets automatically and are expected
+to pass `crypta-app ui lint --strict` and `crypta-app test --strict` before signing. The mock
+development server in `crypta-app dev` serves only staged static assets and does not relax the
+local-resource or permission-disclosure rules. See
+[developer-beta-toolkit.md](developer-beta-toolkit.md).
+
 ## Stable classes
 
 The first stable vocabulary is deliberately narrow:

--- a/docs/developer-beta-toolkit.md
+++ b/docs/developer-beta-toolkit.md
@@ -1,0 +1,418 @@
+# Developer beta toolkit
+
+This guide describes the PR-225 developer beta toolkit workflow for building, testing, signing,
+cataloging, and dry-run publishing a standalone Crypta app bundle.
+
+## Scope
+
+Use this page with a `crypta-app` launcher built from a PR-225-compatible `:platform-devtools`
+tree. Older launchers may expose only the base commands documented in
+[app-dev-cli.md](app-dev-cli.md). Run `crypta-app --help` and the subcommand help before relying on
+beta flags in automation.
+
+The beta toolkit is for developer-owned app bundles outside the first-party `apps/*` Gradle
+projects. It can scaffold a queue dashboard template, run a mock development server, execute
+offline strict checks, generate local signing keys, sign and pack bundles, create and sign catalogs,
+and prepare a dry-run USK publication plan. It does not make unsigned bundles trusted, bypass
+catalog verification, or turn a mock development server into a live daemon install path.
+
+## Install the toolkit
+
+Build the installed CLI launcher with Gradle:
+
+```bash
+./gradlew :platform-devtools:installDist
+```
+
+Use the generated launcher directly from the install distribution:
+
+```bash
+platform-devtools/build/install/crypta-app/bin/crypta-app --help
+```
+
+On Windows, use the matching `crypta-app.bat` under the generated `bin` directory.
+
+The examples below assume the launcher directory is on `PATH`:
+
+```bash
+export PATH="$PWD/platform-devtools/build/install/crypta-app/bin:$PATH"
+```
+
+## Create a queue dashboard app
+
+Scaffold a standalone staged bundle with the queue dashboard template:
+
+```bash
+crypta-app init \
+  --dir build/dev-apps/queue-dashboard \
+  --template queue-dashboard \
+  --app-id queue-dashboard \
+  --name "Queue Dashboard" \
+  --version 0.1.0 \
+  --permission queue.read \
+  --permission queue.write
+```
+
+The output is a staged app bundle directory, not a Gradle subproject. The template should create the
+app manifest, launch files, browser assets, SDK copy, and local design-system assets under the
+bundle directory. Keep generated work under `build/` or `dist/` unless you intentionally want to
+check in source files.
+
+The signed manifest remains authoritative for app id, version, launch behavior, UI mode, requested
+permissions, and Platform API compatibility metadata. Catalog metadata can add display and review
+context, but it does not replace the bundle manifest.
+
+## Run the mock development server
+
+Start the beta development server against the staged bundle:
+
+```bash
+crypta-app dev --bundle-dir build/dev-apps/queue-dashboard
+```
+
+The development server is a mock app-authoring surface. It is useful for iterating on static UI,
+template assets, local SDK wiring, and fixture-backed queue views. It is not the real Cryptad
+daemon, does not install the app into AppHost, does not fetch signed catalogs, and does not prove
+that a live node will grant the same permissions.
+
+Use a real daemon when testing install, update, AppHost lifecycle, catalog refresh, browser session
+issuance, audit behavior, review policy, or Crypta network fetch/insert behavior. Live daemon
+install and update still go through signed bundle and signed catalog verification as described in
+[app-catalogs.md](app-catalogs.md) and [app-update-lifecycle.md](app-update-lifecycle.md).
+
+## Run strict checks
+
+Run the beta test wrapper in strict mode:
+
+```bash
+crypta-app test --bundle-dir build/dev-apps/queue-dashboard --strict
+```
+
+Strict mode should be treated as the pre-signing gate. It is expected to include bundle validation,
+Platform API compatibility verification, and static UI lint checks. For static UI bundles, the UI
+lint checks cover local-resource rules, SDK/bootstrap ordering, obvious CSP mistakes, accessibility
+basics, permission disclosure, and design-system adoption. The base checks are documented in
+[app-ui-design-system.md](app-ui-design-system.md).
+
+You can also run the base commands directly when you need narrower feedback:
+
+```bash
+crypta-app ui lint --bundle-dir build/dev-apps/queue-dashboard --strict
+crypta-app validate --bundle-dir build/dev-apps/queue-dashboard --strict
+crypta-app compat verify --bundle-dir build/dev-apps/queue-dashboard --strict
+```
+
+Do not sign or catalog a bundle that fails strict checks. A warning promoted to an error usually
+means the bundle is relying on an unknown permission, stale compatibility metadata, missing
+permission disclosure, remote UI resource, or unsupported design-system pattern.
+
+## Generate local keys
+
+Generate local development key pairs outside the repository:
+
+```bash
+mkdir -p "$HOME/.crypta-dev/keys"
+crypta-app keys generate \
+  --key-id dev-local-bundle \
+  --private-key-file "$HOME/.crypta-dev/keys/dev-local-bundle-private.der" \
+  --public-key-file "$HOME/.crypta-dev/keys/dev-local-bundle-public.der" \
+  --trusted-keys-file "$HOME/.crypta-dev/keys/trusted-app-keys.properties" \
+  --overwrite
+crypta-app keys generate \
+  --key-id dev-local-catalog \
+  --private-key-file "$HOME/.crypta-dev/keys/dev-local-catalog-private.der" \
+  --public-key-file "$HOME/.crypta-dev/keys/dev-local-catalog-public.der" \
+  --overwrite
+```
+
+Use different key ids for different trust roles when possible:
+
+| Role | Example key id | What it signs |
+| --- | --- | --- |
+| Bundle publisher | `dev-local-bundle` | `cryptad-app.digests` through `cryptad-app.signature`. |
+| Catalog publisher | `dev-local-catalog` | `cryptad-app-catalog.properties` through `cryptad-app-catalog.signature`. |
+| Reviewer | `dev-review` | Independent review receipt payload bytes provisioned through the review-key registry. |
+
+Local development keys are not production keys. Do not commit private keys, reviewer private keys,
+trusted-key registries containing private material, private insert URIs, or generated secrets.
+
+## Sign, pack, and verify the bundle
+
+Sign the staged bundle:
+
+```bash
+crypta-app sign \
+  --bundle-dir build/dev-apps/queue-dashboard \
+  --key-id dev-local-bundle \
+  --private-key-file "$HOME/.crypta-dev/keys/dev-local-bundle-private.der"
+```
+
+The bundle signature authenticates the bundle payload. It writes the root sidecars
+`cryptad-app.digests` and `cryptad-app.signature`. The digest sidecar includes the manifest and
+regular bundle files and excludes reserved distribution sidecars.
+
+Pack the signed bundle as a catalog artifact:
+
+```bash
+mkdir -p dist/apps
+crypta-app pack \
+  --bundle-dir build/dev-apps/queue-dashboard \
+  --output dist/apps/queue-dashboard-0.1.0.zip \
+  --overwrite
+```
+
+Verify the signed staged bundle with the trusted public key:
+
+```bash
+crypta-app verify \
+  --bundle-dir build/dev-apps/queue-dashboard \
+  --trusted-keys-file "$HOME/.crypta-dev/keys/trusted-app-keys.properties"
+```
+
+Packing does not make an unsigned or invalid bundle trusted. The runtime catalog install path still
+verifies artifact size, artifact SHA-256, extracted bundle signature, and manifest id/version before
+AppHost receives the bundle.
+
+## Create a catalog entry descriptor
+
+Create an entry descriptor for the packed artifact:
+
+```bash
+mkdir -p dist/catalog
+crypta-app catalog entry \
+  --bundle-dir build/dev-apps/queue-dashboard \
+  --output dist/catalog/queue-dashboard-entry.properties \
+  --artifact dist/apps/queue-dashboard-0.1.0.zip \
+  --bundle-uri "crypta:CHK@<artifact-key>" \
+  --summary "Inspect and manage local transfer queue state." \
+  --homepage "https://example.invalid/apps/queue-dashboard" \
+  --source "https://example.invalid/src/queue-dashboard" \
+  --license "MIT" \
+  --category productivity \
+  --minimum-crypta-version 1481 \
+  --permission-rationale "queue.read=Reads local queue state." \
+  --permission-rationale "queue.write=Cancels or reprioritizes selected queue entries." \
+  --overwrite
+```
+
+The descriptor is authoring input for `catalog create`; it is not the app manifest and is not the
+signed catalog. It should name the exact ZIP artifact so the catalog writer can compute the public
+artifact size and lowercase SHA-256 digest from the bytes that will be distributed.
+
+If the beta `catalog entry` helper is not available in your launcher, write the descriptor manually
+using the shape in [app-dev-cli.md](app-dev-cli.md#catalog-descriptor-and-flow):
+
+```properties
+artifact.path=/abs/path/to/dist/apps/queue-dashboard-0.1.0.zip
+bundle.uri=crypta:CHK@<artifact-key>
+summary=Inspect and manage local transfer queue state.
+name=Queue Dashboard
+version=0.1.0
+permissions=queue.read,queue.write
+app.id=queue-dashboard
+homepage=https://example.invalid/apps/queue-dashboard
+source=https://example.invalid/src/queue-dashboard
+license=MIT
+categories=productivity
+permissions.rationale.queue.read=Reads local queue state.
+permissions.rationale.queue.write=Cancels or reprioritizes selected queue entries.
+api.minimumVersion=1
+api.maximumTestedVersion=1
+api.experimentalCapabilitiesAccepted=false
+```
+
+Catalog entry metadata is for operator display, compatibility hints, and review context. Permission
+rationales do not grant capabilities. URI fields do not fetch automatically in the Web Shell unless
+the operator takes an explicit action.
+
+## Optional review receipt
+
+A review receipt is independent reviewer evidence. It is not the bundle signature and not the
+catalog signature. Create one before catalog creation when your policy requires review evidence:
+
+```bash
+crypta-app review sign \
+  --catalog-entry dist/catalog/queue-dashboard-entry.properties \
+  --receipt-file dist/catalog/queue-dashboard-review.properties \
+  --reviewer-key-id dev-review \
+  --reviewer-private-key-file /abs/path/outside/repo/dev-review-private.der \
+  --policy-id crypta-app-review-v1 \
+  --policy-version 1 \
+  --status reviewed \
+  --note "Reviewed for local beta testing." \
+  --overwrite
+```
+
+Verify it with a trusted reviewer-key registry:
+
+```bash
+crypta-app review verify \
+  --catalog-entry dist/catalog/queue-dashboard-entry.properties \
+  --receipt-file dist/catalog/queue-dashboard-review.properties \
+  --trusted-reviewer-keys-file /abs/path/outside/repo/trusted-reviewers.properties
+```
+
+The receipt binds a reviewer decision to the app id, app version, artifact digest, artifact size,
+reviewer policy, reviewer key id, timestamps, and optional evidence. A trusted `rejected` receipt
+is still not a positive review. Publisher-advisory `review.status=reviewed` is not the same thing
+as a trusted review receipt.
+
+## Create, sign, and verify the catalog
+
+Create the catalog properties file:
+
+```bash
+crypta-app catalog create \
+  --catalog-file dist/catalog/cryptad-app-catalog.properties \
+  --catalog-id dev-queue-dashboard \
+  --name "Development Queue Dashboard" \
+  --entry dist/catalog/queue-dashboard-entry.properties \
+  --review-receipt dist/catalog/queue-dashboard-review.properties \
+  --overwrite
+```
+
+Sign the exact catalog bytes:
+
+```bash
+crypta-app catalog sign \
+  --catalog-file dist/catalog/cryptad-app-catalog.properties \
+  --key-id dev-local-catalog \
+  --private-key-file "$HOME/.crypta-dev/keys/dev-local-catalog-private.der"
+```
+
+Verify the catalog and sibling signature:
+
+```bash
+crypta-app catalog verify \
+  --catalog-file dist/catalog/cryptad-app-catalog.properties \
+  --trusted-key-id dev-local-catalog \
+  --trusted-public-key-file "$HOME/.crypta-dev/keys/dev-local-catalog-public.der"
+```
+
+The catalog signature authenticates the exact bytes of
+`dist/catalog/cryptad-app-catalog.properties`. Do not sort, rewrite, or reformat that file after
+signing. A valid catalog signature authenticates catalog bytes and publisher metadata only; it does
+not authenticate the extracted app payload, does not grant Platform API permissions, and does not
+make reviewer claims trusted.
+
+## Dry-run USK publication
+
+Prepare a dry-run catalog publication plan:
+
+```bash
+crypta-app publish-usk \
+  --catalog-file dist/catalog/cryptad-app-catalog.properties \
+  --catalog-signature-file dist/catalog/cryptad-app-catalog.signature \
+  --catalog-source "crypta:USK@<public-key>/apps/dev-queue-dashboard/cryptad-app-catalog.properties" \
+  --output dist/catalog/publish-plan.md \
+  --dry-run
+```
+
+Dry-run mode must not insert catalog bytes, signature bytes, or app artifacts into Crypta. Treat it
+as a plan and validation step: it should confirm which files would be published, which USK path
+would be used, which public source URI operators would add, and whether the catalog and signature
+sidecar files are present and parse.
+
+Live insertion is different. A live publish uses an insert-capable key, contacts a real daemon or
+publishing transport, consumes network resources, and may make the catalog source discoverable to
+anyone who knows the corresponding public URI. Do not run live insertion with private insert URIs
+or production keys in logs, shell history, CI summaries, review evidence, or release-certification
+artifacts.
+
+## Runtime trust model
+
+Keep the beta toolkit boundaries explicit:
+
+| Boundary | What it means | What it does not mean |
+| --- | --- | --- |
+| Mock dev server | Local fixture-backed UI and SDK iteration. | Real daemon install, real AppHost launch, live catalog refresh, or network insertion. |
+| Real daemon | Runtime Platform API, AppHost lifecycle, browser-session issuance, audit, catalog refresh, and Crypta transport. | Automatic trust in unsigned bundles or untrusted catalogs. |
+| Dry-run publish | Local validation and publication plan. | Live insertion or public availability. |
+| Live insertion | Bytes are submitted to Crypta through a real insert path. | Catalog or bundle trust; signatures still verify locally. |
+| Catalog signature | Authenticates catalog properties bytes and publisher metadata. | Bundle payload trust or reviewer trust. |
+| Bundle signature | Authenticates the staged app payload through digest and signature sidecars. | Catalog publisher trust or reviewer approval. |
+| Review receipt | Authenticates independent reviewer evidence with a trusted reviewer key. | App signing authority, catalog signing authority, or permission grant. |
+| `crypta:` URI | Transport location for catalog sidecars or immutable CHK artifacts. | Trust boundary. Signatures, sizes, and digests remain mandatory. |
+
+Catalog sources may use `crypta:` USK/SSK paths for catalog sidecars or CHK companion forms for
+immutable catalog bytes. App ZIP artifacts published through catalogs must use supported artifact
+URI forms documented in [app-catalogs.md](app-catalogs.md#source-and-artifact-fetching). A
+`crypta:CHK@...` artifact URI is only a byte transport. The runtime still enforces the catalog
+declared size and SHA-256 before extracting and verifying the signed bundle.
+
+## Process tokens and browser sessions
+
+AppHost launch tokens and app browser sessions are separate credentials.
+
+An AppHost process receives a fresh `CRYPTAD_APP_TOKEN` at launch. Process-originated Platform API
+requests authenticate with that token and then pass the central capability matrix. The token must
+not appear in browser bootstrap JSON, logs, diagnostics, catalog responses, audit entries, or
+operator-facing errors.
+
+An app-owned static UI receives a short-lived browser session through the app bootstrap route and
+uses it as `X-Crypta-App-Session`. The browser session is origin-bound to the installed app UI and
+is not an AppHost process token. The browser SDK keeps it in memory and must not persist it to
+`localStorage`, `sessionStorage`, cookies, or catalog metadata.
+
+A valid process token or browser session is still not enough by itself. The requested route must
+allow the app principal and the signed manifest must declare the required capability. Missing
+capability returns an authorization failure even when authentication succeeds.
+
+## UI lint and design-system expectations
+
+Static app UI should use local bundle assets only. Load the browser SDK from
+`./crypta-platform.js` and the design-system assets from `./crypta-ui/`. Do not add CDN CSS,
+remote JavaScript, third-party font loads, or silent screenshot/image fetches from catalog
+metadata.
+
+`crypta-app test --strict` and `crypta-app ui lint --strict` should fail static UI bundles that
+violate the local-resource model, omit permission disclosure, drift from SDK/bootstrap ordering, or
+depend on unsupported design-system patterns. The lint is an offline developer gate. Runtime
+authorization, token handling, and catalog verification still happen server-side.
+
+## API compatibility
+
+Bundle manifests should declare Platform API compatibility metadata:
+
+```properties
+api.minimumVersion=1
+api.maximumTestedVersion=1
+api.experimentalCapabilitiesAccepted=false
+```
+
+Stable-only templates such as `queue-dashboard` and `publisher` keep experimental capability
+acceptance disabled. The `vault-profile` template enables
+`api.experimentalCapabilitiesAccepted=true` because its default `vault.*` permissions exercise
+experimental app-vault capabilities.
+
+Run compatibility checks before signing:
+
+```bash
+crypta-app api snapshot --output build/platform-api-contract.json
+crypta-app compat verify \
+  --bundle-dir build/dev-apps/queue-dashboard \
+  --contract build/platform-api-contract.json \
+  --strict
+crypta-app compat verify \
+  --catalog-entry dist/catalog/queue-dashboard-entry.properties \
+  --contract build/platform-api-contract.json \
+  --strict
+```
+
+The verifier checks declared API versions, optional and experimental capability use, deprecated or
+scheduled capabilities, and catalog descriptor mismatches against the referenced bundle. Warnings
+become failures with `--strict`.
+
+## Related docs
+
+- [app-dev-cli.md](app-dev-cli.md) documents the base standalone CLI workflow.
+- [app-distribution.md](app-distribution.md) documents signed bundle sidecars and runtime trusted
+  key inputs.
+- [app-catalogs.md](app-catalogs.md) documents catalog format, source transport, artifact
+  verification, and review trust.
+- [app-ui-design-system.md](app-ui-design-system.md) documents static UI assets and offline lint.
+- [platform-sdk-js.md](platform-sdk-js.md) documents the browser SDK and browser session handling.
+- [app-permissions-and-audit.md](app-permissions-and-audit.md) documents process principals,
+  browser principals, permission checks, and audit redaction.
+- [platform-api-contract.md](platform-api-contract.md) documents API compatibility snapshots and
+  verifier behavior.

--- a/docs/first-party-beta-catalog.md
+++ b/docs/first-party-beta-catalog.md
@@ -11,6 +11,11 @@ weaken any existing gates. Catalog signatures, bundle signatures, review receipt
 SHA-256 checks, Platform API compatibility metadata, sandbox metadata, and permission review remain
 separate layers.
 
+The third-party developer beta toolkit extends the standalone CLI with scaffold templates, a mock
+dev server, offline app tests, catalog entry generation, and a dry-run USK publication checklist.
+It does not replace this first-party beta catalog flow or its release gates. See
+[developer-beta-toolkit.md](developer-beta-toolkit.md) for the app-author workflow.
+
 `crypta:` transport is not a trust boundary. Crypta-hosted catalog and bundle artifacts still must
 match signed catalog metadata and signed bundle sidecars before AppHost can install or update them.
 

--- a/docs/platform-api-contract.md
+++ b/docs/platform-api-contract.md
@@ -50,6 +50,11 @@ The snapshot is deterministic and excludes raw app process tokens, browser sessi
 bootstrap nonces, form passwords, request bodies, query strings, filesystem paths, sandbox command
 lines, environment variables, private keys, and private insert URIs.
 
+The developer beta toolkit uses the same contract metadata in `crypta-app test` and
+`crypta-app compat verify`. Scaffolded beta templates declare conservative `api.minimumVersion` and
+`api.maximumTestedVersion` values, and catalog entry generation copies the manifest compatibility
+metadata into descriptor output. See [developer-beta-toolkit.md](developer-beta-toolkit.md).
+
 ## Descriptor fields
 
 Capability descriptors contain:

--- a/docs/platform-sdk-js.md
+++ b/docs/platform-sdk-js.md
@@ -26,6 +26,13 @@ static` can see the SDK resource, its template copies or vendors the file as
 `static/crypta-platform.js` in the staged bundle. The scaffolded HTML should still load it with the
 relative `./crypta-platform.js` path shown above.
 
+The developer beta toolkit also serves scaffolded static bundles through `crypta-app dev`. That
+mock server exposes both `/.well-known/cryptad-bootstrap.json` and
+`/apps/{appId}/.well-known/cryptad-bootstrap.json`, then requires the SDK's
+`X-Crypta-App-Session` header for mock Platform API calls. See
+[developer-beta-toolkit.md](developer-beta-toolkit.md) for the local mock-server flow and its
+limits.
+
 ## Bootstrap
 
 Call `CryptaPlatform.bootstrap.load()` before using API helpers:

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -99,6 +99,7 @@ Release-candidate mode requires these evidence ids:
 | `performance.smoke` | `build/perf-smoke/summary.json` | Performance smoke did not fail required metrics or deterministic regression thresholds. |
 | `app-platform.first-party` | App-platform smoke summary. | First-party staged apps, including Site Publisher, have valid manifests, launchers, static UI assets, and SDK wiring. |
 | `app-platform.devtools-cli` | App-platform smoke summary. | `crypta-app init`, `validate`, and `pack` work for a generated sample app. |
+| `app-platform.developer-beta-toolkit` | App-platform smoke summary. | Developer beta toolkit command, template, mock-dev, offline-test, catalog entry, dry-run publication, docs, and self-test evidence is present. |
 | `app-platform.signed-bundles` | App-platform smoke summary. | First-party and sample bundle signing/verification evidence exists with configured non-production or release signing inputs. |
 | `catalog.smoke` | App-platform smoke summary. | Signed catalog create/sign/verify evidence exists and records digest, catalog id, and app id without private key material. |
 | `app-catalog.first-party-beta` | App-platform smoke summary. | Recommended first-party beta catalog descriptor, Platform API/Web Shell onboarding, CHK artifact transport tests, first-party metadata docs, and configuration readiness reporting are present without a live public-network fetch. |

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractor.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractor.java
@@ -7,6 +7,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -17,15 +18,19 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipInputStream;
+import network.crypta.platform.appdist.AppBundleDigest;
+import network.crypta.platform.appdist.AppBundleDigestVerifier;
 import network.crypta.platform.appdist.AppBundleManifest;
 import network.crypta.platform.appdist.AppBundleManifestParser;
 import network.crypta.platform.appdist.AppBundlePackager;
+import network.crypta.platform.appdist.AppBundleSignature;
 import network.crypta.platform.appdist.AppBundleVerifier;
 import network.crypta.platform.appdist.AppDistributionException;
 import network.crypta.platform.appdist.TrustedAppKeys;
@@ -80,6 +85,42 @@ public final class AppCatalogBundleExtractor {
   }
 
   /**
+   * Safely inspects a local ZIP artifact and requires signed-bundle sidecars.
+   *
+   * <p>This method is intended for offline catalog-authoring tools before they write catalog entry
+   * descriptors. It expands the artifact through the same ZIP safety path used by install/update
+   * extraction, requires canonical root {@code cryptad-app.digests} and {@code
+   * cryptad-app.signature} entries, validates the signature sidecar format, and verifies that the
+   * digest sidecar matches the extracted bundle contents.
+   *
+   * <p>Because catalog entry generation does not receive a trusted-key registry, this inspection
+   * does not make a publisher trust decision. Runtime install and update paths must continue to use
+   * {@link #extract(AppCatalogEntry, Path, Path, TrustedAppKeys)} so the signed digest is also
+   * verified against trusted app signing keys.
+   *
+   * @param artifactZip local artifact ZIP to inspect
+   * @param scratchDirectory host-owned scratch directory used for temporary extraction
+   * @return parsed artifact manifest after sidecar and digest checks
+   * @throws IOException if filesystem, ZIP, sidecar, or bundle validation fails
+   */
+  public static AppBundleManifest inspectSignedArtifact(Path artifactZip, Path scratchDirectory)
+      throws IOException {
+    Path zipPath = requireReadableArtifactZip(artifactZip);
+    Path scratchRoot =
+        Objects.requireNonNull(scratchDirectory, "scratchDirectory").toAbsolutePath().normalize();
+    Files.createDirectories(scratchRoot);
+    Path stagedRoot = Files.createTempDirectory(scratchRoot, "catalog-bundle-inspect-");
+    try {
+      extractZip(zipPath, stagedRoot);
+      return verifyExtractedSignedArtifact(stagedRoot);
+    } catch (AppDistributionException exception) {
+      throw invalidBundle(exception.getMessage(), exception);
+    } finally {
+      deleteRecursively(stagedRoot);
+    }
+  }
+
+  /**
    * Extracts, verifies, and validates one downloaded ZIP artifact.
    *
    * <p>The method creates a new child directory under {@code scratchDirectory}, expands the ZIP
@@ -111,6 +152,18 @@ public final class AppCatalogBundleExtractor {
       deleteRecursively(stagedRoot);
       throw exception;
     }
+  }
+
+  private static Path requireReadableArtifactZip(Path artifactZip) {
+    Path normalized =
+        Objects.requireNonNull(artifactZip, "artifactZip").toAbsolutePath().normalize();
+    if (Files.isSymbolicLink(normalized)) {
+      throw invalidBundle("zip artifact must not be a symbolic link");
+    }
+    if (!Files.isRegularFile(normalized, LinkOption.NOFOLLOW_LINKS)) {
+      throw invalidBundle("zip artifact must be a regular file");
+    }
+    return normalized;
   }
 
   private static void extractZip(Path zipPath, Path stagedRoot) throws IOException {
@@ -454,6 +507,57 @@ public final class AppCatalogBundleExtractor {
       }
     }
     return false;
+  }
+
+  private static AppBundleManifest verifyExtractedSignedArtifact(Path stagedRoot)
+      throws IOException {
+    Path manifestFile = stagedRoot.resolve(AppBundleManifestParser.MANIFEST_FILE_NAME);
+    if (!Files.isRegularFile(manifestFile, LinkOption.NOFOLLOW_LINKS)) {
+      throw invalidBundle("zip artifact must contain cryptad-app.properties at the root");
+    }
+    requireCanonicalSignedSidecars(stagedRoot);
+    AppBundleVerifier.read(stagedRoot.resolve(AppBundleSignature.SIGNATURE_FILE_NAME));
+    AppBundleDigestVerifier.verify(stagedRoot);
+    return AppBundleManifestParser.parse(manifestFile);
+  }
+
+  private static void requireCanonicalSignedSidecars(Path stagedRoot) throws IOException {
+    boolean digest = false;
+    boolean signature = false;
+    try (DirectoryStream<Path> entries = Files.newDirectoryStream(stagedRoot)) {
+      for (Path entry : entries) {
+        String name = Objects.requireNonNull(entry.getFileName(), "artifact root entry").toString();
+        String normalized = name.toLowerCase(Locale.ROOT);
+        if (!isRootDistributionSidecar(normalized)) {
+          continue;
+        }
+        if (!name.equals(normalized)) {
+          throw invalidBundle(
+              "zip artifact contains a non-canonical distribution sidecar name: " + name);
+        }
+        switch (normalized) {
+          case AppBundleDigest.DIGEST_FILE_NAME -> digest = true;
+          case AppBundleSignature.SIGNATURE_FILE_NAME -> signature = true;
+          default -> throw invalidBundle("zip artifact must not contain catalog sidecars");
+        }
+      }
+    }
+    if (!digest || !signature) {
+      throw invalidBundle(
+          "zip artifact must contain signed bundle sidecars "
+              + AppBundleDigest.DIGEST_FILE_NAME
+              + " and "
+              + AppBundleSignature.SIGNATURE_FILE_NAME);
+    }
+  }
+
+  private static boolean isRootDistributionSidecar(String normalizedName) {
+    return AppBundleDigest.DIGEST_FILE_NAME.equals(normalizedName)
+        || AppBundleSignature.SIGNATURE_FILE_NAME.equals(normalizedName)
+        || AppCatalogSignature.CATALOG_FILE_NAME.equals(normalizedName)
+        || AppCatalogSignature.SIGNATURE_FILE_NAME.equals(normalizedName)
+        || "cryptad-app.catalog".equals(normalizedName)
+        || "cryptad-app.catalog.signature".equals(normalizedName);
   }
 
   private static void verifyExtractedBundle(

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractorTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogBundleExtractorTest.java
@@ -4,20 +4,99 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
+import network.crypta.platform.appdist.AppBundleManifest;
+import network.crypta.platform.appdist.AppBundlePackager;
+import network.crypta.platform.appdist.AppBundleSignature;
+import network.crypta.platform.appdist.AppBundleSigner;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
 class AppCatalogBundleExtractorTest {
   private static final int IGNORED_METADATA_BYTES = 32;
 
   @TempDir private Path tempDir;
+
+  @Test
+  void inspectSignedArtifact_whenArtifactHasSignedSidecars_expectManifest() throws Exception {
+    Path bundleRoot = createBundle("signed-artifact-app");
+    AppBundleSigner.sign(bundleRoot, "dev-local", generateEd25519KeyPair().getPrivate());
+    Path artifact = tempDir.resolve("signed-artifact.zip");
+    AppBundlePackager.packageBundle(bundleRoot, artifact);
+
+    AppBundleManifest manifest =
+        AppCatalogBundleExtractor.inspectSignedArtifact(artifact, tempDir.resolve("scratch"));
+
+    assertEquals("signed-artifact-app", manifest.appId());
+    assertEquals("1.0.0", manifest.appVersion());
+  }
+
+  @Test
+  void inspectSignedArtifact_whenArtifactIsUnsigned_expectInvalidAppBundle() throws Exception {
+    Path bundleRoot = createBundle("unsigned-artifact-app");
+    Path artifact = tempDir.resolve("unsigned-artifact.zip");
+    AppBundlePackager.packageBundle(bundleRoot, artifact);
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class,
+            () -> AppCatalogBundleExtractor.inspectSignedArtifact(artifact, tempDir));
+
+    assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
+    assertTrue(exception.getMessage().contains("signed bundle sidecars"));
+  }
+
+  @Test
+  void inspectSignedArtifact_whenSignatureSidecarCaseVariant_expectInvalidAppBundle()
+      throws Exception {
+    Path bundleRoot = createBundle("case-sidecar-app");
+    AppBundleSigner.sign(bundleRoot, "dev-local", generateEd25519KeyPair().getPrivate());
+    Path artifact = tempDir.resolve("case-sidecar.zip");
+    AppBundlePackager.packageBundle(bundleRoot, artifact);
+    Path tampered = zipWithCaseVariantSignatureSidecar(artifact);
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class,
+            () -> AppCatalogBundleExtractor.inspectSignedArtifact(tampered, tempDir));
+
+    assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
+    assertTrue(exception.getMessage().contains("non-canonical distribution sidecar name"));
+  }
+
+  @Test
+  void inspectSignedArtifact_whenCatalogSidecarsAreSignedPayload_expectInvalidAppBundle()
+      throws Exception {
+    Path bundleRoot = createBundle("catalog-sidecar-app");
+    Files.writeString(
+        bundleRoot.resolve(AppCatalogSignature.CATALOG_FILE_NAME),
+        "catalog.version=1\n",
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        bundleRoot.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME),
+        "catalog.signature.version=1\n",
+        StandardCharsets.UTF_8);
+    AppBundleSigner.sign(bundleRoot, "dev-local", generateEd25519KeyPair().getPrivate());
+    Path artifact = tempDir.resolve("catalog-sidecar.zip");
+    AppBundlePackager.packageBundle(bundleRoot, artifact);
+
+    AppCatalogException exception =
+        assertThrows(
+            AppCatalogException.class,
+            () -> AppCatalogBundleExtractor.inspectSignedArtifact(artifact, tempDir));
+
+    assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
+    assertEquals("zip artifact must not contain catalog sidecars", exception.getMessage());
+  }
 
   @Test
   void extractZip_whenIgnoredAppleDoubleEntryExceedsExtractedCap_expectInvalidAppBundle()
@@ -33,6 +112,51 @@ class AppCatalogBundleExtractorTest {
     assertEquals(AppCatalogSidecars.INVALID_APP_BUNDLE, exception.errorCode());
     assertEquals("zip artifact exceeds extracted size cap", exception.getMessage());
     assertFalse(Files.exists(stagedRoot.resolve("._cryptad-app.properties")));
+  }
+
+  private Path createBundle(String appId) throws IOException {
+    Path bundleRoot = Files.createTempDirectory(tempDir, appId + "-");
+    Files.createDirectories(bundleRoot.resolve("bin"));
+    Files.writeString(
+        bundleRoot.resolve("cryptad-app.properties"),
+        """
+        manifest.version=1
+        app.id=%s
+        app.name=Signed Artifact App
+        app.version=1.0.0
+        app.exec=bin/start.sh
+        app.ui.mode=none
+        """
+            .formatted(appId),
+        StandardCharsets.UTF_8);
+    Files.writeString(
+        bundleRoot.resolve("bin").resolve("start.sh"),
+        "#!/bin/sh\nexit 0\n",
+        StandardCharsets.UTF_8);
+    return bundleRoot;
+  }
+
+  private static KeyPair generateEd25519KeyPair() throws Exception {
+    return KeyPairGenerator.getInstance(AppBundleSignature.SIGNATURE_ALGORITHM).generateKeyPair();
+  }
+
+  private Path zipWithCaseVariantSignatureSidecar(Path sourceZip) throws IOException {
+    Path targetZip = tempDir.resolve("renamed-sidecar.zip");
+    try (var input = new java.util.zip.ZipInputStream(Files.newInputStream(sourceZip));
+        var output = new ZipOutputStream(Files.newOutputStream(targetZip))) {
+      ZipEntry entry;
+      while ((entry = input.getNextEntry()) != null) {
+        String name =
+            AppBundleSignature.SIGNATURE_FILE_NAME.equals(entry.getName())
+                ? entry.getName().toUpperCase(java.util.Locale.ROOT)
+                : entry.getName();
+        output.putNextEntry(new ZipEntry(name));
+        input.transferTo(output);
+        output.closeEntry();
+        input.closeEntry();
+      }
+    }
+    return targetZip;
   }
 
   private static Path ignoredAppleDoubleZip(Path targetZip) throws IOException {

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTemplateKind.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTemplateKind.java
@@ -1,0 +1,109 @@
+package network.crypta.platform.devtools;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+/**
+ * Named beta developer templates accepted by {@code crypta-app init --template}.
+ *
+ * <p>The enum is the CLI boundary between user-facing template names and the scaffold renderer.
+ * Each value describes a staged static app bundle that can be validated, served by the mock dev
+ * server, signed, packed, and published through the catalog tooling. Templates deliberately avoid
+ * creating Gradle subprojects or touching a running node; generated apps remain plain staged
+ * bundles. Default permissions are examples for the API surface demonstrated by the template, and
+ * callers may extend them with repeatable {@code --permission} options when building a more
+ * specific app.
+ *
+ * <p>The parsing contract is stable and case-insensitive for CLI input, while {@link #cliName()}
+ * returns the canonical lower-case spelling used in help text, diagnostics, tests, and
+ * documentation. Keep names conservative because they become part of the developer workflow.
+ */
+enum AppTemplateKind {
+  /** Minimal static app equivalent to the pre-template scaffold. */
+  STATIC_BASIC("static-basic"),
+
+  /** Queue dashboard sample that reads and mutates queue entries through the browser SDK. */
+  QUEUE_DASHBOARD("queue-dashboard"),
+
+  /** Content publisher sample that creates insert requests through SDK helpers. */
+  PUBLISHER("publisher"),
+
+  /** Vault profile sample that uses safe mock identity/grant data through app-vault routes. */
+  VAULT_PROFILE("vault-profile");
+
+  /** Canonical lower-case CLI spelling for this template. */
+  private final String cliName;
+
+  /**
+   * Creates one template kind.
+   *
+   * @param cliName stable lower-case name accepted by {@code crypta-app init --template}
+   */
+  AppTemplateKind(String cliName) {
+    this.cliName = cliName;
+  }
+
+  /**
+   * Parses one CLI template name.
+   *
+   * @param rawName user-supplied template name, or {@code null} for the default template
+   * @return matching template kind
+   * @throws IllegalArgumentException if the value does not name a supported template
+   */
+  static AppTemplateKind parse(String rawName) {
+    if (rawName == null || rawName.isBlank()) {
+      return STATIC_BASIC;
+    }
+    String normalized = rawName.trim().toLowerCase(Locale.ROOT);
+    for (AppTemplateKind kind : values()) {
+      if (kind.cliName.equals(normalized)) {
+        return kind;
+      }
+    }
+    throw new IllegalArgumentException(
+        "unsupported app template: " + rawName + " (expected: " + supportedNames() + ")");
+  }
+
+  /**
+   * Returns the stable CLI spelling.
+   *
+   * @return lower-case hyphenated template name
+   */
+  String cliName() {
+    return cliName;
+  }
+
+  /**
+   * Returns permissions that the template demonstrates by default.
+   *
+   * @return immutable permission list in manifest order
+   */
+  List<String> defaultPermissions() {
+    return switch (this) {
+      case STATIC_BASIC -> List.of();
+      case QUEUE_DASHBOARD -> List.of("queue.read", "queue.write");
+      case PUBLISHER -> List.of("content.insert", "queue.read", "queue.write");
+      case VAULT_PROFILE -> List.of("vault.identities.read", "vault.identities.use");
+    };
+  }
+
+  /**
+   * Returns whether the generated manifest should accept experimental Platform API capabilities.
+   *
+   * @return {@code true} when the template's default permissions demonstrate experimental APIs
+   */
+  boolean experimentalCapabilitiesAccepted() {
+    return this == VAULT_PROFILE;
+  }
+
+  /**
+   * Returns a comma-separated list of supported template names for help and diagnostics.
+   *
+   * @return deterministic template name list
+   */
+  static String supportedNames() {
+    return Arrays.stream(values()).map(AppTemplateKind::cliName).collect(Collectors.joining(", "));
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTemplateScaffolder.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTemplateScaffolder.java
@@ -54,6 +54,31 @@ final class AppTemplateScaffolder {
       .sample-status {
         margin-top: var(--cr-space-3);
       }
+
+      .sample-grid {
+        display: grid;
+        gap: var(--cr-space-3);
+        grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+      }
+
+      .sample-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--cr-space-2);
+      }
+
+      .sample-list {
+        display: grid;
+        gap: var(--cr-space-2);
+        margin: 0;
+        padding: 0;
+      }
+
+      .sample-list li {
+        display: flex;
+        justify-content: space-between;
+        gap: var(--cr-space-3);
+      }
       """;
 
   /** Utility class; template generation is exposed through {@link #scaffold(ScaffoldRequest)}. */
@@ -73,6 +98,11 @@ final class AppTemplateScaffolder {
    */
   static Path scaffold(ScaffoldRequest request) throws IOException {
     ScaffoldRequest checked = Objects.requireNonNull(request, "request").normalize();
+    if (checked.templateKind() != AppTemplateKind.STATIC_BASIC
+        && checked.uiMode() != UiMode.STATIC) {
+      throw new AppDistributionException(
+          "template " + checked.templateKind().cliName() + " requires --ui-mode static");
+    }
     ensureWritableTarget(checked.directory(), checked.overwrite());
     createTemplateDirectory(checked.directory(), "target directory");
     createTemplateDirectory(checked.directory().resolve("bin"), "launcher directory");
@@ -306,6 +336,7 @@ final class AppTemplateScaffolder {
               Connecting to Crypta...
             </p>
           </section>
+          ${TEMPLATE_BODY}
         </main>
         <script src="./crypta-platform.js"></script>
         <script type="module" src="./app.js"></script>
@@ -313,7 +344,73 @@ final class AppTemplateScaffolder {
     </html>
     """
         .replace("${APP_NAME}", escapedName)
-        .replace("${PERMISSION_SUMMARY}", permissionSummary(request.permissions()));
+        .replace("${PERMISSION_SUMMARY}", permissionSummary(request.permissions()))
+        .replace("${TEMPLATE_BODY}", templateBody(request.templateKind()));
+  }
+
+  private static String templateBody(AppTemplateKind templateKind) {
+    return switch (templateKind) {
+      case STATIC_BASIC -> "";
+      case QUEUE_DASHBOARD ->
+          """
+          <section class="cr-card" aria-labelledby="queue-heading">
+            <div class="cr-card__header">
+              <h2 id="queue-heading">Queue</h2>
+              <button class="cr-button cr-button--secondary" type="button" id="refresh-queue">Refresh</button>
+            </div>
+            <ul class="sample-list" id="queue-list" aria-live="polite"></ul>
+            <div class="sample-actions">
+              <button class="cr-button" type="button" id="restart-first">Restart first</button>
+              <button class="cr-button cr-button--secondary" type="button" id="raise-priority">Raise priority</button>
+            </div>
+          </section>
+          """;
+      case PUBLISHER ->
+          """
+          <section class="cr-card" aria-labelledby="publisher-heading">
+            <h2 id="publisher-heading">Publisher</h2>
+            <form class="sample-layout" id="publish-form">
+              <label class="cr-field">
+                <span class="cr-label">Source path</span>
+                <input class="cr-input" name="sourcePath" required autocomplete="off">
+              </label>
+              <label class="cr-field">
+                <span class="cr-label">Insert URI</span>
+                <input class="cr-input" name="insertUri" required autocomplete="off">
+              </label>
+              <label class="cr-field">
+                <span class="cr-label">Queue identifier</span>
+                <input class="cr-input" name="identifier" value="sample-insert">
+              </label>
+              <label class="cr-field">
+                <span class="cr-label">Target filename</span>
+                <input class="cr-input" name="targetFilename" value="welcome.txt">
+              </label>
+              <button class="cr-button" type="submit">Queue insert</button>
+            </form>
+            <ul class="sample-list" id="publish-list" aria-live="polite"></ul>
+          </section>
+          """;
+      case VAULT_PROFILE ->
+          """
+          <section class="cr-card" aria-labelledby="vault-heading">
+            <div class="cr-card__header">
+              <h2 id="vault-heading">Vault profile</h2>
+              <button class="cr-button cr-button--secondary" type="button" id="request-grant">Request grant</button>
+            </div>
+            <div class="sample-grid">
+              <div>
+                <p class="cr-label">Identities</p>
+                <ul class="sample-list" id="identity-list" aria-live="polite"></ul>
+              </div>
+              <div>
+                <p class="cr-label">Grants</p>
+                <ul class="sample-list" id="grant-list" aria-live="polite"></ul>
+              </div>
+            </div>
+          </section>
+          """;
+    };
   }
 
   /**
@@ -323,22 +420,187 @@ final class AppTemplateScaffolder {
    * @return module script content for {@code static/app.js}
    */
   private static String staticJavaScript(ScaffoldRequest request) {
+    return switch (request.templateKind()) {
+      case STATIC_BASIC ->
+          """
+          const status = document.querySelector("#status");
+
+          async function main() {
+            const platform = window.CryptaPlatform;
+            const bootstrap = await platform.bootstrap.load({ appId: "${APP_ID}" });
+            status.textContent = `${bootstrap.name} is connected.`;
+            status.className = "cr-status cr-status--success sample-status";
+          }
+
+          main().catch((error) => {
+            status.textContent = error instanceof Error ? error.message : String(error);
+            status.className = "cr-status cr-status--danger sample-status";
+          });
+          """
+              .replace(APP_ID_PLACEHOLDER, request.appId());
+      case QUEUE_DASHBOARD -> queueDashboardJavaScript(request.appId());
+      case PUBLISHER -> publisherJavaScript(request.appId());
+      case VAULT_PROFILE -> vaultProfileJavaScript(request.appId());
+    };
+  }
+
+  private static String queueDashboardJavaScript(String appId) {
     return """
     const status = document.querySelector("#status");
+    const queueList = document.querySelector("#queue-list");
+    const refreshButton = document.querySelector("#refresh-queue");
+    const restartButton = document.querySelector("#restart-first");
+    const priorityButton = document.querySelector("#raise-priority");
+
+    let firstRequestId = "";
+
+    async function loadQueue() {
+      const platform = window.CryptaPlatform;
+      const bootstrap = await platform.bootstrap.load({ appId: "${APP_ID}" });
+      const snapshot = await platform.queue.snapshot({ page: "downloads" });
+      const requests = Array.isArray(snapshot.requests) ? snapshot.requests : [];
+      firstRequestId = requests.length > 0 ? String(requests[0].id || "") : "";
+      queueList.replaceChildren(...requests.map(renderRequest));
+      status.textContent = `${bootstrap.name} loaded ${requests.length} queue item(s).`;
+      status.className = "cr-status cr-status--success sample-status";
+    }
+
+    function renderRequest(request) {
+      const item = document.createElement("li");
+      const label = document.createElement("span");
+      label.textContent = request.name || request.uri || request.id || "Queued request";
+      const state = document.createElement("strong");
+      state.textContent = request.state || "mocked";
+      item.append(label, state);
+      return item;
+    }
+
+    async function mutateFirst(action) {
+      if (!firstRequestId) {
+        status.textContent = "No queue item is available in the mock data.";
+        return;
+      }
+      const form = new URLSearchParams();
+      form.set("identifier", firstRequestId);
+      if (action === "queue/requests/priority") {
+        form.set("priority", "2");
+      }
+      await window.CryptaPlatform.queue.mutate(action, form);
+      await loadQueue();
+    }
+
+    refreshButton.addEventListener("click", () => loadQueue().catch(showError));
+    restartButton.addEventListener("click", () => mutateFirst("queue/requests/restart").catch(showError));
+    priorityButton.addEventListener("click", () => mutateFirst("queue/requests/priority").catch(showError));
+
+    function showError(error) {
+      status.textContent = window.CryptaPlatform.api.errorMessage(error);
+      status.className = "cr-status cr-status--danger sample-status";
+    }
+
+    loadQueue().catch(showError);
+    """
+        .replace(APP_ID_PLACEHOLDER, appId);
+  }
+
+  private static String publisherJavaScript(String appId) {
+    return """
+    const status = document.querySelector("#status");
+    const form = document.querySelector("#publish-form");
+    const publishList = document.querySelector("#publish-list");
 
     async function main() {
       const platform = window.CryptaPlatform;
       const bootstrap = await platform.bootstrap.load({ appId: "${APP_ID}" });
-      status.textContent = `${bootstrap.appName} is connected.`;
+      const snapshot = await platform.queue.snapshot({ page: "uploads" });
+      renderQueue(snapshot);
+      status.textContent = `${bootstrap.name} is ready to queue inserts.`;
       status.className = "cr-status cr-status--success sample-status";
     }
 
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      const data = new FormData(form);
+      const params = new URLSearchParams();
+      const identifier = String(data.get("identifier") || "").trim() || `sample-insert-${Date.now()}`;
+      params.set("sourcePath", String(data.get("sourcePath") || "").trim());
+      params.set("insertUri", String(data.get("insertUri") || "").trim());
+      params.set("identifier", identifier);
+      const targetFilename = String(data.get("targetFilename") || "").trim();
+      if (targetFilename) {
+        params.set("targetFilename", targetFilename);
+      }
+      const result = await window.CryptaPlatform.content.insertFile(params);
+      status.textContent = result.message || "Insert request queued in the mock API.";
+      await main();
+    });
+
+    function renderQueue(snapshot) {
+      const requests = Array.isArray(snapshot.requests) ? snapshot.requests : [];
+      publishList.replaceChildren(...requests.map((request) => {
+        const item = document.createElement("li");
+        const label = document.createElement("span");
+        label.textContent = request.name || request.id || "Insert request";
+        const state = document.createElement("strong");
+        state.textContent = request.state || "queued";
+        item.append(label, state);
+        return item;
+      }));
+    }
+
     main().catch((error) => {
-      status.textContent = error instanceof Error ? error.message : String(error);
+      status.textContent = window.CryptaPlatform.api.errorMessage(error);
       status.className = "cr-status cr-status--danger sample-status";
     });
     """
-        .replace(APP_ID_PLACEHOLDER, request.appId());
+        .replace(APP_ID_PLACEHOLDER, appId);
+  }
+
+  private static String vaultProfileJavaScript(String appId) {
+    return """
+    const status = document.querySelector("#status");
+    const identityList = document.querySelector("#identity-list");
+    const grantList = document.querySelector("#grant-list");
+    const grantButton = document.querySelector("#request-grant");
+
+    async function main() {
+      const platform = window.CryptaPlatform;
+      const bootstrap = await platform.bootstrap.load({ appId: "${APP_ID}" });
+      const identities = await platform.vault.identities.list();
+      const grants = await platform.vault.grants.list();
+      render(identityList, Array.isArray(identities.identities) ? identities.identities : [], "identity");
+      render(grantList, Array.isArray(grants.grants) ? grants.grants : [], "grant");
+      status.textContent = `${bootstrap.name} loaded safe mock vault data.`;
+      status.className = "cr-status cr-status--success sample-status";
+    }
+
+    grantButton.addEventListener("click", async () => {
+      await window.CryptaPlatform.vault.grants.request({
+        identityId: "local-profile",
+        scopes: ["metadata.read", "publish.profile"],
+        reason: "Preview a local beta profile flow.",
+      });
+      await main();
+    });
+
+    function render(target, values, fallback) {
+      target.replaceChildren(...values.map((value) => {
+        const item = document.createElement("li");
+        const label = document.createElement("span");
+        label.textContent = value.displayName || value.id || fallback;
+        const state = document.createElement("strong");
+        state.textContent = value.status || value.kind || "mock";
+        item.append(label, state);
+        return item;
+      }));
+    }
+
+    main().catch((error) => {
+      status.textContent = window.CryptaPlatform.api.errorMessage(error);
+      status.className = "cr-status cr-status--danger sample-status";
+    });
+    """
+        .replace(APP_ID_PLACEHOLDER, appId);
   }
 
   private static String permissionSummary(List<String> permissions) {
@@ -400,18 +662,22 @@ final class AppTemplateScaffolder {
     ## Local workflow
 
     ```bash
-    crypta-app ui lint --bundle-dir . --strict
-    crypta-app validate --bundle-dir . --strict
-    crypta-app sign --bundle-dir . --key-id dev-local --private-key-file /path/to/private.pem
+    crypta-app dev --bundle-dir . --port 0
+    crypta-app test --bundle-dir . --strict
+    crypta-app keys generate --key-id dev-local --private-key-file ../keys/dev-local-private.der --public-key-file ../keys/dev-local-public.der --trusted-keys-file ../keys/trusted-app-keys.properties
+    crypta-app sign --bundle-dir . --key-id dev-local --private-key-file ../keys/dev-local-private.der
     crypta-app pack --bundle-dir . --output ../${APP_ID}-${APP_VERSION}.zip --overwrite
-    crypta-app verify --bundle-dir . --trusted-key-id dev-local --trusted-public-key-file /path/to/public.pem
+    crypta-app verify --bundle-dir . --trusted-keys-file ../keys/trusted-app-keys.properties
     ```
+
+    Template: `${TEMPLATE}`.
 
     Replace `bin/start.sh` with the production launcher before distributing the app.
     """
         .replace("${APP_NAME}", request.name())
         .replace(APP_ID_PLACEHOLDER, request.appId())
-        .replace("${APP_VERSION}", request.version());
+        .replace("${APP_VERSION}", request.version())
+        .replace("${TEMPLATE}", request.templateKind().cliName());
   }
 
   /**
@@ -490,6 +756,7 @@ final class AppTemplateScaffolder {
    * @param name human-readable app name written into the manifest and template UI
    * @param version app version string written into the manifest
    * @param uiMode requested UI template mode, defaulting to static when omitted
+   * @param templateKind named static beta template to render
    * @param permissions manifest permissions requested for the generated app
    * @param overwrite whether an existing non-empty target directory may be reused
    */
@@ -499,6 +766,7 @@ final class AppTemplateScaffolder {
       String name,
       String version,
       UiMode uiMode,
+      AppTemplateKind templateKind,
       List<String> permissions,
       boolean overwrite) {
     /**
@@ -514,6 +782,7 @@ final class AppTemplateScaffolder {
       Objects.requireNonNull(name, "name");
       Objects.requireNonNull(version, "version");
       uiMode = Objects.requireNonNullElse(uiMode, UiMode.STATIC);
+      templateKind = Objects.requireNonNullElse(templateKind, AppTemplateKind.STATIC_BASIC);
       permissions = List.copyOf(Objects.requireNonNull(permissions, "permissions"));
     }
 
@@ -534,8 +803,16 @@ final class AppTemplateScaffolder {
           name.trim(),
           version.trim(),
           uiMode,
-          normalizePermissions(permissions),
+          templateKind,
+          normalizePermissions(templatePermissions(templateKind, permissions)),
           overwrite);
+    }
+
+    private static List<String> templatePermissions(
+        AppTemplateKind templateKind, List<String> permissions) {
+      LinkedHashSet<String> combined = new LinkedHashSet<>(templateKind.defaultPermissions());
+      combined.addAll(permissions);
+      return List.copyOf(combined);
     }
 
     /**
@@ -567,7 +844,9 @@ final class AppTemplateScaffolder {
           .append("api.maximumTestedVersion=")
           .append(currentContractVersion)
           .append('\n')
-          .append("api.experimentalCapabilitiesAccepted=false\n")
+          .append("api.experimentalCapabilitiesAccepted=")
+          .append(templateKind.experimentalCapabilitiesAccepted())
+          .append('\n')
           .append("app.exec=bin/start.sh\n")
           .append("app.ui.mode=")
           .append(uiMode.value)

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestCheck.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestCheck.java
@@ -1,0 +1,35 @@
+package network.crypta.platform.devtools;
+
+/**
+ * One sanitized check result in a {@code crypta-app test} report.
+ *
+ * <p>Each instance represents a single developer-facing gate such as bundle validation, UI linting,
+ * API compatibility, or dev-server smoke testing. The {@code id} is intentionally stable so JSON
+ * consumers can make decisions without parsing human text. The {@code summary} remains
+ * human-readable, but it is redacted during construction because failing checks often include paths
+ * or session-related strings from lower-level exceptions.
+ *
+ * <p>The record is immutable after construction. It does not carry raw exceptions, stack traces, or
+ * private filesystem paths; callers should convert any diagnostic detail into a short summary
+ * before creating a check.
+ *
+ * @param id stable dotted identifier for the check, for example {@code bundle.validate}
+ * @param status normalized pass, warning, or failure status for this individual check
+ * @param summary short human-readable result text, sanitized before storage in the report
+ */
+record AppTestCheck(String id, AppTestStatus status, String summary) {
+  /**
+   * Validates and sanitizes one check result.
+   *
+   * <p>The constructor rejects blank identifiers, requires a status value, and normalizes a {@code
+   * null} summary to an empty redacted string. This keeps both terminal output and JSON reports
+   * deterministic even when a lower-level check omits optional diagnostic text.
+   */
+  AppTestCheck {
+    if (id == null || id.isBlank()) {
+      throw new IllegalArgumentException("check id must not be blank");
+    }
+    java.util.Objects.requireNonNull(status, "status");
+    summary = AppTestRedactor.redact(summary == null ? "" : summary);
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestRedactor.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestRedactor.java
@@ -1,0 +1,313 @@
+package network.crypta.platform.devtools;
+
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Report redaction helpers shared by developer test and publication-plan output.
+ *
+ * <p>The developer toolkit writes human-readable summaries and optional machine-readable JSON from
+ * checks that may touch local files, fixture directories, bootstrap responses, and signing
+ * material. This helper centralizes the last-mile sanitization used before those values leave the
+ * process. It removes common absolute Unix and Windows paths, likely file-path fragments with
+ * sensitive extensions, and browser-session-like tokens from status text.
+ *
+ * <p>The redactor is intentionally conservative and dependency-free. It is not a JSON parser, a log
+ * scrubber for arbitrary input, or a cryptographic guarantee; callers should still avoid passing
+ * private key bytes, passwords, or raw exception traces into reports. The goal is to keep routine
+ * CLI diagnostics useful while avoiding accidental disclosure of local operator paths and mock
+ * session values.
+ */
+final class AppTestRedactor {
+  /** Replacement text used whenever a local path is removed from report output. */
+  private static final String REDACTED_PATH = "[REDACTED_PATH]";
+
+  /** Extensions that make an absolute path worth redacting even when the path contains spaces. */
+  private static final Set<String> REDACTABLE_EXTENSIONS =
+      Set.of(
+          "json",
+          "properties",
+          "pem",
+          "der",
+          "key",
+          "p12",
+          "pfx",
+          "zip",
+          "jar",
+          "txt",
+          "html",
+          "css",
+          "js",
+          "md",
+          "xml",
+          "yml",
+          "yaml",
+          "toml",
+          "csv",
+          "log");
+
+  /** Characters that end a path-like token without consuming surrounding JSON or shell syntax. */
+  private static final String FILE_PATH_STOP_CHARS = "\r\n\"'`{}[]<>";
+
+  /** Characters that end compact path-like tokens that cannot contain spaces. */
+  private static final String COMPACT_PATH_STOP_CHARS = "\r\n\"'`{}[]";
+
+  /** Header and field shapes that commonly carry mock app browser-session values. */
+  private static final Pattern SESSION_TOKEN =
+      Pattern.compile(
+          "browserSessionToken[=: ][-a-z0-9._~+/=]+"
+              + "|X-Crypta-App-Session[=: ][-a-z0-9._~+/=]+"
+              + "|session[=: ][-a-z0-9._~+/=]+",
+          Pattern.CASE_INSENSITIVE);
+
+  /** Prevents construction of this stateless utility class. */
+  private AppTestRedactor() {}
+
+  /**
+   * Redacts common local paths and browser-session tokens from diagnostic text.
+   *
+   * <p>The method is null-safe and preserves the surrounding message so check summaries remain
+   * actionable. More specific file-path scanners run before broader path-token scanners, which lets
+   * reports hide directories with spaces when the final extension identifies a local artifact.
+   *
+   * @param value raw diagnostic value from a test, plan, or lower-level exception
+   * @return sanitized value suitable for terminal summaries and JSON report fields
+   */
+  static String redact(String value) {
+    String text = value == null ? "" : value;
+    text = SESSION_TOKEN.matcher(text).replaceAll(match -> redactSessionToken(match.group()));
+    text = redactAbsoluteFilePaths(text);
+    return redactCompactAbsolutePaths(text);
+  }
+
+  /**
+   * Redacts one matched session-token assignment while preserving the reported field name.
+   *
+   * @param assignment complete matched assignment such as {@code browserSessionToken=abc}
+   * @return assignment with the original value replaced by a fixed marker
+   */
+  private static String redactSessionToken(String assignment) {
+    for (int index = 0; index < assignment.length(); index++) {
+      char character = assignment.charAt(index);
+      if (character == '=' || character == ':' || character == ' ') {
+        return assignment.substring(0, index) + "=[REDACTED]";
+      }
+    }
+    return "[REDACTED]";
+  }
+
+  /**
+   * Redacts absolute file paths that end with a known local-artifact extension.
+   *
+   * @param text diagnostic text after session-token redaction
+   * @return text with extension-identified Unix and Windows paths replaced
+   */
+  private static String redactAbsoluteFilePaths(String text) {
+    StringBuilder redacted = new StringBuilder(text.length());
+    int index = 0;
+    while (index < text.length()) {
+      int end = absoluteFilePathEnd(text, index);
+      if (end > index) {
+        redacted.append(REDACTED_PATH);
+        index = end;
+      } else {
+        redacted.append(text.charAt(index));
+        index++;
+      }
+    }
+    return redacted.toString();
+  }
+
+  /**
+   * Finds the end of an absolute file path at one character offset.
+   *
+   * @param text diagnostic text being scanned
+   * @param index candidate start offset
+   * @return exclusive end offset for a redactable path, or {@code -1}
+   */
+  private static int absoluteFilePathEnd(String text, int index) {
+    if (!isUnixPathStart(text, index) && !isWindowsPathStart(text, index)) {
+      return -1;
+    }
+    return findRedactableExtensionEnd(text, index);
+  }
+
+  /**
+   * Scans for the first known file extension before a stop character.
+   *
+   * @param text diagnostic text being scanned
+   * @param start candidate path start offset
+   * @return exclusive end offset for the extension match, or {@code -1}
+   */
+  private static int findRedactableExtensionEnd(String text, int start) {
+    for (int index = start; index < text.length(); index++) {
+      char character = text.charAt(index);
+      if (FILE_PATH_STOP_CHARS.indexOf(character) >= 0) {
+        return -1;
+      }
+      if (character == '.') {
+        int extensionEnd = extensionEnd(text, index);
+        if (extensionEnd > index) {
+          return extensionEnd;
+        }
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * Checks whether a dot begins a known redacted file extension.
+   *
+   * @param text diagnostic text being scanned
+   * @param dotIndex index of the candidate dot before the extension
+   * @return exclusive extension end offset, or {@code -1}
+   */
+  private static int extensionEnd(String text, int dotIndex) {
+    int start = dotIndex + 1;
+    int end = start;
+    while (end < text.length() && Character.isLetterOrDigit(text.charAt(end))) {
+      end++;
+    }
+    if (end == start || !isExtensionBoundary(text, end)) {
+      return -1;
+    }
+    String extension = text.substring(start, end).toLowerCase(Locale.ROOT);
+    return REDACTABLE_EXTENSIONS.contains(extension) ? end : -1;
+  }
+
+  /**
+   * Checks whether an extension is followed by a non-word boundary.
+   *
+   * @param text diagnostic text being scanned
+   * @param index exclusive extension end offset
+   * @return {@code true} when the extension is complete at this offset
+   */
+  private static boolean isExtensionBoundary(String text, int index) {
+    if (index >= text.length()) {
+      return true;
+    }
+    char next = text.charAt(index);
+    return !Character.isLetterOrDigit(next) && next != '_';
+  }
+
+  /**
+   * Redacts compact absolute path tokens that do not contain whitespace.
+   *
+   * @param text diagnostic text after extension-bearing paths have been redacted
+   * @return text with remaining compact absolute path tokens replaced
+   */
+  private static String redactCompactAbsolutePaths(String text) {
+    StringBuilder redacted = new StringBuilder(text.length());
+    int index = 0;
+    while (index < text.length()) {
+      int end = compactPathEnd(text, index);
+      if (end > index) {
+        redacted.append(REDACTED_PATH);
+        index = end;
+      } else {
+        redacted.append(text.charAt(index));
+        index++;
+      }
+    }
+    return redacted.toString();
+  }
+
+  /**
+   * Finds the end of a compact Unix or Windows path token at one offset.
+   *
+   * @param text diagnostic text being scanned
+   * @param index candidate path start offset
+   * @return exclusive token end offset, or {@code -1}
+   */
+  private static int compactPathEnd(String text, int index) {
+    if (isUnixPathStart(text, index)) {
+      return scanCompactPathEnd(text, index, index + 1);
+    }
+    if (isWindowsPathStart(text, index)) {
+      return scanCompactPathEnd(text, index, index + 3);
+    }
+    return -1;
+  }
+
+  /**
+   * Scans a compact path token until whitespace or shell/JSON punctuation.
+   *
+   * @param text diagnostic text being scanned
+   * @param start candidate path start offset
+   * @param minimumEnd shortest exclusive end offset accepted for this path shape
+   * @return exclusive token end offset, or {@code -1}
+   */
+  private static int scanCompactPathEnd(String text, int start, int minimumEnd) {
+    int end = start;
+    while (end < text.length()
+        && !Character.isWhitespace(text.charAt(end))
+        && COMPACT_PATH_STOP_CHARS.indexOf(text.charAt(end)) < 0) {
+      end++;
+    }
+    return end > minimumEnd ? end : -1;
+  }
+
+  /**
+   * Checks whether a character offset starts a local-looking Unix absolute path.
+   *
+   * @param text diagnostic text being scanned
+   * @param index candidate slash offset
+   * @return {@code true} when the slash can start a local path token
+   */
+  private static boolean isUnixPathStart(String text, int index) {
+    if (text.charAt(index) != '/') {
+      return false;
+    }
+    if (index == 0) {
+      return text.length() > 1;
+    }
+    char previous = text.charAt(index - 1);
+    return previous != '/'
+        && previous != ':'
+        && !isAsciiLetter(previous)
+        && !Character.isDigit(previous);
+  }
+
+  /**
+   * Checks whether a character offset starts a Windows drive absolute path.
+   *
+   * @param text diagnostic text being scanned
+   * @param index candidate drive-letter offset
+   * @return {@code true} when the offset starts a {@code C:\} style path
+   */
+  private static boolean isWindowsPathStart(String text, int index) {
+    return index + 2 < text.length()
+        && isAsciiLetter(text.charAt(index))
+        && text.charAt(index + 1) == ':'
+        && text.charAt(index + 2) == '\\';
+  }
+
+  /**
+   * Checks whether a character is an ASCII letter.
+   *
+   * @param character character to inspect
+   * @return {@code true} for {@code A-Z} and {@code a-z}
+   */
+  private static boolean isAsciiLetter(char character) {
+    return (character >= 'A' && character <= 'Z') || (character >= 'a' && character <= 'z');
+  }
+
+  /**
+   * Returns only the final name for a path that may be included in a report.
+   *
+   * <p>Publication plans need to name the catalog and signature files without exposing the
+   * developer's workspace or temporary directory. A missing path or final component becomes the
+   * empty string so callers can still serialize deterministic output.
+   *
+   * @param path local file path that should not be reported verbatim
+   * @return final path component, or an empty string when no file name exists
+   */
+  static String fileName(Path path) {
+    if (path == null || path.getFileName() == null) {
+      return "";
+    }
+    return path.getFileName().toString();
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestReport.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestReport.java
@@ -1,0 +1,46 @@
+package network.crypta.platform.devtools;
+
+import java.util.List;
+
+/**
+ * Deterministic report model for {@code crypta-app test}.
+ *
+ * <p>The report is the in-memory representation of the optional JSON artifact and the source for
+ * terminal summaries. It carries only stable fields: schema version, app identity, aggregate
+ * status, and ordered check results. The model performs defensive copying and redaction at the
+ * boundary so callers cannot accidentally serialize mutable lists, raw local paths, or session
+ * values after the suite has finished.
+ *
+ * <p>Schema version {@code 1} is the only supported shape for PR-225 developer tooling. Rejecting
+ * unknown versions in the constructor keeps tests and future migrations honest; a new schema must
+ * introduce an explicit model change rather than silently reusing this serializer.
+ *
+ * @param schemaVersion stable JSON schema version, currently required to be {@code 1}
+ * @param appId app identifier from the validated manifest, sanitized before serialization
+ * @param version app version from the validated manifest, sanitized before serialization
+ * @param status aggregate report status after strict-mode warning promotion is applied
+ * @param checks ordered immutable list of individual sanitized check results
+ */
+record AppTestReport(
+    int schemaVersion,
+    String appId,
+    String version,
+    AppTestStatus status,
+    List<AppTestCheck> checks) {
+  /**
+   * Validates the schema version and freezes report content.
+   *
+   * <p>A {@code null} app id or version becomes an empty redacted value, which is useful when
+   * bundle validation fails before a manifest can be trusted. The checklist is copied in order so
+   * the JSON report remains deterministic for snapshot-style assertions and release evidence.
+   */
+  AppTestReport {
+    if (schemaVersion != 1) {
+      throw new IllegalArgumentException("unsupported app test report schema");
+    }
+    appId = AppTestRedactor.redact(appId == null ? "" : appId);
+    version = AppTestRedactor.redact(version == null ? "" : version);
+    java.util.Objects.requireNonNull(status, "status");
+    checks = List.copyOf(checks);
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestReportJson.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestReportJson.java
@@ -1,0 +1,121 @@
+package network.crypta.platform.devtools;
+
+/**
+ * Dependency-light JSON serializer for {@link AppTestReport}.
+ *
+ * <p>The developer CLI needs stable JSON reports without adding a JSON library to the devtools
+ * runtime. This serializer writes the fixed schema used by {@code crypta-app test}: top-level app
+ * metadata, aggregate status, and an ordered array of check objects. It assumes values have already
+ * passed through the report model's redaction boundary, then performs the JSON string escaping
+ * needed for control characters, quotes, and backslashes.
+ *
+ * <p>The output format is deliberately plain and deterministic. Indentation, field order, and
+ * trailing newlines are part of the snapshot-friendly contract used by tests and release evidence.
+ * Extend this class only when the report schema changes; do not use it as a general JSON writer.
+ */
+final class AppTestReportJson {
+  /** Prevents construction of this stateless serializer. */
+  private AppTestReportJson() {}
+
+  /**
+   * Serializes one app test report using schema version {@code 1}.
+   *
+   * @param report sanitized immutable report produced by {@link AppTestSuite}
+   * @return deterministic UTF-8-safe JSON text with a trailing newline
+   */
+  static String write(AppTestReport report) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("{\n");
+    field(builder, 1, "schemaVersion", Integer.toString(report.schemaVersion()), false, true);
+    field(builder, 1, "appId", report.appId(), true, true);
+    field(builder, 1, "version", report.version(), true, true);
+    field(builder, 1, "status", report.status().jsonValue(), true, true);
+    indent(builder, 1).append("\"checks\": [");
+    if (!report.checks().isEmpty()) {
+      builder.append('\n');
+    }
+    for (int index = 0; index < report.checks().size(); index++) {
+      AppTestCheck check = report.checks().get(index);
+      indent(builder, 2).append("{\n");
+      field(builder, 3, "id", check.id(), true, true);
+      field(builder, 3, "status", check.status().jsonValue(), true, true);
+      field(builder, 3, "summary", check.summary(), true, false);
+      indent(builder, 2).append("}");
+      if (index + 1 < report.checks().size()) {
+        builder.append(',');
+      }
+      builder.append('\n');
+    }
+    if (!report.checks().isEmpty()) {
+      indent(builder, 1);
+    }
+    builder.append("]\n");
+    builder.append("}\n");
+    return builder.toString();
+  }
+
+  /**
+   * Appends one scalar JSON field at the requested indentation depth.
+   *
+   * @param builder destination builder for the report document
+   * @param depth indentation depth measured in two-space units
+   * @param name JSON field name to escape and write
+   * @param value scalar JSON value, escaped when {@code quote} is true
+   * @param quote whether the value should be emitted as a JSON string
+   * @param comma whether to append a trailing comma after the value
+   */
+  private static void field(
+      StringBuilder builder, int depth, String name, String value, boolean quote, boolean comma) {
+    indent(builder, depth).append('"').append(escape(name)).append("\": ");
+    if (quote) {
+      builder.append('"').append(escape(value)).append('"');
+    } else {
+      builder.append(value);
+    }
+    if (comma) {
+      builder.append(',');
+    }
+    builder.append('\n');
+  }
+
+  /**
+   * Appends deterministic two-space indentation.
+   *
+   * @param builder destination builder for the report document
+   * @param depth indentation depth measured in two-space units
+   * @return the same builder for fluent appends
+   */
+  private static StringBuilder indent(StringBuilder builder, int depth) {
+    return builder.repeat("  ", depth);
+  }
+
+  /**
+   * Escapes one Java string for inclusion as a JSON string value.
+   *
+   * @param value non-null scalar value to escape
+   * @return escaped value without surrounding quote characters
+   */
+  private static String escape(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int index = 0; index < value.length(); index++) {
+      char character = value.charAt(index);
+      switch (character) {
+        case '"' -> escaped.append("\\\"");
+        case '\\' -> escaped.append("\\\\");
+        case '\b' -> escaped.append("\\b");
+        case '\f' -> escaped.append("\\f");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> {
+          if (character < 0x20) {
+            escaped.append(String.format("\\u%04x", (int) character));
+          } else {
+            escaped.append(character);
+          }
+        }
+      }
+    }
+    return escaped.toString();
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestStatus.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestStatus.java
@@ -1,0 +1,41 @@
+package network.crypta.platform.devtools;
+
+/**
+ * Stable status values for {@code crypta-app test} reports.
+ *
+ * <p>The enum is shared by individual checks and the aggregate report status. The JSON spelling is
+ * lower-case and intentionally decoupled from the Java enum name so CLI reports can remain stable
+ * if Java naming conventions or internal grouping change later. Strict mode does not introduce a
+ * separate status; it promotes warning checks to a failed aggregate report before serialization.
+ */
+enum AppTestStatus {
+  /** The check or aggregate report completed without warnings or failures. */
+  PASS("pass"),
+
+  /** The check found a developer-visible issue that is non-fatal unless strict mode promotes it. */
+  WARN("warn"),
+
+  /** The check or aggregate report failed and should produce a non-zero CLI exit. */
+  FAIL("fail");
+
+  /** Stable lower-case token written into JSON reports and human summaries. */
+  private final String jsonValue;
+
+  /**
+   * Creates one status value.
+   *
+   * @param jsonValue stable lower-case value serialized in schema version {@code 1}
+   */
+  AppTestStatus(String jsonValue) {
+    this.jsonValue = jsonValue;
+  }
+
+  /**
+   * Returns the schema-stable JSON spelling for this status.
+   *
+   * @return lower-case status token used by {@link AppTestReportJson}
+   */
+  String jsonValue() {
+    return jsonValue;
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestSuite.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/AppTestSuite.java
@@ -1,0 +1,404 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import network.crypta.platform.api.PlatformApiContract;
+import network.crypta.platform.api.PlatformApiContractJson;
+import network.crypta.platform.api.PlatformApiContractVerifier.CompatibilityVerificationResult;
+import network.crypta.platform.api.PlatformApiContractVerifier;
+import network.crypta.platform.appcatalog.AppCatalogException;
+import network.crypta.platform.appcatalog.AppCatalogWriter;
+import network.crypta.platform.appdist.AppBundleManifest;
+import network.crypta.platform.appdist.AppDistributionException;
+import network.crypta.platform.appdist.AppUiMode;
+import network.crypta.platform.devtools.devserver.CryptaAppDevServer;
+import network.crypta.platform.devtools.devserver.DevServerConfig;
+import network.crypta.platform.devtools.devserver.DevServerStaticAssets;
+
+/**
+ * Composite offline developer check suite for staged app bundles.
+ *
+ * <p>This class backs {@code crypta-app test}. It runs the same focused checks a third-party app
+ * developer is expected to run before signing and publishing a bundle: bundle validation, static UI
+ * linting, Platform API compatibility, static asset safety, a mock bootstrap/API smoke test, and
+ * optional catalog descriptor sanity. The suite is intentionally offline. It starts only the local
+ * loopback mock server and never connects to a Crypta node, FCP endpoint, or public network.
+ *
+ * <p>Checks run in a stable order and are converted into sanitized {@link AppTestCheck} values.
+ * Bundle validation is the gate for manifest-dependent checks; if the bundle cannot be trusted, the
+ * report stops after that failure. Strict mode affects status promotion, not the shape of the
+ * report: warnings remain visible as warning checks, but they can make the aggregate status fail.
+ */
+final class AppTestSuite {
+  /** JSON field extractor used only for the local bootstrap smoke response. */
+  private static final Pattern BOOTSTRAP_SESSION_PATTERN =
+      Pattern.compile("\"browserSessionToken\"\\s*:\\s*\"([^\"]+)\"");
+
+  /** Stable check id for bundle structure and manifest validation. */
+  private static final String CHECK_BUNDLE_VALIDATE = "bundle.validate";
+
+  /** Stable check id for static UI linting. */
+  private static final String CHECK_UI_LINT = "ui.lint";
+
+  /** Stable check id for Platform API compatibility verification. */
+  private static final String CHECK_API_COMPAT = "api.compat";
+
+  /** Stable check id for local static asset serving safety. */
+  private static final String CHECK_STATIC_ASSETS_SAFETY = "static-assets.safety";
+
+  /** Stable check id for local bootstrap and mock API smoke testing. */
+  private static final String CHECK_DEV_BOOTSTRAP_SMOKE = "dev.bootstrap-smoke";
+
+  /** Stable check id for optional catalog descriptor parsing. */
+  private static final String CHECK_CATALOG_ENTRY_SANITY = "catalog-entry.sanity";
+
+  /** HTTP header used by local smoke requests to ask for predictable content types. */
+  private static final String ACCEPT_HEADER = "Accept";
+
+  /** Prevents construction of this stateless test-suite coordinator. */
+  private AppTestSuite() {}
+
+  /**
+   * Runs the offline app test suite for one staged bundle.
+   *
+   * <p>The returned report is always safe to print or serialize through {@link AppTestReportJson}.
+   * If bundle validation fails before a manifest can be parsed, the report uses empty app identity
+   * fields and a failed aggregate status. Otherwise, the manifest controls which static-app checks
+   * apply and supplies the app id/version for the final report.
+   *
+   * @param request normalized or relative CLI request values for the bundle under test
+   * @return sanitized deterministic report for terminal and JSON output
+   */
+  static AppTestReport run(Request request) {
+    List<AppTestCheck> checks = new ArrayList<>();
+    ValidationHolder validationHolder = new ValidationHolder();
+    checks.add(runCheck(CHECK_BUNDLE_VALIDATE, () -> validateBundle(request, validationHolder)));
+    BundleValidation validation = validationHolder.validation;
+    if (validation != null) {
+      AppBundleManifest manifest = validation.manifest();
+      if (manifest.uiMode() == AppUiMode.STATIC) {
+        checks.add(runCheck(CHECK_UI_LINT, () -> lintUi(request)));
+      } else {
+        checks.add(new AppTestCheck(CHECK_UI_LINT, AppTestStatus.PASS, "UI lint not applicable."));
+      }
+      checks.add(runCheck(CHECK_API_COMPAT, () -> verifyCompatibility(request, manifest)));
+      checks.add(runCheck(CHECK_STATIC_ASSETS_SAFETY, () -> checkStaticAssets(request, manifest)));
+      if (manifest.uiMode() == AppUiMode.STATIC) {
+        checks.add(runCheck(CHECK_DEV_BOOTSTRAP_SMOKE, () -> smokeDevServer(request)));
+      }
+      if (request.catalogEntry() != null) {
+        checks.add(runCheck(CHECK_CATALOG_ENTRY_SANITY, () -> inspectCatalogEntry(request)));
+      }
+      return reportFor(request, manifest, checks);
+    }
+    return new AppTestReport(1, "", "", AppTestStatus.FAIL, checks);
+  }
+
+  /**
+   * Validates bundle structure and captures the parsed manifest for later checks.
+   *
+   * @param request suite request containing the staged bundle directory and strict-mode flag
+   * @param validationHolder mutable holder used to pass successful validation to later checks
+   * @return sanitized check result describing validation success, warning, or failure
+   * @throws IOException if bundle metadata or staged files cannot be read
+   */
+  private static AppTestCheck validateBundle(Request request, ValidationHolder validationHolder)
+      throws IOException {
+    validationHolder.validation = BundleValidator.validate(request.bundleDir(), request.strict());
+    if (validationHolder.validation.permissionLint().hasUnknownPermissions()) {
+      return new AppTestCheck(
+          CHECK_BUNDLE_VALIDATE,
+          request.strict() ? AppTestStatus.FAIL : AppTestStatus.WARN,
+          "Bundle is valid with unknown permission warnings.");
+    }
+    return new AppTestCheck(CHECK_BUNDLE_VALIDATE, AppTestStatus.PASS, "Bundle validation passed.");
+  }
+
+  /**
+   * Runs the static UI linter for a bundle that declares {@code app.ui.mode=static}.
+   *
+   * @param request suite request containing bundle location and strict-mode behavior
+   * @return check result that reports lint pass, warning promotion, or lint failure
+   * @throws IOException if the linter cannot read static UI files
+   */
+  private static AppTestCheck lintUi(Request request) throws IOException {
+    AppUiLintResult result = AppUiLinter.lint(request.bundleDir(), request.strict());
+    if (result.hasErrors()) {
+      return new AppTestCheck(
+          CHECK_UI_LINT,
+          AppTestStatus.FAIL,
+          "UI lint failed: " + result.errorCount() + " error(s).");
+    }
+    if (result.warningCount() > 0) {
+      return new AppTestCheck(
+          CHECK_UI_LINT,
+          request.strict() ? AppTestStatus.FAIL : AppTestStatus.WARN,
+          "UI lint reported " + result.warningCount() + " warning(s).");
+    }
+    return new AppTestCheck(CHECK_UI_LINT, AppTestStatus.PASS, "UI lint passed.");
+  }
+
+  /**
+   * Verifies manifest-declared permissions and API compatibility against a Platform API contract.
+   *
+   * @param request suite request with optional contract override and strict-mode flag
+   * @param manifest validated app manifest from bundle validation
+   * @return check result for compatibility findings under normal or strict mode
+   * @throws IOException if the contract override cannot be loaded or parsed
+   */
+  private static AppTestCheck verifyCompatibility(Request request, AppBundleManifest manifest)
+      throws IOException {
+    PlatformApiContract contract = loadContract(request.contract());
+    CompatibilityVerificationResult result =
+        PlatformApiContractVerifier.verify(
+            manifest.apiCompatibility(), manifest.permissions(), contract, request.strict());
+    if (result.hasErrors()) {
+      return new AppTestCheck(CHECK_API_COMPAT, AppTestStatus.FAIL, "API compatibility failed.");
+    }
+    if (!result.findings().isEmpty()) {
+      return new AppTestCheck(
+          CHECK_API_COMPAT,
+          request.strict() ? AppTestStatus.FAIL : AppTestStatus.WARN,
+          "API compatibility reported " + result.findings().size() + " finding(s).");
+    }
+    return new AppTestCheck(CHECK_API_COMPAT, AppTestStatus.PASS, "API compatibility passed.");
+  }
+
+  /**
+   * Loads the contract used by compatibility verification.
+   *
+   * @param contractFile optional user-supplied contract JSON, or {@code null} for the current
+   *     built-in validation contract
+   * @return parsed Platform API contract used for this suite run
+   * @throws IOException if a user-supplied contract file cannot be read
+   */
+  private static PlatformApiContract loadContract(Path contractFile) throws IOException {
+    if (contractFile == null) {
+      return DevtoolsCapabilityVocabulary.currentValidationContract();
+    }
+    return PlatformApiContractJson.parse(Files.readString(contractFile, StandardCharsets.UTF_8));
+  }
+
+  /**
+   * Checks whether static UI entry files are safe for the local dev server to expose.
+   *
+   * @param request suite request containing the staged bundle root
+   * @param manifest validated app manifest that declares the UI mode and entry path
+   * @return check result explaining whether static asset serving is applicable and safe
+   * @throws IOException if filesystem metadata cannot be read safely
+   */
+  private static AppTestCheck checkStaticAssets(Request request, AppBundleManifest manifest)
+      throws IOException {
+    if (manifest.uiMode() != AppUiMode.STATIC) {
+      return new AppTestCheck(
+          CHECK_STATIC_ASSETS_SAFETY, AppTestStatus.PASS, "Static UI not declared.");
+    }
+    DevServerStaticAssets.checkStaticAssetSafety(request.bundleDir(), manifest);
+    return new AppTestCheck(
+        CHECK_STATIC_ASSETS_SAFETY, AppTestStatus.PASS, "Static assets are safe to serve.");
+  }
+
+  /**
+   * Starts the loopback mock dev server and exercises bootstrap, API, and static UI routes.
+   *
+   * <p>The smoke test proves that the generated bootstrap JSON includes a usable browser-session
+   * token, that the mock API enforces that token, and that the app entry route can serve HTML. It
+   * does not test browser rendering, hot reload, live Crypta insertion, or real AppHost behavior.
+   *
+   * @param request suite request containing the staged static bundle
+   * @return passing check result when all smoke requests return HTTP 200
+   * @throws IOException if the server cannot start or a smoke response cannot be read
+   * @throws InterruptedException if the thread is interrupted while waiting for a smoke response
+   */
+  private static AppTestCheck smokeDevServer(Request request)
+      throws IOException, InterruptedException {
+    try (CryptaAppDevServer server =
+            CryptaAppDevServer.start(
+                new DevServerConfig(
+                    request.bundleDir(), "127.0.0.1", 0, null, false, Duration.ofMinutes(5)));
+        HttpClient client =
+            HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .version(HttpClient.Version.HTTP_1_1)
+                .build()) {
+      HttpResponse<String> bootstrap =
+          client.send(
+              request(URI.create(server.bootstrapUrl()))
+                  .header(ACCEPT_HEADER, "application/json")
+                  .GET()
+                  .build(),
+              HttpResponse.BodyHandlers.ofString());
+      if (bootstrap.statusCode() != 200) {
+        throw new AppDistributionException("bootstrap smoke returned " + bootstrap.statusCode());
+      }
+      String session = extractSession(bootstrap.body());
+      HttpResponse<String> api =
+          client.send(
+              request(URI.create(server.apiRoot() + "queue"))
+                  .header(ACCEPT_HEADER, "application/json")
+                  .header("X-Crypta-App-Session", session)
+                  .GET()
+                  .build(),
+              HttpResponse.BodyHandlers.ofString());
+      if (api.statusCode() != 200) {
+        throw new AppDistributionException("mock API smoke returned " + api.statusCode());
+      }
+      HttpResponse<String> staticUi =
+          client.send(
+              request(URI.create(server.uiUrl())).header(ACCEPT_HEADER, "text/html").GET().build(),
+              HttpResponse.BodyHandlers.ofString());
+      if (staticUi.statusCode() != 200) {
+        throw new AppDistributionException("static UI smoke returned " + staticUi.statusCode());
+      }
+      return new AppTestCheck(
+          CHECK_DEV_BOOTSTRAP_SMOKE,
+          AppTestStatus.PASS,
+          "Bootstrap, mock API, and static UI passed.");
+    }
+  }
+
+  /**
+   * Extracts the mock browser-session token from bootstrap JSON.
+   *
+   * @param body bootstrap response body returned by the local dev server
+   * @return non-blank browser-session token used for the smoke API request
+   */
+  private static String extractSession(String body) {
+    Matcher matcher = BOOTSTRAP_SESSION_PATTERN.matcher(body);
+    if (!matcher.find() || matcher.group(1).isBlank()) {
+      throw new IllegalArgumentException("bootstrap response did not include a browser session");
+    }
+    return matcher.group(1);
+  }
+
+  /**
+   * Creates an HTTP request builder with the suite's short smoke-test timeout.
+   *
+   * @param uri local loopback URI to request
+   * @return request builder configured with a deterministic timeout
+   */
+  private static HttpRequest.Builder request(URI uri) {
+    return HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(5));
+  }
+
+  /**
+   * Parses an optional catalog entry descriptor when the developer supplied one.
+   *
+   * @param request suite request containing the optional descriptor path
+   * @return passing check result when the descriptor is accepted by catalog tooling
+   * @throws IOException if the descriptor cannot be read or parsed
+   */
+  private static AppTestCheck inspectCatalogEntry(Request request) throws IOException {
+    AppCatalogWriter.inspectEntryDescriptor(request.catalogEntry());
+    return new AppTestCheck(
+        CHECK_CATALOG_ENTRY_SANITY, AppTestStatus.PASS, "Catalog entry descriptor parsed.");
+  }
+
+  /**
+   * Runs one suite operation and converts thrown exceptions into sanitized failed checks.
+   *
+   * @param id stable check identifier used when the operation fails before returning a result
+   * @param operation operation that performs the check
+   * @return the operation result or a failed check containing the redacted exception message
+   */
+  private static AppTestCheck runCheck(String id, CheckOperation operation) {
+    try {
+      return operation.run();
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      return new AppTestCheck(id, AppTestStatus.FAIL, exception.getMessage());
+    } catch (IOException | AppCatalogException | IllegalArgumentException exception) {
+      return new AppTestCheck(id, AppTestStatus.FAIL, exception.getMessage());
+    }
+  }
+
+  /**
+   * Computes the aggregate report status and attaches validated app identity fields.
+   *
+   * @param request suite request whose strict flag controls warning promotion
+   * @param manifest validated manifest used for app id and version
+   * @param checks ordered check results collected during this suite run
+   * @return immutable sanitized app test report
+   */
+  private static AppTestReport reportFor(
+      Request request, AppBundleManifest manifest, List<AppTestCheck> checks) {
+    AppTestStatus status = AppTestStatus.PASS;
+    for (AppTestCheck check : checks) {
+      if (check.status() == AppTestStatus.FAIL
+          || (request.strict() && check.status() == AppTestStatus.WARN)) {
+        status = AppTestStatus.FAIL;
+        break;
+      }
+      if (check.status() == AppTestStatus.WARN) {
+        status = AppTestStatus.WARN;
+      }
+    }
+    return new AppTestReport(1, manifest.appId(), manifest.appVersion(), status, checks);
+  }
+
+  /** Operation adapter used so each check can be wrapped with consistent failure handling. */
+  @FunctionalInterface
+  private interface CheckOperation {
+    /**
+     * Runs the underlying check.
+     *
+     * @return sanitized check result produced by the operation
+     * @throws IOException if the operation fails while reading bundle, API, or catalog inputs
+     * @throws InterruptedException if the operation is interrupted while waiting for local HTTP
+     */
+    AppTestCheck run() throws IOException, InterruptedException;
+  }
+
+  /** Mutable bridge from the bundle validation check to later manifest-dependent checks. */
+  private static final class ValidationHolder {
+    /** Creates an empty holder before bundle validation has run. */
+    private ValidationHolder() {}
+
+    /** Successful bundle validation result, or {@code null} when validation failed. */
+    private BundleValidation validation;
+  }
+
+  /**
+   * Input for one test suite run.
+   *
+   * <p>The CLI constructs this record from command-line options before invoking the suite. Paths
+   * are normalized to absolute form once so lower-level checks can open files consistently, while
+   * report generation still redacts any path text that escapes through diagnostics. A {@code null}
+   * contract uses the built-in current Platform API contract, and a {@code null} catalog entry
+   * skips descriptor sanity checking.
+   *
+   * @param bundleDir staged bundle directory to validate and, for static apps, serve locally
+   * @param strict whether warnings should make the aggregate report fail
+   * @param contract optional Platform API contract JSON used instead of the built-in contract
+   * @param catalogEntry optional catalog entry descriptor checked after manifest validation
+   */
+  record Request(Path bundleDir, boolean strict, Path contract, Path catalogEntry) {
+    /**
+     * Normalizes user-supplied paths for deterministic filesystem access.
+     *
+     * <p>The constructor does not require optional paths to exist because later checks own their
+     * specific failure messages. This keeps the request layer simple and lets the report identify
+     * the failing gate precisely.
+     */
+    Request {
+      bundleDir = bundleDir.toAbsolutePath().normalize();
+      if (contract != null) {
+        contract = contract.toAbsolutePath().normalize();
+      }
+      if (catalogEntry != null) {
+        catalogEntry = catalogEntry.toAbsolutePath().normalize();
+      }
+    }
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/CatalogEntryDescriptorGenerator.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/CatalogEntryDescriptorGenerator.java
@@ -1,0 +1,493 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import network.crypta.platform.appcatalog.AppCatalogBundleExtractor;
+import network.crypta.platform.appcatalog.AppCatalogWriter;
+import network.crypta.platform.appcatalog.AppReviewReceipt;
+import network.crypta.platform.appcatalog.AppReviewReceiptIO;
+import network.crypta.platform.appdist.AppBundleManifest;
+import network.crypta.platform.appdist.AppBundleManifestParser;
+import network.crypta.platform.appdist.AppDistributionException;
+
+/**
+ * Writes strict catalog entry descriptors from staged bundle and artifact metadata.
+ *
+ * <p>This helper backs {@code crypta-app catalog entry}. It turns a signed app artifact and a local
+ * staged bundle into the descriptor consumed by {@code crypta-app catalog create}. The artifact is
+ * the source of publishable manifest metadata such as permissions, API compatibility, app identity,
+ * and version. The staged bundle is still parsed, but only to prove that the developer is
+ * generating metadata for the same manifest they just signed and packed.
+ *
+ * <p>The writer is intentionally conservative. It rejects unsigned artifacts through the catalog
+ * bundle extractor, validates the generated descriptor before moving it into place, writes through
+ * a temporary file, and preserves the order of permission rationales supplied on the CLI. It does
+ * not publish bundles or catalogs; it prepares local descriptor input for the existing catalog
+ * signing pipeline.
+ */
+final class CatalogEntryDescriptorGenerator {
+  /** Directory permissions used for artifact-inspection scratch roots before ZIP extraction. */
+  private static final Set<PosixFilePermission> OWNER_ONLY_DIRECTORY =
+      Set.of(
+          PosixFilePermission.OWNER_READ,
+          PosixFilePermission.OWNER_WRITE,
+          PosixFilePermission.OWNER_EXECUTE);
+
+  /** Prevents construction of this stateless descriptor writer. */
+  private CatalogEntryDescriptorGenerator() {}
+
+  /**
+   * Generates and validates one catalog entry descriptor.
+   *
+   * <p>The method normalizes paths, checks overwrite policy, verifies that the packed artifact is a
+   * signed app bundle, compares the staged and artifact manifests, enforces strict permission
+   * rationale requirements, and then writes a descriptor accepted by {@link AppCatalogWriter}. The
+   * output is moved atomically where the filesystem supports it.
+   *
+   * @param request descriptor generation request from CLI options
+   * @return generated app id, version, and any permissions that lacked rationales
+   * @throws IOException if manifests, artifacts, receipts, or output files cannot be read or
+   *     written
+   */
+  static Result write(Request request) throws IOException {
+    Request checked = request.normalize();
+    if (Files.exists(checked.output(), LinkOption.NOFOLLOW_LINKS) && !checked.overwrite()) {
+      throw new AppDistributionException("catalog entry already exists: " + checked.output());
+    }
+    AppBundleManifest bundleManifest =
+        AppBundleManifestParser.parse(
+            checked.bundleDir().resolve(AppBundleManifestParser.MANIFEST_FILE_NAME));
+    AppBundleManifest artifactManifest = inspectArtifactManifest(checked);
+    requireBundleManifestMatchesArtifact(bundleManifest, artifactManifest);
+    List<String> missingRationales =
+        artifactManifest.permissions().stream()
+            .filter(permission -> !checked.permissionRationales().containsKey(permission))
+            .toList();
+    if (checked.strict() && !missingRationales.isEmpty()) {
+      throw new AppDistributionException(
+          "missing permission rationale(s): " + String.join(", ", missingRationales));
+    }
+    String descriptor = descriptorContent(checked, artifactManifest);
+    Path temp = temporaryDescriptor(checked.output());
+    try {
+      Files.writeString(
+          temp,
+          descriptor,
+          StandardCharsets.UTF_8,
+          StandardOpenOption.TRUNCATE_EXISTING,
+          StandardOpenOption.WRITE);
+      AppCatalogWriter.inspectEntryDescriptor(temp);
+      createParent(checked.output());
+      Files.move(
+          temp,
+          checked.output(),
+          checked.overwrite()
+              ? new StandardCopyOption[] {
+                StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE
+              }
+              : new StandardCopyOption[] {StandardCopyOption.ATOMIC_MOVE});
+    } catch (IOException | RuntimeException exception) {
+      Files.deleteIfExists(temp);
+      throw exception;
+    }
+    return new Result(artifactManifest.appId(), artifactManifest.appVersion(), missingRationales);
+  }
+
+  /**
+   * Reads the manifest from the signed artifact using the catalog extractor's verification path.
+   *
+   * @param request normalized request containing the artifact ZIP path
+   * @return manifest embedded in the verified signed artifact
+   * @throws IOException if the artifact cannot be inspected or temporary storage cannot be created
+   */
+  private static AppBundleManifest inspectArtifactManifest(Request request) throws IOException {
+    Path scratchRoot = createPrivateArtifactScratchRoot(request.artifact());
+    try {
+      return AppCatalogBundleExtractor.inspectSignedArtifact(request.artifact(), scratchRoot);
+    } finally {
+      Files.deleteIfExists(scratchRoot);
+    }
+  }
+
+  /**
+   * Creates a private scratch directory next to the artifact being inspected.
+   *
+   * <p>The catalog entry command expands an untrusted ZIP only through {@link
+   * AppCatalogBundleExtractor}, but the extraction root itself must not live in the shared JVM
+   * default temporary directory with broad permissions. Creating the directory beside the artifact
+   * avoids default public temp roots, and POSIX hosts receive owner-only permissions at creation
+   * time. Non-POSIX hosts are restricted immediately through the portable {@link java.io.File}
+   * permission API and fail closed when the runtime reports that permissions could not be applied.
+   *
+   * @param artifact signed artifact path whose parent should hold inspection scratch state
+   * @return owner-only temporary directory for artifact inspection
+   * @throws IOException if the scratch directory cannot be created or restricted
+   */
+  // The directory name is generated atomically under the artifact parent, and permissions are
+  // restricted to the current owner before any ZIP extraction occurs.
+  @SuppressWarnings("java:S5443")
+  private static Path createPrivateArtifactScratchRoot(Path artifact) throws IOException {
+    Path parent = artifact.getParent();
+    if (parent == null) {
+      parent = Path.of("").toAbsolutePath().normalize();
+    }
+    try {
+      return Files.createTempDirectory(
+          parent,
+          ".catalog-entry-artifact-",
+          PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY));
+    } catch (UnsupportedOperationException _) {
+      Path scratchRoot = Files.createTempDirectory(parent, ".catalog-entry-artifact-");
+      try {
+        restrictPortableOwnerOnlyDirectory(scratchRoot);
+        return scratchRoot;
+      } catch (IOException | RuntimeException exception) {
+        Files.deleteIfExists(scratchRoot);
+        throw exception;
+      }
+    }
+  }
+
+  /**
+   * Applies owner-only access to a scratch directory on non-POSIX filesystems.
+   *
+   * @param directory scratch directory that must be accessible only by the current owner
+   * @throws IOException if any portable permission operation is rejected by the runtime
+   */
+  private static void restrictPortableOwnerOnlyDirectory(Path directory) throws IOException {
+    java.io.File file = directory.toFile();
+    if (!file.setReadable(false, false)
+        || !file.setWritable(false, false)
+        || !file.setExecutable(false, false)
+        || !file.setReadable(true, true)
+        || !file.setWritable(true, true)
+        || !file.setExecutable(true, true)) {
+      throw new IOException("failed to restrict catalog entry scratch directory: " + directory);
+    }
+  }
+
+  /**
+   * Ensures the mutable staged bundle and immutable artifact describe the same app bundle.
+   *
+   * @param bundleManifest manifest parsed from the staged bundle directory
+   * @param artifactManifest manifest parsed from the signed artifact ZIP
+   * @throws AppDistributionException if any manifest field differs
+   */
+  private static void requireBundleManifestMatchesArtifact(
+      AppBundleManifest bundleManifest, AppBundleManifest artifactManifest)
+      throws AppDistributionException {
+    if (!bundleManifest.equals(artifactManifest)) {
+      throw new AppDistributionException(
+          "bundle manifest must match artifact manifest before catalog entry generation");
+    }
+  }
+
+  /**
+   * Renders descriptor properties in the order expected by catalog fixture tests.
+   *
+   * @param request normalized request containing CLI metadata and optional review receipt
+   * @param manifest artifact-derived manifest that supplies app and API metadata
+   * @return descriptor properties text with one {@code key=value} pair per line
+   * @throws IOException if an optional review receipt cannot be read
+   */
+  private static String descriptorContent(Request request, AppBundleManifest manifest)
+      throws IOException {
+    StringBuilder builder = new StringBuilder();
+    append(builder, "artifact.path", request.artifact().toString());
+    append(builder, "bundle.uri", request.bundleUri().toString());
+    append(builder, "summary", request.summary());
+    append(builder, "app.id", manifest.appId());
+    append(builder, "name", manifest.appName());
+    append(builder, "version", manifest.appVersion());
+    appendOptionalUri(builder, "homepage", request.homepage().orElse(null));
+    appendOptionalUri(builder, "source", request.source().orElse(null));
+    appendOptional(builder, "license", request.license().orElse(null));
+    appendOptional(builder, "categories", request.category().orElse(null));
+    appendOptional(builder, "minimumCryptaVersion", request.minimumCryptaVersion().orElse(null));
+    if (!manifest.permissions().isEmpty()) {
+      append(builder, "permissions", String.join(",", manifest.permissions()));
+    }
+    if (manifest.apiCompatibility().minimumVersion() != null) {
+      append(
+          builder, "api.minimumVersion", manifest.apiCompatibility().minimumVersion().toString());
+    }
+    if (manifest.apiCompatibility().maximumTestedVersion() != null) {
+      append(
+          builder,
+          "api.maximumTestedVersion",
+          manifest.apiCompatibility().maximumTestedVersion().toString());
+    }
+    if (!manifest.apiCompatibility().optionalCapabilities().isEmpty()) {
+      append(
+          builder,
+          "api.optionalCapabilities",
+          String.join(",", manifest.apiCompatibility().optionalCapabilities()));
+    }
+    if (manifest.apiCompatibility().declared()) {
+      append(
+          builder,
+          "api.experimentalCapabilitiesAccepted",
+          Boolean.toString(manifest.apiCompatibility().experimentalCapabilitiesAccepted()));
+    }
+    for (Map.Entry<String, String> entry : request.permissionRationales().entrySet()) {
+      append(builder, "permissions.rationale." + entry.getKey(), entry.getValue());
+    }
+    for (int index = 0; index < request.screenshots().size(); index++) {
+      append(builder, "screenshot." + (index + 1), request.screenshots().get(index).toString());
+    }
+    appendOptional(builder, "changelog.summary", request.changelogSummary().orElse(null));
+    appendReviewReceipt(builder, request.reviewReceipt());
+    return builder.toString();
+  }
+
+  /**
+   * Appends a URI-valued property only when the CLI option was supplied.
+   *
+   * @param builder descriptor builder receiving the property
+   * @param key catalog descriptor property key
+   * @param value URI value supplied by the developer, or {@code null} when omitted
+   * @throws AppDistributionException if the URI text contains a line break
+   */
+  private static void appendOptionalUri(StringBuilder builder, String key, URI value)
+      throws AppDistributionException {
+    if (value == null) {
+      return;
+    }
+    append(builder, key, value.toString());
+  }
+
+  /**
+   * Appends a string-valued property only when the CLI option was supplied.
+   *
+   * @param builder descriptor builder receiving the property
+   * @param key catalog descriptor property key
+   * @param value text supplied by the developer or review receipt, or {@code null} when omitted
+   * @throws AppDistributionException if the value contains a line break
+   */
+  private static void appendOptional(StringBuilder builder, String key, String value)
+      throws AppDistributionException {
+    if (value == null) {
+      return;
+    }
+    append(builder, key, value);
+  }
+
+  /**
+   * Copies review metadata from an optional receipt file into the descriptor.
+   *
+   * @param builder descriptor builder receiving review fields
+   * @param reviewReceipt optional review receipt path supplied on the CLI
+   * @throws IOException if the review receipt cannot be read
+   */
+  private static void appendReviewReceipt(StringBuilder builder, Path reviewReceipt)
+      throws IOException {
+    if (reviewReceipt != null) {
+      AppReviewReceipt receipt = AppReviewReceiptIO.read(reviewReceipt);
+      append(builder, "review.status", receipt.payload().status().catalogValue());
+      appendOptional(builder, "review.note", receipt.payload().note().orElse(null));
+    }
+  }
+
+  /**
+   * Appends one single-line properties value.
+   *
+   * @param builder descriptor builder receiving the property
+   * @param key catalog descriptor property key
+   * @param value property value, trimmed before writing
+   * @throws AppDistributionException if the value contains a line break
+   */
+  private static void append(StringBuilder builder, String key, String value)
+      throws AppDistributionException {
+    if (value.indexOf('\n') >= 0 || value.indexOf('\r') >= 0) {
+      throw new AppDistributionException("catalog entry value must be a single line: " + key);
+    }
+    builder.append(key).append('=').append(value.trim()).append('\n');
+  }
+
+  /**
+   * Creates a temporary descriptor file next to the requested output.
+   *
+   * @param output final descriptor path requested by the user
+   * @return temporary file path in the same directory as the final output
+   * @throws IOException if the parent directory or temporary file cannot be created
+   */
+  private static Path temporaryDescriptor(Path output) throws IOException {
+    Path parent = descriptorParent(output);
+    return Files.createTempFile(parent, ".catalog-entry-", ".properties");
+  }
+
+  /**
+   * Resolves and creates the directory used for descriptor staging.
+   *
+   * @param output final descriptor path requested by the user
+   * @return directory where the temporary descriptor should be created
+   * @throws IOException if the directory cannot be created
+   */
+  private static Path descriptorParent(Path output) throws IOException {
+    Path parent = output.getParent();
+    if (parent == null) {
+      parent = Path.of("").toAbsolutePath().normalize();
+    }
+    Files.createDirectories(parent);
+    return parent;
+  }
+
+  /**
+   * Creates the parent directory for a file when it has one.
+   *
+   * @param file file path whose parent should exist before a move or write
+   * @throws IOException if the parent directory cannot be created
+   */
+  private static void createParent(Path file) throws IOException {
+    Path parent = file.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+  }
+
+  /**
+   * Parses repeatable {@code --permission-rationale permission=text} CLI values.
+   *
+   * <p>The returned map preserves insertion order so repeated command runs generate byte-identical
+   * descriptors when all other inputs are unchanged. Permission keys are normalized to lower case
+   * to match manifest permission spelling.
+   *
+   * @param values raw CLI values supplied for permission rationales
+   * @return immutable insertion-ordered map from permission id to rationale text
+   * @throws AppDistributionException if a value is malformed or duplicates a permission
+   */
+  static Map<String, String> normalizeRationales(List<String> values)
+      throws AppDistributionException {
+    Map<String, String> rationales = new LinkedHashMap<>();
+    for (String value : values) {
+      int separator = value.indexOf('=');
+      if (separator <= 0 || separator == value.length() - 1) {
+        throw new AppDistributionException(
+            "--permission-rationale must use permission=text syntax");
+      }
+      String permission = value.substring(0, separator).trim().toLowerCase(java.util.Locale.ROOT);
+      String rationale = value.substring(separator + 1).trim();
+      if (rationales.putIfAbsent(permission, rationale) != null) {
+        throw new AppDistributionException("duplicate permission rationale: " + permission);
+      }
+    }
+    return java.util.Collections.unmodifiableMap(new LinkedHashMap<>(rationales));
+  }
+
+  /**
+   * Input for catalog entry descriptor generation.
+   *
+   * <p>The request combines paths for local artifacts with catalog-facing metadata supplied by the
+   * developer. Only {@code artifact.path} is expected to preserve a local path in the descriptor;
+   * other manifest-derived fields come from the signed artifact, and optional URI or review fields
+   * are copied only after validation by the existing catalog tooling.
+   *
+   * @param bundleDir staged bundle directory used to confirm the local manifest matches the
+   *     artifact manifest
+   * @param artifact signed packed bundle artifact whose size, digest, and manifest metadata are
+   *     used by the catalog
+   * @param bundleUri public or local URI that catalog consumers should use to fetch the artifact
+   * @param output descriptor file to write for {@code crypta-app catalog create --entry}
+   * @param summary short user-facing summary required by catalog entries
+   * @param homepage optional project or app homepage URI copied into the descriptor
+   * @param source optional source repository URI copied into the descriptor
+   * @param license optional license label or identifier copied into the descriptor
+   * @param category optional catalog category value copied into the descriptor
+   * @param minimumCryptaVersion optional minimum daemon version advertised by the catalog entry
+   * @param reviewReceipt optional trusted review receipt whose status and note are copied
+   * @param changelogSummary optional short changelog text for this app release
+   * @param permissionRationales insertion-ordered rationales keyed by manifest permission id
+   * @param screenshots optional screenshot URIs copied as ordered descriptor entries
+   * @param strict whether missing rationales for declared permissions should fail generation
+   * @param overwrite whether an existing descriptor output may be replaced
+   */
+  record Request(
+      Path bundleDir,
+      Path artifact,
+      URI bundleUri,
+      Path output,
+      String summary,
+      Optional<URI> homepage,
+      Optional<URI> source,
+      Optional<String> license,
+      Optional<String> category,
+      Optional<String> minimumCryptaVersion,
+      Path reviewReceipt,
+      Optional<String> changelogSummary,
+      Map<String, String> permissionRationales,
+      List<URI> screenshots,
+      boolean strict,
+      boolean overwrite) {
+    /**
+     * Validates required fields and freezes collection-valued inputs.
+     *
+     * <p>The compact constructor accepts already-normalized or relative paths. Call {@link
+     * #normalize()} before filesystem access so path handling remains consistent across CLI entry
+     * points and tests.
+     */
+    Request {
+      Objects.requireNonNull(bundleDir, "bundleDir");
+      Objects.requireNonNull(artifact, "artifact");
+      Objects.requireNonNull(bundleUri, "bundleUri");
+      Objects.requireNonNull(output, "output");
+      Objects.requireNonNull(summary, "summary");
+      Objects.requireNonNull(homepage, "homepage");
+      Objects.requireNonNull(source, "source");
+      Objects.requireNonNull(license, "license");
+      Objects.requireNonNull(category, "category");
+      Objects.requireNonNull(minimumCryptaVersion, "minimumCryptaVersion");
+      Objects.requireNonNull(changelogSummary, "changelogSummary");
+      permissionRationales =
+          java.util.Collections.unmodifiableMap(new LinkedHashMap<>(permissionRationales));
+      screenshots = List.copyOf(screenshots);
+    }
+
+    /**
+     * Converts local paths to absolute normalized form.
+     *
+     * @return equivalent request with normalized filesystem paths and unchanged catalog metadata
+     */
+    Request normalize() {
+      return new Request(
+          bundleDir.toAbsolutePath().normalize(),
+          artifact.toAbsolutePath().normalize(),
+          bundleUri,
+          output.toAbsolutePath().normalize(),
+          summary.trim(),
+          homepage,
+          source,
+          license,
+          category,
+          minimumCryptaVersion,
+          reviewReceipt == null ? null : reviewReceipt.toAbsolutePath().normalize(),
+          changelogSummary,
+          permissionRationales,
+          screenshots,
+          strict,
+          overwrite);
+    }
+  }
+
+  /**
+   * Summary of a generated descriptor.
+   *
+   * @param appId app id copied from the verified artifact manifest
+   * @param version app version copied from the verified artifact manifest
+   * @param missingRationales manifest permissions that did not have supplied rationale text
+   */
+  record Result(String appId, String version, List<String> missingRationales) {}
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/CryptaAppCli.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/CryptaAppCli.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HexFormat;
@@ -45,6 +46,8 @@ import network.crypta.platform.appdist.AppDistributionException;
 import network.crypta.platform.appdist.AppDistributionTool;
 import network.crypta.platform.appdist.PackagedAppBundle;
 import network.crypta.platform.appdist.TrustedAppKeys;
+import network.crypta.platform.devtools.devserver.CryptaAppDevServer;
+import network.crypta.platform.devtools.devserver.DevServerConfig;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
@@ -72,7 +75,10 @@ import picocli.CommandLine;
     description = "Create, validate, lint, package, sign, and catalog Crypta app bundles.",
     subcommands = {
       CryptaAppCli.InitCommand.class,
+      CryptaAppCli.DevCommand.class,
+      CryptaAppCli.AppTestCommand.class,
       CryptaAppCli.ValidateCommand.class,
+      CryptaAppCli.KeysCommand.class,
       CryptaAppCli.PackCommand.class,
       CryptaAppCli.SignCommand.class,
       CryptaAppCli.VerifyCommand.class,
@@ -80,7 +86,8 @@ import picocli.CommandLine;
       CryptaAppCli.CompatCommand.class,
       CryptaAppCli.UiCommand.class,
       CryptaAppCli.ReviewCommand.class,
-      CryptaAppCli.CatalogCommand.class
+      CryptaAppCli.CatalogCommand.class,
+      CryptaAppCli.PublishUskCommand.class
     })
 public final class CryptaAppCli implements Runnable {
   private CommandSpec spec;
@@ -187,6 +194,14 @@ public final class CryptaAppCli implements Runnable {
         description = "UI template mode: static, shell-panel, or none.")
     private String uiMode;
 
+    @Option(
+        names = "--template",
+        defaultValue = "static-basic",
+        description =
+            "Beta app template: ${COMPLETION-CANDIDATES}. Supported: "
+                + "static-basic, queue-dashboard, publisher, vault-profile.")
+    private String template;
+
     @Option(names = "--permission", description = "Manifest permission to add; repeatable.")
     private List<String> permissions = new ArrayList<>();
 
@@ -203,10 +218,178 @@ public final class CryptaAppCli implements Runnable {
                   name,
                   version,
                   AppTemplateScaffolder.UiMode.parse(uiMode),
+                  AppTemplateKind.parse(template),
                   permissions,
                   overwrite));
       super.commandLine().getOut().println("Initialized app bundle at " + scaffolded);
       return CommandLine.ExitCode.OK;
+    }
+  }
+
+  /** Implements {@code crypta-app dev} for local static UI and mock Platform API serving. */
+  @Command(name = "dev", description = "Serve a staged static app bundle with a mock Platform API.")
+  static final class DevCommand extends SpecAwareCommand implements Callable<Integer> {
+    @Option(names = "--bundle-dir", required = true, description = "Staged bundle directory.")
+    private Path bundleDir;
+
+    @Option(names = "--host", defaultValue = "127.0.0.1", description = "Listener host.")
+    private String host;
+
+    @Option(names = "--port", defaultValue = "0", description = "Listener port, or 0 for any.")
+    private int port;
+
+    @Option(names = "--fixture-dir", description = "Directory containing JSON mock fixtures.")
+    private Path fixtureDir;
+
+    @Option(
+        names = "--open",
+        defaultValue = "false",
+        arity = "1",
+        description = "Print browser-open hint: true or false.")
+    private boolean open;
+
+    @Option(
+        names = "--session-ttl-seconds",
+        defaultValue = "3600",
+        description = "Mock browser-session lifetime.")
+    private long sessionTtlSeconds;
+
+    @Option(
+        names = "--allow-non-loopback",
+        description = "Allow binding the dev server to a non-loopback host.")
+    private boolean allowNonLoopback;
+
+    @Override
+    public Integer call() throws Exception {
+      try (CryptaAppDevServer server =
+          CryptaAppDevServer.start(
+              new DevServerConfig(
+                  bundleDir,
+                  host,
+                  port,
+                  fixtureDir,
+                  allowNonLoopback,
+                  Duration.ofSeconds(sessionTtlSeconds)))) {
+        Runtime.getRuntime().addShutdownHook(new Thread(server::close, "crypta-app-dev-shutdown"));
+        super.commandLine().getOut().println(server.startupSummary());
+        if (open) {
+          super.commandLine().getOut().println("Open: " + server.uiUrl());
+        }
+        Thread.currentThread().join();
+      }
+      return CommandLine.ExitCode.OK;
+    }
+  }
+
+  /** Implements {@code crypta-app test} for offline developer checks. */
+  @Command(name = "test", description = "Run the offline app developer test suite.")
+  static final class AppTestCommand extends SpecAwareCommand implements Callable<Integer> {
+    @Option(names = "--bundle-dir", required = true, description = "Staged bundle directory.")
+    private Path bundleDir;
+
+    @Option(names = "--strict", description = "Treat warnings as failures.")
+    private boolean strict;
+
+    @Option(names = "--contract", description = "Platform API contract JSON snapshot.")
+    private Path contract;
+
+    @Option(names = "--catalog-entry", description = "Optional catalog entry descriptor.")
+    private Path catalogEntry;
+
+    @Option(names = "--json", description = "Write deterministic JSON report.")
+    private Path jsonOutput;
+
+    @Override
+    public Integer call() throws Exception {
+      AppTestReport report =
+          AppTestSuite.run(new AppTestSuite.Request(bundleDir, strict, contract, catalogEntry));
+      for (AppTestCheck check : report.checks()) {
+        super.commandLine()
+            .getOut()
+            .println(check.id() + " " + check.status().jsonValue() + ": " + check.summary());
+      }
+      super.commandLine()
+          .getOut()
+          .println(
+              "App test suite "
+                  + report.status().jsonValue()
+                  + ": "
+                  + report.appId()
+                  + " "
+                  + report.version());
+      if (jsonOutput != null) {
+        Path normalizedJsonOutput = jsonOutput.toAbsolutePath().normalize();
+        Path parent = normalizedJsonOutput.getParent();
+        if (parent != null) {
+          Files.createDirectories(parent);
+        }
+        Files.writeString(
+            normalizedJsonOutput, AppTestReportJson.write(report), StandardCharsets.UTF_8);
+      }
+      return report.status() == AppTestStatus.FAIL
+          ? CommandLine.ExitCode.SOFTWARE
+          : CommandLine.ExitCode.OK;
+    }
+  }
+
+  /** Parent command for local developer signing key operations. */
+  @Command(
+      name = "keys",
+      description = "Generate local developer app signing keys.",
+      subcommands = {KeysGenerateCommand.class})
+  static final class KeysCommand extends SpecAwareCommand implements Runnable {
+    @Override
+    public void run() {
+      super.commandLine().usage(super.commandLine().getOut());
+    }
+  }
+
+  /** Implements {@code crypta-app keys generate}. */
+  @Command(name = "generate", description = "Generate a local Ed25519 app signing key pair.")
+  static final class KeysGenerateCommand extends SpecAwareCommand implements Callable<Integer> {
+    @Option(names = "--key-id", required = true, description = "Signing key id.")
+    private String keyId;
+
+    @Option(names = "--private-key-file", required = true, description = "Private key output file.")
+    private Path privateKeyFile;
+
+    @Option(names = "--public-key-file", required = true, description = "Public key output file.")
+    private Path publicKeyFile;
+
+    @Option(names = "--trusted-keys-file", description = "Trusted app keys properties output.")
+    private Path trustedKeysFile;
+
+    @Option(names = "--overwrite", description = "Replace existing key files.")
+    private boolean overwrite;
+
+    @Override
+    public Integer call() throws Exception {
+      printKeyPathWarning(privateKeyFile);
+      printKeyPathWarning(publicKeyFile);
+      if (trustedKeysFile != null) {
+        printKeyPathWarning(trustedKeysFile);
+      }
+      DeveloperKeyGenerator.GeneratedKeys generated =
+          DeveloperKeyGenerator.generate(
+              keyId, privateKeyFile, publicKeyFile, trustedKeysFile, overwrite);
+      super.commandLine()
+          .getOut()
+          .println(
+              "Generated app signing key: "
+                  + keyId
+                  + " public="
+                  + generated.publicKeyFile().getFileName());
+      if (generated.trustedKeysFile() != null) {
+        super.commandLine().getOut().println("Wrote trusted keys file.");
+      }
+      return CommandLine.ExitCode.OK;
+    }
+
+    private void printKeyPathWarning(Path path) {
+      String warning = DeveloperKeyGenerator.repoPathWarning(path);
+      if (!warning.isBlank()) {
+        super.commandLine().getErr().println(warning);
+      }
     }
   }
 
@@ -813,6 +996,7 @@ public final class CryptaAppCli implements Runnable {
       name = "catalog",
       description = "Create, sign, and verify signed app catalogs.",
       subcommands = {
+        CatalogEntryCommand.class,
         CatalogCreateCommand.class,
         CatalogSignCommand.class,
         CatalogVerifyCommand.class
@@ -821,6 +1005,103 @@ public final class CryptaAppCli implements Runnable {
     @Override
     public void run() {
       super.commandLine().usage(super.commandLine().getOut());
+    }
+  }
+
+  /** Implements {@code crypta-app catalog entry}. */
+  @Command(name = "entry", description = "Generate a catalog entry descriptor for a signed bundle.")
+  static final class CatalogEntryCommand extends SpecAwareCommand implements Callable<Integer> {
+    @Option(
+        names = "--bundle-dir",
+        required = true,
+        description = "Signed staged bundle directory.")
+    private Path bundleDir;
+
+    @Option(names = "--artifact", required = true, description = "Packaged ZIP artifact.")
+    private Path artifact;
+
+    @Option(names = "--bundle-uri", required = true, description = "Public bundle artifact URI.")
+    private URI bundleUri;
+
+    @Option(names = "--output", required = true, description = "Catalog entry descriptor output.")
+    private Path output;
+
+    @Option(names = "--summary", required = true, description = "Catalog summary.")
+    private String summary;
+
+    @Option(names = "--homepage", description = "App homepage URI.")
+    private URI homepage;
+
+    @Option(names = "--source", description = "Source code URI.")
+    private URI source;
+
+    @Option(names = "--license", description = "License identifier.")
+    private String license;
+
+    @Option(names = "--category", description = "Catalog category list.")
+    private String category;
+
+    @Option(names = "--minimum-crypta-version", description = "Minimum Crypta build/version.")
+    private String minimumCryptaVersion;
+
+    @Option(
+        names = "--review-receipt",
+        description = "Review receipt to copy advisory metadata from.")
+    private Path reviewReceipt;
+
+    @Option(names = "--changelog-summary", description = "Short changelog summary.")
+    private String changelogSummary;
+
+    @Option(
+        names = "--permission-rationale",
+        description = "Permission rationale in permission=text form; repeatable.")
+    private List<String> permissionRationales = new ArrayList<>();
+
+    @Option(names = "--screenshot", description = "Screenshot URI; repeatable.")
+    private List<URI> screenshots = new ArrayList<>();
+
+    @Option(names = "--strict", description = "Require a rationale for every permission.")
+    private boolean strict;
+
+    @Option(names = "--overwrite", description = "Replace an existing descriptor.")
+    private boolean overwrite;
+
+    @Override
+    public Integer call() throws Exception {
+      CatalogEntryDescriptorGenerator.Result result =
+          CatalogEntryDescriptorGenerator.write(
+              new CatalogEntryDescriptorGenerator.Request(
+                  bundleDir,
+                  artifact,
+                  bundleUri,
+                  output,
+                  summary,
+                  Optional.ofNullable(homepage),
+                  Optional.ofNullable(source),
+                  Optional.ofNullable(license),
+                  Optional.ofNullable(category),
+                  Optional.ofNullable(minimumCryptaVersion),
+                  reviewReceipt,
+                  Optional.ofNullable(changelogSummary),
+                  CatalogEntryDescriptorGenerator.normalizeRationales(permissionRationales),
+                  screenshots,
+                  strict,
+                  overwrite));
+      for (String permission : result.missingRationales()) {
+        super.commandLine()
+            .getErr()
+            .println("Warning: missing permission rationale for " + permission);
+      }
+      super.commandLine()
+          .getOut()
+          .println(
+              "Wrote catalog entry descriptor: "
+                  + result.appId()
+                  + " "
+                  + result.version()
+                  + " -> "
+                  + output.toAbsolutePath().normalize().getFileName());
+      return CommandLine.ExitCode.OK;
     }
   }
 
@@ -960,6 +1241,55 @@ public final class CryptaAppCli implements Runnable {
       }
       AppCatalog catalog = AppCatalogVerifier.verify(catalogFile, trustedKeys);
       super.commandLine().getOut().println("Verified catalog: " + catalog.catalogId());
+      return CommandLine.ExitCode.OK;
+    }
+  }
+
+  /** Implements {@code crypta-app publish-usk}. */
+  @Command(name = "publish-usk", description = "Write an offline Crypta USK publication plan.")
+  static final class PublishUskCommand extends SpecAwareCommand implements Callable<Integer> {
+    @Option(names = "--catalog-file", required = true, description = "Catalog properties file.")
+    private Path catalogFile;
+
+    @Option(
+        names = "--catalog-signature-file",
+        required = true,
+        description = "Catalog signature sidecar.")
+    private Path catalogSignatureFile;
+
+    @Option(
+        names = "--catalog-source",
+        required = true,
+        description = "Public crypta:USK catalog source URI.")
+    private String catalogSource;
+
+    @Option(names = "--output", required = true, description = "Publication plan output.")
+    private Path output;
+
+    @Option(names = "--dry-run", description = "Generate a plan without live insertion.")
+    private boolean dryRun;
+
+    @Override
+    public Integer call() throws Exception {
+      PublicationPlanWriter.Result result =
+          PublicationPlanWriter.write(
+              new PublicationPlanWriter.Request(
+                  catalogFile, catalogSignatureFile, catalogSource, output));
+      if (!dryRun) {
+        throw new AppDistributionException(
+            "live_publish_not_supported: wrote offline plan "
+                + result.output().getFileName()
+                + "; perform Crypta inserts with a reviewed insertion workflow");
+      }
+      super.commandLine()
+          .getOut()
+          .println(
+              "Wrote Crypta USK publication plan: "
+                  + result.catalogId()
+                  + " entries="
+                  + result.entryCount()
+                  + " output="
+                  + result.output().getFileName());
       return CommandLine.ExitCode.OK;
     }
   }

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/DeveloperKeyGenerator.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/DeveloperKeyGenerator.java
@@ -1,0 +1,411 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Set;
+import network.crypta.platform.appdist.AppBundleSignature;
+import network.crypta.platform.appdist.AppDistributionException;
+
+/**
+ * Generates local Ed25519 key material for developer signing workflows.
+ *
+ * <p>This class backs {@code crypta-app keys generate}. It creates key pairs using the same Ed25519
+ * algorithm expected by bundle and catalog signatures, then writes encoded key files and optional
+ * trusted-app-key property files that the existing signing and verification commands can consume.
+ *
+ * <p>The private key path receives stricter handling than public material. The generator checks for
+ * duplicate output paths before writing anything, refuses symlink outputs, creates new private-key
+ * files with owner-only permissions where the filesystem supports POSIX attributes, and fails if a
+ * portable fallback cannot restrict access. It never formats or returns private key bytes for
+ * terminal output.
+ */
+final class DeveloperKeyGenerator {
+  /** POSIX permissions used for private key files: owner read/write only. */
+  private static final Set<PosixFilePermission> OWNER_ONLY =
+      Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE);
+
+  private static final String PRIVATE_KEY_FILE_LABEL = "private key file";
+  private static final String PUBLIC_KEY_FILE_LABEL = "public key file";
+  private static final String TRUSTED_KEYS_FILE_LABEL = "trusted keys file";
+
+  /** Prevents construction of this stateless key-generation helper. */
+  private DeveloperKeyGenerator() {}
+
+  /**
+   * Generates one key pair and writes the requested output files.
+   *
+   * <p>All output paths are validated and checked for collisions before key material is generated.
+   * Public keys and trust files are normal files; private keys are written through the owner-only
+   * path. When {@code trustedKeysFile} is supplied, it is written in the trusted app-key format
+   * consumed by bundle verification.
+   *
+   * @param keyId stable key id written into generated trust-store entries
+   * @param privateKeyFile output path for encoded private key bytes
+   * @param publicKeyFile output path for encoded public key bytes
+   * @param trustedKeysFile optional trust-store properties file to write alongside the key pair
+   * @param overwrite whether existing regular output files may be replaced
+   * @return normalized paths for the files written by this invocation
+   * @throws IOException if generation succeeds but an output file cannot be written safely
+   */
+  static GeneratedKeys generate(
+      String keyId,
+      Path privateKeyFile,
+      Path publicKeyFile,
+      Path trustedKeysFile,
+      boolean overwrite)
+      throws IOException {
+    validateKeyId(keyId);
+    Path privateOut = normalizeOutput(privateKeyFile, PRIVATE_KEY_FILE_LABEL);
+    Path publicOut = normalizeOutput(publicKeyFile, PUBLIC_KEY_FILE_LABEL);
+    Path trustedOut =
+        trustedKeysFile == null ? null : normalizeOutput(trustedKeysFile, TRUSTED_KEYS_FILE_LABEL);
+    requireDistinctOutputPaths(privateOut, publicOut, trustedOut);
+    requireWritable(privateOut, overwrite);
+    requireWritable(publicOut, overwrite);
+    if (trustedOut != null) {
+      requireWritable(trustedOut, overwrite);
+    }
+    KeyPair keyPair = generatePair();
+    writePrivateKey(privateOut, keyPair.getPrivate().getEncoded(), overwrite);
+    writeBytes(publicOut, keyPair.getPublic().getEncoded(), overwrite);
+    if (trustedOut != null) {
+      writeString(trustedOut, trustedAppKeys(keyId, keyPair.getPublic().getEncoded()), overwrite);
+    }
+    return new GeneratedKeys(privateOut, publicOut, trustedOut);
+  }
+
+  /**
+   * Builds a warning when a key output appears to live in a repository or artifact directory.
+   *
+   * <p>The warning is advisory rather than fatal because tests and controlled local workflows may
+   * intentionally write into temporary repository paths. The CLI prints this text separately from
+   * generated key material.
+   *
+   * @param path requested output path for a key or trust-store file
+   * @return warning text, or an empty string when no repository-like path is detected
+   */
+  static String repoPathWarning(Path path) {
+    Path root = Path.of("").toAbsolutePath().normalize();
+    Path normalized = path.toAbsolutePath().normalize();
+    if (normalized.startsWith(root)) {
+      return "Warning: key output is inside the repository: " + root.relativize(normalized);
+    }
+    String text = normalized.toString().replace('\\', '/');
+    if (text.contains("/build/") || text.contains("/dist/")) {
+      return "Warning: key output appears to be under a generated artifact directory.";
+    }
+    return "";
+  }
+
+  /**
+   * Validates the single-line key id stored in trust files and signatures.
+   *
+   * @param keyId key id supplied by the developer
+   * @throws AppDistributionException if the id is blank or contains a line break
+   */
+  private static void validateKeyId(String keyId) throws AppDistributionException {
+    if (keyId == null || keyId.isBlank() || keyId.contains("\n") || keyId.contains("\r")) {
+      throw new AppDistributionException("key id must be a non-blank single line");
+    }
+  }
+
+  /**
+   * Generates an Ed25519 key pair using the JCA provider available to the runtime.
+   *
+   * @return generated key pair using the app bundle signature algorithm
+   * @throws AppDistributionException if the configured signature algorithm is unavailable
+   */
+  private static KeyPair generatePair() throws AppDistributionException {
+    try {
+      return KeyPairGenerator.getInstance(AppBundleSignature.SIGNATURE_ALGORITHM).generateKeyPair();
+    } catch (GeneralSecurityException exception) {
+      throw new AppDistributionException("failed to generate Ed25519 key pair", exception);
+    }
+  }
+
+  /**
+   * Normalizes and validates one output file path.
+   *
+   * @param path user-supplied output path
+   * @param label human-readable label used in CLI diagnostics
+   * @return absolute normalized output path
+   * @throws AppDistributionException if the path is missing or does not name a file
+   */
+  private static Path normalizeOutput(Path path, String label) throws AppDistributionException {
+    if (path == null) {
+      throw new AppDistributionException(label + " is required");
+    }
+    Path normalized = path.toAbsolutePath().normalize();
+    if (normalized.getFileName() == null) {
+      throw new AppDistributionException(label + " must name a file");
+    }
+    return normalized;
+  }
+
+  /**
+   * Ensures no generated output path can overwrite another generated output.
+   *
+   * @param privateOut normalized private key path
+   * @param publicOut normalized public key path
+   * @param trustedOut optional normalized trust-store path
+   * @throws AppDistributionException if any two paths are identical
+   */
+  private static void requireDistinctOutputPaths(Path privateOut, Path publicOut, Path trustedOut)
+      throws AppDistributionException {
+    requireDistinctOutputPath(privateOut, PRIVATE_KEY_FILE_LABEL, publicOut, PUBLIC_KEY_FILE_LABEL);
+    if (trustedOut != null) {
+      requireDistinctOutputPath(
+          privateOut, PRIVATE_KEY_FILE_LABEL, trustedOut, TRUSTED_KEYS_FILE_LABEL);
+      requireDistinctOutputPath(
+          publicOut, PUBLIC_KEY_FILE_LABEL, trustedOut, TRUSTED_KEYS_FILE_LABEL);
+    }
+  }
+
+  /**
+   * Checks one pair of output paths for equality.
+   *
+   * @param left first normalized path
+   * @param leftLabel CLI label for the first path
+   * @param right second normalized path
+   * @param rightLabel CLI label for the second path
+   * @throws AppDistributionException if both paths are equal
+   */
+  private static void requireDistinctOutputPath(
+      Path left, String leftLabel, Path right, String rightLabel) throws AppDistributionException {
+    if (left.equals(right)) {
+      throw new AppDistributionException(
+          "key output paths must be distinct: " + leftLabel + " and " + rightLabel);
+    }
+  }
+
+  /**
+   * Checks whether an output path can be written under the requested overwrite policy.
+   *
+   * @param file normalized output path
+   * @param overwrite whether an existing regular file may be replaced
+   * @throws AppDistributionException if the path is a symlink, non-regular file, or protected
+   *     existing file
+   */
+  private static void requireWritable(Path file, boolean overwrite)
+      throws AppDistributionException {
+    if (!Files.exists(file, LinkOption.NOFOLLOW_LINKS)) {
+      return;
+    }
+    if (Files.isSymbolicLink(file)) {
+      throw new AppDistributionException("key output must not be a symbolic link: " + file);
+    }
+    if (!Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppDistributionException("key output must be a regular file: " + file);
+    }
+    if (!overwrite) {
+      throw new AppDistributionException("key output already exists: " + file);
+    }
+  }
+
+  /**
+   * Writes non-private binary output such as the public key file.
+   *
+   * @param file normalized output path
+   * @param bytes encoded bytes to write
+   * @param overwrite whether an existing regular file may be truncated
+   * @throws IOException if the file cannot be created or written
+   */
+  private static void writeBytes(Path file, byte[] bytes, boolean overwrite) throws IOException {
+    createParent(file);
+    if (overwrite) {
+      Files.write(
+          file,
+          bytes,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING,
+          StandardOpenOption.WRITE,
+          LinkOption.NOFOLLOW_LINKS);
+      return;
+    }
+    Files.write(
+        file,
+        bytes,
+        StandardOpenOption.CREATE_NEW,
+        StandardOpenOption.WRITE,
+        LinkOption.NOFOLLOW_LINKS);
+  }
+
+  /**
+   * Writes private key bytes after enforcing owner-only permissions.
+   *
+   * <p>New files are created before any key bytes are written, and failure during permission
+   * enforcement removes a newly created placeholder. Existing files are rechecked by the shared
+   * writability guard and restricted before and after truncation.
+   *
+   * @param file normalized private key output path
+   * @param bytes encoded private key bytes
+   * @param overwrite whether an existing regular private key file may be replaced
+   * @throws IOException if permissions cannot be enforced or bytes cannot be written
+   */
+  private static void writePrivateKey(Path file, byte[] bytes, boolean overwrite)
+      throws IOException {
+    createParent(file);
+    boolean created = false;
+    if (Files.exists(file, LinkOption.NOFOLLOW_LINKS)) {
+      requireWritable(file, overwrite);
+      restrictOwnerOnly(file);
+    } else {
+      createEmptyOwnerOnlyFile(file);
+      created = true;
+    }
+    try {
+      restrictOwnerOnly(file);
+      try (OutputStream output =
+          Files.newOutputStream(
+              file,
+              StandardOpenOption.WRITE,
+              StandardOpenOption.TRUNCATE_EXISTING,
+              LinkOption.NOFOLLOW_LINKS)) {
+        output.write(bytes);
+      }
+      restrictOwnerOnly(file);
+    } catch (IOException | RuntimeException exception) {
+      if (created) {
+        Files.deleteIfExists(file);
+      }
+      throw exception;
+    }
+  }
+
+  /**
+   * Creates an empty private-key file with owner-only access before writing material.
+   *
+   * @param file normalized private key output path that does not already exist
+   * @throws IOException if the file cannot be created or access cannot be restricted
+   */
+  private static void createEmptyOwnerOnlyFile(Path file) throws IOException {
+    try {
+      FileAttribute<Set<PosixFilePermission>> permissions =
+          PosixFilePermissions.asFileAttribute(OWNER_ONLY);
+      Files.createFile(file, permissions);
+    } catch (UnsupportedOperationException _) {
+      Files.createFile(file);
+      try {
+        restrictPortableOwnerOnly(file);
+      } catch (IOException | RuntimeException exception) {
+        Files.deleteIfExists(file);
+        throw exception;
+      }
+    }
+  }
+
+  /**
+   * Writes non-private UTF-8 properties output such as generated trust stores.
+   *
+   * @param file normalized output path
+   * @param text properties text to write
+   * @param overwrite whether an existing regular file may be truncated
+   * @throws IOException if the file cannot be created or written
+   */
+  private static void writeString(Path file, String text, boolean overwrite) throws IOException {
+    createParent(file);
+    if (overwrite) {
+      Files.writeString(
+          file,
+          text,
+          StandardCharsets.UTF_8,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING,
+          StandardOpenOption.WRITE,
+          LinkOption.NOFOLLOW_LINKS);
+      return;
+    }
+    Files.writeString(
+        file,
+        text,
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE_NEW,
+        StandardOpenOption.WRITE,
+        LinkOption.NOFOLLOW_LINKS);
+  }
+
+  /**
+   * Creates the parent directory for an output file when it has one.
+   *
+   * @param file normalized output file path
+   * @throws IOException if the parent directory cannot be created
+   */
+  private static void createParent(Path file) throws IOException {
+    Path parent = file.getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+  }
+
+  /**
+   * Restricts a private key file to owner read/write access.
+   *
+   * @param file private key file whose permissions should be tightened
+   * @throws IOException if POSIX or portable permission enforcement fails
+   */
+  private static void restrictOwnerOnly(Path file) throws IOException {
+    try {
+      Files.setPosixFilePermissions(file, OWNER_ONLY);
+    } catch (UnsupportedOperationException _) {
+      restrictPortableOwnerOnly(file);
+    }
+  }
+
+  /**
+   * Applies best-effort owner-only permissions through {@link java.io.File} APIs.
+   *
+   * @param file private key file on a filesystem without POSIX permission support
+   * @throws IOException if the runtime reports that any permission change failed
+   */
+  private static void restrictPortableOwnerOnly(Path file) throws IOException {
+    java.io.File javaFile = file.toFile();
+    if (!javaFile.setReadable(false, false)
+        || !javaFile.setWritable(false, false)
+        || !javaFile.setExecutable(false, false)
+        || !javaFile.setReadable(true, true)
+        || !javaFile.setWritable(true, true)) {
+      throw new IOException("failed to restrict private key file permissions: " + file);
+    }
+  }
+
+  /**
+   * Renders a trusted app-key properties file.
+   *
+   * @param keyId trusted app signing key id
+   * @param publicKeyBytes encoded public key bytes
+   * @return properties text accepted by bundle verification commands
+   */
+  private static String trustedAppKeys(String keyId, byte[] publicKeyBytes) {
+    return "trusted.keys.version=1\n"
+        + "key.0.id="
+        + keyId
+        + "\n"
+        + "key.0.algorithm="
+        + AppBundleSignature.SIGNATURE_ALGORITHM
+        + "\n"
+        + "key.0.public.key.base64="
+        + Base64.getEncoder().encodeToString(publicKeyBytes)
+        + "\n";
+  }
+
+  /**
+   * Paths written by a successful key-generation command.
+   *
+   * @param privateKeyFile normalized private key output path
+   * @param publicKeyFile normalized public key output path
+   * @param trustedKeysFile optional normalized generated trust-store path
+   */
+  record GeneratedKeys(Path privateKeyFile, Path publicKeyFile, Path trustedKeysFile) {}
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/PublicationPlanWriter.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/PublicationPlanWriter.java
@@ -1,0 +1,280 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import network.crypta.platform.appcatalog.AppCatalog;
+import network.crypta.platform.appcatalog.AppCatalogEntry;
+import network.crypta.platform.appcatalog.AppCatalogParser;
+import network.crypta.platform.appcatalog.AppCatalogSignature;
+import network.crypta.platform.appcatalog.AppCatalogVerifier;
+import network.crypta.platform.appdist.AppDistributionException;
+
+/**
+ * Writes offline Crypta USK publication plans for signed app catalogs.
+ *
+ * <p>This helper backs {@code crypta-app publish-usk --dry-run}. It validates that a catalog file
+ * parses, that its signature sidecar is structurally readable, and that the advertised catalog
+ * source is a public {@code crypta:USK@.../cryptad-app-catalog.properties} path. It then writes a
+ * redacted markdown or JSON checklist that developers can follow when publishing catalog bytes and
+ * signature bytes through a separate, trusted insertion workflow.
+ *
+ * <p>The writer does not perform live inserts and does not validate network availability. Its
+ * responsibility is local evidence: name the catalog artifacts, summarize entries, remind the
+ * developer about immutable bundle URIs and review receipts, and avoid leaking local paths or
+ * private Crypta insert material into generated plans.
+ */
+final class PublicationPlanWriter {
+  /** Prevents construction of this stateless plan writer. */
+  private PublicationPlanWriter() {}
+
+  /**
+   * Validates catalog inputs and writes one publication plan.
+   *
+   * @param request local catalog artifacts, public source URI, and output path
+   * @return catalog id, entry count, and normalized output path for the generated plan
+   * @throws IOException if catalog artifacts cannot be read or the plan cannot be written
+   */
+  static Result write(Request request) throws IOException {
+    Request checked = request.normalize();
+    requireUskSource(checked.catalogSource());
+    requireReadable(checked.catalogFile(), "catalog file");
+    requireReadable(checked.catalogSignatureFile(), "catalog signature file");
+    byte[] catalogBytes = Files.readAllBytes(checked.catalogFile());
+    byte[] signatureBytes = Files.readAllBytes(checked.catalogSignatureFile());
+    AppCatalog catalog = AppCatalogParser.parse(catalogBytes);
+    AppCatalogVerifier.readSignature(signatureBytes);
+    if (!AppCatalogSignature.SIGNATURE_FILE_NAME.equals(
+        checked.catalogSignatureFile().getFileName().toString())) {
+      throw new AppDistributionException(
+          "catalog signature sidecar must be cryptad-app-catalog.signature");
+    }
+    String content =
+        checked.output().toString().endsWith(".json")
+            ? json(checked, catalog)
+            : markdown(checked, catalog);
+    Path parent = checked.output().getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    Files.writeString(
+        checked.output(),
+        content,
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+        StandardOpenOption.WRITE,
+        LinkOption.NOFOLLOW_LINKS);
+    return new Result(catalog.catalogId(), catalog.entries().size(), checked.output());
+  }
+
+  /**
+   * Ensures a plan input is a real local file and not a symlink.
+   *
+   * @param file normalized input path to check
+   * @param label human-readable label used in CLI diagnostics
+   * @throws AppDistributionException if the input is missing, a symlink, or not a regular file
+   */
+  private static void requireReadable(Path file, String label) throws AppDistributionException {
+    if (Files.isSymbolicLink(file) || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppDistributionException(label + " must be a regular file");
+    }
+  }
+
+  /**
+   * Validates the public catalog source URI required by {@code publish-usk}.
+   *
+   * @param source catalog source URI supplied by the developer
+   * @throws AppDistributionException if the source is not the expected Crypta USK catalog path
+   */
+  private static void requireUskSource(String source) throws AppDistributionException {
+    String value = source == null ? "" : source.trim();
+    if (!value.startsWith("crypta:USK@")
+        || value.contains("?")
+        || value.contains("#")
+        || !value.endsWith("/" + AppCatalogSignature.CATALOG_FILE_NAME)) {
+      throw new AppDistributionException(
+          "publish-usk requires --catalog-source crypta:USK@.../"
+              + AppCatalogSignature.CATALOG_FILE_NAME);
+    }
+  }
+
+  /**
+   * Renders the human-readable publication checklist.
+   *
+   * @param request normalized plan request with local file names and catalog source
+   * @param catalog parsed signed catalog metadata
+   * @return Markdown plan text with redacted Crypta URI material
+   */
+  private static String markdown(Request request, AppCatalog catalog) {
+    StringBuilder builder = new StringBuilder();
+    builder
+        .append("# Crypta Catalog USK Publication Plan\n\n")
+        .append("- Catalog: `")
+        .append(AppTestRedactor.fileName(request.catalogFile()))
+        .append("`\n")
+        .append("- Signature sidecar: `")
+        .append(AppTestRedactor.fileName(request.catalogSignatureFile()))
+        .append("`\n")
+        .append("- Expected public source: `")
+        .append(redactCryptaUri(request.catalogSource()))
+        .append("`\n")
+        .append("- Catalog id: `")
+        .append(catalog.catalogId())
+        .append("`\n")
+        .append("- Entries: `")
+        .append(catalog.entries().size())
+        .append("`\n\n")
+        .append("## Checklist\n\n")
+        .append("- Insert the catalog properties bytes as `")
+        .append(AppCatalogSignature.CATALOG_FILE_NAME)
+        .append("`.\n")
+        .append("- Insert the signature sidecar bytes as `")
+        .append(AppCatalogSignature.SIGNATURE_FILE_NAME)
+        .append("` at the same USK path edition.\n")
+        .append(
+            "- Publish app bundle artifacts first and use immutable `crypta:CHK@...` bundle URIs in"
+                + " catalog entries.\n")
+        .append(
+            "- Attach trusted review receipts when the target catalog policy requires review"
+                + " evidence.\n")
+        .append(
+            "- Add or refresh the catalog source in Web Shell using the public catalog source"
+                + " URI.\n")
+        .append("- Verify catalog and bundle signatures after fetching from Crypta.\n\n")
+        .append("## Bundle Artifacts\n\n");
+    for (AppCatalogEntry entry : catalog.entries()) {
+      builder
+          .append("- `")
+          .append(entry.appId())
+          .append("` ")
+          .append(entry.version())
+          .append(": ")
+          .append(redactCryptaUri(entry.bundleUri().toString()))
+          .append("\n");
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Renders the machine-readable publication checklist.
+   *
+   * @param request normalized plan request with local file names and catalog source
+   * @param catalog parsed signed catalog metadata
+   * @return deterministic JSON plan text with redacted Crypta URI material
+   */
+  private static String json(Request request, AppCatalog catalog) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("{\n");
+    field(builder, "schemaVersion", "1", false);
+    field(builder, "catalogId", catalog.catalogId(), true);
+    field(builder, "catalogFile", AppTestRedactor.fileName(request.catalogFile()), true);
+    field(
+        builder,
+        "catalogSignatureFile",
+        AppTestRedactor.fileName(request.catalogSignatureFile()),
+        true);
+    field(builder, "catalogSource", redactCryptaUri(request.catalogSource()), true);
+    builder.append("  \"entries\": [");
+    if (!catalog.entries().isEmpty()) {
+      builder.append('\n');
+    }
+    List<AppCatalogEntry> entries = catalog.entries();
+    for (int index = 0; index < entries.size(); index++) {
+      AppCatalogEntry entry = entries.get(index);
+      builder
+          .append("    {\"appId\":\"")
+          .append(escape(entry.appId()))
+          .append("\",\"version\":\"")
+          .append(escape(entry.version()))
+          .append("\",\"bundleUri\":\"")
+          .append(escape(redactCryptaUri(entry.bundleUri().toString())))
+          .append("\"}");
+      if (index + 1 < entries.size()) {
+        builder.append(',');
+      }
+      builder.append('\n');
+    }
+    if (!entries.isEmpty()) {
+      builder.append("  ");
+    }
+    builder.append("]\n}\n");
+    return builder.toString();
+  }
+
+  /**
+   * Appends one top-level scalar field to a JSON publication plan.
+   *
+   * @param builder destination builder for the JSON plan
+   * @param name JSON field name to escape
+   * @param value scalar value to write
+   * @param quote whether the value should be emitted as a JSON string
+   */
+  private static void field(StringBuilder builder, String name, String value, boolean quote) {
+    builder.append("  \"").append(escape(name)).append("\": ");
+    if (quote) {
+      builder.append('"').append(escape(value)).append('"');
+    } else {
+      builder.append(value);
+    }
+    builder.append(",\n");
+  }
+
+  /**
+   * Redacts private or capability-bearing parts of Crypta URIs in generated plans.
+   *
+   * @param uri catalog source or bundle URI from local catalog metadata
+   * @return URI text with USK, SSK, and CHK payload material replaced
+   */
+  private static String redactCryptaUri(String uri) {
+    return uri.replaceAll("crypta:USK@[^/]+", "crypta:USK@[REDACTED]")
+        .replaceAll("crypta:SSK@[^/]+", "crypta:SSK@[REDACTED]")
+        .replaceAll("crypta:CHK@[^?\\s]+", "crypta:CHK@[REDACTED]");
+  }
+
+  /**
+   * Escapes the subset of JSON string characters used by publication-plan fields.
+   *
+   * @param value non-null scalar field value
+   * @return escaped value without surrounding quote characters
+   */
+  private static String escape(String value) {
+    return value.replace("\\", "\\\\").replace("\"", "\\\"");
+  }
+
+  /**
+   * Input for one offline publication plan.
+   *
+   * @param catalogFile local catalog properties file to publish
+   * @param catalogSignatureFile local catalog signature sidecar to publish at the same edition
+   * @param catalogSource expected public {@code crypta:USK@...} catalog source URI
+   * @param output Markdown or JSON plan output path
+   */
+  record Request(Path catalogFile, Path catalogSignatureFile, String catalogSource, Path output) {
+    /**
+     * Normalizes local filesystem paths before validation and output.
+     *
+     * @return equivalent request with absolute normalized paths
+     */
+    Request normalize() {
+      return new Request(
+          catalogFile.toAbsolutePath().normalize(),
+          catalogSignatureFile.toAbsolutePath().normalize(),
+          catalogSource,
+          output.toAbsolutePath().normalize());
+    }
+  }
+
+  /**
+   * Summary of a written publication plan.
+   *
+   * @param catalogId catalog id parsed from the local catalog properties
+   * @param entryCount number of app entries included in the parsed catalog
+   * @param output normalized path where the plan was written
+   */
+  record Result(String catalogId, int entryCount, Path output) {}
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/CryptaAppDevServer.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/CryptaAppDevServer.java
@@ -1,0 +1,377 @@
+package network.crypta.platform.devtools.devserver;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import network.crypta.platform.appdist.AppBundleManifest;
+import network.crypta.platform.appdist.AppBundleStructureValidator;
+import network.crypta.platform.appdist.AppDistributionException;
+import network.crypta.platform.appdist.AppUiMode;
+
+/**
+ * Loopback static app server with a deterministic mock Platform API.
+ *
+ * <p>The server is intended for local development of staged static bundles created by {@code
+ * crypta-app init}. It serves app-owned files beneath {@code /apps/{appId}/}, exposes the SDK
+ * bootstrap JSON at both the app and root well-known locations, and provides a fixture-backed mock
+ * Platform API beneath {@code /api/v1/}. It never talks to a real Crypta node, never exposes
+ * AppHost process tokens, and does not install, update, or publish apps.
+ *
+ * <p>Instances own a JDK {@link HttpServer}, a small daemon-thread executor, and one mock browser
+ * session issuer. Callers must close the server when a CLI process exits or a test finishes. The
+ * default host policy keeps the listener on loopback unless the CLI explicitly allows a wider
+ * binding and surfaces the resulting warning in {@link #startupSummary()}.
+ */
+public final class CryptaAppDevServer implements AutoCloseable {
+  /** SDK bootstrap endpoint served at the origin root and within the app route. */
+  private static final String BOOTSTRAP_PATH = "/.well-known/cryptad-bootstrap.json";
+
+  /** Prefix for all app-owned UI routes served by the local development origin. */
+  private static final String APPS_ROUTE_PREFIX = "/apps/";
+
+  /** Normalized server configuration captured at startup. */
+  private final DevServerConfig config;
+
+  /** Validated static app manifest for the staged bundle being served. */
+  private final AppBundleManifest manifest;
+
+  /** Mock browser-session issuer used by bootstrap and API authorization checks. */
+  private final DevServerBrowserSession browserSession;
+
+  /** JDK HTTP listener that owns route dispatch for the local dev origin. */
+  private final HttpServer server;
+
+  /** Daemon-thread executor used by the JDK HTTP server. */
+  private final ExecutorService executor;
+
+  /** Fixture-backed mock Platform API handler. */
+  private final MockPlatformApi mockApi;
+
+  /** Startup warning shown when the caller explicitly allows a non-loopback listener. */
+  private final String warning;
+
+  /**
+   * Creates a wrapper around already-startable server components.
+   *
+   * @param config normalized server configuration
+   * @param manifest validated static app manifest
+   * @param browserSession mock browser-session issuer for bootstrap and API requests
+   * @param server configured JDK HTTP server
+   * @param executor daemon-thread executor assigned to the server
+   * @param mockApi fixture-backed mock Platform API handler
+   * @param warning optional startup warning for non-loopback listeners
+   */
+  private CryptaAppDevServer(
+      DevServerConfig config,
+      AppBundleManifest manifest,
+      DevServerBrowserSession browserSession,
+      HttpServer server,
+      ExecutorService executor,
+      MockPlatformApi mockApi,
+      String warning) {
+    this.config = config;
+    this.manifest = manifest;
+    this.browserSession = browserSession;
+    this.server = server;
+    this.executor = executor;
+    this.mockApi = mockApi;
+    this.warning = warning;
+  }
+
+  /**
+   * Starts one dev server.
+   *
+   * @param config server configuration supplied by CLI or tests
+   * @return running server instance that must be closed by the caller
+   * @throws IOException if the bundle cannot be validated or the listener cannot be opened
+   */
+  public static CryptaAppDevServer start(DevServerConfig config) throws IOException {
+    return start(config, Clock.systemUTC(), new SecureRandom());
+  }
+
+  /**
+   * Starts one dev server with injectable time and randomness for deterministic tests.
+   *
+   * @param config server configuration supplied by CLI or tests
+   * @param clock clock used for browser-session expiration decisions
+   * @param random randomness source used to create browser-session tokens
+   * @return running server instance that must be closed by the caller
+   * @throws IOException if validation, fixture setup, or listener creation fails
+   */
+  static CryptaAppDevServer start(DevServerConfig config, Clock clock, SecureRandom random)
+      throws IOException {
+    DevServerConfig checked = Objects.requireNonNull(config, "config");
+    Clock checkedClock = Objects.requireNonNull(clock, "clock");
+    SecureRandom checkedRandom = Objects.requireNonNull(random, "random");
+    String warning =
+        LoopbackHostPolicy.requireAllowedHost(checked.host(), checked.allowNonLoopback());
+    AppBundleStructureValidator.ValidatedBundle validated =
+        AppBundleStructureValidator.validate(checked.bundleDir());
+    AppBundleManifest manifest = validated.manifest();
+    if (manifest.uiMode() != AppUiMode.STATIC) {
+      throw new AppDistributionException("crypta-app dev supports only app.ui.mode=static bundles");
+    }
+    DevServerStaticAssets.checkStaticAssetSafety(checked.bundleDir(), manifest);
+    HttpServer server = HttpServer.create(new InetSocketAddress(checked.host(), checked.port()), 0);
+    AtomicInteger threadIds = new AtomicInteger();
+    ExecutorService executor =
+        Executors.newFixedThreadPool(
+            4,
+            runnable -> {
+              Thread thread =
+                  new Thread(runnable, "crypta-app-dev-server-" + threadIds.incrementAndGet());
+              thread.setDaemon(true);
+              return thread;
+            });
+    DevServerBrowserSession browserSession =
+        new DevServerBrowserSession(checked.sessionTtl(), checkedClock, checkedRandom);
+    MockPlatformApiFixtures fixtures =
+        new MockPlatformApiFixtures(
+            checked.fixtureDir(), manifest.appId(), manifest.appName(), manifest.appVersion());
+    MockPlatformApi mockApi = new MockPlatformApi(browserSession::isValid, fixtures);
+    CryptaAppDevServer devServer =
+        new CryptaAppDevServer(
+            checked, manifest, browserSession, server, executor, mockApi, warning);
+    server.createContext("/", devServer::handle);
+    server.setExecutor(executor);
+    server.start();
+    return devServer;
+  }
+
+  /**
+   * Returns the assigned listener port.
+   *
+   * @return concrete TCP port, including the OS-assigned value when configured with port {@code 0}
+   */
+  public int port() {
+    return server.getAddress().getPort();
+  }
+
+  /**
+   * Returns the listener host text.
+   *
+   * @return normalized host value from {@link DevServerConfig}
+   */
+  @SuppressWarnings("unused")
+  public String host() {
+    return config.host();
+  }
+
+  /**
+   * Returns the app id being served.
+   *
+   * @return manifest app id used in local app routes
+   */
+  public String appId() {
+    return manifest.appId();
+  }
+
+  /**
+   * Returns the browser launch URL for the app.
+   *
+   * @return entry-directory URL that gives relative static references the same base as production
+   */
+  public String uiUrl() {
+    return DevServerBootstrapJson.entryDirectoryUrl(manifest, baseUrl());
+  }
+
+  /**
+   * Returns the root bootstrap JSON URL used by the SDK's first probe.
+   *
+   * @return same-origin well-known bootstrap URL for the local dev server
+   */
+  public String bootstrapUrl() {
+    return baseUrl() + BOOTSTRAP_PATH;
+  }
+
+  /**
+   * Returns the local mock Platform API root.
+   *
+   * @return base URL for mock {@code /api/v1/} endpoints, including a trailing slash
+   */
+  public String apiRoot() {
+    return baseUrl() + "/api/v1/";
+  }
+
+  /**
+   * Returns a startup banner with no token or private path material.
+   *
+   * @return redacted multi-line summary suitable for CLI stdout
+   */
+  public String startupSummary() {
+    StringBuilder builder = new StringBuilder();
+    if (!warning.isBlank()) {
+      builder.append(warning).append('\n');
+    }
+    builder
+        .append("Crypta app dev server\n")
+        .append("App: ")
+        .append(manifest.appId())
+        .append(' ')
+        .append(manifest.appVersion())
+        .append('\n')
+        .append("UI:  ")
+        .append(uiUrl())
+        .append('\n')
+        .append("API: ")
+        .append(apiRoot());
+    return builder.toString();
+  }
+
+  @Override
+  public void close() {
+    server.stop(0);
+    executor.shutdownNow();
+  }
+
+  /**
+   * Dispatches one HTTP exchange by raw path so encoded separators remain visible to route checks.
+   *
+   * @param exchange incoming JDK HTTP exchange
+   * @throws IOException if a response cannot be written
+   */
+  private void handle(HttpExchange exchange) throws IOException {
+    String path = exchange.getRequestURI().getRawPath();
+    try {
+      if (path.equals(BOOTSTRAP_PATH)
+          || path.equals(APPS_ROUTE_PREFIX + manifest.appId() + BOOTSTRAP_PATH)) {
+        sendBootstrap(exchange);
+        return;
+      }
+      if (path.startsWith("/api/v1/") || path.equals("/api/v1")) {
+        mockApi.handle(exchange);
+        return;
+      }
+      String appRootPath = DevServerBootstrapJson.appRootPath(manifest);
+      String entryDirectoryPath = DevServerBootstrapJson.entryDirectoryPath(manifest);
+      if (path.equals(APPS_ROUTE_PREFIX + manifest.appId())) {
+        redirect(exchange, entryDirectoryPath);
+        return;
+      }
+      if (path.equals(appRootPath) && !entryDirectoryPath.equals(appRootPath)) {
+        redirect(exchange, entryDirectoryPath);
+        return;
+      }
+      if (path.startsWith(APPS_ROUTE_PREFIX)) {
+        sendStatic(exchange, path);
+        return;
+      }
+      sendNotFound(exchange);
+    } catch (AppDistributionException exception) {
+      sendError(exchange, 400, "invalid_static_asset", exception.getMessage());
+    }
+  }
+
+  /**
+   * Sends SDK bootstrap JSON with the current or freshly rotated mock browser session.
+   *
+   * @param exchange incoming bootstrap request
+   * @throws IOException if the JSON response cannot be written
+   */
+  private void sendBootstrap(HttpExchange exchange) throws IOException {
+    DevServerBrowserSession.Session session = browserSession.currentForBootstrap();
+    String json =
+        DevServerBootstrapJson.serialize(manifest, baseUrl(), session.token(), session.expiresAt());
+    byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+    exchange.getResponseHeaders().set("Cache-Control", "no-store");
+    exchange.sendResponseHeaders(200, bytes.length);
+    try (OutputStream body = exchange.getResponseBody()) {
+      body.write(bytes);
+    }
+  }
+
+  /**
+   * Resolves and sends one static app asset from the staged bundle.
+   *
+   * @param exchange incoming static asset request
+   * @param path raw request path beneath the local app route
+   * @throws IOException if route resolution or response writing fails
+   */
+  private void sendStatic(HttpExchange exchange, String path) throws IOException {
+    var asset = DevServerStaticAssets.resolve(config.bundleDir(), manifest, path);
+    if (asset.isEmpty()) {
+      sendNotFound(exchange);
+      return;
+    }
+    byte[] bytes = asset.get().bytes();
+    exchange.getResponseHeaders().set("Content-Type", asset.get().contentType());
+    exchange.getResponseHeaders().set("X-Content-Type-Options", "nosniff");
+    exchange.sendResponseHeaders(200, bytes.length);
+    try (OutputStream body = exchange.getResponseBody()) {
+      body.write(bytes);
+    }
+  }
+
+  /**
+   * Sends a JSON {@code 404} response consistent with mock API errors.
+   *
+   * @param exchange incoming request that did not match a route
+   * @throws IOException if the response cannot be written
+   */
+  private static void sendNotFound(HttpExchange exchange) throws IOException {
+    sendError(exchange, 404, "not_found", "Not found.");
+  }
+
+  /**
+   * Sends one JSON error response.
+   *
+   * @param exchange incoming request to complete
+   * @param status HTTP response status code
+   * @param code stable error code for clients and tests
+   * @param message human-readable error message
+   * @throws IOException if the response cannot be written
+   */
+  private static void sendError(HttpExchange exchange, int status, String code, String message)
+      throws IOException {
+    MockPlatformApi.sendJson(
+        exchange,
+        status,
+        "{\"error\":{\"code\":\""
+            + MockPlatformApiFixtures.Json.escape(code)
+            + "\",\"message\":\""
+            + MockPlatformApiFixtures.Json.escape(message)
+            + "\"}}");
+  }
+
+  /**
+   * Sends a local redirect to the static entry directory.
+   *
+   * @param exchange incoming app-root request
+   * @param location relative route location for the entry directory
+   * @throws IOException if response headers cannot be sent
+   */
+  private static void redirect(HttpExchange exchange, String location) throws IOException {
+    exchange.getResponseHeaders().set("Location", location);
+    exchange.sendResponseHeaders(302, -1);
+    exchange.close();
+  }
+
+  /**
+   * Builds the origin URL for this listener.
+   *
+   * @return HTTP origin URL without a trailing slash
+   */
+  private String baseUrl() {
+    return "http://" + bracketIpv6(config.host()) + ":" + port();
+  }
+
+  /**
+   * Wraps IPv6 literal hosts for use in HTTP URLs.
+   *
+   * @param host normalized listener host text
+   * @return host text suitable for inclusion in a URL authority
+   */
+  private static String bracketIpv6(String host) {
+    return host.indexOf(':') >= 0 && !host.startsWith("[") ? "[" + host + "]" : host;
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/DevServerBootstrapJson.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/DevServerBootstrapJson.java
@@ -1,0 +1,179 @@
+package network.crypta.platform.devtools.devserver;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import network.crypta.platform.appdist.AppBundleManifest;
+import network.crypta.platform.appui.AppUiOriginMode;
+import network.crypta.platform.appui.AppUiOriginStatus;
+
+/**
+ * Builds bootstrap JSON for the local mock app origin.
+ *
+ * <p>The browser SDK discovers the Platform API by reading {@code
+ * /.well-known/cryptad-bootstrap.json}. In the local dev server this JSON must look like a real
+ * app-origin bootstrap response while remaining clearly offline: it points at the mock {@code
+ * /api/v1/} routes, uses same-origin fallback fields, and includes a short-lived mock
+ * browser-session token. The app root remains {@code /apps/{appId}/}; the asset root follows the
+ * directory that contains {@code app.ui.entry} so relative asset references resolve as they do when
+ * hosted by AppHost.
+ */
+final class DevServerBootstrapJson {
+  /** Prevents construction of this stateless bootstrap renderer. */
+  private DevServerBootstrapJson() {}
+
+  /**
+   * Serializes one SDK bootstrap response.
+   *
+   * @param manifest validated static app manifest being served locally
+   * @param baseUrl listener origin URL without a trailing slash
+   * @param sessionToken mock browser-session token required by the mock API
+   * @param expiresAt instant when the mock browser session expires
+   * @return compact JSON object consumed by {@code crypta-platform.js}
+   */
+  static String serialize(
+      AppBundleManifest manifest, String baseUrl, String sessionToken, Instant expiresAt) {
+    String appRoot = appRootUrl(manifest, baseUrl);
+    String assetRoot = entryDirectoryUrl(manifest, baseUrl);
+    return "{"
+        + stringField("appId", manifest.appId())
+        + ","
+        + stringField("name", manifest.appName())
+        + ","
+        + stringField("uiRoot", appRoot)
+        + ","
+        + stringField("assetRoot", assetRoot)
+        + ","
+        + stringField("platformApiRoot", baseUrl + "/api/v1/")
+        + ","
+        + stringField("shellRoot", baseUrl + "/app/node/")
+        + ","
+        + stringField("uiOrigin", origin(baseUrl))
+        + ","
+        + stringField("uiOriginMode", AppUiOriginMode.SAME_ORIGIN_FALLBACK.jsonValue())
+        + ","
+        + stringField("uiOriginStatus", AppUiOriginStatus.FALLBACK.jsonValue())
+        + ","
+        + stringField("sameOriginFallbackUrl", appRoot)
+        + ","
+        + stringField("browserSessionToken", sessionToken)
+        + ","
+        + stringField("browserSessionExpiresAt", expiresAt.toString())
+        + "}";
+  }
+
+  /**
+   * Builds the local app root path.
+   *
+   * @param manifest validated app manifest
+   * @return path ending in {@code /apps/{appId}/}
+   */
+  static String appRootPath(AppBundleManifest manifest) {
+    return "/apps/" + manifest.appId() + "/";
+  }
+
+  /**
+   * Builds the path used as the static entry-directory base.
+   *
+   * @param manifest validated app manifest with the static UI entry
+   * @return app root path or nested entry directory path with encoded path segments
+   */
+  static String entryDirectoryPath(AppBundleManifest manifest) {
+    String appRoot = appRootPath(manifest);
+    String entryDirectory = entryDirectory(manifest.uiEntry());
+    return entryDirectory.isEmpty() ? appRoot : appRoot + encodeRelativePath(entryDirectory) + "/";
+  }
+
+  /**
+   * Builds the absolute local app root URL.
+   *
+   * @param manifest validated app manifest
+   * @param baseUrl listener origin URL without a trailing slash
+   * @return absolute URL ending in {@code /apps/{appId}/}
+   */
+  static String appRootUrl(AppBundleManifest manifest, String baseUrl) {
+    return baseUrl + appRootPath(manifest);
+  }
+
+  /**
+   * Builds the absolute static entry-directory URL used for {@code assetRoot}.
+   *
+   * @param manifest validated app manifest with the static UI entry
+   * @param baseUrl listener origin URL without a trailing slash
+   * @return absolute URL ending at the encoded entry directory
+   */
+  static String entryDirectoryUrl(AppBundleManifest manifest, String baseUrl) {
+    return baseUrl + entryDirectoryPath(manifest);
+  }
+
+  /**
+   * Renders one escaped JSON string field.
+   *
+   * @param name field name to escape
+   * @param value field value to escape
+   * @return JSON string field without surrounding object braces
+   */
+  private static String stringField(String name, String value) {
+    return "\""
+        + MockPlatformApiFixtures.Json.escape(name)
+        + "\":\""
+        + MockPlatformApiFixtures.Json.escape(value)
+        + "\"";
+  }
+
+  /**
+   * Extracts the origin from a local base URL.
+   *
+   * @param baseUrl listener base URL, with or without a path
+   * @return scheme and authority portion of the URL
+   */
+  private static String origin(String baseUrl) {
+    int pathStart = baseUrl.indexOf('/', "http://".length());
+    return pathStart < 0 ? baseUrl : baseUrl.substring(0, pathStart);
+  }
+
+  /**
+   * Returns the directory containing a static UI entry path.
+   *
+   * @param uiEntry manifest {@code app.ui.entry} value
+   * @return relative directory path, or an empty string for root-level entries
+   */
+  private static String entryDirectory(String uiEntry) {
+    int slash = uiEntry.lastIndexOf('/');
+    return slash < 0 ? "" : uiEntry.substring(0, slash);
+  }
+
+  /**
+   * Encodes a relative path one segment at a time.
+   *
+   * @param relativePath slash-separated manifest path without a leading slash
+   * @return path with each segment URL-encoded and slashes preserved
+   */
+  private static String encodeRelativePath(String relativePath) {
+    StringBuilder encoded = new StringBuilder(relativePath.length());
+    int start = 0;
+    while (start < relativePath.length()) {
+      int slash = relativePath.indexOf('/', start);
+      if (!encoded.isEmpty()) {
+        encoded.append('/');
+      }
+      if (slash < 0) {
+        encoded.append(encodePathSegment(relativePath.substring(start)));
+        break;
+      }
+      encoded.append(encodePathSegment(relativePath.substring(start, slash)));
+      start = slash + 1;
+    }
+    return encoded.toString();
+  }
+
+  /**
+   * Encodes one URL path segment using percent escapes for spaces and reserved characters.
+   *
+   * @param segment raw path segment from a manifest entry directory
+   * @return URL-encoded path segment
+   */
+  private static String encodePathSegment(String segment) {
+    return URLEncoder.encode(segment, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/DevServerBrowserSession.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/DevServerBrowserSession.java
@@ -1,0 +1,102 @@
+package network.crypta.platform.devtools.devserver;
+
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Objects;
+
+/**
+ * Issues and validates mock browser sessions for one local dev server.
+ *
+ * <p>The mock Platform API requires the same {@code X-Crypta-App-Session} header shape as the
+ * browser SDK uses with a real daemon-side app session. This class owns the single active token for
+ * a dev server, its expiration instant, and token refresh on subsequent bootstrap requests. It is
+ * synchronized because the JDK HTTP server can dispatch bootstrap and API requests concurrently on
+ * several worker threads.
+ *
+ * <p>Tokens are generated with URL-safe Base64 and are never logged by this class. Expired tokens
+ * fail API validation immediately; the next bootstrap request receives a fresh token and expiry.
+ */
+final class DevServerBrowserSession {
+  /** Lifetime assigned to each issued mock browser session. */
+  private final Duration ttl;
+
+  /** Clock used for expiration checks and for deterministic tests. */
+  private final Clock clock;
+
+  /** Randomness source used to generate opaque session tokens. */
+  private final SecureRandom random;
+
+  /** Current active session, replaced when bootstrap observes expiration. */
+  private Session current;
+
+  /**
+   * Creates a session issuer using system UTC time and secure randomness.
+   *
+   * @param ttl positive lifetime for each issued browser session
+   */
+  @SuppressWarnings("unused")
+  DevServerBrowserSession(Duration ttl) {
+    this(ttl, Clock.systemUTC(), new SecureRandom());
+  }
+
+  /**
+   * Creates a session issuer with injectable time and randomness.
+   *
+   * @param ttl positive lifetime for each issued browser session
+   * @param clock clock used to compute and validate expiration times
+   * @param random randomness source used to create token bytes
+   */
+  DevServerBrowserSession(Duration ttl, Clock clock, SecureRandom random) {
+    this.ttl = Objects.requireNonNull(ttl, "ttl");
+    this.clock = Objects.requireNonNull(clock, "clock");
+    this.random = Objects.requireNonNull(random, "random");
+    this.current = newSession(clock.instant());
+  }
+
+  /**
+   * Returns the session that should be embedded in the next bootstrap response.
+   *
+   * @return current non-expired session, or a freshly generated replacement when expired
+   */
+  synchronized Session currentForBootstrap() {
+    Instant now = clock.instant();
+    if (!current.expiresAt().isAfter(now)) {
+      current = newSession(now);
+    }
+    return current;
+  }
+
+  /**
+   * Checks whether an API request presented the current, non-expired token.
+   *
+   * @param token token value from the {@code X-Crypta-App-Session} request header
+   * @return {@code true} only when the token matches the current session and has not expired
+   */
+  synchronized boolean isValid(String token) {
+    return current.token().equals(token) && current.expiresAt().isAfter(clock.instant());
+  }
+
+  /**
+   * Generates a new opaque token and expiration instant.
+   *
+   * @param now current time used as the base for the session lifetime
+   * @return newly issued mock browser session
+   */
+  private Session newSession(Instant now) {
+    byte[] bytes = new byte[32];
+    random.nextBytes(bytes);
+    return new Session(
+        Base64.getUrlEncoder().withoutPadding().encodeToString(bytes), now.plus(ttl));
+  }
+
+  /**
+   * Opaque browser-session value returned in bootstrap JSON.
+   *
+   * @param token URL-safe opaque token required by mock API requests
+   * @param expiresAt instant after which the token must no longer be accepted
+   */
+  record Session(String token, Instant expiresAt) {}
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/DevServerConfig.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/DevServerConfig.java
@@ -1,0 +1,62 @@
+package network.crypta.platform.devtools.devserver;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Configuration for one local {@code crypta-app dev} server instance.
+ *
+ * <p>The record is the normalized boundary between CLI options and server startup. It turns a
+ * missing host into the loopback default, converts local paths to absolute normalized form, accepts
+ * port {@code 0} for OS assignment, and supplies the default mock browser-session lifetime when the
+ * caller does not specify one. Host exposure policy is checked by {@link LoopbackHostPolicy} during
+ * server startup rather than in this record, because tests and CLI parsing both need to construct
+ * the same values before deciding whether to allow non-loopback binding.
+ *
+ * <p>Instances are immutable after construction and safe to share with the server wrapper. They do
+ * not validate that the bundle or fixture directory exists; startup performs those checks so errors
+ * can use the same app-distribution exception path as the rest of devtools.
+ *
+ * @param bundleDir staged app bundle root
+ * @param host listener host, loopback unless explicitly allowed by the caller
+ * @param port listener port, where {@code 0} asks the OS to allocate one
+ * @param fixtureDir optional directory containing deterministic JSON fixture files
+ * @param allowNonLoopback whether the caller explicitly accepted a non-loopback listener
+ * @param sessionTtl browser-session lifetime used in bootstrap JSON
+ */
+public record DevServerConfig(
+    Path bundleDir,
+    String host,
+    int port,
+    Path fixtureDir,
+    boolean allowNonLoopback,
+    Duration sessionTtl) {
+  /** Default loopback host used by {@code crypta-app dev}. */
+  public static final String DEFAULT_HOST = "127.0.0.1";
+
+  /** Default browser-session lifetime for local developer bootstrap responses. */
+  public static final Duration DEFAULT_SESSION_TTL = Duration.ofHours(1);
+
+  /**
+   * Creates a normalized configuration snapshot.
+   *
+   * <p>The constructor rejects invalid port numbers and non-positive session lifetimes immediately.
+   * It does not resolve symlinks or open files; that work belongs to the static asset and fixture
+   * safety checks that run after the bundle manifest is parsed.
+   */
+  public DevServerConfig {
+    bundleDir = Objects.requireNonNull(bundleDir, "bundleDir").toAbsolutePath().normalize();
+    host = host == null || host.isBlank() ? DEFAULT_HOST : host.trim();
+    if (port < 0 || port > 65535) {
+      throw new IllegalArgumentException("port must be between 0 and 65535");
+    }
+    if (fixtureDir != null) {
+      fixtureDir = fixtureDir.toAbsolutePath().normalize();
+    }
+    sessionTtl = Objects.requireNonNullElse(sessionTtl, DEFAULT_SESSION_TTL);
+    if (sessionTtl.isZero() || sessionTtl.isNegative()) {
+      throw new IllegalArgumentException("session TTL must be positive");
+    }
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/DevServerStaticAssets.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/DevServerStaticAssets.java
@@ -1,0 +1,423 @@
+package network.crypta.platform.devtools.devserver;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import network.crypta.platform.appdist.AppBundleDigest;
+import network.crypta.platform.appdist.AppBundleManifest;
+import network.crypta.platform.appdist.AppBundleManifestParser;
+import network.crypta.platform.appdist.AppBundleSignature;
+import network.crypta.platform.appdist.AppDistributionException;
+import network.crypta.platform.appui.AppUiContentTypes;
+
+/**
+ * Resolves safe staged-bundle static assets for the local dev server.
+ *
+ * <p>The dev server serves files directly from a developer's staged bundle, so route parsing and
+ * filesystem resolution must stay stricter than a generic static file server. This resolver accepts
+ * raw request paths under {@code /apps/{appId}/}, decodes path segments one at a time, rejects
+ * encoded separators, traversal, control characters, hidden sidecars, signature material, private
+ * key-like names, and symlinks in any path segment. It then verifies the real file remains beneath
+ * the real bundle root before reading bytes.
+ *
+ * <p>The resolver also mirrors the app UI routing behavior for nested static entries. Requests to
+ * the app root serve the manifest entry file, and relative paths from a nested entry directory can
+ * resolve against that directory when they do not exist at the bundle root. This keeps scaffolded
+ * apps practical while preserving the same safety checks for every candidate file.
+ */
+public final class DevServerStaticAssets {
+  /** Raw route prefix for app-owned UI files on the local dev origin. */
+  private static final String APPS_ROOT = "/apps/";
+
+  /** Percent marker used by the small raw-path decoder. */
+  private static final char PERCENT = '%';
+
+  /** Prevents construction of this stateless resolver. */
+  private DevServerStaticAssets() {}
+
+  /**
+   * Resolves one raw request path beneath {@code /apps/{appId}/}.
+   *
+   * @param bundleRoot staged bundle root
+   * @param manifest parsed app manifest
+   * @param rawRequestPath raw HTTP request path
+   * @return safe file response, or empty when the route is not for the app
+   * @throws IOException if filesystem metadata cannot be read safely
+   */
+  public static Optional<StaticAsset> resolve(
+      Path bundleRoot, AppBundleManifest manifest, String rawRequestPath) throws IOException {
+    LocalRoute route = parseRoute(rawRequestPath);
+    if (!manifest.appId().equals(route.appId())) {
+      return Optional.empty();
+    }
+    String assetPath = route.assetPath();
+    if (assetPath == null || isEntryDirectoryRequest(rawRequestPath, assetPath, manifest)) {
+      assetPath = manifest.uiEntry();
+    }
+    Optional<StaticAsset> direct = resolveBundlePath(bundleRoot, assetPath);
+    if (direct.isPresent()) {
+      return direct;
+    }
+    String entryDirectory = entryDirectory(manifest.uiEntry());
+    if (!entryDirectory.isEmpty()
+        && !assetPath.equals(entryDirectory)
+        && !assetPath.startsWith(entryDirectory + "/")) {
+      return resolveBundlePath(bundleRoot, entryDirectory + "/" + assetPath);
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Runs a static asset safety pass for offline app tests.
+   *
+   * @param bundleRoot staged bundle root
+   * @param manifest parsed manifest
+   * @throws IOException if an unsafe static asset is found
+   */
+  public static void checkStaticAssetSafety(Path bundleRoot, AppBundleManifest manifest)
+      throws IOException {
+    if (manifest.uiEntry() == null) {
+      return;
+    }
+    if (resolveBundlePath(bundleRoot, manifest.uiEntry()).isEmpty()) {
+      throw new AppDistributionException("static UI entry is not safe to serve");
+    }
+  }
+
+  /**
+   * Resolves one already-normalized asset path against the staged bundle root.
+   *
+   * @param bundleRoot staged bundle root supplied to the dev server
+   * @param assetPath slash-separated relative asset path from the local app route
+   * @return safe static asset response, or empty when the candidate is absent or unsafe
+   * @throws IOException if filesystem metadata cannot be inspected safely
+   */
+  private static Optional<StaticAsset> resolveBundlePath(Path bundleRoot, String assetPath)
+      throws IOException {
+    requireSafeAssetName(assetPath);
+    Path root = Objects.requireNonNull(bundleRoot, "bundleRoot").toAbsolutePath().normalize();
+    Path realRoot = root.toRealPath();
+    Path file = root.resolve(assetPath).normalize();
+    if (!file.startsWith(root) || hasSymbolicLinkSegment(root, assetPath)) {
+      return Optional.empty();
+    }
+    if (!Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+      return Optional.empty();
+    }
+    Path realFile = file.toRealPath();
+    if (!realFile.startsWith(realRoot)) {
+      return Optional.empty();
+    }
+    return Optional.of(
+        new StaticAsset(
+            realFile, Files.readAllBytes(realFile), AppUiContentTypes.forPath(assetPath)));
+  }
+
+  /**
+   * Checks each path segment for symlinks before any file bytes are read.
+   *
+   * @param root normalized staged bundle root
+   * @param assetPath relative asset path being resolved
+   * @return {@code true} when a segment is a symlink or escapes the root during normalization
+   */
+  private static boolean hasSymbolicLinkSegment(Path root, String assetPath) {
+    Path current = root;
+    for (String segment : assetPath.replace('\\', '/').split("/", -1)) {
+      current = current.resolve(segment).normalize();
+      if (!current.startsWith(root) || Files.isSymbolicLink(current)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Rejects path segments and file names that must never be served as UI assets.
+   *
+   * @param assetPath slash-separated relative path after route decoding
+   * @throws AppDistributionException if the path is empty, hidden, reserved, or key-like
+   */
+  private static void requireSafeAssetName(String assetPath) throws AppDistributionException {
+    String normalized = assetPath.replace('\\', '/');
+    for (String segment : normalized.split("/", -1)) {
+      String name = segment.toLowerCase(Locale.ROOT);
+      if (segment.isBlank() || segment.equals(".") || segment.equals("..")) {
+        throw new AppDistributionException("static asset path is unsafe");
+      }
+      if (segment.startsWith(".")
+          || sidecarName(segment)
+          || privateMaterialName(segment)
+          || AppBundleManifestParser.MANIFEST_FILE_NAME.equals(name)) {
+        throw new AppDistributionException("static asset is reserved and cannot be served");
+      }
+    }
+  }
+
+  /**
+   * Identifies bundle, signature, digest, and catalog sidecar names reserved by app tooling.
+   *
+   * @param segment single decoded path segment
+   * @return {@code true} when the segment names a reserved sidecar file
+   */
+  private static boolean sidecarName(String segment) {
+    String name = segment.toLowerCase(Locale.ROOT);
+    return AppBundleDigest.DIGEST_FILE_NAME.equals(name)
+        || AppBundleSignature.SIGNATURE_FILE_NAME.equals(name)
+        || "cryptad-app.catalog".equals(name)
+        || "cryptad-app.catalog.signature".equals(name)
+        || "cryptad-app-catalog.properties".equals(name)
+        || "cryptad-app-catalog.signature".equals(name);
+  }
+
+  /**
+   * Identifies file names that commonly contain private keys, passwords, or tokens.
+   *
+   * @param segment single decoded path segment
+   * @return {@code true} when the name is treated as private material
+   */
+  private static boolean privateMaterialName(String segment) {
+    String name = segment.toLowerCase(Locale.ROOT);
+    return name.endsWith(".pem")
+        || name.endsWith(".key")
+        || name.endsWith(".p12")
+        || name.endsWith(".pfx")
+        || name.endsWith(".der")
+        || name.contains("private")
+        || name.contains("password")
+        || name.equals("token")
+        || name.equals("tokens")
+        || name.startsWith("token.")
+        || name.startsWith("tokens.")
+        || name.endsWith(".token")
+        || name.endsWith(".tokens");
+  }
+
+  /**
+   * Checks whether a request targets the directory that contains the manifest UI entry.
+   *
+   * @param rawRequestPath raw HTTP request path from the exchange
+   * @param assetPath decoded route asset path
+   * @param manifest validated app manifest with the static entry path
+   * @return {@code true} when the request should serve the manifest entry file
+   */
+  private static boolean isEntryDirectoryRequest(
+      String rawRequestPath, String assetPath, AppBundleManifest manifest) {
+    return rawRequestPath.endsWith("/")
+        && !assetPath.isEmpty()
+        && assetPath.equals(entryDirectory(manifest.uiEntry()));
+  }
+
+  /**
+   * Returns the directory that contains a manifest entry path.
+   *
+   * @param uiEntry manifest static UI entry path
+   * @return relative directory path, or an empty string for root-level entries
+   */
+  private static String entryDirectory(String uiEntry) {
+    int slash = uiEntry.lastIndexOf('/');
+    return slash < 0 ? "" : uiEntry.substring(0, slash);
+  }
+
+  /**
+   * Parses a raw local app route into app id and optional asset path.
+   *
+   * @param rawPath raw request path from {@link java.net.URI#getRawPath()}
+   * @return parsed local app route with normalized app id and decoded asset path
+   * @throws AppDistributionException if the route is malformed or unsafe
+   */
+  private static LocalRoute parseRoute(String rawPath) throws AppDistributionException {
+    if (rawPath == null || !rawPath.startsWith(APPS_ROOT)) {
+      throw new AppDistributionException("App UI path must start with /apps/.");
+    }
+    String remainder = rawPath.substring(APPS_ROOT.length());
+    if (remainder.isEmpty()) {
+      throw new AppDistributionException("App UI route not found.");
+    }
+    int slashIndex = remainder.indexOf('/');
+    String rawAppId = slashIndex < 0 ? remainder : remainder.substring(0, slashIndex);
+    String appId;
+    try {
+      appId = AppBundleManifest.normalizeAppId(decodePathSegment(rawAppId));
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException("App UI route not found.", exception);
+    }
+    if (slashIndex < 0 || slashIndex == remainder.length() - 1) {
+      return new LocalRoute(appId, null);
+    }
+    return new LocalRoute(appId, normalizeAssetPath(remainder.substring(slashIndex + 1)));
+  }
+
+  /**
+   * Decodes and validates a raw asset path from the local app route.
+   *
+   * @param rawPath raw path suffix after {@code /apps/{appId}/}
+   * @return slash-separated decoded asset path with no traversal or encoded separators
+   * @throws AppDistributionException if any segment is unsafe or malformed
+   */
+  private static String normalizeAssetPath(String rawPath) throws AppDistributionException {
+    if (rawPath.isEmpty() || rawPath.charAt(0) == '/') {
+      throw new AppDistributionException("App UI asset path is unsafe.");
+    }
+    String[] rawSegments = rawPath.split("/", -1);
+    boolean trailingSlash = rawSegments.length > 1 && rawSegments[rawSegments.length - 1].isEmpty();
+    int segmentCount = trailingSlash ? rawSegments.length - 1 : rawSegments.length;
+    StringBuilder builder = new StringBuilder(rawPath.length());
+    for (int index = 0; index < segmentCount; index++) {
+      String segment = decodePathSegment(rawSegments[index]);
+      validateAssetSegment(segment);
+      if (index > 0) {
+        builder.append('/');
+      }
+      builder.append(segment);
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Validates one decoded route segment before it becomes part of a filesystem path.
+   *
+   * @param segment decoded route segment
+   * @throws AppDistributionException if the segment is blank, traversal, separator-bearing, or
+   *     control-character-bearing
+   */
+  private static void validateAssetSegment(String segment) throws AppDistributionException {
+    if (segment.isBlank()
+        || segment.equals(".")
+        || segment.equals("..")
+        || segment.indexOf('/') >= 0
+        || segment.indexOf('\\') >= 0
+        || segment.indexOf(':') >= 0
+        || segment.indexOf('\0') >= 0) {
+      throw new AppDistributionException("App UI asset path is unsafe.");
+    }
+    for (int index = 0; index < segment.length(); index++) {
+      if (Character.isISOControl(segment.charAt(index))) {
+        throw new AppDistributionException("App UI asset path is unsafe.");
+      }
+    }
+  }
+
+  /**
+   * Decodes percent-encoded UTF-8 for one route segment without allowing encoded separators.
+   *
+   * @param rawSegment raw URL path segment with percent escapes still present
+   * @return decoded UTF-8 segment
+   * @throws AppDistributionException if percent encoding is malformed
+   */
+  private static String decodePathSegment(String rawSegment) throws AppDistributionException {
+    if (rawSegment == null || rawSegment.isEmpty()) {
+      throw new AppDistributionException("App UI path segment is unsafe.");
+    }
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream(rawSegment.length());
+    int index = 0;
+    while (index < rawSegment.length()) {
+      char character = rawSegment.charAt(index);
+      if (character == PERCENT) {
+        writePercentDecodedByte(bytes, rawSegment, index);
+        index += 3;
+      } else if (character > 0x7F) {
+        bytes.writeBytes(
+            Character.toString(character).getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        index++;
+      } else {
+        bytes.write((byte) character);
+        index++;
+      }
+    }
+    return bytes.toString(java.nio.charset.StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Decodes one percent escape into a byte buffer.
+   *
+   * @param bytes destination buffer for decoded bytes
+   * @param rawSegment raw URL path segment containing the percent escape
+   * @param percentIndex index of the percent character in {@code rawSegment}
+   * @throws AppDistributionException if the escape is incomplete or non-hexadecimal
+   */
+  private static void writePercentDecodedByte(
+      ByteArrayOutputStream bytes, String rawSegment, int percentIndex)
+      throws AppDistributionException {
+    if (percentIndex + 2 >= rawSegment.length()) {
+      throw new AppDistributionException("App UI path contains malformed percent-encoding.");
+    }
+    int high = Character.digit(rawSegment.charAt(percentIndex + 1), 16);
+    int low = Character.digit(rawSegment.charAt(percentIndex + 2), 16);
+    if (high < 0 || low < 0) {
+      throw new AppDistributionException("App UI path contains malformed percent-encoding.");
+    }
+    bytes.write((high << 4) + low);
+  }
+
+  /**
+   * Parsed local app route.
+   *
+   * @param appId normalized app id from the first route segment
+   * @param assetPath decoded asset path, or {@code null} when the app root was requested
+   */
+  private record LocalRoute(String appId, String assetPath) {}
+
+  /**
+   * Safe static file response.
+   *
+   * <p>The response owns a defensive copy of the file bytes because callers hand the array to the
+   * HTTP response body. The file path is the resolved real file path after containment checks; it
+   * is useful for tests and diagnostics but should not be printed in user-facing reports.
+   */
+  @SuppressWarnings({"ClassCanBeRecord", "java:S6206"})
+  public static final class StaticAsset {
+    /** Real resolved file path inside the staged bundle root. */
+    private final Path file;
+
+    /** Immutable response bytes copied from the resolved file. */
+    private final byte[] bytes;
+
+    /** HTTP content type selected from the app UI content type table. */
+    private final String contentType;
+
+    /**
+     * Creates an immutable response.
+     *
+     * @param file real resolved file path inside the staged bundle root
+     * @param bytes file bytes to copy into the response object
+     * @param contentType HTTP content type to return for the asset
+     */
+    public StaticAsset(Path file, byte[] bytes, String contentType) {
+      this.file = Objects.requireNonNull(file, "file");
+      this.bytes = Objects.requireNonNull(bytes, "bytes").clone();
+      this.contentType = Objects.requireNonNull(contentType, "contentType");
+    }
+
+    /**
+     * Returns the resolved staged asset path.
+     *
+     * @return real file path inside the staged bundle root
+     */
+    public Path file() {
+      return file;
+    }
+
+    /**
+     * Returns the HTTP response content type.
+     *
+     * @return content type selected for this asset path
+     */
+    public String contentType() {
+      return contentType;
+    }
+
+    /**
+     * Returns a fresh copy of file bytes.
+     *
+     * @return defensive copy of the immutable response payload
+     */
+    public byte[] bytes() {
+      return bytes.clone();
+    }
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/LoopbackHostPolicy.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/LoopbackHostPolicy.java
@@ -1,0 +1,65 @@
+package network.crypta.platform.devtools.devserver;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import network.crypta.platform.appdist.AppDistributionException;
+
+/**
+ * Host binding policy for the local development server.
+ *
+ * <p>The dev server is safe by default only when it listens on loopback. This helper keeps the
+ * policy small and testable: common loopback literals are accepted without DNS work, other host
+ * values are resolved through {@link InetAddress}, and non-loopback listeners require an explicit
+ * caller opt-in. The returned warning is intended for CLI startup output so developers can see when
+ * they have exposed the mock API beyond the local machine.
+ */
+public final class LoopbackHostPolicy {
+  /** Prevents construction of this stateless host-policy helper. */
+  private LoopbackHostPolicy() {}
+
+  /**
+   * Ensures the requested host is loopback unless the caller explicitly opted into exposure.
+   *
+   * @param host listener host text
+   * @param allowNonLoopback whether non-loopback binding was explicitly allowed
+   * @return warning text for explicit non-loopback binding, or an empty string
+   * @throws AppDistributionException if the host is non-loopback and override is not enabled
+   */
+  public static String requireAllowedHost(String host, boolean allowNonLoopback)
+      throws AppDistributionException {
+    if (isLoopback(host)) {
+      return "";
+    }
+    if (!allowNonLoopback) {
+      throw new AppDistributionException(
+          "refusing non-loopback dev server host: "
+              + host
+              + " (use --allow-non-loopback to override)");
+    }
+    return "Warning: dev server is bound to a non-loopback host; use only on trusted networks.";
+  }
+
+  /**
+   * Returns whether the host resolves to a loopback address.
+   *
+   * @param host listener host text, with surrounding whitespace ignored
+   * @return {@code true} for loopback literals or resolvable loopback host names
+   */
+  public static boolean isLoopback(String host) {
+    String value = host == null ? "" : host.trim();
+    if (value.isEmpty()) {
+      return false;
+    }
+    if ("localhost".equalsIgnoreCase(value)
+        || "127.0.0.1".equals(value)
+        || "::1".equals(value)
+        || "0:0:0:0:0:0:0:1".equals(value)) {
+      return true;
+    }
+    try {
+      return InetAddress.getByName(value).isLoopbackAddress();
+    } catch (UnknownHostException _) {
+      return false;
+    }
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/MockPlatformApi.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/MockPlatformApi.java
@@ -1,0 +1,271 @@
+package network.crypta.platform.devtools.devserver;
+
+import com.sun.net.httpserver.HttpExchange;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Deterministic mock Platform API used by {@code crypta-app dev} and app tests.
+ *
+ * <p>The handler implements the small Platform API subset needed by scaffold templates and offline
+ * smoke tests: node metadata, queue reads and mutations, content insert requests, app-vault
+ * identity/grant examples, and current-app metadata. Every endpoint requires the {@code
+ * X-Crypta-App-Session} header value issued by the dev bootstrap response, which keeps local
+ * examples aligned with the browser SDK's production calling convention.
+ *
+ * <p>This is not a daemon simulator. Responses are deterministic JSON fixtures or simple mutation
+ * acknowledgements, and no request reaches FCP, a live node, disk-backed queue state, or real vault
+ * identity material. Form validation is intentionally limited to fields that live Platform API
+ * handlers require from the generated templates.
+ */
+final class MockPlatformApi {
+  /** Browser-session header required by all mock API endpoints. */
+  static final String SESSION_HEADER = "X-Crypta-App-Session";
+
+  private static final String IDENTIFIER_FIELD = "identifier";
+
+  /** Validator supplied by the dev server's browser-session issuer. */
+  private final Predicate<String> sessionValidator;
+
+  /** Fixture source for deterministic JSON responses. */
+  private final MockPlatformApiFixtures fixtures;
+
+  /**
+   * Creates a mock API handler.
+   *
+   * @param sessionValidator predicate that accepts the current non-expired browser-session token
+   * @param fixtures fixture provider for read endpoints and mutation acknowledgements
+   */
+  MockPlatformApi(Predicate<String> sessionValidator, MockPlatformApiFixtures fixtures) {
+    this.sessionValidator = sessionValidator;
+    this.fixtures = fixtures;
+  }
+
+  /**
+   * Handles one request under {@code /api/v1/}.
+   *
+   * @param exchange incoming JDK HTTP exchange
+   * @throws IOException if fixture loading or response writing fails
+   */
+  void handle(HttpExchange exchange) throws IOException {
+    if (!sessionValid(exchange)) {
+      sendJson(
+          exchange,
+          401,
+          """
+          {"error":{"code":"invalid_app_browser_session","message":"Invalid app browser session."}}
+          """);
+      return;
+    }
+    String method = exchange.getRequestMethod();
+    String path = exchange.getRequestURI().getRawPath();
+    String suffix = path.substring("/api/v1".length());
+    try {
+      route(exchange, method, suffix);
+    } catch (UnsupportedOperationException _) {
+      sendJson(
+          exchange,
+          404,
+          "{\"error\":{\"code\":\"mock_endpoint_not_found\",\"message\":\"Mock endpoint not"
+              + " found.\"}}");
+    }
+  }
+
+  /**
+   * Checks whether the request carries a valid mock browser session header.
+   *
+   * @param exchange incoming API request
+   * @return {@code true} when any header value matches the current non-expired session
+   */
+  private boolean sessionValid(HttpExchange exchange) {
+    List<String> values = exchange.getRequestHeaders().get(SESSION_HEADER);
+    return values != null && values.stream().anyMatch(value -> sessionValidator.test(value.trim()));
+  }
+
+  /**
+   * Routes one authorized mock API request.
+   *
+   * @param exchange authorized incoming request
+   * @param method HTTP method from the exchange
+   * @param suffix raw path suffix after {@code /api/v1}
+   * @throws IOException if a fixture or response cannot be written
+   */
+  private void route(HttpExchange exchange, String method, String suffix) throws IOException {
+    switch (method) {
+      case "GET" -> routeGet(exchange, suffix);
+      case "POST" -> routePost(exchange, suffix);
+      default -> throw new UnsupportedOperationException(suffix);
+    }
+  }
+
+  private void routeGet(HttpExchange exchange, String suffix) throws IOException {
+    if (suffix.equals("/node") || suffix.equals("/node/greeting")) {
+      sendJson(exchange, 200, fixtures.node());
+    } else if (suffix.equals("/queue")) {
+      sendJson(exchange, 200, fixtures.queue());
+    } else if (suffix.equals("/app-vault/identities")) {
+      sendJson(exchange, 200, fixtures.vaultIdentities());
+    } else if (suffix.matches("/app-vault/identities/[^/]+")) {
+      sendJson(exchange, 200, oneIdentity(suffix.substring("/app-vault/identities/".length())));
+    } else if (suffix.equals("/app-vault/grants")) {
+      sendJson(exchange, 200, fixtures.vaultGrants());
+    } else if (suffix.equals("/apps/current")) {
+      sendJson(exchange, 200, fixtures.appsCurrent());
+    } else {
+      throw new UnsupportedOperationException(suffix);
+    }
+  }
+
+  private void routePost(HttpExchange exchange, String suffix) throws IOException {
+    if (suffix.startsWith("/queue/")) {
+      routeQueuePost(exchange, suffix);
+    } else if (suffix.equals("/app-vault/grants/request")) {
+      sendJson(exchange, 200, fixtures.mutation("app-vault.grants.request"));
+    } else {
+      throw new UnsupportedOperationException(suffix);
+    }
+  }
+
+  private void routeQueuePost(HttpExchange exchange, String suffix) throws IOException {
+    switch (suffix) {
+      case "/queue/downloads" ->
+          sendJson(exchange, 200, fixtures.mutation("queue.downloads.create"));
+      case "/queue/inserts/file" ->
+          sendFormMutation(
+              exchange, "queue.inserts.file", "sourcePath", "insertUri", IDENTIFIER_FIELD);
+      case "/queue/inserts/directory" ->
+          sendFormMutation(
+              exchange, "queue.inserts.directory", "sourcePath", "insertUri", IDENTIFIER_FIELD);
+      case "/queue/requests/remove" ->
+          sendJson(exchange, 200, fixtures.mutation("queue.requests.remove"));
+      case "/queue/requests/restart" ->
+          sendJson(exchange, 200, fixtures.mutation("queue.requests.restart"));
+      case "/queue/requests/priority" ->
+          sendFormMutation(exchange, "queue.requests.priority", IDENTIFIER_FIELD, "priority");
+      default -> routeQueueItemMutation(exchange, suffix);
+    }
+  }
+
+  private void routeQueueItemMutation(HttpExchange exchange, String suffix) throws IOException {
+    if (!suffix.matches("/queue/[^/]+/(cancel|restart|priority)")) {
+      throw new UnsupportedOperationException(suffix);
+    }
+    sendJson(exchange, 200, fixtures.mutation(suffix.substring(1).replace('/', '.')));
+  }
+
+  private void sendFormMutation(HttpExchange exchange, String mutation, String... fieldNames)
+      throws IOException {
+    if (!rejectMissingFormFields(exchange, fieldNames)) {
+      sendJson(exchange, 200, fixtures.mutation(mutation));
+    }
+  }
+
+  /**
+   * Sends a {@code 400} response when a form mutation omits required fields.
+   *
+   * @param exchange mutation request whose body contains form data
+   * @param fieldNames required form field names for the endpoint
+   * @return {@code true} when the request was rejected and a response was sent
+   * @throws IOException if the request body or rejection response cannot be processed
+   */
+  private static boolean rejectMissingFormFields(HttpExchange exchange, String... fieldNames)
+      throws IOException {
+    Map<String, List<String>> form = readForm(exchange);
+    for (String fieldName : fieldNames) {
+      if (!hasNonBlankValue(form, fieldName)) {
+        sendJson(
+            exchange,
+            400,
+            "{\"error\":{\"code\":\"invalid_mock_form\",\"message\":\"Missing required form field '"
+                + MockPlatformApiFixtures.Json.escape(fieldName)
+                + "'.\"}}");
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Parses an {@code application/x-www-form-urlencoded}-style body into ordered field values.
+   *
+   * @param exchange request containing the mutation body
+   * @return ordered map of decoded field names to decoded field values
+   * @throws IOException if the request body cannot be read
+   */
+  private static Map<String, List<String>> readForm(HttpExchange exchange) throws IOException {
+    String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    LinkedHashMap<String, List<String>> form = new LinkedHashMap<>();
+    if (body.isBlank()) {
+      return form;
+    }
+    for (String pair : body.split("&", -1)) {
+      if (pair.isEmpty()) {
+        continue;
+      }
+      int separator = pair.indexOf('=');
+      String key = decodeFormComponent(separator < 0 ? pair : pair.substring(0, separator));
+      String value = separator < 0 ? "" : decodeFormComponent(pair.substring(separator + 1));
+      form.computeIfAbsent(key, ignored -> new ArrayList<>()).add(value);
+    }
+    return form;
+  }
+
+  /**
+   * Decodes one URL-encoded form component using UTF-8.
+   *
+   * @param value raw form key or value component
+   * @return decoded component text
+   */
+  private static String decodeFormComponent(String value) {
+    return URLDecoder.decode(value, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Checks whether a parsed form contains a non-blank value for a field.
+   *
+   * @param form parsed form data
+   * @param fieldName field name to inspect
+   * @return {@code true} when at least one submitted value is non-blank
+   */
+  private static boolean hasNonBlankValue(Map<String, List<String>> form, String fieldName) {
+    List<String> values = form.get(fieldName);
+    return values != null && values.stream().anyMatch(value -> !value.isBlank());
+  }
+
+  /**
+   * Builds a deterministic single-identity response for an app-vault identity route.
+   *
+   * @param identityId decoded identity id suffix from the request route
+   * @return compact JSON object for the requested mock identity
+   */
+  private static String oneIdentity(String identityId) {
+    return "{\"id\":\""
+        + MockPlatformApiFixtures.Json.escape(identityId)
+        + "\",\"displayName\":\"Local Profile\",\"kind\":\"mock\",\"status\":\"available\"}";
+  }
+
+  /**
+   * Sends a JSON response with conservative cache headers.
+   *
+   * @param exchange request to complete
+   * @param status HTTP response status code
+   * @param json JSON text to strip and send as UTF-8
+   * @throws IOException if response headers or body cannot be written
+   */
+  static void sendJson(HttpExchange exchange, int status, String json) throws IOException {
+    byte[] bytes = json.strip().getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+    exchange.getResponseHeaders().set("Cache-Control", "no-store");
+    exchange.sendResponseHeaders(status, bytes.length);
+    try (OutputStream body = exchange.getResponseBody()) {
+      body.write(bytes);
+    }
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/MockPlatformApiFixtures.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/MockPlatformApiFixtures.java
@@ -1,0 +1,239 @@
+package network.crypta.platform.devtools.devserver;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.Map;
+import network.crypta.platform.appdist.AppDistributionException;
+
+/**
+ * Loads deterministic mock Platform API JSON fixtures.
+ *
+ * <p>The dev server can serve built-in fixture JSON or developer-provided JSON files from a single
+ * fixture directory. Built-ins keep scaffolded apps useful without setup, while file fixtures let
+ * tests and local demos exercise specific queue, vault, node, and current-app states. Fixture
+ * values remain static for the life of the request; mutation routes return acknowledgements rather
+ * than modifying fixture files.
+ *
+ * <p>When reading developer fixtures, this class refuses symlink fixture directories, symlink
+ * files, non-regular files, path traversal outside the fixture directory, and JSON strings that
+ * contain obvious absolute local paths. That keeps mock output from leaking workstation paths into
+ * browser-visible responses or app test reports.
+ */
+final class MockPlatformApiFixtures {
+  /** Built-in JSON fixtures keyed by the optional fixture file names accepted by the CLI. */
+  private static final Map<String, String> DEFAULTS =
+      Map.of(
+          "node.json",
+          """
+          {"nodeName":"Crypta local dev","status":"mock","apiVersion":"v1"}
+          """,
+          "queue.json",
+          """
+          {"page":"downloads","requests":[{"id":"mock-download-1","name":"Example download","state":"running","priority":"normal"},{"id":"mock-insert-1","name":"Example insert","state":"queued","priority":"low"}],"contentHtml":"<p>Mock queue data</p>"}
+          """,
+          "vault-identities.json",
+          """
+          {"identities":[{"id":"local-profile","displayName":"Local Profile","kind":"mock","status":"available"}]}
+          """,
+          "vault-grants.json",
+          """
+          {"grants":[{"id":"grant-local-profile","identityId":"local-profile","scopes":["metadata.read"],"status":"mock-granted"}]}
+          """,
+          "apps-current.json",
+          """
+          {"appId":"${APP_ID}","name":"${APP_NAME}","version":"${APP_VERSION}","mode":"mock-dev"}
+          """);
+
+  /** Optional normalized directory containing user-supplied JSON fixture files. */
+  private final Path fixtureDir;
+
+  /** App id used to fill placeholders in the current-app fixture. */
+  private final String appId;
+
+  /** App display name used to fill placeholders in the current-app fixture. */
+  private final String appName;
+
+  /** App version used to fill placeholders in the current-app fixture. */
+  private final String appVersion;
+
+  /**
+   * Creates a fixture provider for one staged app.
+   *
+   * @param fixtureDir optional fixture directory supplied by the developer
+   * @param appId app id used by default current-app responses
+   * @param appName app display name used by default current-app responses
+   * @param appVersion app version used by default current-app responses
+   */
+  MockPlatformApiFixtures(Path fixtureDir, String appId, String appName, String appVersion) {
+    this.fixtureDir = fixtureDir == null ? null : fixtureDir.toAbsolutePath().normalize();
+    this.appId = appId;
+    this.appName = appName;
+    this.appVersion = appVersion;
+  }
+
+  /**
+   * Returns node metadata fixture JSON.
+   *
+   * @return fixture-backed or built-in node JSON
+   * @throws IOException if fixture loading fails
+   */
+  String node() throws IOException {
+    return fixture("node.json");
+  }
+
+  /**
+   * Returns queue listing fixture JSON.
+   *
+   * @return fixture-backed or built-in queue JSON
+   * @throws IOException if fixture loading fails
+   */
+  String queue() throws IOException {
+    return fixture("queue.json");
+  }
+
+  /**
+   * Returns app-vault identity listing fixture JSON.
+   *
+   * @return fixture-backed or built-in identity JSON with safe mock data
+   * @throws IOException if fixture loading fails
+   */
+  String vaultIdentities() throws IOException {
+    return fixture("vault-identities.json");
+  }
+
+  /**
+   * Returns app-vault grant listing fixture JSON.
+   *
+   * @return fixture-backed or built-in grant JSON with safe mock data
+   * @throws IOException if fixture loading fails
+   */
+  String vaultGrants() throws IOException {
+    return fixture("vault-grants.json");
+  }
+
+  /**
+   * Returns current-app metadata fixture JSON.
+   *
+   * @return fixture-backed or built-in current-app JSON after placeholder replacement
+   * @throws IOException if fixture loading fails
+   */
+  String appsCurrent() throws IOException {
+    return fixture("apps-current.json");
+  }
+
+  /**
+   * Builds a deterministic mutation acknowledgement.
+   *
+   * @param action stable action label for the route that accepted the mutation
+   * @return compact JSON acknowledgement with no persistent state change
+   */
+  String mutation(String action) {
+    return "{\"status\":\"ok\",\"mock\":true,\"action\":\"" + Json.escape(action) + "\"}";
+  }
+
+  /**
+   * Loads a named fixture from disk when present, otherwise uses the built-in default.
+   *
+   * @param name fixture file name such as {@code queue.json}
+   * @return fixture JSON after placeholder replacement and whitespace trimming
+   * @throws IOException if a present fixture is unsafe or cannot be read
+   */
+  private String fixture(String name) throws IOException {
+    String json = fixtureDir == null ? null : readFixture(name);
+    if (json == null) {
+      json = DEFAULTS.get(name);
+    }
+    return applyAppPlaceholders(json.strip());
+  }
+
+  /**
+   * Reads one user fixture file from the configured fixture directory.
+   *
+   * @param name file name selected from the supported fixture list
+   * @return fixture text, or {@code null} when the file is absent
+   * @throws IOException if the directory or file is unsafe or unreadable
+   */
+  private String readFixture(String name) throws IOException {
+    if (!Files.isDirectory(fixtureDir, LinkOption.NOFOLLOW_LINKS)
+        || Files.isSymbolicLink(fixtureDir)) {
+      throw new AppDistributionException("fixture directory must be a real directory");
+    }
+    Path file = fixtureDir.resolve(name).normalize();
+    if (!file.startsWith(fixtureDir) || !Files.exists(file, LinkOption.NOFOLLOW_LINKS)) {
+      return null;
+    }
+    if (Files.isSymbolicLink(file) || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppDistributionException("fixture file must be a regular file: " + name);
+    }
+    String text = Files.readString(file, StandardCharsets.UTF_8);
+    rejectLocalPathLeaks(text, name);
+    return text;
+  }
+
+  /**
+   * Rejects fixture JSON that appears to expose absolute local filesystem paths.
+   *
+   * @param text fixture text read from disk
+   * @param name fixture file name used in diagnostics
+   * @throws AppDistributionException if a quoted Unix or Windows absolute path is detected
+   */
+  private static void rejectLocalPathLeaks(String text, String name)
+      throws AppDistributionException {
+    if (text.matches("(?s).*\"/[^\"]*\".*")
+        || text.matches("(?s).*\"[A-Za-z]:\\\\\\\\[^\"]*\".*")) {
+      throw new AppDistributionException("fixture output contains an absolute local path: " + name);
+    }
+  }
+
+  /**
+   * Replaces app metadata placeholders in fixture JSON.
+   *
+   * @param json fixture JSON that may contain {@code ${APP_ID}}, {@code ${APP_NAME}}, or {@code
+   *     ${APP_VERSION}}
+   * @return fixture JSON with placeholders replaced by escaped app metadata
+   */
+  private String applyAppPlaceholders(String json) {
+    return json.replace("${APP_ID}", Json.escape(appId))
+        .replace("${APP_NAME}", Json.escape(appName))
+        .replace("${APP_VERSION}", Json.escape(appVersion));
+  }
+
+  /** Small JSON string escaper for mock response values. */
+  static final class Json {
+    /** Prevents construction of this stateless JSON helper. */
+    private Json() {}
+
+    /**
+     * Escapes one string for inclusion in mock JSON responses.
+     *
+     * @param value raw value to escape
+     * @return escaped JSON string content without surrounding quote characters
+     */
+    static String escape(String value) {
+      StringBuilder out = new StringBuilder(value.length());
+      for (int index = 0; index < value.length(); index++) {
+        char c = value.charAt(index);
+        switch (c) {
+          case '"' -> out.append("\\\"");
+          case '\\' -> out.append("\\\\");
+          case '\b' -> out.append("\\b");
+          case '\f' -> out.append("\\f");
+          case '\n' -> out.append("\\n");
+          case '\r' -> out.append("\\r");
+          case '\t' -> out.append("\\t");
+          default -> {
+            if (c < 0x20) {
+              out.append(String.format("\\u%04x", (int) c));
+            } else {
+              out.append(c);
+            }
+          }
+        }
+      }
+      return out.toString();
+    }
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/package-info.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/devserver/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * Loopback-only local development server for staged static Crypta app bundles.
+ *
+ * <p>The package is owned by {@code platform-devtools}. It serves scaffolded static assets and a
+ * deterministic mock Platform API for offline developer testing. The server provides the same
+ * bootstrap and browser-session shape used by the browser SDK, but all data is local fixture data
+ * or built-in safe mock content. It is useful for template development, app lint/test smoke checks,
+ * and documentation examples that need a same-origin Platform API without a running daemon.
+ *
+ * <p>This package is not an AppHost replacement and does not install, update, sandbox, review, or
+ * publish apps. Static asset resolution stays within the staged bundle, rejects reserved sidecars
+ * and private-material names, and refuses symlink escapes. The default host policy binds to
+ * loopback; non-loopback listeners are an explicit developer opt-in and should be used only on
+ * trusted networks.
+ */
+package network.crypta.platform.devtools.devserver;

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/AppTestReportJsonTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/AppTestReportJsonTest.java
@@ -1,0 +1,43 @@
+package network.crypta.platform.devtools;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class AppTestReportJsonTest {
+  @Test
+  void write_whenReportContainsPathsAndControls_expectEscapedRedactedJson() {
+    AppTestReport report =
+        new AppTestReport(
+            1,
+            "/Users/alice/My Keys/app.properties",
+            "0.1.0",
+            AppTestStatus.WARN,
+            List.of(
+                new AppTestCheck(
+                    "fixture.path",
+                    AppTestStatus.WARN,
+                    "Missing C:\\Users\\Alice Keys\\trusted.pem \"quoted\"\nnext\tfield")));
+
+    String json = AppTestReportJson.write(report);
+
+    assertTrue(json.contains("\"appId\": \"[REDACTED_PATH]\""));
+    assertTrue(json.contains("\\\"quoted\\\"\\nnext\\tfield"));
+    assertFalse(json.contains("My Keys"));
+    assertFalse(json.contains("Alice Keys"));
+    assertFalse(json.contains("trusted.pem"));
+  }
+
+  @Test
+  void constructor_whenSchemaVersionUnsupported_expectFailure() {
+    List<AppTestCheck> checks = List.of();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> new AppTestReport(2, "sample", "0.1.0", AppTestStatus.PASS, checks));
+  }
+}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/DeveloperBetaToolkitCliTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/DeveloperBetaToolkitCliTest.java
@@ -1,0 +1,871 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.time.Duration;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import network.crypta.platform.devtools.devserver.CryptaAppDevServer;
+import network.crypta.platform.devtools.devserver.DevServerConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import picocli.CommandLine;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class DeveloperBetaToolkitCliTest {
+  private static final Pattern BOOTSTRAP_SESSION_PATTERN =
+      Pattern.compile("\"browserSessionToken\"\\s*:\\s*\"([^\"]+)\"");
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void init_whenBetaTemplatesRequested_expectStrictTestCleanStaticApps() throws Exception {
+    assertTemplate(
+        "queue-dashboard",
+        "queue-app",
+        "app.permissions=queue.read,queue.write\n",
+        "api.experimentalCapabilitiesAccepted=false\n",
+        "platform.queue.snapshot");
+    assertTemplate(
+        "publisher",
+        "publisher-app",
+        "app.permissions=content.insert,queue.read,queue.write\n",
+        "api.experimentalCapabilitiesAccepted=false\n",
+        "window.CryptaPlatform.content.insertFile");
+    assertTemplate(
+        "vault-profile",
+        "vault-app",
+        "app.permissions=vault.identities.read,vault.identities.use\n",
+        "api.experimentalCapabilitiesAccepted=true\n",
+        "loaded safe mock vault data");
+  }
+
+  @Test
+  void init_whenUnknownTemplateRequested_expectClearFailure() {
+    Path appDir = tempDir.resolve("unknown-template");
+
+    CliResult result =
+        runCli(
+            "init",
+            "--dir",
+            appDir.toString(),
+            "--app-id",
+            "sample-app",
+            "--name",
+            "Sample App",
+            "--version",
+            "0.1.0",
+            "--template",
+            "missing-template");
+
+    assertEquals(CommandLine.ExitCode.SOFTWARE, result.exitCode());
+    assertTrue(result.err().contains("unsupported app template: missing-template"));
+    assertTrue(result.err().contains("queue-dashboard"));
+    assertFalse(Files.exists(appDir.resolve("cryptad-app.properties")));
+  }
+
+  @Test
+  void init_whenStaticTemplateRequestedWithNonStaticMode_expectNoPartialScaffold() {
+    Path appDir = tempDir.resolve("bad-template-mode");
+
+    CliResult result =
+        runCli(
+            "init",
+            "--dir",
+            appDir.toString(),
+            "--app-id",
+            "bad-template-mode",
+            "--name",
+            "Bad Template Mode",
+            "--version",
+            "0.1.0",
+            "--template",
+            "queue-dashboard",
+            "--ui-mode",
+            "none");
+
+    assertEquals(CommandLine.ExitCode.SOFTWARE, result.exitCode());
+    assertTrue(result.err().contains("template queue-dashboard requires --ui-mode static"));
+    assertFalse(Files.exists(appDir));
+  }
+
+  @Test
+  void devServer_whenStaticAppServed_expectBootstrapStaticAndSessionProtectedApi()
+      throws Exception {
+    Path appDir = scaffold("queue-dashboard", "queue-app");
+    Files.writeString(appDir.resolve("cryptad-app.catalog"), "private catalog sidecar");
+    Files.writeString(appDir.resolve("cryptad-app.catalog.signature"), "private catalog signature");
+
+    try (CryptaAppDevServer server =
+        CryptaAppDevServer.start(
+            new DevServerConfig(appDir, "127.0.0.1", 0, null, false, Duration.ofMinutes(10)))) {
+      HttpClient client =
+          HttpClient.newBuilder()
+              .connectTimeout(Duration.ofSeconds(5))
+              .version(HttpClient.Version.HTTP_1_1)
+              .build();
+      HttpResponse<String> bootstrap =
+          get(client, server.apiRoot().replace("/api/v1/", "/.well-known/cryptad-bootstrap.json"));
+      String sessionToken = sessionToken(bootstrap.body());
+
+      String appRoot = server.apiRoot().replace("/api/v1/", "/apps/queue-app/");
+      verifyDevServerBootstrap(bootstrap, server, appDir, sessionToken);
+      verifyStaticUiAndMockQueueApi(client, server, sessionToken);
+      verifySessionAndStaticSafety(client, server, appRoot, sessionToken);
+    }
+  }
+
+  @Test
+  void devServer_whenEntryIsRootOrNestedDirectory_expectNormalizedAssetRoot() throws Exception {
+    HttpClient client =
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .version(HttpClient.Version.HTTP_1_1)
+            .build();
+    Path rootEntryApp = scaffold("static-basic", "root-entry-app");
+    Files.move(
+        rootEntryApp.resolve("static").resolve("index.html"), rootEntryApp.resolve("index.html"));
+    replaceManifestLine(rootEntryApp, "app.ui.entry=static/index.html", "app.ui.entry=index.html");
+
+    try (CryptaAppDevServer server =
+        CryptaAppDevServer.start(
+            new DevServerConfig(
+                rootEntryApp, "127.0.0.1", 0, null, false, Duration.ofMinutes(10)))) {
+      String bootstrap =
+          get(client, server.apiRoot().replace("/api/v1/", "/.well-known/cryptad-bootstrap.json"))
+              .body();
+
+      assertTrue(bootstrap.contains("\"assetRoot\":\"" + server.uiUrl() + "\""));
+    }
+
+    Path nestedEntryApp = scaffold("static-basic", "nested-entry-app");
+    Path nestedDir = nestedEntryApp.resolve("static").resolve("pages with spaces");
+    Files.createDirectories(nestedDir);
+    Files.move(
+        nestedEntryApp.resolve("static").resolve("index.html"), nestedDir.resolve("index.html"));
+    replaceManifestLine(
+        nestedEntryApp,
+        "app.ui.entry=static/index.html",
+        "app.ui.entry=static/pages with spaces/index.html");
+
+    try (CryptaAppDevServer server =
+        CryptaAppDevServer.start(
+            new DevServerConfig(
+                nestedEntryApp, "127.0.0.1", 0, null, false, Duration.ofMinutes(10)))) {
+      String appRoot = server.apiRoot().replace("/api/v1/", "/apps/nested-entry-app/");
+      String expectedAssetRoot =
+          server
+              .apiRoot()
+              .replace("/api/v1/", "/apps/nested-entry-app/static/pages%20with%20spaces/");
+      String bootstrap =
+          get(client, server.apiRoot().replace("/api/v1/", "/.well-known/cryptad-bootstrap.json"))
+              .body();
+      HttpResponse<String> appRootRedirect = get(client, appRoot);
+      HttpResponse<String> nestedEntry = get(client, server.uiUrl());
+
+      assertEquals(expectedAssetRoot, server.uiUrl());
+      assertTrue(bootstrap.contains("\"assetRoot\":\"" + expectedAssetRoot + "\""));
+      assertEquals(302, appRootRedirect.statusCode());
+      assertEquals(
+          URI.create(expectedAssetRoot).getRawPath(),
+          appRootRedirect.headers().firstValue("Location").orElse(""));
+      assertEquals(200, nestedEntry.statusCode());
+      assertTrue(nestedEntry.body().contains("<title>Nested Entry App</title>"));
+    }
+  }
+
+  @Test
+  void devServer_whenStaticAssetPathContainsSymlinkParent_expectOutsideFileNotServed()
+      throws Exception {
+    Path appDir = scaffold("static-basic", "symlink-app");
+    Path outsideDir = tempDir.resolve("outside-static");
+    Files.createDirectories(outsideDir);
+    Files.writeString(outsideDir.resolve("secret.txt"), "outside secret", StandardCharsets.UTF_8);
+    Path link = appDir.resolve("static").resolve("link");
+    try {
+      Files.createSymbolicLink(link, outsideDir);
+    } catch (IOException | UnsupportedOperationException | SecurityException exception) {
+      org.junit.jupiter.api.Assumptions.assumeTrue(
+          false, "symlink creation unavailable: " + exception.getMessage());
+    }
+
+    try (CryptaAppDevServer server =
+        CryptaAppDevServer.start(
+            new DevServerConfig(appDir, "127.0.0.1", 0, null, false, Duration.ofMinutes(10)))) {
+      HttpClient client =
+          HttpClient.newBuilder()
+              .connectTimeout(Duration.ofSeconds(5))
+              .version(HttpClient.Version.HTTP_1_1)
+              .build();
+      HttpResponse<String> response = get(client, server.uiUrl() + "link/secret.txt");
+
+      assertEquals(404, response.statusCode());
+      assertFalse(response.body().contains("outside secret"));
+    }
+  }
+
+  @Test
+  void test_whenFreshStaticTemplateCheckedStrict_expectPassingHumanAndJsonReport()
+      throws Exception {
+    Path appDir = scaffold("static-basic", "sample-app");
+    Path report = tempDir.resolve("reports").resolve("app-test.json");
+
+    CliResult result =
+        runCli("test", "--bundle-dir", appDir.toString(), "--strict", "--json", report.toString());
+
+    String json = Files.readString(report, StandardCharsets.UTF_8);
+    assertEquals(CommandLine.ExitCode.OK, result.exitCode());
+    assertTrue(result.out().contains("bundle.validate pass"));
+    assertTrue(result.out().contains("dev.bootstrap-smoke pass"));
+    assertTrue(result.out().contains("App test suite pass: sample-app 0.1.0"));
+    assertTrue(json.contains("\"schemaVersion\": 1"));
+    assertTrue(json.contains("\"status\": \"pass\""));
+    assertTrue(json.contains("\"id\": \"dev.bootstrap-smoke\""));
+    assertFalse(json.contains("browserSessionToken"));
+    assertFalse(json.contains(tempDir.toString()));
+  }
+
+  @Test
+  void test_whenUiUsesRemoteScript_expectStrictFailureAndRedactedJson() throws Exception {
+    Path appDir = scaffold("static-basic", "remote-app");
+    Path index = appDir.resolve("static").resolve("index.html");
+    Files.writeString(
+        index,
+        Files.readString(index, StandardCharsets.UTF_8)
+            .replace(
+                "<script src=\"./crypta-platform.js\"></script>",
+                "<script src=\"https://cdn.example.invalid/crypta-platform.js\"></script>"),
+        StandardCharsets.UTF_8);
+    Path report = tempDir.resolve("reports").resolve("remote-test.json");
+
+    CliResult result =
+        runCli(
+            "test",
+            "--bundle-dir",
+            appDir.toString(),
+            "--strict",
+            "--contract",
+            tempDir.resolve("missing-contract.json").toString(),
+            "--catalog-entry",
+            tempDir.resolve("missing-entry.properties").toString(),
+            "--json",
+            report.toString());
+
+    String json = Files.readString(report, StandardCharsets.UTF_8);
+    assertEquals(CommandLine.ExitCode.SOFTWARE, result.exitCode());
+    assertTrue(result.out().contains("ui.lint fail"));
+    assertTrue(result.out().contains("catalog-entry.sanity fail"));
+    assertTrue(json.contains("\"status\": \"fail\""));
+    assertTrue(json.contains("[REDACTED_PATH]"));
+    assertFalse(json.contains(tempDir.toString()));
+    assertFalse(json.contains("browserSessionToken"));
+    assertFalse(json.contains("https://cdn.example.invalid/crypta-platform.js"));
+  }
+
+  @Test
+  void testReportRedactor_whenPathsContainSpaces_expectWholePathRedacted() {
+    String redacted =
+        AppTestRedactor.redact(
+            "missing /Users/alice/My Keys/contract.json and "
+                + "C:\\Users\\Alice Keys\\trusted.pem");
+
+    assertTrue(redacted.contains("[REDACTED_PATH]"));
+    assertFalse(redacted.contains("My Keys"));
+    assertFalse(redacted.contains("Alice Keys"));
+    assertFalse(redacted.contains("contract.json"));
+    assertFalse(redacted.contains("trusted.pem"));
+  }
+
+  @Test
+  void keysGenerate_whenUsedForBundleSigning_expectVerifyConsumesTrustedKeysAndNoPrivateOutput()
+      throws Exception {
+    Path appDir = scaffold("static-basic", "signed-app");
+    Path keysDir = tempDir.resolve("keys");
+    Path privateKey = keysDir.resolve("dev-local-private.der");
+    Path publicKey = keysDir.resolve("dev-local-public.der");
+    Path trustedKeys = keysDir.resolve("trusted-app-keys.properties");
+
+    CliResult generate =
+        runCli(
+            "keys",
+            "generate",
+            "--key-id",
+            "dev-local",
+            "--private-key-file",
+            privateKey.toString(),
+            "--public-key-file",
+            publicKey.toString(),
+            "--trusted-keys-file",
+            trustedKeys.toString());
+    CliResult overwriteFailure =
+        runCli(
+            "keys",
+            "generate",
+            "--key-id",
+            "dev-local",
+            "--private-key-file",
+            privateKey.toString(),
+            "--public-key-file",
+            publicKey.toString());
+    CliResult sign =
+        runCli(
+            "sign",
+            "--bundle-dir",
+            appDir.toString(),
+            "--key-id",
+            "dev-local",
+            "--private-key-file",
+            privateKey.toString());
+    CliResult verify =
+        runCli(
+            "verify",
+            "--bundle-dir",
+            appDir.toString(),
+            "--trusted-keys-file",
+            trustedKeys.toString());
+
+    assertEquals(CommandLine.ExitCode.OK, generate.exitCode());
+    assertTrue(Files.isRegularFile(privateKey));
+    assertTrue(Files.isRegularFile(publicKey));
+    assertPrivateKeyOwnerOnly(privateKey);
+    assertTrue(
+        Files.readString(trustedKeys, StandardCharsets.UTF_8).contains("key.0.id=dev-local"));
+    assertFalse(generate.out().contains(privateKey.toString()));
+    assertFalse(generate.err().contains(privateKey.toString()));
+    assertEquals(CommandLine.ExitCode.SOFTWARE, overwriteFailure.exitCode());
+    assertTrue(overwriteFailure.err().contains("key output already exists"));
+    assertEquals(CommandLine.ExitCode.OK, sign.exitCode());
+    assertEquals(CommandLine.ExitCode.OK, verify.exitCode());
+    assertTrue(verify.out().contains("Verified bundle:"));
+  }
+
+  @Test
+  void keysGenerate_whenOutputPathsDuplicate_expectNoPartialKeyMaterial() {
+    Path keysDir = tempDir.resolve("duplicate-keys");
+    Path duplicate = keysDir.resolve("duplicate.der");
+    Path privateKey = keysDir.resolve("private.der");
+
+    CliResult samePrivatePublic =
+        runCli(
+            "keys",
+            "generate",
+            "--key-id",
+            "dev-local",
+            "--private-key-file",
+            duplicate.toString(),
+            "--public-key-file",
+            duplicate.toString());
+    CliResult samePublicTrusted =
+        runCli(
+            "keys",
+            "generate",
+            "--key-id",
+            "dev-local",
+            "--private-key-file",
+            privateKey.toString(),
+            "--public-key-file",
+            duplicate.toString(),
+            "--trusted-keys-file",
+            duplicate.toString(),
+            "--overwrite");
+
+    assertEquals(CommandLine.ExitCode.SOFTWARE, samePrivatePublic.exitCode());
+    assertTrue(samePrivatePublic.err().contains("key output paths must be distinct"));
+    assertFalse(Files.exists(duplicate));
+    assertEquals(CommandLine.ExitCode.SOFTWARE, samePublicTrusted.exitCode());
+    assertTrue(samePublicTrusted.err().contains("key output paths must be distinct"));
+    assertFalse(Files.exists(privateKey));
+    assertFalse(Files.exists(duplicate));
+  }
+
+  @Test
+  void catalogEntryAndPublishUsk_whenSignedArtifactsPrepared_expectOfflinePlan() throws Exception {
+    Path appDir = scaffold("queue-dashboard", "catalog-app");
+    Path keysDir = tempDir.resolve("catalog-keys");
+    Path privateKey = keysDir.resolve("dev-local-private.der");
+    Path publicKey = keysDir.resolve("dev-local-public.der");
+    Path trustedKeys = keysDir.resolve("trusted-app-keys.properties");
+    Path artifact = tempDir.resolve("catalog-app.zip");
+    Path entry = tempDir.resolve("catalog-entry.properties");
+    Path catalog = tempDir.resolve("cryptad-app-catalog.properties");
+    Path plan = tempDir.resolve("publish-plan.md");
+
+    runCli(
+        "keys",
+        "generate",
+        "--key-id",
+        "dev-local",
+        "--private-key-file",
+        privateKey.toString(),
+        "--public-key-file",
+        publicKey.toString(),
+        "--trusted-keys-file",
+        trustedKeys.toString());
+    runCli(
+        "sign",
+        "--bundle-dir",
+        appDir.toString(),
+        "--key-id",
+        "dev-local",
+        "--private-key-file",
+        privateKey.toString());
+    runCli("pack", "--bundle-dir", appDir.toString(), "--output", artifact.toString());
+
+    CliResult entryResult =
+        runCli(
+            "catalog",
+            "entry",
+            "--bundle-dir",
+            appDir.toString(),
+            "--artifact",
+            artifact.toString(),
+            "--bundle-uri",
+            "crypta:CHK@catalog-app-bundle",
+            "--output",
+            entry.toString(),
+            "--summary",
+            "Queue dashboard for local development.",
+            "--homepage",
+            "https://example.invalid/catalog-app",
+            "--source",
+            "https://example.invalid/catalog-app/source",
+            "--license",
+            "MIT",
+            "--category",
+            "Productivity",
+            "--permission-rationale",
+            "queue.read=Reads mock transfer queue state.",
+            "--permission-rationale",
+            "queue.write=Exercises mock queue mutation controls.",
+            "--strict");
+    CliResult create =
+        runCli(
+            "catalog",
+            "create",
+            "--catalog-file",
+            catalog.toString(),
+            "--catalog-id",
+            "dev",
+            "--name",
+            "Development Apps",
+            "--generated-at",
+            "2026-05-14T00:00:00Z",
+            "--entry",
+            entry.toString());
+    CliResult sign =
+        runCli(
+            "catalog",
+            "sign",
+            "--catalog-file",
+            catalog.toString(),
+            "--key-id",
+            "dev-local",
+            "--private-key-file",
+            privateKey.toString());
+    CliResult verify =
+        runCli(
+            "catalog",
+            "verify",
+            "--catalog-file",
+            catalog.toString(),
+            "--trusted-keys-file",
+            trustedKeys.toString());
+    Path signature = catalog.resolveSibling("cryptad-app-catalog.signature");
+    CliResult publish =
+        runCli(
+            "publish-usk",
+            "--catalog-file",
+            catalog.toString(),
+            "--catalog-signature-file",
+            signature.toString(),
+            "--catalog-source",
+            "crypta:USK@private-insert-material/cryptad-app-catalog.properties",
+            "--output",
+            plan.toString(),
+            "--dry-run");
+    CliResult livePublish =
+        runCli(
+            "publish-usk",
+            "--catalog-file",
+            catalog.toString(),
+            "--catalog-signature-file",
+            signature.toString(),
+            "--catalog-source",
+            "crypta:USK@private-insert-material/cryptad-app-catalog.properties",
+            "--output",
+            tempDir.resolve("live-plan.md").toString());
+
+    String descriptor = Files.readString(entry, StandardCharsets.UTF_8);
+    String planText = Files.readString(plan, StandardCharsets.UTF_8);
+    assertEquals(CommandLine.ExitCode.OK, entryResult.exitCode());
+    assertTrue(descriptor.contains("bundle.uri=crypta:CHK@catalog-app-bundle\n"));
+    assertTrue(
+        descriptor.contains("permissions.rationale.queue.read=Reads mock transfer queue state.\n"));
+    assertEquals(CommandLine.ExitCode.OK, create.exitCode());
+    assertEquals(CommandLine.ExitCode.OK, sign.exitCode());
+    assertEquals(CommandLine.ExitCode.OK, verify.exitCode());
+    assertEquals(CommandLine.ExitCode.OK, publish.exitCode());
+    assertTrue(publish.out().contains("Wrote Crypta USK publication plan: dev entries=1"));
+    assertTrue(planText.contains("Crypta Catalog USK Publication Plan"));
+    assertTrue(planText.contains("crypta:USK@[REDACTED]/cryptad-app-catalog.properties"));
+    assertTrue(planText.contains("crypta:CHK@[REDACTED]"));
+    assertFalse(planText.contains("private-insert-material"));
+    assertFalse(planText.contains(tempDir.toString()));
+    assertEquals(CommandLine.ExitCode.SOFTWARE, livePublish.exitCode());
+    assertTrue(livePublish.err().contains("live_publish_not_supported"));
+  }
+
+  @Test
+  void catalogEntryRationales_whenNormalized_expectInsertionOrderPreserved() throws Exception {
+    var rationales =
+        CatalogEntryDescriptorGenerator.normalizeRationales(
+            java.util.List.of("queue.write=Mutates queue.", "queue.read=Reads queue."));
+
+    assertEquals("queue.write,queue.read", String.join(",", rationales.keySet()));
+  }
+
+  @Test
+  void catalogEntry_whenArtifactPackedBeforeSigning_expectUnsignedArtifactFailure() {
+    Path appDir = scaffold("queue-dashboard", "unsigned-catalog-app");
+    Path artifact = tempDir.resolve("unsigned-catalog-app.zip");
+    Path entry = tempDir.resolve("unsigned-catalog-entry.properties");
+    runCli("pack", "--bundle-dir", appDir.toString(), "--output", artifact.toString());
+
+    CliResult result =
+        runCli(
+            "catalog",
+            "entry",
+            "--bundle-dir",
+            appDir.toString(),
+            "--artifact",
+            artifact.toString(),
+            "--bundle-uri",
+            "crypta:CHK@unsigned-catalog-app-bundle",
+            "--output",
+            entry.toString(),
+            "--summary",
+            "Unsigned artifact check.");
+
+    assertEquals(CommandLine.ExitCode.SOFTWARE, result.exitCode());
+    assertTrue(result.err().contains("zip artifact must contain signed bundle sidecars"));
+    assertFalse(Files.exists(entry));
+  }
+
+  @Test
+  void catalogEntry_whenBundleManifestChangedAfterPacking_expectArtifactMismatchFailure()
+      throws Exception {
+    Path appDir = scaffold("queue-dashboard", "stale-catalog-app");
+    Path keysDir = tempDir.resolve("stale-catalog-keys");
+    Path privateKey = keysDir.resolve("dev-local-private.der");
+    Path publicKey = keysDir.resolve("dev-local-public.der");
+    Path artifact = tempDir.resolve("stale-catalog-app.zip");
+    Path entry = tempDir.resolve("stale-catalog-entry.properties");
+    runCli(
+        "keys",
+        "generate",
+        "--key-id",
+        "dev-local",
+        "--private-key-file",
+        privateKey.toString(),
+        "--public-key-file",
+        publicKey.toString());
+    runCli(
+        "sign",
+        "--bundle-dir",
+        appDir.toString(),
+        "--key-id",
+        "dev-local",
+        "--private-key-file",
+        privateKey.toString());
+    runCli("pack", "--bundle-dir", appDir.toString(), "--output", artifact.toString());
+    replaceManifestLine(
+        appDir, "app.permissions=queue.read,queue.write", "app.permissions=queue.read");
+
+    CliResult result =
+        runCli(
+            "catalog",
+            "entry",
+            "--bundle-dir",
+            appDir.toString(),
+            "--artifact",
+            artifact.toString(),
+            "--bundle-uri",
+            "crypta:CHK@stale-catalog-app-bundle",
+            "--output",
+            entry.toString(),
+            "--summary",
+            "Stale catalog metadata check.");
+
+    assertEquals(CommandLine.ExitCode.SOFTWARE, result.exitCode());
+    assertTrue(result.err().contains("bundle manifest must match artifact manifest"));
+    assertFalse(Files.exists(entry));
+  }
+
+  @Test
+  void help_whenRequested_expectDeveloperBetaToolkitCommandsExposed() {
+    CliResult root = runCli("--help");
+    CliResult catalog = runCli("catalog");
+
+    assertEquals(CommandLine.ExitCode.OK, root.exitCode());
+    assertTrue(root.out().contains("dev"));
+    assertTrue(root.out().contains("test"));
+    assertTrue(root.out().contains("keys"));
+    assertTrue(root.out().contains("publish-usk"));
+    assertEquals(CommandLine.ExitCode.OK, catalog.exitCode());
+    assertTrue(catalog.out().contains("entry"));
+  }
+
+  private void assertTemplate(
+      String template,
+      String appId,
+      String expectedPermissionsLine,
+      String expectedExperimentalLine,
+      String expectedScript)
+      throws Exception {
+    Path appDir = scaffold(template, appId);
+    CliResult test = runCli("test", "--bundle-dir", appDir.toString(), "--strict");
+    String manifest =
+        Files.readString(appDir.resolve("cryptad-app.properties"), StandardCharsets.UTF_8);
+    String index =
+        Files.readString(appDir.resolve("static").resolve("index.html"), StandardCharsets.UTF_8);
+    String script =
+        Files.readString(appDir.resolve("static").resolve("app.js"), StandardCharsets.UTF_8);
+
+    assertEquals(CommandLine.ExitCode.OK, test.exitCode(), test.err());
+    assertTrue(manifest.contains(expectedPermissionsLine));
+    assertTrue(manifest.contains(expectedExperimentalLine));
+    assertTrue(index.contains("data-crypta-permission-summary"));
+    assertTrue(script.contains(expectedScript));
+    if ("queue-dashboard".equals(template)) {
+      assertTrue(script.contains("form.set(\"priority\", \"2\");"));
+    }
+    if ("publisher".equals(template)) {
+      assertTrue(index.contains("name=\"sourcePath\""));
+      assertTrue(index.contains("name=\"insertUri\""));
+      assertTrue(index.contains("name=\"identifier\""));
+      assertTrue(script.contains("params.set(\"sourcePath\""));
+      assertTrue(script.contains("params.set(\"insertUri\""));
+      assertTrue(script.contains("params.set(\"identifier\""));
+      assertFalse(script.contains("params.set(\"content\""));
+      assertFalse(script.contains("params.set(\"target\""));
+    }
+    assertFalse(index.contains("https://"));
+    assertFalse(index.contains("http://"));
+    assertFalse(script.contains("https://"));
+    assertFalse(script.contains("http://"));
+    assertFalse(script.contains("vault.secrets"));
+    assertFalse(script.toLowerCase(java.util.Locale.ROOT).contains("seed phrase"));
+  }
+
+  private Path scaffold(String template, String appId) {
+    Path appDir = tempDir.resolve(appId);
+    CliResult result =
+        runCli(
+            "init",
+            "--dir",
+            appDir.toString(),
+            "--app-id",
+            appId,
+            "--name",
+            titleCase(appId),
+            "--version",
+            "0.1.0",
+            "--template",
+            template);
+    assertEquals(CommandLine.ExitCode.OK, result.exitCode(), result.err());
+    return appDir;
+  }
+
+  private static void verifyDevServerBootstrap(
+      HttpResponse<String> bootstrap, CryptaAppDevServer server, Path appDir, String sessionToken) {
+    assertEquals(200, bootstrap.statusCode());
+    assertTrue(bootstrap.body().contains("\"appId\":\"queue-app\""));
+    assertTrue(bootstrap.body().contains("\"platformApiRoot\":\"" + server.apiRoot()));
+    assertFalse(server.startupSummary().contains(sessionToken));
+    assertFalse(server.startupSummary().contains(appDir.toString()));
+  }
+
+  private static void verifyStaticUiAndMockQueueApi(
+      HttpClient client, CryptaAppDevServer server, String sessionToken) throws Exception {
+    HttpResponse<String> staticUi = get(client, server.uiUrl());
+    HttpResponse<String> tokenStylesheet =
+        get(client, server.uiUrl() + "crypta-ui/crypta-ui-tokens.css");
+    HttpResponse<String> api =
+        getWithSession(client, URI.create(server.apiRoot() + "queue"), sessionToken);
+    HttpResponse<String> missingPriority =
+        postFormWithSession(
+            client,
+            URI.create(server.apiRoot() + "queue/requests/priority"),
+            sessionToken,
+            "identifier=mock-download-1");
+    HttpResponse<String> priorityMutation =
+        postFormWithSession(
+            client,
+            URI.create(server.apiRoot() + "queue/requests/priority"),
+            sessionToken,
+            "identifier=mock-download-1&priority=2");
+    HttpResponse<String> missingInsertField =
+        postFormWithSession(
+            client,
+            URI.create(server.apiRoot() + "queue/inserts/file"),
+            sessionToken,
+            "sourcePath=sample.txt&identifier=sample-insert");
+    HttpResponse<String> fileInsert =
+        postFormWithSession(
+            client,
+            URI.create(server.apiRoot() + "queue/inserts/file"),
+            sessionToken,
+            "sourcePath=sample.txt&insertUri=CHK%40sample&identifier=sample-insert");
+
+    assertEquals(200, staticUi.statusCode());
+    assertTrue(staticUi.body().contains("<title>Queue App</title>"));
+    assertEquals(200, tokenStylesheet.statusCode());
+    assertTrue(
+        tokenStylesheet.headers().firstValue("Content-Type").orElse("").startsWith("text/css"));
+    assertEquals(200, api.statusCode());
+    assertTrue(api.body().contains("mock-download-1"));
+    assertEquals(400, missingPriority.statusCode());
+    assertTrue(missingPriority.body().contains("invalid_mock_form"));
+    assertEquals(200, priorityMutation.statusCode());
+    assertTrue(priorityMutation.body().contains("queue.requests.priority"));
+    assertEquals(400, missingInsertField.statusCode());
+    assertTrue(missingInsertField.body().contains("insertUri"));
+    assertEquals(200, fileInsert.statusCode());
+    assertTrue(fileInsert.body().contains("queue.inserts.file"));
+  }
+
+  private static void verifySessionAndStaticSafety(
+      HttpClient client, CryptaAppDevServer server, String appRoot, String sessionToken)
+      throws Exception {
+    HttpResponse<String> missingSession = get(client, server.apiRoot() + "queue");
+    HttpResponse<String> wrongSession =
+        getWithSession(client, URI.create(server.apiRoot() + "queue"), "wrong-session");
+    HttpResponse<String> unsafeManifest = get(client, appRoot + "%2e%2e/cryptad-app.properties");
+    HttpResponse<String> encodedSeparator = get(client, appRoot + "static%2Findex.html");
+    HttpResponse<String> appRootRedirect = get(client, appRoot);
+    HttpResponse<String> reservedManifest = get(client, appRoot + "cryptad-app.properties");
+    HttpResponse<String> reservedManifestCaseVariant =
+        get(client, appRoot + "CRYPTAD-APP.PROPERTIES");
+    HttpResponse<String> reservedCatalog = get(client, appRoot + "cryptad-app.catalog");
+    HttpResponse<String> reservedCatalogSignature =
+        get(client, appRoot + "cryptad-app.catalog.signature");
+
+    assertEquals(401, missingSession.statusCode());
+    assertTrue(missingSession.body().contains("invalid_app_browser_session"));
+    assertEquals(401, wrongSession.statusCode());
+    assertTrue(wrongSession.body().contains("invalid_app_browser_session"));
+    assertEquals(400, unsafeManifest.statusCode());
+    assertEquals(400, encodedSeparator.statusCode());
+    assertEquals(302, appRootRedirect.statusCode());
+    assertEquals(
+        URI.create(server.uiUrl()).getRawPath(),
+        appRootRedirect.headers().firstValue("Location").orElse(""));
+    assertEquals(400, reservedManifest.statusCode());
+    assertEquals(400, reservedManifestCaseVariant.statusCode());
+    assertEquals(400, reservedCatalog.statusCode());
+    assertEquals(400, reservedCatalogSignature.statusCode());
+    assertFalse(missingSession.body().contains(sessionToken));
+    assertFalse(wrongSession.body().contains("wrong-session"));
+  }
+
+  private static String titleCase(String appId) {
+    StringBuilder builder = new StringBuilder(appId.length());
+    boolean capitalize = true;
+    for (int index = 0; index < appId.length(); index++) {
+      char character = appId.charAt(index);
+      if (character == '-') {
+        builder.append(' ');
+        capitalize = true;
+      } else if (capitalize) {
+        builder.append(Character.toUpperCase(character));
+        capitalize = false;
+      } else {
+        builder.append(character);
+      }
+    }
+    return builder.toString();
+  }
+
+  private static HttpResponse<String> get(HttpClient client, String uri) throws Exception {
+    return get(client, URI.create(uri));
+  }
+
+  private static HttpResponse<String> get(HttpClient client, URI uri) throws Exception {
+    return client.send(
+        HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(5)).GET().build(),
+        HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static HttpResponse<String> getWithSession(HttpClient client, URI uri, String session)
+      throws Exception {
+    return client.send(
+        HttpRequest.newBuilder(uri)
+            .timeout(Duration.ofSeconds(5))
+            .header("X-Crypta-App-Session", session)
+            .GET()
+            .build(),
+        HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static HttpResponse<String> postFormWithSession(
+      HttpClient client, URI uri, String session, String body) throws Exception {
+    return client.send(
+        HttpRequest.newBuilder(uri)
+            .timeout(Duration.ofSeconds(5))
+            .header("X-Crypta-App-Session", session)
+            .header("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8")
+            .POST(HttpRequest.BodyPublishers.ofString(body))
+            .build(),
+        HttpResponse.BodyHandlers.ofString());
+  }
+
+  private static void replaceManifestLine(Path appDir, String currentLine, String replacementLine)
+      throws Exception {
+    Path manifest = appDir.resolve("cryptad-app.properties");
+    String text = Files.readString(manifest, StandardCharsets.UTF_8);
+    Files.writeString(manifest, text.replace(currentLine, replacementLine), StandardCharsets.UTF_8);
+  }
+
+  private static void assertPrivateKeyOwnerOnly(Path privateKey) throws Exception {
+    try {
+      assertEquals(
+          Set.of(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE),
+          Files.getPosixFilePermissions(privateKey));
+    } catch (UnsupportedOperationException _) {
+      assertTrue(privateKey.toFile().canRead());
+      assertTrue(privateKey.toFile().canWrite());
+    }
+  }
+
+  private static String sessionToken(String bootstrapJson) {
+    Matcher matcher = BOOTSTRAP_SESSION_PATTERN.matcher(bootstrapJson);
+    if (!matcher.find()) {
+      throw new AssertionError("bootstrap did not include a browser session token");
+    }
+    return matcher.group(1);
+  }
+
+  private static CliResult runCli(String... arguments) {
+    StringWriter out = new StringWriter();
+    StringWriter err = new StringWriter();
+    int exitCode =
+        CryptaAppCli.execute(new PrintWriter(out, true), new PrintWriter(err, true), arguments);
+    return new CliResult(exitCode, out.toString(), err.toString());
+  }
+
+  private record CliResult(int exitCode, String out, String err) {}
+}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/PublicationPlanWriterTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/PublicationPlanWriterTest.java
@@ -1,0 +1,129 @@
+package network.crypta.platform.devtools;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.platform.appcatalog.AppCatalogSignature;
+import network.crypta.platform.appdist.AppDistributionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class PublicationPlanWriterTest {
+  private static final String SHA256 = "0".repeat(64);
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void write_whenJsonOutputRequested_expectRedactedPlanAndResult() throws Exception {
+    Path catalogFile = writeCatalog();
+    Path signatureFile = writeSignature(AppCatalogSignature.SIGNATURE_FILE_NAME);
+    Path output = tempDir.resolve("plan.json");
+
+    PublicationPlanWriter.Result result =
+        PublicationPlanWriter.write(
+            new PublicationPlanWriter.Request(
+                catalogFile,
+                signatureFile,
+                "crypta:USK@private-insert-material/catalog/"
+                    + AppCatalogSignature.CATALOG_FILE_NAME,
+                output));
+
+    String json = Files.readString(output, StandardCharsets.UTF_8);
+    assertEquals("dev", result.catalogId());
+    assertEquals(1, result.entryCount());
+    assertEquals(output.toAbsolutePath().normalize(), result.output());
+    assertTrue(json.contains("\"schemaVersion\": 1"));
+    assertTrue(json.contains("\"catalogSource\": \"crypta:USK@[REDACTED]/catalog/"));
+    assertTrue(json.contains("\"bundleUri\":\"crypta:CHK@[REDACTED]\""));
+    assertTrue(json.contains(AppCatalogSignature.CATALOG_FILE_NAME));
+    assertTrue(json.contains(AppCatalogSignature.SIGNATURE_FILE_NAME));
+    assertFalse(json.contains("private-insert-material"));
+    assertFalse(json.contains("private-bundle-key"));
+    assertFalse(json.contains(tempDir.toString()));
+  }
+
+  @Test
+  void write_whenCatalogSourceIsNotUskCatalogProperties_expectFailure() throws Exception {
+    Path catalogFile = writeCatalog();
+    Path signatureFile = writeSignature(AppCatalogSignature.SIGNATURE_FILE_NAME);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                PublicationPlanWriter.write(
+                    new PublicationPlanWriter.Request(
+                        catalogFile,
+                        signatureFile,
+                        "crypta:CHK@catalog/" + AppCatalogSignature.CATALOG_FILE_NAME,
+                        tempDir.resolve("plan.md"))));
+
+    assertTrue(exception.getMessage().contains("publish-usk requires --catalog-source"));
+  }
+
+  @Test
+  void write_whenSignatureSidecarNameIsNotCanonical_expectFailure() throws Exception {
+    Path catalogFile = writeCatalog();
+    Path signatureFile = writeSignature("catalog.sig");
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                PublicationPlanWriter.write(
+                    new PublicationPlanWriter.Request(
+                        catalogFile,
+                        signatureFile,
+                        "crypta:USK@private/catalog/" + AppCatalogSignature.CATALOG_FILE_NAME,
+                        tempDir.resolve("plan.md"))));
+
+    assertEquals(
+        "catalog signature sidecar must be cryptad-app-catalog.signature", exception.getMessage());
+  }
+
+  private Path writeCatalog() throws Exception {
+    Path catalogFile = tempDir.resolve(AppCatalogSignature.CATALOG_FILE_NAME);
+    Files.writeString(
+        catalogFile,
+        """
+        catalog.version=1
+        catalog.id=dev
+        catalog.name=Development Apps
+        catalog.generatedAt=2026-05-14T00:00:00Z
+        catalog.entries=queue-app
+        app.queue-app.id=queue-app
+        app.queue-app.name=Queue App
+        app.queue-app.version=0.1.0
+        app.queue-app.summary=Queue dashboard.
+        app.queue-app.bundle.uri=crypta:CHK@private-bundle-key
+        app.queue-app.bundle.sha256=%s
+        app.queue-app.bundle.size.bytes=0
+        app.queue-app.bundle.type=zip
+        app.queue-app.permissions=queue.read
+        """
+            .formatted(SHA256),
+        StandardCharsets.UTF_8);
+    return catalogFile;
+  }
+
+  private Path writeSignature(String fileName) throws Exception {
+    Path signatureFile = tempDir.resolve(fileName);
+    Files.writeString(
+        signatureFile,
+        """
+        catalog.signature.version=1
+        catalog.signature.algorithm=Ed25519
+        catalog.signature.key.id=dev-local
+        catalog.signature.payload=cryptad-app-catalog.properties
+        catalog.signature.value.base64=AQID
+        """,
+        StandardCharsets.UTF_8);
+    return signatureFile;
+  }
+}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/devserver/CryptaAppDevServerSessionTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/devserver/CryptaAppDevServerSessionTest.java
@@ -1,0 +1,169 @@
+package network.crypta.platform.devtools.devserver;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class CryptaAppDevServerSessionTest {
+  private static final Pattern BOOTSTRAP_SESSION_PATTERN =
+      Pattern.compile("\"browserSessionToken\"\\s*:\\s*\"([^\"]+)\"");
+  private static final Instant START = Instant.parse("2026-05-14T00:00:00Z");
+  private static final String EXPIRING_APP_ID = "expiring-app";
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void devServer_whenSessionExpires_expectApiRejectsOldTokenAndBootstrapRefreshes()
+      throws IOException, InterruptedException {
+    Path appDir = scaffoldExpiringApp();
+    MutableClock clock = new MutableClock(START);
+
+    try (CryptaAppDevServer server =
+            CryptaAppDevServer.start(
+                new DevServerConfig(appDir, "127.0.0.1", 0, null, false, Duration.ofMinutes(10)),
+                clock,
+                new SecureRandom());
+        HttpClient client =
+            HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .version(HttpClient.Version.HTTP_1_1)
+                .build()) {
+      URI bootstrapUri =
+          URI.create(server.apiRoot().replace("/api/v1/", "/.well-known/cryptad-bootstrap.json"));
+      URI queueUri = URI.create(server.apiRoot() + "queue");
+      String firstToken = sessionToken(get(client, bootstrapUri).body());
+
+      assertEquals(200, getWithSession(client, queueUri, firstToken).statusCode());
+
+      clock.advance(Duration.ofMinutes(10).plusSeconds(1));
+      HttpResponse<String> expired = getWithSession(client, queueUri, firstToken);
+      String refreshedToken = sessionToken(get(client, bootstrapUri).body());
+
+      assertEquals(401, expired.statusCode());
+      assertTrue(expired.body().contains("invalid_app_browser_session"));
+      assertNotEquals(firstToken, refreshedToken);
+      assertEquals(200, getWithSession(client, queueUri, refreshedToken).statusCode());
+    }
+  }
+
+  private Path scaffoldExpiringApp() {
+    Path appDir = tempDir.resolve(EXPIRING_APP_ID);
+    try {
+      Files.createDirectories(appDir.resolve("bin"));
+      Files.createDirectories(appDir.resolve("static"));
+      Files.writeString(
+          appDir.resolve("cryptad-app.properties"),
+          """
+          manifest.version=1
+          app.id=%s
+          app.name=Expiring App
+          app.version=0.1.0
+          api.minimumVersion=1
+          api.maximumTestedVersion=1
+          api.experimentalCapabilitiesAccepted=false
+          app.exec=bin/start.sh
+          app.ui.mode=static
+          app.ui.entry=static/index.html
+          sandbox.mode=none
+          sandbox.required=false
+          quota.data.bytes=0
+          quota.cache.bytes=0
+          app.restart.policy=never
+          app.restart.maxAttempts=0
+          app.restart.backoff.ms=0
+          """
+              .formatted(EXPIRING_APP_ID),
+          StandardCharsets.UTF_8);
+      Files.writeString(appDir.resolve("bin").resolve("start.sh"), "#!/bin/sh\nexit 0\n");
+      Files.writeString(
+          appDir.resolve("static").resolve("index.html"),
+          "<!doctype html><title>Expiring App</title>",
+          StandardCharsets.UTF_8);
+      return appDir;
+    } catch (IOException exception) {
+      throw new AssertionError("failed to create test app " + EXPIRING_APP_ID, exception);
+    }
+  }
+
+  private static HttpResponse<String> get(HttpClient client, URI uri)
+      throws IOException, InterruptedException {
+    return client.send(
+        HttpRequest.newBuilder(uri).timeout(Duration.ofSeconds(5)).GET().build(),
+        HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+  }
+
+  private static HttpResponse<String> getWithSession(HttpClient client, URI uri, String session)
+      throws IOException, InterruptedException {
+    return client.send(
+        HttpRequest.newBuilder(uri)
+            .timeout(Duration.ofSeconds(5))
+            .header("X-Crypta-App-Session", session)
+            .GET()
+            .build(),
+        HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+  }
+
+  private static String sessionToken(String bootstrapJson) {
+    Matcher matcher = BOOTSTRAP_SESSION_PATTERN.matcher(bootstrapJson);
+    if (!matcher.find()) {
+      throw new AssertionError("bootstrap did not include a browser session token");
+    }
+    return matcher.group(1);
+  }
+
+  private static final class MutableClock extends Clock {
+    private Instant current;
+
+    private MutableClock(Instant current) {
+      this.current = current;
+    }
+
+    private void advance(Duration duration) {
+      current = current.plus(duration);
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneId.of("UTC");
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return current;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return this == other;
+    }
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(this);
+    }
+  }
+}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/devserver/LoopbackHostPolicyTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/devserver/LoopbackHostPolicyTest.java
@@ -1,0 +1,38 @@
+package network.crypta.platform.devtools.devserver;
+
+import network.crypta.platform.appdist.AppDistributionException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class LoopbackHostPolicyTest {
+  @Test
+  void requireAllowedHost_whenHostIsLoopback_expectNoWarning() throws Exception {
+    assertEquals("", LoopbackHostPolicy.requireAllowedHost("127.0.0.1", false));
+    assertEquals("", LoopbackHostPolicy.requireAllowedHost(" localhost ", false));
+    assertTrue(LoopbackHostPolicy.isLoopback("::1"));
+  }
+
+  @Test
+  void requireAllowedHost_whenHostIsNonLoopbackWithoutOverride_expectFailure() {
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () -> LoopbackHostPolicy.requireAllowedHost("0.0.0.0", false));
+
+    assertTrue(exception.getMessage().contains("refusing non-loopback dev server host"));
+  }
+
+  @Test
+  void requireAllowedHost_whenHostIsNonLoopbackAllowed_expectWarning() throws Exception {
+    String warning = LoopbackHostPolicy.requireAllowedHost("0.0.0.0", true);
+
+    assertTrue(warning.contains("non-loopback host"));
+    assertFalse(LoopbackHostPolicy.isLoopback(""));
+    assertFalse(LoopbackHostPolicy.isLoopback("not a host name"));
+  }
+}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/devserver/MockPlatformApiFixturesTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/devserver/MockPlatformApiFixturesTest.java
@@ -1,0 +1,66 @@
+package network.crypta.platform.devtools.devserver;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import network.crypta.platform.appdist.AppDistributionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class MockPlatformApiFixturesTest {
+  @TempDir private Path tempDir;
+
+  @Test
+  void appsCurrent_whenFixtureMissing_expectDefaultWithEscapedAppPlaceholders() throws Exception {
+    Files.createDirectories(tempDir);
+    MockPlatformApiFixtures fixtures =
+        new MockPlatformApiFixtures(tempDir, "sample-app", "Name \"One\"", "0.1\\beta");
+
+    String json = fixtures.appsCurrent();
+
+    assertTrue(json.contains("\"appId\":\"sample-app\""));
+    assertTrue(json.contains("\"name\":\"Name \\\"One\\\"\""));
+    assertTrue(json.contains("\"version\":\"0.1\\\\beta\""));
+  }
+
+  @Test
+  void node_whenFixtureContainsAbsoluteUnixPath_expectRejected() throws Exception {
+    Files.writeString(
+        tempDir.resolve("node.json"),
+        "{\"path\":\"/Users/alice/private/node.json\"}",
+        StandardCharsets.UTF_8);
+    MockPlatformApiFixtures fixtures =
+        new MockPlatformApiFixtures(tempDir, "sample-app", "Sample App", "0.1.0");
+
+    AppDistributionException exception =
+        assertThrows(AppDistributionException.class, fixtures::node);
+
+    assertTrue(exception.getMessage().contains("fixture output contains an absolute local path"));
+  }
+
+  @Test
+  void queue_whenFixtureDirectoryIsSymlink_expectRejected() throws Exception {
+    Path realFixtureDir = tempDir.resolve("fixtures");
+    Path linkedFixtureDir = tempDir.resolve("linked-fixtures");
+    Files.createDirectories(realFixtureDir);
+    try {
+      Files.createSymbolicLink(linkedFixtureDir, realFixtureDir);
+    } catch (UnsupportedOperationException | SecurityException exception) {
+      org.junit.jupiter.api.Assumptions.assumeTrue(
+          false, "symlink creation unavailable: " + exception.getMessage());
+    }
+    MockPlatformApiFixtures fixtures =
+        new MockPlatformApiFixtures(linkedFixtureDir, "sample-app", "Sample App", "0.1.0");
+
+    AppDistributionException exception =
+        assertThrows(AppDistributionException.class, fixtures::queue);
+
+    assertTrue(exception.getMessage().contains("fixture directory must be a real directory"));
+    assertFalse(Files.exists(realFixtureDir.resolve("queue.json")));
+  }
+}

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -78,6 +78,7 @@ interop.smoke
 performance.smoke
 app-platform.first-party
 app-platform.devtools-cli
+app-platform.developer-beta-toolkit
 app-platform.signed-bundles
 catalog.smoke
 app-catalog.first-party-beta
@@ -99,10 +100,11 @@ app-review.policy
 app-review.first-party-catalog
 ```
 
-`platform-api.contract`, `app-vault.capabilities`, `app-ui.design-system`, `app-ui.lint`,
-`app-ui.first-party-adoption`, `reference-apps.content`, `apphost.sandbox-provider`,
-`app-update.lifecycle`, `app-update.scheduler`, `app-update.rollback`,
-`app-catalog.first-party-beta`, `app-review.trusted-receipts`, and
+`platform-api.contract`, `app-vault.capabilities`, `app-platform.developer-beta-toolkit`,
+`app-ui.design-system`, `app-ui.lint`, `app-ui.first-party-adoption`,
+`reference-apps.content`, `apphost.sandbox-provider`, `app-update.lifecycle`,
+`app-update.scheduler`, `app-update.rollback`, `app-catalog.first-party-beta`,
+`app-review.trusted-receipts`, and
 `app-review.policy` use deterministic source checks, fixtures, and fake/offline tests; they do not
 require a live node or host-installed bubblewrap in normal CI. `app-catalog.first-party-beta`
 reports source/key configuration readiness but does not fetch the public Crypta catalog.

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -50,6 +50,7 @@ LEGACY_REMOVAL_WAVE_ONE_IDS = (
 )
 APP_UI_DESIGN_SYSTEM_DOC = Path("docs/app-ui-design-system.md")
 APP_VAULT_DOC = Path("docs/app-secret-and-identity-vault.md")
+DEVELOPER_BETA_TOOLKIT_DOC = Path("docs/developer-beta-toolkit.md")
 APP_VAULT_CAPABILITIES = (
     "vault.secrets.read",
     "vault.secrets.write",
@@ -1026,6 +1027,102 @@ def collect_cli_evidence(settings: Settings, cli: Path | None) -> tuple[Evidence
             details,
         ),
         sample_paths,
+    )
+
+
+def collect_developer_beta_toolkit_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    devtools_dir = workspace / "platform-devtools/src/main/java/network/crypta/platform/devtools"
+    devserver_dir = devtools_dir / "devserver"
+    test_dir = workspace / "platform-devtools/src/test/java/network/crypta/platform/devtools"
+    docs_path = workspace / DEVELOPER_BETA_TOOLKIT_DOC
+    sources = {
+        "cli": devtools_dir / "CryptaAppCli.java",
+        "templateKind": devtools_dir / "AppTemplateKind.java",
+        "scaffolder": devtools_dir / "AppTemplateScaffolder.java",
+        "testSuite": devtools_dir / "AppTestSuite.java",
+        "devServer": devserver_dir / "CryptaAppDevServer.java",
+        "devServerConfig": devserver_dir / "DevServerConfig.java",
+        "mockApi": devserver_dir / "MockPlatformApi.java",
+        "catalogEntry": devtools_dir / "CatalogEntryDescriptorGenerator.java",
+        "publishPlan": devtools_dir / "PublicationPlanWriter.java",
+        "keyGenerator": devtools_dir / "DeveloperKeyGenerator.java",
+        "toolkitTests": test_dir / "DeveloperBetaToolkitCliTest.java",
+        "docs": docs_path,
+    }
+    text = {name: read_source(path) for name, path in sources.items()}
+    required_templates = {
+        "static-basic": "STATIC_BASIC",
+        "queue-dashboard": "QUEUE_DASHBOARD",
+        "publisher": "PUBLISHER",
+        "vault-profile": "VAULT_PROFILE",
+    }
+    command_checks = {
+        "devCommand": '@Command(name = "dev"' in text["cli"],
+        "testCommand": '@Command(name = "test"' in text["cli"],
+        "keysGenerateCommand": '@Command(name = "generate"' in text["cli"] and "KeysGenerateCommand" in text["cli"],
+        "catalogEntryCommand": '@Command(name = "entry"' in text["cli"] and "CatalogEntryCommand" in text["cli"],
+        "publishUskCommand": '@Command(name = "publish-usk"' in text["cli"],
+    }
+    template_checks = {
+        template: template in text["templateKind"] and enum_name in text["scaffolder"]
+        for template, enum_name in required_templates.items()
+    }
+    flow_checks = {
+        "devServerLoopbackDefault": "127.0.0.1" in text["devServerConfig"] and "allowNonLoopback" in text["devServer"],
+        "mockSessionRequired": "invalid_app_browser_session" in text["mockApi"] and "X-Crypta-App-Session" in text["mockApi"],
+        "offlineTestSmoke": "dev.bootstrap-smoke" in text["testSuite"] and "AppTestReport" in text["testSuite"],
+        "catalogDescriptorGenerator": "artifact.path" in text["catalogEntry"] and "permissions.rationale." in text["catalogEntry"],
+        "publishPlanDryRunOnly": "live_publish_not_supported" in text["cli"] and "Crypta Catalog USK Publication Plan" in text["publishPlan"],
+        "keyGeneration": "Ed25519" in text["keyGenerator"] and "trusted.keys.version=1" in text["keyGenerator"],
+        "selfTestsCoverFlow": (
+            "test_whenFreshStaticTemplateCheckedStrict_expectPassingHumanAndJsonReport" in text["toolkitTests"]
+            and "catalogEntryAndPublishUsk_whenSignedArtifactsPrepared_expectOfflinePlan" in text["toolkitTests"]
+            and "devServer_whenStaticAppServed_expectBootstrapStaticAndSessionProtectedApi" in text["toolkitTests"]
+        ),
+        "guideExists": docs_path.is_file(),
+        "guideCoversFlow": (
+            "crypta-app init" in text["docs"]
+            and "--template queue-dashboard" in text["docs"]
+            and "crypta-app dev --bundle-dir" in text["docs"]
+            and "crypta-app test --bundle-dir" in text["docs"]
+            and "crypta-app keys generate" in text["docs"]
+            and "crypta-app catalog entry" in text["docs"]
+            and "crypta-app publish-usk" in text["docs"]
+        ),
+    }
+    checks = {**command_checks, "templates": template_checks, **flow_checks}
+    missing_files = [
+        name
+        for name, path in sources.items()
+        if not path.is_file()
+    ]
+    failed_checks = [
+        name
+        for name, value in checks.items()
+        if value is False or (isinstance(value, dict) and not all(value.values()))
+    ]
+    details = {
+        "sources": {name: display_path(path, workspace) for name, path in sources.items()},
+        "checks": checks,
+    }
+    if missing_files or failed_checks:
+        return EvidenceItem(
+            "app-platform.developer-beta-toolkit",
+            root_consequence(settings, "fail"),
+            True,
+            "Developer beta toolkit evidence found missing commands, docs, or self-test coverage.",
+            source,
+            {"missingFiles": missing_files, "failedChecks": failed_checks, **details},
+        )
+    return EvidenceItem(
+        "app-platform.developer-beta-toolkit",
+        "pass",
+        True,
+        "Developer beta toolkit command, mock-dev, test, catalog, and publication-plan evidence passed.",
+        source,
+        details,
     )
 
 
@@ -3383,6 +3480,7 @@ def run(settings: Settings) -> tuple[dict[str, Any], int]:
     evidence = [
         collect_first_party_evidence(settings, cli if isinstance(cli, Path) else None),
         cli_item,
+        collect_developer_beta_toolkit_evidence(settings),
         collect_platform_api_contract_evidence(settings, cli if isinstance(cli, Path) else None, sample_paths),
         collect_app_vault_evidence(settings),
         collect_signed_bundle_evidence(settings, sample_paths),
@@ -3832,6 +3930,10 @@ def run_self_test(repo_root: Path) -> None:
         evidence_by_id = {item["id"]: item for item in summary["evidence"]}
         assert evidence_by_id["app-platform.first-party"]["status"] == "pass"
         assert evidence_by_id["app-platform.devtools-cli"]["status"] == "pass"
+        toolkit_item = evidence_by_id["app-platform.developer-beta-toolkit"]
+        assert toolkit_item["status"] == "pass", toolkit_item
+        assert toolkit_item["details"]["checks"]["devCommand"] is True, toolkit_item
+        assert toolkit_item["details"]["checks"]["templates"]["queue-dashboard"] is True, toolkit_item
         assert evidence_by_id["legacy-admin.removal-wave-1"]["status"] == "pass"
         assert evidence_by_id["legacy-admin.removal-wave-1"]["requiredForReleaseCandidate"] is True
         contract_item = evidence_by_id["platform-api.contract"]
@@ -4502,6 +4604,69 @@ def make_self_test_workspace(workspace: Path) -> None:
     devtools_dir.mkdir(parents=True, exist_ok=True)
     (devtools_dir / "DevtoolsCapabilityVocabulary.java").write_text(
         "\n".join(APP_VAULT_CAPABILITIES) + "\n",
+        encoding="utf-8",
+    )
+    (devtools_dir / "CryptaAppCli.java").write_text(
+        '@Command(name = "dev") class DevCommand {}\n'
+        '@Command(name = "test") class AppTestCommand {}\n'
+        '@Command(name = "generate") class KeysGenerateCommand {}\n'
+        '@Command(name = "entry") class CatalogEntryCommand {}\n'
+        '@Command(name = "publish-usk") class PublishUskCommand { String e = "live_publish_not_supported"; }\n',
+        encoding="utf-8",
+    )
+    (devtools_dir / "AppTemplateKind.java").write_text(
+        "static-basic queue-dashboard publisher vault-profile\n",
+        encoding="utf-8",
+    )
+    (devtools_dir / "AppTemplateScaffolder.java").write_text(
+        "STATIC_BASIC QUEUE_DASHBOARD PUBLISHER VAULT_PROFILE\n",
+        encoding="utf-8",
+    )
+    (devtools_dir / "AppTestSuite.java").write_text(
+        "class AppTestSuite { String s = \"dev.bootstrap-smoke AppTestReport\"; }\n",
+        encoding="utf-8",
+    )
+    (devtools_dir / "DeveloperKeyGenerator.java").write_text(
+        "class DeveloperKeyGenerator { String s = \"Ed25519 trusted.keys.version=1\"; }\n",
+        encoding="utf-8",
+    )
+    (devtools_dir / "CatalogEntryDescriptorGenerator.java").write_text(
+        "class CatalogEntryDescriptorGenerator { String s = \"artifact.path permissions.rationale.\"; }\n",
+        encoding="utf-8",
+    )
+    (devtools_dir / "PublicationPlanWriter.java").write_text(
+        "class PublicationPlanWriter { String s = \"Crypta Catalog USK Publication Plan\"; }\n",
+        encoding="utf-8",
+    )
+    devserver_dir = devtools_dir / "devserver"
+    devserver_dir.mkdir(parents=True, exist_ok=True)
+    (devserver_dir / "CryptaAppDevServer.java").write_text(
+        "class CryptaAppDevServer { boolean allowNonLoopback; }\n",
+        encoding="utf-8",
+    )
+    (devserver_dir / "DevServerConfig.java").write_text(
+        "class DevServerConfig { String host = \"127.0.0.1\"; }\n",
+        encoding="utf-8",
+    )
+    (devserver_dir / "MockPlatformApi.java").write_text(
+        "class MockPlatformApi { String s = \"invalid_app_browser_session X-Crypta-App-Session\"; }\n",
+        encoding="utf-8",
+    )
+    toolkit_test_dir = workspace / "platform-devtools/src/test/java/network/crypta/platform/devtools"
+    toolkit_test_dir.mkdir(parents=True, exist_ok=True)
+    (toolkit_test_dir / "DeveloperBetaToolkitCliTest.java").write_text(
+        "void test_whenFreshStaticTemplateCheckedStrict_expectPassingHumanAndJsonReport() {}\n"
+        "void catalogEntryAndPublishUsk_whenSignedArtifactsPrepared_expectOfflinePlan() {}\n"
+        "void devServer_whenStaticAppServed_expectBootstrapStaticAndSessionProtectedApi() {}\n",
+        encoding="utf-8",
+    )
+    (docs / DEVELOPER_BETA_TOOLKIT_DOC.name).write_text(
+        "crypta-app init --template queue-dashboard\n"
+        "crypta-app dev --bundle-dir .\n"
+        "crypta-app test --bundle-dir . --strict\n"
+        "crypta-app keys generate\n"
+        "crypta-app catalog entry\n"
+        "crypta-app publish-usk --dry-run\n",
         encoding="utf-8",
     )
     (workspace / APP_UI_DESIGN_SYSTEM_DOC).write_text(

--- a/tools/release-certification/fixtures/self-test-app-platform-smoke.json
+++ b/tools/release-certification/fixtures/self-test-app-platform-smoke.json
@@ -26,6 +26,34 @@
     },
     {
       "details": {
+        "checks": {
+          "catalogEntryCommand": true,
+          "devCommand": true,
+          "guideCoversFlow": true,
+          "guideExists": true,
+          "keyGeneration": true,
+          "mockSessionRequired": true,
+          "offlineTestSmoke": true,
+          "publishPlanDryRunOnly": true,
+          "publishUskCommand": true,
+          "selfTestsCoverFlow": true,
+          "templates": {
+            "publisher": true,
+            "queue-dashboard": true,
+            "static-basic": true,
+            "vault-profile": true
+          },
+          "testCommand": true
+        }
+      },
+      "id": "app-platform.developer-beta-toolkit",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Developer beta toolkit command, mock-dev, test, catalog, and publication-plan evidence passed."
+    },
+    {
+      "details": {
         "apiVersion": "v1",
         "capabilityCount": 23,
         "contractVersion": 2,

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -834,6 +834,7 @@ def app_platform_evidence(
     expected_ids = [
         "app-platform.first-party",
         "app-platform.devtools-cli",
+        "app-platform.developer-beta-toolkit",
         "platform-api.contract",
         "app-vault.capabilities",
         "app-platform.signed-bundles",
@@ -2230,6 +2231,7 @@ def render_report(summary: dict[str, Any]) -> str:
     for evidence_id in (
         "app-platform.first-party",
         "app-platform.devtools-cli",
+        "app-platform.developer-beta-toolkit",
         "platform-api.contract",
         "app-vault.capabilities",
         "app-platform.signed-bundles",


### PR DESCRIPTION
## Summary
- Add `crypta-app init --template` beta templates, plus `dev`, `test`, `keys generate`, `catalog entry`, and `publish-usk` developer workflow commands.
- Add a loopback-only static app dev server with mock Platform API/bootstrap/session handling, fixture support, static-asset safety checks, and deterministic offline app test reporting.
- Add signed-artifact catalog descriptor generation, developer signing-key generation, USK publication checklist output, appcatalog signed-artifact inspection coverage, and release-certification evidence.
- Add `docs/developer-beta-toolkit.md` and update related CLI, SDK, catalog, design-system, permissions, API contract, beta catalog, and release-certification docs.

## Testing
- `./gradlew spotlessApply`
- `./gradlew :platform-devtools:test :platform-sdk-js:test :platform-appcatalog:test :platform-appdist:test`
- `python3 tools/release-certification/release_certification.py --self-test`
- `git diff --check HEAD --`
- `./gradlew sonarlintFile -Psonarlint.file=platform-devtools/src/main/java/network/crypta/platform/devtools/CatalogEntryDescriptorGenerator.java`

## Notes
- `crypta-app publish-usk --dry-run` produces an offline plan/checklist only. Live catalog insertion remains intentionally unsupported in devtools for this PR.