### PR TITLE
feat(app-review): add governance transparency log

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ Cryptad now uses a partial multi-project Gradle build.
   verify staged AppHost bundles, including optional manifest API compatibility metadata.
 - `:platform-appcatalog` owns signed app catalog parsing, catalog writing, signature verification,
   remote/local/Crypta catalog fetching, app-store metadata parsing, artifact digest checks, safe
-  ZIP extraction, and verified staging for AppHost install/update flows.
+  ZIP extraction, reviewer-key lifecycle governance, local review transparency logging, and
+  verified staging for AppHost install/update flows.
 - `:platform-devtools` owns the standalone `crypta-app` developer CLI for scaffolding, validating,
   UI linting, signing, packaging, verifying, catalog-authoring, API contract snapshotting, and
   compatibility verification for standalone staged bundles.
@@ -375,10 +376,14 @@ Signed app catalogs add a verified source layer above signed bundles. See
 [`docs/app-catalogs.md`](docs/app-catalogs.md) for the `cryptad-app-catalog.properties` format,
 catalog signatures, trusted-key configuration, optional app-store/API compatibility metadata,
 independent app review receipts, reviewer-key configuration, review policy modes, and
-`/api/v1/app-catalogs` install/update flow. Catalog signatures authenticate catalog bytes and
-publisher metadata, artifact digests bind entries to ZIP bytes, bundle signatures authenticate app
-bundles, and review receipt signatures independently authenticate reviewer evidence. Legacy
-catalog `review.status` and `review.note` metadata remains publisher-advisory only.
+`/api/v1/app-catalogs` install/update flow. See
+[`docs/app-review-governance.md`](docs/app-review-governance.md) for reviewer-key v2 lifecycle
+metadata, policy-version constraints, the local tamper-evident review transparency log, governance
+API routes, Web Shell review-history surfaces, and `crypta-app review` inspection commands. Catalog
+signatures authenticate catalog bytes and publisher metadata, artifact digests bind entries to ZIP
+bytes, bundle signatures authenticate app bundles, and review receipt signatures independently
+authenticate reviewer evidence. Legacy catalog `review.status` and `review.note` metadata remains
+publisher-advisory only.
 
 Installed apps can also declare browser UI ownership with `app.ui.mode` and `app.ui.entry`.
 Static UI bundles prefer isolated loopback origins per app; `/apps/{appId}/` remains a

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -71,10 +71,18 @@ Independent app review receipts use a separate trusted reviewer-key registry. A 
 signature binds the reviewer key id, app id, app version, artifact digest, artifact size, review
 policy id/version, reviewer status, timestamps, and optional evidence metadata to canonical receipt
 payload bytes. Do not reuse app or catalog signing trust implicitly for review receipts, and do not
-commit reviewer private keys. Platform API and Web Shell review-trust responses may expose reviewer
-key ids, display names, policy ids, timestamps, evidence digests, and evidence URIs, but must not
-expose reviewer public key bytes, reviewer private key material, local receipt or evidence paths,
-catalog scratch paths, staging paths, browser session tokens, or AppHost process tokens.
+commit reviewer private keys. Reviewer-key registry v1 remains supported, but governed deployments
+should prefer v2 entries with active, retired, or revoked lifecycle state, strict validity windows,
+rotation metadata, and policy-version constraints. Revoked keys fail closed for all receipts;
+retired keys can verify only historical receipts inside their configured windows.
+
+The app-review transparency log is local and tamper-evident. It is not a global public log and does
+not create trust by itself. Platform API, Web Shell, CLI, and release-certification review surfaces
+may expose reviewer key ids, display names, lifecycle status, policy ids/versions, timestamps,
+evidence digests, evidence URIs, record counts, and latest hashes, but must not expose reviewer
+public key bytes, reviewer private key material, raw receipt signatures, local receipt or evidence
+paths, transparency-log paths, catalog scratch paths, staging paths, browser session tokens,
+request bodies, form passwords, or AppHost process tokens.
 
 Catalog fetches support local files, `https:`, and loopback-only `http:` sources. Catalog ZIP
 extraction drops macOS `__MACOSX/**` and AppleDouble `._*` metadata entries before verification;

--- a/docs/app-catalogs.md
+++ b/docs/app-catalogs.md
@@ -319,6 +319,30 @@ reviewer.1.display.name=Crypta First-Party Review
 reviewer.1.policy.id=crypta-app-review-v1
 ```
 
+Version 2 reviewer registries are preferred for governed catalogs. They remain node-local trust
+roots and add policy-version constraints plus lifecycle metadata:
+
+```properties
+trusted.reviewers.version=2
+reviewer.1.id=crypta-first-party-review-2026q2
+reviewer.1.algorithm=Ed25519
+reviewer.1.public.key.base64=<X.509 Ed25519 public key bytes>
+reviewer.1.display.name=Crypta First-Party Review Q2 2026
+reviewer.1.policy.id=crypta-app-review
+reviewer.1.policy.version=1
+reviewer.1.status=active
+reviewer.1.valid.from=2026-04-01T00:00:00Z
+reviewer.1.valid.until=2026-07-01T00:00:00Z
+reviewer.1.rotates.from=crypta-first-party-review-2026q1
+reviewer.1.rotates.to=crypta-first-party-review-2026q3
+```
+
+Reviewer key status is local governance state. `active` keys can trust receipts inside their
+validity window. `retired` keys can trust only historical receipts inside their window and render as
+historical trust. `revoked` keys fail closed for all receipts and are reported as revoked reviewer
+evidence rather than being hidden as unknown reviewers. A configured `policy.version` must match
+the receipt policy version; mismatches are reported as `review_policy_mismatch`.
+
 Unknown algorithms, duplicate key ids, malformed public keys, and incomplete entries fail closed.
 Platform API and Web Shell responses expose reviewer key ids, display names, policy ids, timestamps,
 evidence metadata, and warnings; they do not expose reviewer public key bytes, private key material,
@@ -335,8 +359,16 @@ Review policy is local operator policy, not catalog metadata. Configure it with
 | `require_trusted_review_for_apply_when_stopped` | Require a trusted positive receipt for policy-driven apply-when-stopped updates; manual install/update can still proceed after acknowledgement. |
 
 Stable review-trust statuses include `trusted_reviewed`, `trusted_caution`, `trusted_rejected`,
-`missing_receipt`, `unknown_reviewer`, `invalid_signature`, `artifact_mismatch`, `app_mismatch`,
-`expired`, `publisher_claim_only`, and `not_configured`.
+`missing_receipt`, `unknown_reviewer`, `retired_reviewer`, `revoked_reviewer`,
+`reviewer_not_yet_valid`, `reviewer_expired`, `review_policy_mismatch`, `invalid_signature`,
+`artifact_mismatch`, `app_mismatch`, `expired`, `publisher_claim_only`, and `not_configured`.
+
+Cryptad also keeps a local review transparency log for review governance events. The log is
+host-owned and tamper-evident through a local hash chain. It is not a global public transparency
+log and does not make catalogs or apps trusted by itself. Web Shell review status is a local trust
+decision and can change when reviewer keys, lifecycle metadata, policy constraints, or policy mode
+change. See [app-review-governance.md](app-review-governance.md) for the lifecycle model,
+transparency-log fields, Platform API routes, and CLI inspection commands.
 
 ## Developer CLI catalog flow
 

--- a/docs/app-dev-cli.md
+++ b/docs/app-dev-cli.md
@@ -460,12 +460,55 @@ reviewer.1.display.name=Crypta First-Party Review
 reviewer.1.policy.id=crypta-app-review-v1
 ```
 
+Registry version 1 remains supported and treats keys as active with no explicit validity window.
+For governed review workflows, prefer registry version 2 so the local trust root records
+policy-version constraints and reviewer key lifecycle state:
+
+```properties
+trusted.reviewers.version=2
+reviewer.1.id=crypta-first-party-review-2026q2
+reviewer.1.algorithm=Ed25519
+reviewer.1.public.key.base64=<X.509 Ed25519 public key bytes>
+reviewer.1.display.name=Crypta First-Party Review Q2 2026
+reviewer.1.policy.id=crypta-app-review
+reviewer.1.policy.version=1
+reviewer.1.status=active
+reviewer.1.valid.from=2026-04-01T00:00:00Z
+reviewer.1.valid.until=2026-07-01T00:00:00Z
+```
+
+Inspect, migrate, and validate reviewer registries with:
+
+```bash
+crypta-app review keys inspect \
+  --trusted-reviewer-keys-file trusted-reviewers.properties
+
+crypta-app review keys migrate \
+  --trusted-reviewer-keys-file trusted-reviewers-v1.properties \
+  --output trusted-reviewers-v2.properties
+
+crypta-app review keys verify-lifecycle \
+  --trusted-reviewer-keys-file trusted-reviewers.properties
+```
+
+Verify a local review transparency log with:
+
+```bash
+crypta-app review transparency verify \
+  --log-file review-transparency-log.jsonl
+```
+
+These commands print redacted summaries. They do not print reviewer private keys, raw public key
+bytes, raw receipt signatures, local evidence contents, app browser sessions, AppHost process
+tokens, or local transparency-store paths.
+
 `review sign` accepts `--reviewer-private-key-base64`, `--reviewer-private-key-file`, or
 `--reviewer-private-key-env`. `--evidence-file` records the file's SHA-256 in the receipt; use
 `--evidence-sha256` when the evidence digest was computed elsewhere. Verification fails closed for
-app id/version mismatches, artifact digest or size mismatches, unknown reviewer keys, expired
-receipts, invalid signatures, malformed fields, and unsupported algorithms. A verified `rejected`
-receipt is trusted evidence but is not a positive review.
+app id/version mismatches, artifact digest or size mismatches, unknown reviewer keys,
+retired/revoked/out-of-window reviewer keys, policy id/version mismatches, expired receipts,
+invalid signatures, malformed fields, and unsupported algorithms. A verified `rejected` receipt is
+trusted evidence but is not a positive review.
 
 Create the catalog properties file after the receipt exists:
 

--- a/docs/app-review-governance.md
+++ b/docs/app-review-governance.md
@@ -1,0 +1,140 @@
+# App Review Governance
+
+Crypta app review governance is local node policy for independent app review receipts. It does not
+replace catalog signatures, bundle signatures, artifact digest checks, Platform API compatibility
+checks, permission-delta handling, sandbox checks, update rollback gates, or operator approval
+flows.
+
+Review receipts are independent of catalog signatures and app bundle signatures:
+
+- Catalog signatures authenticate catalog publisher metadata.
+- Bundle signatures authenticate the signed app bundle.
+- Review receipts authenticate review evidence from a locally trusted reviewer key.
+
+A catalog publisher can include advisory review metadata, but advisory metadata is not trusted
+review evidence unless a receipt verifies against the node-local trusted reviewer-key registry.
+
+## Trusted Reviewer Registries
+
+Registry version 1 remains supported. A v1 entry is treated as an active trusted reviewer key with
+no explicit validity window:
+
+```properties
+trusted.reviewers.version=1
+reviewer.1.id=crypta-first-party-review
+reviewer.1.algorithm=Ed25519
+reviewer.1.public.key.base64=<X.509 Ed25519 public key bytes>
+reviewer.1.display.name=Crypta First-Party Review
+reviewer.1.policy.id=crypta-app-review-v1
+```
+
+Registry version 2 is preferred for governed deployments because it records policy-version
+constraints and key lifecycle state:
+
+```properties
+trusted.reviewers.version=2
+
+reviewer.1.id=crypta-first-party-review-2026q2
+reviewer.1.algorithm=Ed25519
+reviewer.1.public.key.base64=<X.509 Ed25519 public key bytes>
+reviewer.1.display.name=Crypta First-Party Review Q2 2026
+reviewer.1.policy.id=crypta-app-review
+reviewer.1.policy.version=1
+reviewer.1.status=active
+reviewer.1.valid.from=2026-04-01T00:00:00Z
+reviewer.1.valid.until=2026-07-01T00:00:00Z
+reviewer.1.rotates.from=crypta-first-party-review-2026q1
+reviewer.1.rotates.to=crypta-first-party-review-2026q3
+```
+
+Reviewer private keys must never be committed, embedded in catalogs, exposed through Platform API,
+printed by Web Shell, printed by `crypta-app`, or copied into release-certification reports. The
+trusted reviewer registry stores public verification keys only. API, Web Shell, CLI inspection, and
+certification evidence expose redacted summaries: key ids, display names, algorithms, lifecycle
+status, policy constraints, validity bounds, and rotation ids.
+
+## Lifecycle Semantics
+
+Reviewer key statuses are local governance state:
+
+- `active`: receipts can be trusted when their `reviewedAt` timestamp is inside the configured
+  validity window, if one is configured.
+- `retired`: receipts can be trusted only as historical evidence when `reviewedAt` is inside the
+  configured validity window. Receipts outside that window fail as `retired_reviewer`.
+- `revoked`: receipts from the key fail closed as `revoked_reviewer`, including historical
+  receipts. Revocation is distinct from `unknown_reviewer` so operators can see revoked-key
+  evidence.
+
+Validity timestamps are strict ISO-8601 instants. `valid.until` is treated as an exclusive boundary:
+a receipt reviewed at or after that instant is outside the key window.
+
+Rotation metadata (`rotates.from` and `rotates.to`) is informational. It helps operators audit key
+lifecycle continuity, but it does not automatically trust a successor or predecessor key.
+
+## Policy ID And Version
+
+Review receipts carry `policy.id` and `policy.version`. A trusted reviewer-key registry entry can
+constrain both fields:
+
+- If only `policy.id` is configured, any receipt policy version for that policy id can verify.
+- If both `policy.id` and `policy.version` are configured, both must match.
+- A mismatch produces `review_policy_mismatch`, not `unknown_reviewer`.
+
+This lets operators answer which review policy produced a receipt and whether the local registry
+currently accepts that policy id/version for the reviewer key.
+
+## Local Transparency Log
+
+Crypta keeps a host-owned app review transparency log below the app-catalog store. The log is local
+and tamper-evident, not a global public transparency log and not a distributed consensus service.
+
+The log stores redacted review governance events such as receipt observation, trust evaluation,
+install/update review gates, policy apply gates, reviewer-key lifecycle events, and hash-chain
+verification. Each record includes a sequence, previous record hash, and record hash over canonical
+fields. The verifier recomputes the chain and reports sequence gaps or hash mismatches.
+
+The transparency log must not contain secrets, local filesystem paths, app browser sessions, AppHost
+process tokens, private keys, raw public key bytes, raw receipt signatures, form passwords, request
+bodies, or raw exception traces.
+
+## Platform API And Web Shell
+
+Operator-readable review governance routes include:
+
+- `GET /api/v1/app-review/governance`
+- `GET /api/v1/app-review/reviewer-keys`
+- `GET /api/v1/app-review/transparency-log`
+- `GET /api/v1/app-review/transparency-log/verify`
+- `GET /api/v1/app-catalogs/{catalogId}/apps/{appId}/review-history`
+
+Responses are redacted. They expose reviewer key ids and lifecycle summaries, but not public key
+bytes, private keys, registry paths, transparency-log paths, local evidence paths, tokens, or raw
+receipt signatures.
+
+Web Shell displays review governance in the Apps/Catalogs area. Its review status is a local trust
+decision. It can change when local reviewer keys, reviewer lifecycle metadata, policy constraints,
+or review policy mode change, even if the signed catalog bytes remain the same.
+
+## Developer Tooling
+
+`crypta-app review` includes lifecycle and transparency helpers:
+
+```bash
+crypta-app review keys inspect \
+  --trusted-reviewer-keys-file trusted-reviewers.properties
+
+crypta-app review keys migrate \
+  --trusted-reviewer-keys-file trusted-reviewers-v1.properties \
+  --output trusted-reviewers-v2.properties
+
+crypta-app review keys verify-lifecycle \
+  --trusted-reviewer-keys-file trusted-reviewers.properties
+
+crypta-app review transparency verify \
+  --log-file review-transparency-log.jsonl
+```
+
+CLI output is redacted. It may print reviewer key ids, display names, policy ids/versions, lifecycle
+status, counts, warnings, record counts, and latest transparency hashes. It must not print private
+key material, raw public key bytes, raw signatures, local evidence contents, local store paths, or
+tokens.

--- a/docs/first-party-beta-catalog.md
+++ b/docs/first-party-beta-catalog.md
@@ -20,6 +20,12 @@ It does not replace this first-party beta catalog flow or its release gates. See
 `crypta:` transport is not a trust boundary. Crypta-hosted catalog and bundle artifacts still must
 match signed catalog metadata and signed bundle sidecars before AppHost can install or update them.
 
+First-party review receipts are governed by the node-local trusted reviewer-key registry. Registry
+v1 remains supported, but release candidates should prefer v2 reviewer registries with explicit
+active, retired, or revoked lifecycle state and policy-version constraints. The local review
+transparency log records first-party review-chain events for operator audit; it is local and
+tamper-evident, not a global public transparency service.
+
 ## Runtime configuration
 
 Set the recommended catalog source and trusted key hint in runtime or packaging configuration:
@@ -189,15 +195,20 @@ or `dist/`. Do not check generated signed production catalogs or private keys in
 
 ## Certification evidence
 
-Release certification records `app-catalog.first-party-beta`. The evidence is deterministic and
-offline: it checks for the recommended descriptor, API/Web Shell onboarding, Crypta CHK artifact
-transport tests, first-party metadata documentation, and whether the certification environment has
-source and key hints configured. Profile Publisher is also covered by
+Release certification records `app-catalog.first-party-beta` plus app-review governance evidence
+such as `app-review.governance`, `app-review.reviewer-key-lifecycle`,
+`app-review.transparency-log`, `app-review.review-history-api`, and
+`app-review.first-party-review-chain`. The evidence is deterministic and offline: it checks for the
+recommended descriptor, API/Web Shell onboarding, Crypta CHK artifact transport tests,
+first-party metadata documentation, governed reviewer-key parsing, transparency-log verification,
+review-history routing, and whether the certification environment has source and key hints
+configured. Profile Publisher is also covered by
 `reference-app.profile-publisher`, `app-platform.identity-profile-publish`, and
 `app-platform.generated-document-insert`. Feed Reader is covered by `reference-app.feed-reader`
 and `app-platform.content-fetch`. Trust Graph Preview is covered by
 `reference-app.trust-graph`, `app-platform.trust-graph-preview`, and
 `app-platform.trust-statement-signing`. Normal certification must not record tokens, form
 passwords, private insert URIs, raw request bodies, raw feed bodies, raw trust statement bodies
-from real users, private keys, signatures, or absolute staging paths. It does not fetch a public
-Crypta network catalog during normal unit tests.
+from real users, private keys, raw public key bytes, raw receipt signatures, transparency-log
+paths, or absolute staging paths. It does not fetch a public Crypta network catalog during normal
+unit tests.

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -103,6 +103,11 @@ Release-candidate mode requires these evidence ids:
 | `app-platform.signed-bundles` | App-platform smoke summary. | First-party and sample bundle signing/verification evidence exists with configured non-production or release signing inputs. |
 | `catalog.smoke` | App-platform smoke summary. | Signed catalog create/sign/verify evidence exists and records digest, catalog id, and app id without private key material. |
 | `app-catalog.first-party-beta` | App-platform smoke summary. | Recommended first-party beta catalog descriptor, Platform API/Web Shell onboarding, CHK artifact transport tests, first-party metadata docs, and configuration readiness reporting are present without a live public-network fetch. |
+| `app-review.governance` | App-platform smoke summary. | Reviewer-key lifecycle statuses, policy-version constraints, governance API routes, and Web Shell governance rendering are present and redacted. |
+| `app-review.reviewer-key-lifecycle` | App-platform smoke summary. | Trusted reviewer registry v2 parsing, active/retired/revoked semantics, duplicate-id fail-closed behavior, strict instants, and lifecycle verifier tests are present. |
+| `app-review.transparency-log` | App-platform smoke summary. | A local hash-chained review transparency log exists, can be verified, deduplicates receipt observation, and has tamper/redaction tests. |
+| `app-review.review-history-api` | App-platform smoke summary. | Review governance, reviewer-key, transparency-log, verification, and catalog-app review-history Platform API routes are present and Web Shell consumes review-history data. |
+| `app-review.first-party-review-chain` | App-platform smoke summary. | First-party review receipt evidence, review-history/governance readiness, and transparency-log evidence are tied together for release promotion. |
 | `platform-api.contract` | App-platform smoke summary. | The deterministic Platform API compatibility contract snapshot was generated, parsed, and used for offline compatibility verification of first-party/sample apps. |
 | `app-vault.capabilities` | App-platform smoke summary. | App secret and identity vault capability docs, devtools vocabulary, grant lifecycle notes, and redaction checks are present. |
 | `app-platform.identity-profile-publish` | App-platform smoke summary. | The profile-document signing route `POST /api/v1/app-vault/identities/{identityId}/profile-document` is present, documented, capability-gated by `vault.identities.read` plus `vault.identities.use`, and covered by redaction evidence. |
@@ -190,6 +195,17 @@ coverage categories: trusted positive, missing, expired, mismatched, unknown rev
 rejected. Reports may include reviewer key ids, reviewer display names, policy ids, and key
 fingerprints; they must not include private reviewer keys, raw public key bytes, local evidence
 paths, app/session/process tokens, or local staging paths.
+
+Review governance evidence extends that receipt check with reviewer-key lifecycle readiness and the
+local transparency log. Registry v1 remains valid, but release candidates should prefer v2
+registries with explicit `active`, `retired`, or `revoked` status, optional validity windows, and
+policy-version constraints. The transparency log is local and tamper-evident, not a public global
+log. In release-candidate mode, missing governance, reviewer-key lifecycle, transparency-log,
+review-history API, or first-party review-chain evidence is blocking unless a waiver is recorded in
+the release summary. Reports may include lifecycle counts, status names, policy ids/versions,
+record counts, and latest hashes; they must not include raw public key bytes, private keys, raw
+receipt signatures, local transparency-log paths, local evidence paths, browser sessions, AppHost
+process tokens, form passwords, request bodies, or catalog scratch paths.
 
 App UI design evidence is offline. Release-candidate mode treats first-party strict UI lint errors
 as blocking evidence because first-party apps ship with the node. Advisory

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppRoutes.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppRoutes.java
@@ -162,6 +162,40 @@ final class PlatformApiAppRoutes {
     };
   }
 
+  /**
+   * Routes requests beneath the {@code /app-review} endpoint family.
+   *
+   * @param segments decoded path segments relative to the Platform API mount point
+   * @param request full request metadata
+   * @return JSON response for review governance endpoints
+   */
+  PlatformApiResponse routeAppReviewRequest(List<String> segments, PlatformApiRequest request) {
+    if (appCatalogsApiHandler == null) {
+      throw notFound();
+    }
+    if (!METHOD_GET.equals(request.method())) {
+      return methodNotAllowed(METHOD_GET, GET_ONLY_MESSAGE);
+    }
+    if (segments.size() == 2 && "governance".equals(segments.get(1))) {
+      return PlatformApiResponse.ok(envelope("governance", appCatalogsApiHandler.governance()));
+    }
+    if (segments.size() == 2 && "reviewer-keys".equals(segments.get(1))) {
+      return PlatformApiResponse.ok(envelope("reviewerKeys", appCatalogsApiHandler.reviewerKeys()));
+    }
+    if (segments.size() == 2 && "transparency-log".equals(segments.get(1))) {
+      return PlatformApiResponse.ok(
+          envelope(
+              "transparencyLog", appCatalogsApiHandler.transparencyLog(request.queryParameters())));
+    }
+    if (segments.size() == 3
+        && "transparency-log".equals(segments.get(1))
+        && "verify".equals(segments.get(2))) {
+      return PlatformApiResponse.ok(
+          envelope("verification", appCatalogsApiHandler.verifyTransparencyLog()));
+    }
+    throw notFound();
+  }
+
   private PlatformApiResponse routeAppsCollection(PlatformApiRequest request) {
     if (!METHOD_GET.equals(request.method())) {
       return methodNotAllowed(METHOD_GET, GET_ONLY_MESSAGE);
@@ -448,6 +482,13 @@ final class PlatformApiAppRoutes {
       PlatformApiRequest request) {
     if (!"apps".equals(appsSegment)) {
       throw notFound();
+    }
+    if ("review-history".equals(action)) {
+      if (!METHOD_GET.equals(request.method())) {
+        return methodNotAllowed(METHOD_GET, GET_ONLY_MESSAGE);
+      }
+      return PlatformApiResponse.ok(
+          envelope("reviewHistory", appCatalogsApiHandler.reviewHistory(catalogId, appId)));
     }
     if (!METHOD_POST.equals(request.method())) {
       return methodNotAllowed(METHOD_POST, POST_ONLY_MESSAGE);

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -452,50 +452,24 @@ public final class PlatformApiRouter {
     }
 
     String firstSegment = segments.getFirst();
-    if ("platform".equals(firstSegment)) {
-      return routePlatformRequest(segments, request);
-    }
-    if ("app-catalogs".equals(firstSegment)) {
-      return appRoutes.routeAppCatalogsRequest(segments, request);
-    }
-    if ("apps".equals(firstSegment)) {
-      return appRoutes.routeAppsRequest(segments, request);
-    }
-    if ("app-vault".equals(firstSegment)) {
-      return appRoutes.routeAppVaultRequest(segments, request);
-    }
-    if ("identity-vault".equals(firstSegment)) {
-      return appRoutes.routeIdentityVaultRequest(segments, request);
-    }
-    if ("queue".equals(firstSegment)) {
-      return routeQueueRequest(segments, request);
-    }
-    if ("content".equals(firstSegment)) {
-      return routeContentRequest(segments, request);
-    }
-    if ("trust-graph".equals(firstSegment)) {
-      return routeTrustGraphRequest(segments, request);
-    }
-    if ("peers".equals(firstSegment)) {
-      return routePeersRequest(segments, request);
-    }
-    if ("config".equals(firstSegment)) {
-      return routeConfigRequest(segments, request);
-    }
-    if ("security-levels".equals(firstSegment)) {
-      return routeSecurityLevelsRequest(segments, request);
-    }
-    if (UPDATES_ROUTE_SEGMENT.equals(firstSegment)) {
-      return routeUpdatesRequest(segments, request);
-    }
-    if ("wizard".equals(firstSegment)) {
-      return routeWizardRequest(segments, request);
-    }
-    if ("alerts".equals(firstSegment)) {
-      return routeAlertsRequest(segments, request);
-    }
-
-    return routeGetOnlyRequest(segments, request, firstSegment);
+    return switch (firstSegment) {
+      case "platform" -> routePlatformRequest(segments, request);
+      case "app-catalogs" -> appRoutes.routeAppCatalogsRequest(segments, request);
+      case "app-review" -> appRoutes.routeAppReviewRequest(segments, request);
+      case "apps" -> appRoutes.routeAppsRequest(segments, request);
+      case "app-vault" -> appRoutes.routeAppVaultRequest(segments, request);
+      case "identity-vault" -> appRoutes.routeIdentityVaultRequest(segments, request);
+      case "queue" -> routeQueueRequest(segments, request);
+      case "content" -> routeContentRequest(segments, request);
+      case "trust-graph" -> routeTrustGraphRequest(segments, request);
+      case "peers" -> routePeersRequest(segments, request);
+      case "config" -> routeConfigRequest(segments, request);
+      case "security-levels" -> routeSecurityLevelsRequest(segments, request);
+      case UPDATES_ROUTE_SEGMENT -> routeUpdatesRequest(segments, request);
+      case "wizard" -> routeWizardRequest(segments, request);
+      case "alerts" -> routeAlertsRequest(segments, request);
+      default -> routeGetOnlyRequest(segments, request, firstSegment);
+    };
   }
 
   private PlatformApiResponse routePlatformRequest(

--- a/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
@@ -28,9 +28,14 @@ import network.crypta.platform.appcatalog.AppCatalogReviewMetadata;
 import network.crypta.platform.appcatalog.AppCatalogSourceSnapshot;
 import network.crypta.platform.appcatalog.AppReviewPolicy;
 import network.crypta.platform.appcatalog.AppReviewReceiptVerifier;
+import network.crypta.platform.appcatalog.AppReviewTransparencyEventKind;
+import network.crypta.platform.appcatalog.AppReviewTransparencyLog;
+import network.crypta.platform.appcatalog.AppReviewTransparencyQuery;
+import network.crypta.platform.appcatalog.AppReviewTransparencyVerificationResult;
 import network.crypta.platform.appcatalog.AppReviewTrustDecision;
 import network.crypta.platform.appcatalog.RecommendedAppCatalog;
 import network.crypta.platform.appcatalog.RecommendedAppCatalogs;
+import network.crypta.platform.appcatalog.TrustedReviewerKeySummary;
 import network.crypta.platform.appcatalog.TrustedReviewerKeys;
 import network.crypta.platform.appcatalog.TrustedReviewerKeysLoader;
 import network.crypta.platform.appdist.AppApiCompatibilityMetadata;
@@ -83,6 +88,8 @@ public final class AppCatalogsApiHandler {
   private static final String SOURCE_TYPE_FIELD = "sourceType";
   private static final String SOURCE_KIND_FIELD = "sourceKind";
   private static final String CATALOG_ID_FIELD = "catalogId";
+  private static final String APP_ID_FIELD = "appId";
+  private static final String INSTALLED_VERSION_FIELD = "installedVersion";
   private static final String LAST_ATTEMPT_AT_FIELD = "lastAttemptAt";
   private static final String LAST_SUCCESSFUL_REFRESH_AT_FIELD = "lastSuccessfulRefreshAt";
   private static final String LAST_FETCH_STATUS_FIELD = "lastFetchStatus";
@@ -605,6 +612,92 @@ public final class AppCatalogsApiHandler {
   }
 
   /**
+   * Returns redacted app-review governance state.
+   *
+   * @return review policy, reviewer registry, and transparency-log status
+   */
+  public Map<String, Object> governance() {
+    TrustedReviewerKeys keys = trustedReviewerKeysOrEmpty();
+    AppReviewTransparencyLog log = reviewTransparencyLog();
+    AppReviewTransparencyVerificationResult verification = log.verify();
+    LinkedHashMap<String, Object> transparency = LinkedHashMap.newLinkedHashMap(4);
+    transparency.put("configured", log.configured());
+    transparency.put("recordCount", log.recordCount());
+    transparency.put("latestRecordHash", log.latestRecordHash());
+    transparency.put("verified", verification.verified());
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(3);
+    json.put("reviewPolicyMode", reviewPolicy.mode().jsonValue());
+    json.put("trustedReviewerRegistry", keys.summary().toJsonValue());
+    json.put("transparencyLog", transparency);
+    return json;
+  }
+
+  /**
+   * Returns redacted trusted-reviewer key summaries.
+   *
+   * @return reviewer-key list and registry summary
+   */
+  public Map<String, Object> reviewerKeys() {
+    TrustedReviewerKeys keys = trustedReviewerKeysOrEmpty();
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put(
+        "keys", keys.summaries().stream().map(TrustedReviewerKeySummary::toJsonValue).toList());
+    json.put("registry", keys.summary().toJsonValue());
+    return json;
+  }
+
+  /**
+   * Returns one bounded transparency-log page.
+   *
+   * @param queryParameters decoded query parameters
+   * @return redacted transparency page
+   */
+  public Map<String, Object> transparencyLog(Map<String, List<String>> queryParameters) {
+    return reviewTransparencyLog().page(transparencyQuery(queryParameters)).toJsonValue();
+  }
+
+  /**
+   * Verifies the local transparency-log hash chain.
+   *
+   * @return redacted verification result
+   */
+  public Map<String, Object> verifyTransparencyLog() {
+    return reviewTransparencyLog().verify().toJsonValue();
+  }
+
+  /**
+   * Returns review history for one catalog app.
+   *
+   * @param catalogId catalog identifier
+   * @param appId app identifier
+   * @return current review metadata, local trust decision, reviewer summary, and log records
+   */
+  public Map<String, Object> reviewHistory(String catalogId, String appId) {
+    try {
+      AppCatalogEntry entry = catalogManager.getApp(catalogId, appId);
+      AppReviewTrustDecision decision = reviewTrust(entry);
+      AppReviewTransparencyQuery query =
+          new AppReviewTransparencyQuery(
+              AppReviewTransparencyQuery.DEFAULT_LIMIT, null, entry.appId(), catalogId, null, null);
+      LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(7);
+      json.put(CATALOG_ID_FIELD, catalogId);
+      json.put(APP_ID_FIELD, entry.appId());
+      json.put("catalogVersion", entry.version());
+      json.put(INSTALLED_VERSION_FIELD, installedVersion(entry.appId()));
+      json.put("review", summarizeReview(entry.review()));
+      json.put(REVIEW_TRUST_FIELD, decision.toJsonValue());
+      json.put("reviewerKey", reviewerKeySummary(decision.reviewerKeyId()));
+      json.put("transparencyLog", reviewTransparencyLog().page(query).toJsonValue());
+      json.put("trustDelta", reviewTrustDelta(entry, decision));
+      return json;
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError("Failed to read catalog app review history.");
+    }
+  }
+
+  /**
    * Installs one catalog app through AppHost.
    *
    * <p>The method first confirms that the catalog entry exists and that the app is not already
@@ -641,6 +734,13 @@ public final class AppCatalogsApiHandler {
         throw conflict(APP_ALREADY_INSTALLED_PREFIX + normalizedAppId);
       }
       initialReviewTrust = reviewTrust(entry);
+      recordReviewGate(
+          AppReviewTransparencyEventKind.REVIEW_GATE_INSTALL,
+          catalogId,
+          entry,
+          initialReviewTrust,
+          reviewAcknowledged,
+          "catalog_entry");
       requireReviewGate(initialReviewTrust, reviewAcknowledged, true);
     } catch (AppCatalogException exception) {
       throw catalogFailure(exception);
@@ -651,6 +751,13 @@ public final class AppCatalogsApiHandler {
     try {
       plan = catalogManager.prepareInstallPlan(catalogId, normalizedAppId);
       AppReviewTrustDecision preparedReviewTrust = reviewTrust(plan.entry());
+      recordReviewGate(
+          AppReviewTransparencyEventKind.REVIEW_GATE_INSTALL,
+          catalogId,
+          plan.entry(),
+          preparedReviewTrust,
+          reviewAcknowledged,
+          "prepared_plan");
       requireReviewGate(
           preparedReviewTrust,
           reviewAcknowledgementStillApplies(
@@ -718,11 +825,25 @@ public final class AppCatalogsApiHandler {
     }
     AppReviewTrustDecision initialReviewTrust = reviewTrust(entry);
     boolean reviewAcknowledged = reviewAcknowledged(queryParameters);
+    recordReviewGate(
+        AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE,
+        catalogId,
+        entry,
+        initialReviewTrust,
+        reviewAcknowledged,
+        "catalog_entry");
     requireReviewGate(initialReviewTrust, reviewAcknowledged, false);
     AppCatalogInstallPlan plan = null;
     try {
       plan = catalogManager.prepareInstallPlan(catalogId, normalizedAppId);
       AppReviewTrustDecision preparedReviewTrust = reviewTrust(plan.entry());
+      recordReviewGate(
+          AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE,
+          catalogId,
+          plan.entry(),
+          preparedReviewTrust,
+          reviewAcknowledged,
+          "prepared_plan");
       requireReviewGate(
           preparedReviewTrust,
           reviewAcknowledgementStillApplies(
@@ -780,11 +901,96 @@ public final class AppCatalogsApiHandler {
         entry, trustedReviewerKeysOrEmpty(), reviewPolicy, Instant.now());
   }
 
+  private void recordReviewGate(
+      AppReviewTransparencyEventKind kind,
+      String catalogId,
+      AppCatalogEntry entry,
+      AppReviewTrustDecision decision,
+      boolean reviewAcknowledged,
+      String phase) {
+    reviewTransparencyLog()
+        .recordCatalogDecision(
+            kind,
+            catalogId,
+            entry,
+            decision,
+            List.of("phase=" + phase, "reviewAcknowledged=" + reviewAcknowledged));
+  }
+
   private TrustedReviewerKeys trustedReviewerKeysOrEmpty() {
     try {
       return reviewerKeysProvider.trustedReviewerKeys();
     } catch (AppCatalogException | IOException _) {
       return TrustedReviewerKeys.empty();
+    }
+  }
+
+  private AppReviewTransparencyLog reviewTransparencyLog() {
+    AppReviewTransparencyLog log = catalogManager.reviewTransparencyLog();
+    return log == null ? AppReviewTransparencyLog.disabled() : log;
+  }
+
+  private Map<String, Object> reviewerKeySummary(String reviewerKeyId) {
+    if (reviewerKeyId == null || reviewerKeyId.isBlank()) {
+      return Map.of();
+    }
+    return trustedReviewerKeysOrEmpty()
+        .find(reviewerKeyId)
+        .map(key -> TrustedReviewerKeySummary.from(key).toJsonValue())
+        .orElseGet(Map::of);
+  }
+
+  private String installedVersion(String appId) {
+    InstalledAppSnapshot installed = installed(appId);
+    return installed == null ? null : installed.manifest().appVersion();
+  }
+
+  private Map<String, Object> reviewTrustDelta(
+      AppCatalogEntry entry, AppReviewTrustDecision decision) {
+    String installedVersion = installedVersion(entry.appId());
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(6);
+    json.put(INSTALLED_VERSION_FIELD, installedVersion);
+    json.put("catalogVersion", entry.version());
+    json.put(
+        "versionChanged", installedVersion != null && !installedVersion.equals(entry.version()));
+    json.put("reviewerKeyId", decision.reviewerKeyId());
+    json.put("reviewerKeyStatus", decision.reviewerKeyStatus());
+    json.put("trustStatus", decision.status().jsonValue());
+    json.put("policyId", decision.policyId());
+    json.put("policyVersion", decision.policyVersion());
+    return json;
+  }
+
+  private static AppReviewTransparencyQuery transparencyQuery(
+      Map<String, List<String>> queryParameters) {
+    int limit = parseLimit(PlatformApiParameters.readOptionalString(queryParameters, "limit"));
+    String cursor = PlatformApiParameters.readOptionalString(queryParameters, "cursor");
+    String appId = PlatformApiParameters.readOptionalString(queryParameters, APP_ID_FIELD);
+    String catalogId = PlatformApiParameters.readOptionalString(queryParameters, CATALOG_ID_FIELD);
+    String reviewerKeyId =
+        PlatformApiParameters.readOptionalString(queryParameters, "reviewerKeyId");
+    String kindText = PlatformApiParameters.readOptionalString(queryParameters, "kind");
+    AppReviewTransparencyEventKind kind = null;
+    if (kindText != null && !kindText.isBlank()) {
+      try {
+        kind = AppReviewTransparencyEventKind.parse(kindText);
+      } catch (AppCatalogException _) {
+        throw new PlatformApiException(
+            400, "invalid_query_parameter", "kind is not a supported transparency event kind.");
+      }
+    }
+    return new AppReviewTransparencyQuery(limit, cursor, appId, catalogId, reviewerKeyId, kind);
+  }
+
+  private static int parseLimit(String value) {
+    if (value == null || value.isBlank()) {
+      return AppReviewTransparencyQuery.DEFAULT_LIMIT;
+    }
+    try {
+      return Integer.parseInt(value.trim());
+    } catch (NumberFormatException _) {
+      throw new PlatformApiException(
+          400, "invalid_query_parameter", "limit must be a positive integer.");
     }
   }
 
@@ -820,7 +1026,7 @@ public final class AppCatalogsApiHandler {
     return switch (status) {
       case "missing_receipt", "publisher_claim_only", "not_configured" -> ERROR_APP_REVIEW_MISSING;
       case "artifact_mismatch", "app_mismatch" -> ERROR_APP_REVIEW_MISMATCH;
-      case "expired" -> ERROR_APP_REVIEW_EXPIRED;
+      case "expired", "reviewer_expired", "retired_reviewer" -> ERROR_APP_REVIEW_EXPIRED;
       case "trusted_rejected" -> ERROR_APP_REVIEW_REJECTED;
       default -> ERROR_APP_REVIEW_UNTRUSTED;
     };
@@ -913,7 +1119,7 @@ public final class AppCatalogsApiHandler {
     RunningAppSnapshot running = appHost.status(entry.appId()).orElse(null);
     String installedVersion = installed == null ? null : installed.manifest().appVersion();
     LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(28);
-    json.put("appId", entry.appId());
+    json.put(APP_ID_FIELD, entry.appId());
     json.put("name", entry.name());
     json.put("version", entry.version());
     json.put("summary", entry.summary());
@@ -933,7 +1139,7 @@ public final class AppCatalogsApiHandler {
     json.put("screenshots", entry.screenshots().stream().map(URI::toString).toList());
     json.put("bundle", summarizeBundle(entry));
     json.put("installed", installed != null);
-    json.put("installedVersion", installedVersion);
+    json.put(INSTALLED_VERSION_FIELD, installedVersion);
     json.put(
         "versionDifferent", versionDifferent(entry.version(), installedVersion, installed != null));
     json.put(
@@ -1145,7 +1351,7 @@ public final class AppCatalogsApiHandler {
 
   private static Map<String, Object> summarizeInstalledApp(AppManifest manifest) {
     LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(13);
-    json.put("appId", manifest.appId());
+    json.put(APP_ID_FIELD, manifest.appId());
     json.put("name", manifest.appName());
     json.put("version", manifest.appVersion());
     json.put("uiMode", manifest.uiMode().manifestValue());

--- a/platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateService.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateService.java
@@ -23,6 +23,8 @@ import network.crypta.platform.appcatalog.AppCatalogReviewStatus;
 import network.crypta.platform.appcatalog.AppCatalogSourceSnapshot;
 import network.crypta.platform.appcatalog.AppReviewPolicy;
 import network.crypta.platform.appcatalog.AppReviewReceiptVerifier;
+import network.crypta.platform.appcatalog.AppReviewTransparencyEventKind;
+import network.crypta.platform.appcatalog.AppReviewTransparencyLog;
 import network.crypta.platform.appcatalog.AppReviewTrustDecision;
 import network.crypta.platform.appcatalog.TrustedReviewerKeys;
 import network.crypta.platform.appcatalog.TrustedReviewerKeysLoader;
@@ -434,7 +436,17 @@ public final class AppUpdateService {
     String normalizedAppId = normalizeInstalledAppId(appId);
     InstalledAppSnapshot installed = requireInstalled(normalizedAppId);
     AppUpdateCandidate candidate = candidateOrDetect(normalizedAppId, installed);
-    requireStageableCandidate(candidate, reviewAcknowledged);
+    try {
+      requireStageableCandidate(candidate, reviewAcknowledged);
+      recordUpdateReviewGate(
+          AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE, candidate, "explicit_stage_allowed");
+    } catch (PlatformApiException exception) {
+      recordUpdateReviewGate(
+          AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE,
+          candidate,
+          "explicit_stage_blocked:" + exception.errorCode());
+      throw exception;
+    }
     stageCandidate(normalizedAppId, installed, candidate);
     return summary(normalizedAppId, installed);
   }
@@ -456,7 +468,20 @@ public final class AppUpdateService {
     String normalizedAppId = normalizeInstalledAppId(appId);
     InstalledAppSnapshot installed = requireInstalled(normalizedAppId);
     StagedUpdate staged = requireStagedUpdate(normalizedAppId);
-    boolean wasRunning = validateApplyRequest(normalizedAppId, staged, installed, options);
+    boolean wasRunning;
+    try {
+      wasRunning = validateApplyRequest(normalizedAppId, staged, installed, options);
+      recordUpdateReviewGate(
+          AppReviewTransparencyEventKind.REVIEW_GATE_POLICY_APPLY,
+          staged.candidate(),
+          "explicit_apply_allowed");
+    } catch (PlatformApiException exception) {
+      recordUpdateReviewGate(
+          AppReviewTransparencyEventKind.REVIEW_GATE_POLICY_APPLY,
+          staged.candidate(),
+          "explicit_apply_blocked:" + exception.errorCode());
+      throw exception;
+    }
 
     InstalledAppSnapshot updated = null;
     HealthFailureState healthFailureState = new HealthFailureState();
@@ -481,6 +506,10 @@ public final class AppUpdateService {
           staged.candidate().targetVersion(),
           null,
           vaultCleanupFailed ? MESSAGE_APPLY_VAULT_CLEANUP_FAILED : "Staged update applied.");
+      recordUpdateReviewGate(
+          AppReviewTransparencyEventKind.REVIEW_GATE_POLICY_APPLY,
+          staged.candidate(),
+          "explicit_apply_applied");
       return summary(normalizedAppId, updated);
     } catch (PlatformApiException exception) {
       closeStage(normalizedAppId);
@@ -561,6 +590,10 @@ public final class AppUpdateService {
         candidate.targetVersion(),
         errorCode,
         MESSAGE_APPLY_FAILED);
+    recordUpdateReviewGate(
+        AppReviewTransparencyEventKind.REVIEW_GATE_POLICY_APPLY,
+        candidate,
+        "apply_failed:" + errorCode);
   }
 
   private PlatformApiException appHostApplyFailure(
@@ -811,6 +844,10 @@ public final class AppUpdateService {
             candidate.targetVersion(),
             ERROR_APP_RUNNING,
             "Policy skipped apply because the app is running.");
+        recordUpdateReviewGate(
+            AppReviewTransparencyEventKind.REVIEW_GATE_POLICY_APPLY,
+            candidate,
+            "policy_apply_skipped:" + ERROR_APP_RUNNING);
         return;
       }
       if (!candidate.reviewTrustAllowsAutomaticApply()) {
@@ -819,6 +856,10 @@ public final class AppUpdateService {
       }
       if (!candidate.apiCompatibilityAllowsAutomaticApply()) {
         appendCompatibilityGateHistory(appId, candidate);
+        recordUpdateReviewGate(
+            AppReviewTransparencyEventKind.REVIEW_GATE_POLICY_APPLY,
+            candidate,
+            "policy_apply_blocked:" + ERROR_UPDATE_INCOMPATIBLE);
         return;
       }
       stageCandidate(appId, installed, candidate);
@@ -839,6 +880,10 @@ public final class AppUpdateService {
           candidate.targetVersion(),
           ERROR_UPDATE_CANDIDATE_CHANGED,
           "Candidate no longer matches the installed app version.");
+      recordUpdateReviewGate(
+          AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE,
+          candidate,
+          "stage_blocked:" + ERROR_UPDATE_CANDIDATE_CHANGED);
       throw lifecycleFailure(
           409,
           ERROR_UPDATE_CANDIDATE_CHANGED,
@@ -857,6 +902,10 @@ public final class AppUpdateService {
           candidate.targetVersion(),
           ERROR_UPDATE_CANDIDATE_CHANGED,
           "Prepared catalog plan no longer matches the reviewed candidate.");
+      recordUpdateReviewGate(
+          AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE,
+          candidate,
+          "stage_blocked:" + ERROR_UPDATE_CANDIDATE_CHANGED);
       throw lifecycleFailure(
           409,
           ERROR_UPDATE_CANDIDATE_CHANGED,
@@ -872,6 +921,8 @@ public final class AppUpdateService {
         candidate.targetVersion(),
         null,
         "Verified update candidate staged.");
+    recordUpdateReviewGate(
+        AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE, candidate, "stage_staged");
   }
 
   private AppCatalogInstallPlan prepareStagePlan(String appId, AppUpdateCandidate candidate) {
@@ -899,6 +950,8 @@ public final class AppUpdateService {
         candidate.targetVersion(),
         errorCode,
         MESSAGE_STAGE_FAILED);
+    recordUpdateReviewGate(
+        AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE, candidate, "stage_failed:" + errorCode);
   }
 
   private AppUpdateCandidate detectCandidate(
@@ -1028,6 +1081,11 @@ public final class AppUpdateService {
           case "publisher_claim_only" -> 40;
           case "missing_receipt", "not_configured" -> 30;
           case "unknown_reviewer",
+              "retired_reviewer",
+              "revoked_reviewer",
+              "reviewer_not_yet_valid",
+              "reviewer_expired",
+              "review_policy_mismatch",
               "invalid_signature",
               "artifact_mismatch",
               "app_mismatch",
@@ -1072,6 +1130,26 @@ public final class AppUpdateService {
   private AppReviewTrustDecision reviewTrust(AppCatalogEntry entry) {
     return AppReviewReceiptVerifier.evaluate(
         entry, trustedReviewerKeysOrEmpty(), reviewPolicy, Instant.now());
+  }
+
+  private AppReviewTransparencyLog reviewTransparencyLog() {
+    AppReviewTransparencyLog log = catalogManager.reviewTransparencyLog();
+    return log == null ? AppReviewTransparencyLog.disabled() : log;
+  }
+
+  private void recordUpdateReviewGate(
+      AppReviewTransparencyEventKind kind, AppUpdateCandidate candidate, String phase) {
+    reviewTransparencyLog()
+        .recordReviewTrustMap(
+            kind,
+            new AppReviewTransparencyLog.ReviewTrustMapSubject(
+                candidate.appId(),
+                candidate.targetVersion(),
+                candidate.catalogId(),
+                candidate.bundleSha256(),
+                candidate.bundleSizeBytes()),
+            candidate.reviewTrust(),
+            List.of("phase=" + phase));
   }
 
   private TrustedReviewerKeys trustedReviewerKeysOrEmpty() {
@@ -1224,6 +1302,12 @@ public final class AppUpdateService {
         candidate.targetVersion(),
         reviewGateFailureCode(candidate.reviewTrust()),
         "Policy skipped update because no trusted positive review receipt verified.");
+    recordUpdateReviewGate(
+        ACTION_STAGE.equals(action)
+            ? AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE
+            : AppReviewTransparencyEventKind.REVIEW_GATE_POLICY_APPLY,
+        candidate,
+        "policy_" + action + "_blocked:" + reviewGateFailureCode(candidate.reviewTrust()));
   }
 
   private void appendCompatibilityGateHistory(String appId, AppUpdateCandidate candidate) {
@@ -1245,7 +1329,7 @@ public final class AppUpdateService {
     return switch (status) {
       case "missing_receipt", "publisher_claim_only", "not_configured" -> ERROR_APP_REVIEW_MISSING;
       case "artifact_mismatch", "app_mismatch" -> ERROR_APP_REVIEW_MISMATCH;
-      case "expired" -> ERROR_APP_REVIEW_EXPIRED;
+      case "expired", "reviewer_expired", "retired_reviewer" -> ERROR_APP_REVIEW_EXPIRED;
       case "trusted_rejected" -> ERROR_APP_REVIEW_REJECTED;
       default -> ERROR_APP_REVIEW_UNTRUSTED;
     };

--- a/platform-api/src/test/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandlerTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -28,6 +29,8 @@ import network.crypta.platform.appcatalog.AppReviewReceipt;
 import network.crypta.platform.appcatalog.AppReviewReceiptPayload;
 import network.crypta.platform.appcatalog.AppReviewReceiptSigner;
 import network.crypta.platform.appcatalog.AppReviewReceiptStatus;
+import network.crypta.platform.appcatalog.AppReviewTransparencyEventKind;
+import network.crypta.platform.appcatalog.AppReviewTransparencyLog;
 import network.crypta.platform.appcatalog.RecommendedAppCatalog;
 import network.crypta.platform.appcatalog.RecommendedAppCatalogs;
 import network.crypta.platform.appcatalog.TrustedReviewerKey;
@@ -51,6 +54,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -496,6 +500,172 @@ class AppCatalogsApiHandlerTest {
   }
 
   @Test
+  void governance_whenReviewRegistryAndTransparencyLogConfigured_expectRedactedStatus()
+      throws Exception {
+    KeyPair reviewerKeyPair = reviewerKeyPair();
+    AppReviewTransparencyLog log = AppReviewTransparencyLog.inMemory();
+    log.recordReviewTrustMap(
+        AppReviewTransparencyEventKind.REVIEW_TRUST_EVALUATED,
+        reviewTrustMapSubject("1.2.0", "0".repeat(64), 0L),
+        trustedReviewTrustMap(),
+        List.of("api-test"));
+    when(catalogManager.reviewTransparencyLog()).thenReturn(log);
+    AppCatalogsApiHandler handler =
+        new AppCatalogsApiHandler(
+            catalogManager,
+            appHost,
+            () -> null,
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
+
+    Map<String, Object> governance = handler.governance();
+
+    assertEquals(AppReviewPolicy.DEFAULT.mode().jsonValue(), governance.get("reviewPolicyMode"));
+    Map<String, Object> registry = (Map<String, Object>) governance.get("trustedReviewerRegistry");
+    assertEquals(true, registry.get("configured"));
+    Map<String, Object> counts = (Map<String, Object>) registry.get("counts");
+    assertEquals(1, counts.get("active"));
+    assertEquals(0, counts.get("retired"));
+    assertEquals(0, counts.get("revoked"));
+    Map<String, Object> transparency = (Map<String, Object>) governance.get("transparencyLog");
+    assertEquals(true, transparency.get("configured"));
+    assertEquals(1L, transparency.get("recordCount"));
+    assertEquals(true, transparency.get("verified"));
+    assertTrue(transparency.get("latestRecordHash") instanceof String);
+    assertRedactsReviewerPublicKey(governance, reviewerKeyPair);
+  }
+
+  @Test
+  void reviewerKeys_whenCalled_expectRedactedKeySummaries() throws Exception {
+    KeyPair reviewerKeyPair = reviewerKeyPair();
+    AppCatalogsApiHandler handler =
+        new AppCatalogsApiHandler(
+            catalogManager,
+            appHost,
+            () -> null,
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
+
+    Map<String, Object> response = handler.reviewerKeys();
+
+    List<Map<String, Object>> keys = (List<Map<String, Object>>) response.get("keys");
+    assertEquals(1, keys.size());
+    Map<String, Object> key = keys.getFirst();
+    assertEquals(REVIEWER_KEY_ID, key.get("keyId"));
+    assertEquals("Crypta First-Party Review", key.get("displayName"));
+    assertEquals("Ed25519", key.get("algorithm"));
+    assertEquals("active", key.get("status"));
+    assertEquals(REVIEW_POLICY_ID, key.get("policyId"));
+    assertFalse(key.containsKey("publicKey"));
+    assertFalse(key.containsKey("publicKeyBase64"));
+    assertRedactsReviewerPublicKey(response, reviewerKeyPair);
+  }
+
+  @Test
+  void transparencyLog_whenFilteredByKind_expectPagedRedactedRecords() {
+    AppReviewTransparencyLog log = AppReviewTransparencyLog.inMemory();
+    log.recordReviewTrustMap(
+        AppReviewTransparencyEventKind.REVIEW_TRUST_EVALUATED,
+        reviewTrustMapSubject("1.2.0", "0".repeat(64), 0L),
+        trustedReviewTrustMap(),
+        List.of("api-test"));
+    log.recordReviewTrustMap(
+        AppReviewTransparencyEventKind.REVIEW_GATE_INSTALL,
+        reviewTrustMapSubject("1.2.0", "0".repeat(64), 0L),
+        trustedReviewTrustMap(),
+        List.of("phase=install"));
+    when(catalogManager.reviewTransparencyLog()).thenReturn(log);
+    AppCatalogsApiHandler handler =
+        new AppCatalogsApiHandler(
+            catalogManager,
+            appHost,
+            () -> null,
+            AppReviewPolicy.DEFAULT,
+            TrustedReviewerKeys::empty);
+
+    Map<String, Object> page =
+        handler.transparencyLog(
+            Map.of("kind", List.of("review_gate_install"), "limit", List.of("1")));
+
+    List<Map<String, Object>> records = (List<Map<String, Object>>) page.get("records");
+    assertEquals(1, records.size());
+    Map<String, Object> record = records.getFirst();
+    assertEquals("review_gate_install", record.get("kind"));
+    assertEquals(APP_ID, record.get("appId"));
+    assertEquals("core", record.get("catalogId"));
+    assertEquals("trusted_reviewed", record.get("trustStatus"));
+    assertFalse(page.toString().contains(tempDir.toString()));
+  }
+
+  @Test
+  void transparencyLog_whenKindIsInvalid_expectBadRequest() {
+    AppCatalogsApiHandler handler =
+        new AppCatalogsApiHandler(
+            catalogManager,
+            appHost,
+            () -> null,
+            AppReviewPolicy.DEFAULT,
+            TrustedReviewerKeys::empty);
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class,
+            () -> handler.transparencyLog(Map.of("kind", List.of("not-a-kind"))));
+
+    assertEquals(400, exception.statusCode());
+    assertEquals("invalid_query_parameter", exception.errorCode());
+  }
+
+  @Test
+  void reviewHistory_whenTrustedReceiptExists_expectTrustReviewerAndTransparencyHistory()
+      throws Exception {
+    KeyPair reviewerKeyPair = reviewerKeyPair();
+    AppCatalogEntry entry = richCatalogEntryWithTrustedReceipt(reviewerKeyPair);
+    AppReviewTransparencyLog log = AppReviewTransparencyLog.inMemory();
+    log.recordReviewTrustMap(
+        AppReviewTransparencyEventKind.REVIEW_TRUST_EVALUATED,
+        reviewTrustMapSubject(entry.version(), entry.bundleSha256(), entry.bundleSizeBytes()),
+        trustedReviewTrustMap(),
+        List.of("api-test"));
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(entry);
+    when(catalogManager.reviewTransparencyLog()).thenReturn(log);
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
+    AppCatalogsApiHandler handler =
+        new AppCatalogsApiHandler(
+            catalogManager,
+            appHost,
+            () -> null,
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
+
+    Map<String, Object> history = handler.reviewHistory("core", APP_ID);
+
+    assertEquals("core", history.get("catalogId"));
+    assertEquals(APP_ID, history.get("appId"));
+    assertEquals("1.2.0", history.get("catalogVersion"));
+    assertEquals("1.1.0", history.get("installedVersion"));
+    Map<String, Object> reviewTrust = (Map<String, Object>) history.get("reviewTrust");
+    assertEquals("trusted_reviewed", reviewTrust.get("status"));
+    assertEquals(true, reviewTrust.get("trusted"));
+    assertEquals(true, reviewTrust.get("positive"));
+    assertEquals(REVIEWER_KEY_ID, reviewTrust.get("reviewerKeyId"));
+    assertEquals("active", reviewTrust.get("reviewerKeyStatus"));
+    assertEquals(REVIEW_POLICY_VERSION, reviewTrust.get("policyVersion"));
+    Map<String, Object> reviewerKey = (Map<String, Object>) history.get("reviewerKey");
+    assertNotNull(reviewerKey);
+    assertEquals(REVIEWER_KEY_ID, reviewerKey.get("keyId"));
+    assertEquals("active", reviewerKey.get("status"));
+    Map<String, Object> transparency = (Map<String, Object>) history.get("transparencyLog");
+    List<Map<String, Object>> records = (List<Map<String, Object>>) transparency.get("records");
+    assertEquals(1, records.size());
+    assertEquals("review_trust_evaluated", records.getFirst().get("kind"));
+    Map<String, Object> delta = (Map<String, Object>) history.get("trustDelta");
+    assertEquals(true, delta.get("versionChanged"));
+    assertEquals("trusted_reviewed", delta.get("trustStatus"));
+    assertRedactsReviewerPublicKey(history, reviewerKeyPair);
+  }
+
+  @Test
   void install_whenPolicyRequiresTrustedReviewAndReceiptIsMissing_expectStableReviewError()
       throws Exception {
     AppCatalogsApiHandler handler =
@@ -893,6 +1063,38 @@ class AppCatalogsApiHandlerTest {
 
   private static Map<String, List<String>> reviewAcknowledgedQuery() {
     return Map.of("reviewAcknowledged", List.of("true"));
+  }
+
+  private static Map<String, Object> trustedReviewTrustMap() {
+    return Map.of(
+        "status",
+        "trusted_reviewed",
+        "trusted",
+        true,
+        "positive",
+        true,
+        "reviewerKeyId",
+        REVIEWER_KEY_ID,
+        "reviewerKeyStatus",
+        "active",
+        "policyId",
+        REVIEW_POLICY_ID,
+        "policyVersion",
+        REVIEW_POLICY_VERSION);
+  }
+
+  private static AppReviewTransparencyLog.ReviewTrustMapSubject reviewTrustMapSubject(
+      String appVersion, String artifactSha256, long artifactSizeBytes) {
+    return new AppReviewTransparencyLog.ReviewTrustMapSubject(
+        APP_ID, appVersion, "core", artifactSha256, artifactSizeBytes);
+  }
+
+  private static void assertRedactsReviewerPublicKey(Object output, KeyPair reviewerKeyPair) {
+    String encodedPublicKey =
+        Base64.getEncoder().encodeToString(reviewerKeyPair.getPublic().getEncoded());
+    String rendered = output.toString();
+    assertFalse(rendered.contains(encodedPublicKey));
+    assertFalse(rendered.contains("public.key.base64"));
   }
 
   private static KeyPair reviewerKeyPair() throws Exception {

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogManager.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogManager.java
@@ -30,6 +30,7 @@ public final class AppCatalogManager {
   private final AppCatalogFetcher fetcher;
   private final AppCatalogArtifactDownloader artifactDownloader;
   private final AppCatalogBundleExtractor bundleExtractor;
+  private final AppReviewTransparencyLog reviewTransparencyLog;
 
   /**
    * Creates a manager with default JDK fetch and download helpers.
@@ -48,7 +49,8 @@ public final class AppCatalogManager {
         trustedKeyProvider,
         new AppCatalogFetcher(),
         new AppCatalogArtifactDownloader(),
-        new AppCatalogBundleExtractor());
+        new AppCatalogBundleExtractor(),
+        defaultReviewTransparencyLog(sourceStore));
   }
 
   /**
@@ -70,7 +72,8 @@ public final class AppCatalogManager {
         trustedKeyProvider,
         new AppCatalogFetcher(contentFetchPort),
         new AppCatalogArtifactDownloader(contentFetchPort),
-        new AppCatalogBundleExtractor());
+        new AppCatalogBundleExtractor(),
+        defaultReviewTransparencyLog(sourceStore));
   }
 
   /**
@@ -92,11 +95,54 @@ public final class AppCatalogManager {
       AppCatalogFetcher fetcher,
       AppCatalogArtifactDownloader artifactDownloader,
       AppCatalogBundleExtractor bundleExtractor) {
+    this(
+        sourceStore,
+        trustedKeyProvider,
+        fetcher,
+        artifactDownloader,
+        bundleExtractor,
+        defaultReviewTransparencyLog(sourceStore));
+  }
+
+  /**
+   * Creates a manager with explicit collaborators and transparency log.
+   *
+   * @param sourceStore file-backed catalog source store
+   * @param trustedKeyProvider provider for the current trusted app/catalog keys
+   * @param fetcher catalog source fetcher
+   * @param artifactDownloader artifact downloader and digest checker
+   * @param bundleExtractor ZIP extractor and signed-bundle verifier
+   * @param reviewTransparencyLog local review transparency log
+   */
+  public AppCatalogManager(
+      AppCatalogSourceStore sourceStore,
+      TrustedKeyProvider trustedKeyProvider,
+      AppCatalogFetcher fetcher,
+      AppCatalogArtifactDownloader artifactDownloader,
+      AppCatalogBundleExtractor bundleExtractor,
+      AppReviewTransparencyLog reviewTransparencyLog) {
     this.sourceStore = Objects.requireNonNull(sourceStore, "sourceStore");
     this.trustedKeyProvider = Objects.requireNonNull(trustedKeyProvider, "trustedKeyProvider");
     this.fetcher = Objects.requireNonNull(fetcher, "fetcher");
     this.artifactDownloader = Objects.requireNonNull(artifactDownloader, "artifactDownloader");
     this.bundleExtractor = Objects.requireNonNull(bundleExtractor, "bundleExtractor");
+    this.reviewTransparencyLog =
+        Objects.requireNonNull(reviewTransparencyLog, "reviewTransparencyLog");
+  }
+
+  /**
+   * Returns the local review transparency log used by API gates.
+   *
+   * @return redacted review transparency log facade
+   */
+  public AppReviewTransparencyLog reviewTransparencyLog() {
+    return reviewTransparencyLog;
+  }
+
+  private static AppReviewTransparencyLog defaultReviewTransparencyLog(
+      AppCatalogSourceStore sourceStore) {
+    return AppReviewTransparencyLog.fileBacked(
+        Objects.requireNonNull(sourceStore, "sourceStore").reviewTransparencyLogFile());
   }
 
   /**
@@ -222,7 +268,7 @@ public final class AppCatalogManager {
     try {
       return fetcher.fetch(stored.source());
     } catch (AppCatalogException exception) {
-      recordRefreshFailure(normalizedCatalogId, stored, attemptedAt, exception);
+      recordRefreshFailure(stored, attemptedAt, exception);
       throw exception;
     } catch (IOException exception) {
       AppCatalogException catalogException =
@@ -230,7 +276,7 @@ public final class AppCatalogManager {
               AppCatalogSidecars.CATALOG_FETCH_FAILED,
               "failed to refresh catalog source: " + normalizedCatalogId,
               exception);
-      recordRefreshFailure(normalizedCatalogId, stored, attemptedAt, catalogException);
+      recordRefreshFailure(stored, attemptedAt, catalogException);
       throw catalogException;
     }
   }
@@ -252,11 +298,7 @@ public final class AppCatalogManager {
       return catalog;
     } catch (AppCatalogException exception) {
       recordRefreshFailure(
-          normalizedCatalogId,
-          stored,
-          attemptedAt,
-          exception,
-          resolvedCatalogUri(fetched, stored.source()));
+          stored, attemptedAt, exception, resolvedCatalogUri(fetched, stored.source()));
       throw exception;
     }
   }
@@ -361,27 +403,17 @@ public final class AppCatalogManager {
   }
 
   private void recordRefreshFailure(
-      String normalizedCatalogId,
-      StoredCatalogSource stored,
-      Instant attemptedAt,
-      AppCatalogException exception) {
-    recordRefreshFailure(
-        normalizedCatalogId,
-        stored,
-        attemptedAt,
-        exception,
-        stored.source().resolvedCatalogFetchUri());
+      StoredCatalogSource stored, Instant attemptedAt, AppCatalogException exception) {
+    recordRefreshFailure(stored, attemptedAt, exception, stored.source().resolvedCatalogFetchUri());
   }
 
   private void recordRefreshFailure(
-      String normalizedCatalogId,
       StoredCatalogSource stored,
       Instant attemptedAt,
       AppCatalogException exception,
       String resolvedUri) {
     try {
-      sourceStore.recordRefreshFailure(
-          normalizedCatalogId, stored, attemptedAt, exception, resolvedUri);
+      sourceStore.recordRefreshFailure(stored, attemptedAt, exception, resolvedUri);
     } catch (IOException metadataException) {
       exception.addSuppressed(metadataException);
     }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppCatalogSourceStore.java
@@ -94,6 +94,20 @@ public final class AppCatalogSourceStore {
   }
 
   /**
+   * Returns the host-owned review transparency log file below the catalog store root.
+   *
+   * <p>The returned path is operational state and must not be exposed through API, Web Shell, CLI
+   * summaries, logs, or certification reports.
+   *
+   * @return local transparency log file path
+   */
+  public Path reviewTransparencyLogFile() {
+    return rootDirectory
+        .resolve(".review-transparency-log")
+        .resolve(FileAppReviewTransparencyStore.LOG_FILE_NAME);
+  }
+
+  /**
    * Returns whether a catalog id is already stored.
    *
    * <p>The check looks for the source metadata sidecar rather than only the directory. This avoids
@@ -213,23 +227,18 @@ public final class AppCatalogSourceStore {
   }
 
   void recordRefreshFailure(
-      String catalogId,
-      StoredCatalogSource stored,
-      Instant attemptedAt,
-      AppCatalogException exception)
+      StoredCatalogSource stored, Instant attemptedAt, AppCatalogException exception)
       throws IOException {
-    recordRefreshFailure(
-        catalogId, stored, attemptedAt, exception, stored.source().resolvedCatalogFetchUri());
+    recordRefreshFailure(stored, attemptedAt, exception, stored.source().resolvedCatalogFetchUri());
   }
 
   void recordRefreshFailure(
-      String catalogId,
       StoredCatalogSource stored,
       Instant attemptedAt,
       AppCatalogException exception,
       String resolvedUri)
       throws IOException {
-    String normalizedCatalogId = AppCatalog.normalizeCatalogId(catalogId);
+    String normalizedCatalogId = AppCatalog.normalizeCatalogId(stored.catalogId());
     AppCatalogSourceRefreshMetadata metadata =
         stored.refreshMetadata().failedAttempt(attemptedAt, exception, resolvedUri);
     Path directory = catalogDirectory(normalizedCatalogId);
@@ -284,7 +293,7 @@ public final class AppCatalogSourceStore {
           "unsupported catalog source property: " + properties.keySet().iterator().next());
     }
     return new StoredCatalogSource(
-        source, addedAt, refreshedAt, refreshMetadata, readFetchedCatalog(directory));
+        catalogId, source, addedAt, refreshedAt, refreshMetadata, readFetchedCatalog(directory));
   }
 
   private static AppCatalogSourceRefreshMetadata parseRefreshMetadata(

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewReceiptVerifier.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewReceiptVerifier.java
@@ -134,13 +134,31 @@ public final class AppReviewReceiptVerifier {
           List.of("No trusted reviewer keys are configured."));
     }
     TrustedReviewerKey reviewerKey = keys.find(receipt.payload().reviewerKeyId()).orElse(null);
-    if (reviewerKey == null || reviewerPolicyMismatch(reviewerKey, receipt)) {
+    if (reviewerKey == null) {
       return decision(
           AppReviewTrustStatus.UNKNOWN_REVIEWER,
           receipt,
           null,
           checkedPolicy,
           List.of("Review receipt reviewer key is not trusted by this node."));
+    }
+    if (reviewerPolicyMismatch(reviewerKey, receipt)) {
+      return decision(
+          AppReviewTrustStatus.REVIEW_POLICY_MISMATCH,
+          receipt,
+          reviewerKey,
+          checkedPolicy,
+          List.of("Review receipt policy id or version is not accepted for this reviewer key."));
+    }
+    AppReviewTrustStatus lifecycleFailure =
+        reviewerKey.lifecycle().trustFailureAt(receipt.payload().reviewedAt()).orElse(null);
+    if (lifecycleFailure != null) {
+      return decision(
+          lifecycleFailure,
+          receipt,
+          reviewerKey,
+          checkedPolicy,
+          lifecycleWarnings(lifecycleFailure));
     }
     if (!receipt.signature().algorithm().equals(reviewerKey.algorithm())) {
       return decision(
@@ -222,8 +240,22 @@ public final class AppReviewReceiptVerifier {
 
   private static boolean reviewerPolicyMismatch(
       TrustedReviewerKey reviewerKey, AppReviewReceipt receipt) {
-    String reviewerPolicyId = reviewerKey.policyId().orElse(null);
-    return reviewerPolicyId != null && !reviewerPolicyId.equals(receipt.payload().policyId());
+    return !reviewerKey
+        .policyConstraint()
+        .matches(receipt.payload().policyId(), receipt.payload().policyVersion());
+  }
+
+  private static List<String> lifecycleWarnings(AppReviewTrustStatus status) {
+    return switch (status) {
+      case REVOKED_REVIEWER -> List.of("Review receipt reviewer key is revoked by local policy.");
+      case RETIRED_REVIEWER ->
+          List.of("Review receipt reviewer key is retired for this review timestamp.");
+      case REVIEWER_NOT_YET_VALID ->
+          List.of("Review receipt predates the reviewer key validity window.");
+      case REVIEWER_EXPIRED ->
+          List.of("Review receipt was produced after the reviewer key validity window.");
+      default -> List.of("Review receipt reviewer key lifecycle policy rejected the receipt.");
+    };
   }
 
   private static boolean verifySignature(AppReviewReceipt receipt, TrustedReviewerKey reviewerKey) {
@@ -275,14 +307,35 @@ public final class AppReviewReceiptVerifier {
         policy.blocksPolicyApply(status),
         payload == null ? null : payload.reviewerKeyId(),
         reviewerKey == null ? null : reviewerKey.displayName().orElse(null),
+        reviewerKey == null ? null : reviewerKey.status().jsonValue(),
         payload == null ? null : payload.policyId(),
         payload == null ? null : payload.policyVersion(),
+        policyVersionStatus(status, reviewerKey),
         payload == null ? null : payload.reviewedAt(),
         payload == null ? null : payload.expiresAt().orElse(null),
         payload == null ? null : payload.evidenceSha256().orElse(null),
         payload == null ? null : payload.evidenceUri().orElse(null),
         List.copyOf(warnings),
         policy.mode());
+  }
+
+  private static String policyVersionStatus(
+      AppReviewTrustStatus status, TrustedReviewerKey reviewerKey) {
+    if (reviewerKey == null) {
+      return null;
+    }
+    if (status == AppReviewTrustStatus.REVIEW_POLICY_MISMATCH
+        || status == AppReviewTrustStatus.REVOKED_REVIEWER) {
+      return "rejected";
+    }
+    if (status == AppReviewTrustStatus.RETIRED_REVIEWER
+        || reviewerKey.status() == TrustedReviewerKeyStatus.RETIRED) {
+      return "retired";
+    }
+    if (reviewerKey.status() == TrustedReviewerKeyStatus.ACTIVE) {
+      return "active";
+    }
+    return reviewerKey.status().jsonValue();
   }
 
   private record ReviewEvaluationTarget(

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyEventKind.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyEventKind.java
@@ -1,0 +1,151 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Locale;
+
+/**
+ * Stable event kinds for the local review transparency log.
+ *
+ * <p>These values form the on-disk and JSON vocabulary for host-owned review governance events.
+ * They are deliberately narrower than the catalog model: an event records that this node observed a
+ * receipt, evaluated local trust, applied an installation or update gate, or loaded reviewer
+ * governance state. The values do not imply that a catalog, bundle, or reviewer is trusted by
+ * itself; callers must read the associated trust-status fields on each record.
+ *
+ * <p>The lowercase strings returned by {@link #jsonValue()} are stable API values. They are used in
+ * JSONL log records, Platform API filters, Web Shell views, developer tooling, and release
+ * certification evidence. Add new values only when older readers can safely reject or ignore them.
+ */
+public enum AppReviewTransparencyEventKind {
+  /**
+   * A signed independent review receipt was observed locally.
+   *
+   * <p>The record is de-duplicated by receipt fingerprint so the same receipt is not appended for
+   * every catalog listing. The subject fields come from the receipt payload rather than publisher
+   * advisory metadata, which keeps malformed catalog entries from rewriting receipt history.
+   */
+  REVIEW_RECEIPT_OBSERVED("review_receipt_observed"),
+
+  /**
+   * A catalog app review receipt or publisher advisory state was evaluated against local policy.
+   *
+   * <p>This event captures the computed trust status, reviewer lifecycle status, policy id/version,
+   * acknowledgement flags, and redacted evidence fields for an operator-visible evaluation.
+   */
+  REVIEW_TRUST_EVALUATED("review_trust_evaluated"),
+
+  /**
+   * The installation path applied the local app-review gate to a candidate catalog entry.
+   *
+   * <p>The event records the final gate status and warning flags after the candidate has been
+   * rechecked. It is audit evidence for the local decision, not authorization to skip bundle or
+   * catalog signature validation.
+   */
+  REVIEW_GATE_INSTALL("review_gate_install"),
+
+  /**
+   * The update path applied the local app-review gate to a candidate replacement version.
+   *
+   * <p>Records with this kind let operators compare installed state with update-candidate review
+   * state and explain review deltas such as policy changes, reviewer rotation, or rejection.
+   */
+  REVIEW_GATE_UPDATE("review_gate_update"),
+
+  /**
+   * A policy-driven apply operation evaluated local app-review trust before continuing.
+   *
+   * <p>This kind is used for scheduler or policy surfaces that can apply updates when an app is
+   * stopped. The record documents the local policy decision without exposing scheduler internals.
+   */
+  REVIEW_GATE_POLICY_APPLY("review_gate_policy_apply"),
+
+  /**
+   * A trusted-reviewer registry was loaded by the local node.
+   *
+   * <p>The associated record should contain only registry counts and warnings, never the registry
+   * path or raw public key bytes. It gives operators an audit point for governance configuration.
+   */
+  REVIEWER_REGISTRY_LOADED("reviewer_registry_loaded"),
+
+  /**
+   * Local governance identified a reviewer key as active.
+   *
+   * <p>Active status means the key may authenticate receipts within its configured policy and
+   * validity constraints. It does not bypass receipt signature, artifact, or app-id checks.
+   */
+  REVIEWER_KEY_ACTIVE("reviewer_key_active"),
+
+  /**
+   * Local governance identified a reviewer key as retired.
+   *
+   * <p>Retired keys can explain historical trust only inside an explicit validity window. The
+   * status should be rendered separately from active trust in operator-facing views.
+   */
+  REVIEWER_KEY_RETIRED("reviewer_key_retired"),
+
+  /**
+   * Local governance identified a reviewer key as revoked.
+   *
+   * <p>Revoked keys fail closed for every receipt from that key id. Records of this kind help an
+   * operator see why a previously trusted review no longer verifies locally.
+   */
+  REVIEWER_KEY_REVOKED("reviewer_key_revoked"),
+
+  /**
+   * Local governance observed or configured a reviewer-key rotation relationship.
+   *
+   * <p>The record may mention predecessor or successor key ids, but it must not include public key
+   * bytes. Rotation metadata is explanatory and does not create transitive trust.
+   */
+  REVIEWER_KEY_ROTATED("reviewer_key_rotated"),
+
+  /**
+   * The local transparency log hash chain was verified.
+   *
+   * <p>This event is audit evidence for a verification action. The verification result still lives
+   * on the record fields and can indicate either success or a redacted failure reason.
+   */
+  TRANSPARENCY_LOG_VERIFIED("transparency_log_verified");
+
+  private final String jsonValue;
+
+  AppReviewTransparencyEventKind(String jsonValue) {
+    this.jsonValue = jsonValue;
+  }
+
+  /**
+   * Parses a stable event-kind value.
+   *
+   * <p>Input is trimmed through the shared sidecar validator and compared case-insensitively to the
+   * stable lowercase values. Unsupported text fails closed with the same catalog-entry error family
+   * used by other governance sidecar parsers, which lets API query parsing and file verification
+   * report malformed values without accepting partial data.
+   *
+   * @param raw configured, persisted, or query-string event kind text
+   * @return matching event kind for the stable JSON value
+   */
+  public static AppReviewTransparencyEventKind parse(String raw) {
+    String value =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+                raw, "review transparency event kind", AppCatalogSidecars.INVALID_CATALOG_ENTRY)
+            .toLowerCase(Locale.ROOT);
+    for (AppReviewTransparencyEventKind kind : values()) {
+      if (kind.jsonValue.equals(value)) {
+        return kind;
+      }
+    }
+    throw AppCatalogSidecars.invalidEntry("unsupported review transparency event kind: " + raw);
+  }
+
+  /**
+   * Returns the stable lowercase JSON value.
+   *
+   * <p>The returned value is the only representation that should be written to JSONL transparency
+   * records or exposed through Platform API responses. Enum names are implementation details and
+   * should not be used as external contract values.
+   *
+   * @return lowercase event kind used by JSON, CLI, and UI surfaces
+   */
+  public String jsonValue() {
+    return jsonValue;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyLog.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyLog.java
@@ -1,0 +1,361 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Local host-owned review transparency log facade.
+ *
+ * <p>This is not a global public log and does not change catalog, bundle, receipt, or update-gate
+ * verification. It records redacted local governance events in a hash chain so operators can see
+ * how local review trust decisions changed over time.
+ *
+ * <p>The facade is the safety boundary used by catalog install, update, API, and certification
+ * code. Append methods are intentionally best-effort: malformed or unavailable log storage is
+ * contained inside this class so audit logging cannot turn a valid install or update into a
+ * failure. Read methods return redacted empty or failed summaries when storage cannot be read.
+ * Callers that need a hard release gate should verify the returned {@link
+ * AppReviewTransparencyVerificationResult} rather than relying on exceptions.
+ *
+ * <p>Instances are immutable wrappers around a store implementation. File-backed instances persist
+ * JSONL records, in-memory instances are deterministic test fixtures, and the disabled singleton is
+ * a no-op for deployments that have not configured host-owned governance state.
+ */
+public final class AppReviewTransparencyLog {
+  private static final AppReviewTransparencyLog DISABLED =
+      new AppReviewTransparencyLog(new NoOpStore(), false);
+
+  private final AppReviewTransparencyStore store;
+  private final boolean configured;
+
+  /**
+   * Redacted app and artifact identity for review-trust map events.
+   *
+   * <p>Update and API paths often have review governance data as a JSON-compatible {@code
+   * reviewTrust} map rather than a full catalog entry. This subject carries the catalog-facing
+   * fields that identify the candidate being evaluated without bundling local paths, process state,
+   * app browser sessions, or other host-only details into the transparency record.
+   *
+   * @param appId app id for the candidate being evaluated
+   * @param appVersion candidate app version displayed to operators
+   * @param catalogId catalog id that supplied the candidate, when known
+   * @param artifactSha256 lowercase SHA-256 digest of the candidate artifact
+   * @param artifactSizeBytes candidate artifact size in bytes
+   */
+  public record ReviewTrustMapSubject(
+      String appId,
+      String appVersion,
+      String catalogId,
+      String artifactSha256,
+      long artifactSizeBytes) {}
+
+  private AppReviewTransparencyLog(AppReviewTransparencyStore store, boolean configured) {
+    this.store = Objects.requireNonNull(store, "store");
+    this.configured = configured;
+  }
+
+  /**
+   * Returns a disabled no-op log.
+   *
+   * <p>The disabled instance reports no records and accepts append calls without side effects. It
+   * is useful when runtime composition has not configured a host-owned log location, and it lets
+   * callers keep one code path without treating audit logging as mandatory.
+   *
+   * @return shared disabled log that never persists records
+   */
+  public static AppReviewTransparencyLog disabled() {
+    return DISABLED;
+  }
+
+  /**
+   * Returns an in-memory log.
+   *
+   * <p>The store assigns the same sequence and hash-chain metadata as the file-backed store but
+   * does not write to disk. Tests and embedded callers use it to exercise governance surfaces
+   * without creating local state or exposing filesystem paths.
+   *
+   * @return configured in-memory transparency log
+   */
+  public static AppReviewTransparencyLog inMemory() {
+    return new AppReviewTransparencyLog(new InMemoryAppReviewTransparencyStore(), true);
+  }
+
+  /**
+   * Returns a file-backed JSONL log.
+   *
+   * <p>The file path is host-owned local state and must not be exposed through API, CLI, Web Shell,
+   * or certification output. The underlying store creates parent directories lazily when the first
+   * record is appended.
+   *
+   * @param logFile local JSONL file used for redacted transparency records
+   * @return configured file-backed transparency log
+   */
+  public static AppReviewTransparencyLog fileBacked(Path logFile) {
+    return new AppReviewTransparencyLog(new FileAppReviewTransparencyStore(logFile), true);
+  }
+
+  /**
+   * Returns whether the log is configured for append and read operations.
+   *
+   * <p>A configured log may still be temporarily unreadable or contain malformed records. Use
+   * {@link #verify()} when the caller needs to distinguish an available, intact hash chain from a
+   * best-effort failure summary.
+   *
+   * @return {@code true} when a real store is attached to this facade
+   */
+  public boolean configured() {
+    return configured;
+  }
+
+  /**
+   * Appends a record draft, failing only inside this method.
+   *
+   * <p>The store assigns sequence, creation time, previous hash, and record hash. IO failures,
+   * parser failures while reading existing records, and other runtime failures are swallowed so
+   * review logging never changes install, update, or verification behavior. Callers should treat
+   * this as audit the best effort rather than durable confirmation.
+   *
+   * @param recordDraft unchained redacted record draft to persist when storage is available
+   */
+  public void appendBestEffort(AppReviewTransparencyRecord recordDraft) {
+    if (!configured) {
+      return;
+    }
+    try {
+      store.append(recordDraft);
+    } catch (IOException | RuntimeException _) {
+      // Review logging must not change install/update security semantics.
+    }
+  }
+
+  /**
+   * Records a redacted catalog-app review decision and receipt observation, when present.
+   *
+   * <p>If the catalog entry contains an independent receipt, a de-duplicated {@code
+   * review_receipt_observed} record is written using fields from the receipt payload. The requested
+   * event kind is then appended with the local trust decision and any additional warning strings.
+   * Both records are redacted and best-effort; a corrupt log cannot block the gate that produced
+   * the decision.
+   *
+   * @param kind event kind that describes the local evaluation or gate path
+   * @param catalogId catalog id associated with the candidate entry
+   * @param entry catalog entry whose receipt and artifact metadata were evaluated
+   * @param decision local trust decision produced by the receipt verifier
+   * @param warnings extra bounded event warnings supplied by the caller
+   */
+  public void recordCatalogDecision(
+      AppReviewTransparencyEventKind kind,
+      String catalogId,
+      AppCatalogEntry entry,
+      AppReviewTrustDecision decision,
+      List<String> warnings) {
+    if (!configured) {
+      return;
+    }
+    try {
+      entry.reviewReceipt().ifPresent(receipt -> recordReceiptObserved(catalogId, receipt));
+      List<String> combinedWarnings = new ArrayList<>(decision.warnings());
+      if (warnings != null) {
+        combinedWarnings.addAll(warnings);
+      }
+      appendBestEffort(
+          AppReviewTransparencyRecord.fromCatalogDecision(
+              kind, catalogId, entry, decision, combinedWarnings));
+    } catch (RuntimeException _) {
+      // Logging must not change review-gate behavior.
+    }
+  }
+
+  /**
+   * Records a redacted app-update review gate decision from a reviewTrust map.
+   *
+   * <p>Update scheduler and API code sometimes carry review trust as JSON-compatible maps rather
+   * than full catalog entries. This method preserves the same redaction and hash-chain behavior for
+   * those paths. Missing optional trust fields remain absent in the resulting record; malformed
+   * values are contained by the best-effort wrapper.
+   *
+   * @param kind event kind that describes the update or policy gate being recorded
+   * @param subject redacted app and artifact identity for the candidate
+   * @param reviewTrust JSON-compatible reviewTrust map from API or scheduler code
+   * @param warnings bounded warnings that explain gate context or acknowledgements
+   */
+  public void recordReviewTrustMap(
+      AppReviewTransparencyEventKind kind,
+      ReviewTrustMapSubject subject,
+      Map<String, Object> reviewTrust,
+      List<String> warnings) {
+    try {
+      ReviewTrustMapSubject checkedSubject = Objects.requireNonNull(subject, "subject");
+      appendBestEffort(
+          AppReviewTransparencyRecord.fromReviewTrustMap(
+              kind,
+              checkedSubject.appId(),
+              checkedSubject.appVersion(),
+              checkedSubject.catalogId(),
+              checkedSubject.artifactSha256(),
+              checkedSubject.artifactSizeBytes(),
+              reviewTrust,
+              warnings == null ? List.of() : warnings));
+    } catch (RuntimeException _) {
+      // Logging must not change update lifecycle behavior.
+    }
+  }
+
+  /**
+   * Returns one bounded page, or an empty page if unavailable.
+   *
+   * <p>The query defaults to {@link AppReviewTransparencyQuery#defaultQuery()} when {@code null}.
+   * Any IO or parser failure is converted to an empty page to keep operator API reads redacted and
+   * non-disruptive. Callers that need tamper evidence should call {@link #verify()} separately.
+   *
+   * @param query optional bounded query with cursor and filter constraints
+   * @return matching redacted page, or an empty page when the log cannot be read
+   */
+  public AppReviewTransparencyPage page(AppReviewTransparencyQuery query) {
+    if (!configured) {
+      return new AppReviewTransparencyPage(List.of(), null);
+    }
+    try {
+      return store.page(query == null ? AppReviewTransparencyQuery.defaultQuery() : query);
+    } catch (IOException | RuntimeException _) {
+      return new AppReviewTransparencyPage(List.of(), null);
+    }
+  }
+
+  /**
+   * Verifies the hash chain and returns a redacted result.
+   *
+   * <p>The verification result never includes the local store path or raw record contents. Disabled
+   * logs verify as an empty chain because there is no configured local evidence to inspect. A
+   * configured but unreadable or malformed log returns a failed result with a stable, display-safe
+   * error string.
+   *
+   * @return verification status, record count, latest hash, and redacted error text
+   */
+  public AppReviewTransparencyVerificationResult verify() {
+    if (!configured) {
+      return AppReviewTransparencyVerificationResult.verified(0L, null);
+    }
+    try {
+      return store.verify();
+    } catch (IOException | RuntimeException _) {
+      return AppReviewTransparencyVerificationResult.failed(
+          0L, null, "review transparency log unavailable");
+    }
+  }
+
+  /**
+   * Returns the record count, or zero when unavailable.
+   *
+   * <p>This is a summary helper for governance status responses. It intentionally hides read
+   * failures because verification is the explicit API for diagnosing log integrity.
+   *
+   * @return number of persisted records, or {@code 0} for disabled or unreadable logs
+   */
+  public long recordCount() {
+    if (!configured) {
+      return 0L;
+    }
+    try {
+      return store.recordCount();
+    } catch (IOException | RuntimeException _) {
+      return 0L;
+    }
+  }
+
+  /**
+   * Returns the latest record hash, or {@code null} when empty or unavailable.
+   *
+   * <p>The latest hash is display-safe evidence for the current local chain head. It is not a
+   * global checkpoint and should not be interpreted as public consensus about review state.
+   *
+   * @return lowercase SHA-256 chain head, or {@code null} when no head is available
+   */
+  public String latestRecordHash() {
+    if (!configured) {
+      return null;
+    }
+    try {
+      return store.latestRecordHash();
+    } catch (IOException | RuntimeException _) {
+      return null;
+    }
+  }
+
+  private void recordReceiptObserved(String catalogId, AppReviewReceipt receipt) {
+    try {
+      AppReviewReceiptPayload payload = receipt.payload();
+      appendBestEffort(
+          new AppReviewTransparencyRecord(
+              AppReviewTransparencyRecord.SCHEMA_VERSION,
+              0L,
+              "receipt:" + receiptFingerprint(receipt),
+              null,
+              AppReviewTransparencyEventKind.REVIEW_RECEIPT_OBSERVED,
+              "app",
+              payload.appId(),
+              payload.appVersion(),
+              catalogId,
+              payload.artifactSha256(),
+              payload.artifactSizeBytes(),
+              payload.reviewerKeyId(),
+              null,
+              payload.policyId(),
+              payload.policyVersion(),
+              payload.status().catalogValue(),
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              null,
+              payload.evidenceSha256().orElse(null),
+              payload.evidenceUri().map(Object::toString).orElse(null),
+              null,
+              null,
+              List.of()));
+    } catch (RuntimeException _) {
+      // Logging must not change catalog behavior.
+    }
+  }
+
+  private static String receiptFingerprint(AppReviewReceipt receipt) {
+    MessageDigest digest = AppCatalogSidecars.newArtifactSha256Digest();
+    digest.update(receipt.payload().canonicalPayloadBytes());
+    digest.update(receipt.signature().signatureBytes());
+    return AppCatalogSidecars.lowercaseHex(digest.digest());
+  }
+
+  private static final class NoOpStore implements AppReviewTransparencyStore {
+    @Override
+    public AppReviewTransparencyRecord append(AppReviewTransparencyRecord recordDraft) {
+      return recordDraft;
+    }
+
+    @Override
+    public AppReviewTransparencyPage page(AppReviewTransparencyQuery query) {
+      return new AppReviewTransparencyPage(List.of(), null);
+    }
+
+    @Override
+    public AppReviewTransparencyVerificationResult verify() {
+      return AppReviewTransparencyVerificationResult.verified(0L, null);
+    }
+
+    @Override
+    public long recordCount() {
+      return 0L;
+    }
+
+    @Override
+    public String latestRecordHash() {
+      return null;
+    }
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyPage.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyPage.java
@@ -1,0 +1,52 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * One bounded page of local review transparency records.
+ *
+ * <p>Pages are the read model returned by the transparency store and Platform API. They contain
+ * already-redacted records and a cursor for continuing from the last record returned by a matching
+ * query. The cursor is intentionally an opaque string to API callers even though the current store
+ * uses record sequence numbers internally.
+ *
+ * <p>The record list is defensively copied on construction, so callers can safely retain a page
+ * without being affected by later appends. A {@code null} cursor means there are no more matching
+ * records known to this local store at the time of the read.
+ *
+ * @param records redacted records included in this bounded page
+ * @param nextCursor cursor to pass to the next query, or {@code null} at the end
+ */
+public record AppReviewTransparencyPage(
+    List<AppReviewTransparencyRecord> records, String nextCursor) {
+  /**
+   * Creates an immutable page.
+   *
+   * <p>The constructor copies the incoming records and preserves their order. Stores are expected
+   * to supply records in ascending sequence order after applying cursor and filter constraints.
+   *
+   * @param records records selected by the bounded query
+   * @param nextCursor cursor for the next page, or {@code null} when complete
+   */
+  public AppReviewTransparencyPage {
+    records = List.copyOf(records);
+  }
+
+  /**
+   * Converts this page to JSON-compatible values.
+   *
+   * <p>The returned map is safe for operator-facing API output. It delegates record conversion to
+   * {@link AppReviewTransparencyRecord#toJsonValue()} and does not include store paths, raw key
+   * material, private keys, or local process state.
+   *
+   * @return JSON-compatible page with {@code records} and {@code nextCursor}
+   */
+  public Map<String, Object> toJsonValue() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(2);
+    json.put("records", records.stream().map(AppReviewTransparencyRecord::toJsonValue).toList());
+    json.put("nextCursor", nextCursor);
+    return json;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyQuery.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyQuery.java
@@ -1,0 +1,110 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Objects;
+
+/**
+ * Bounded read query for the local review transparency log.
+ *
+ * <p>The query is the shared filtering contract for file-backed stores, in-memory stores, Platform
+ * API handlers, and CLI verification helpers. It keeps reads conservative by normalizing blank
+ * filters to {@code null}, clamping limits to {@link #MAX_LIMIT}, and treating invalid cursors as
+ * the start of the log. Filtering is exact-match and local to the current host-owned log.
+ *
+ * <p>The cursor currently represents the last sequence number returned by a previous page, but
+ * callers should treat it as an opaque token. Future stores may keep the same API shape while using
+ * a different cursor encoding.
+ *
+ * @param limit requested page size before clamping to the local maximum
+ * @param cursor opaque cursor from a previous page, or {@code null} for the first page
+ * @param appId optional app id filter applied to record app ids
+ * @param catalogId optional catalog id filter applied to record catalog ids
+ * @param reviewerKeyId optional reviewer key id filter applied to record reviewer ids
+ * @param kind optional event-kind filter applied to record kinds
+ */
+public record AppReviewTransparencyQuery(
+    int limit,
+    String cursor,
+    String appId,
+    String catalogId,
+    String reviewerKeyId,
+    AppReviewTransparencyEventKind kind) {
+  /**
+   * Default page size for operator-facing log reads.
+   *
+   * <p>The default keeps governance responses small enough for Web Shell and CLI display while
+   * still returning enough context to explain recent review decisions.
+   */
+  public static final int DEFAULT_LIMIT = 25;
+
+  /**
+   * Maximum page size accepted by API and CLI callers.
+   *
+   * <p>Stores clamp larger values to this limit. The cap prevents a single governance request from
+   * forcing an unbounded read of a local JSONL log.
+   */
+  public static final int MAX_LIMIT = 100;
+
+  /**
+   * Returns an unconstrained query with the default limit.
+   *
+   * <p>The query starts at the beginning of the local log and applies no app, catalog, reviewer, or
+   * event-kind filters. Stores use this when callers pass {@code null} for a query object.
+   *
+   * @return default bounded query for operator-facing reads
+   */
+  public static AppReviewTransparencyQuery defaultQuery() {
+    return new AppReviewTransparencyQuery(DEFAULT_LIMIT, null, null, null, null, null);
+  }
+
+  /**
+   * Creates a normalized query.
+   *
+   * <p>Non-positive limits are replaced by {@link #DEFAULT_LIMIT}, larger limits are clamped to
+   * {@link #MAX_LIMIT}, and blank text filters become {@code null}. Normalization happens once at
+   * construction time so store implementations can apply a query without repeating validation.
+   *
+   * @param limit requested page size before defaulting and clamping
+   * @param cursor opaque cursor token from the previous page
+   * @param appId optional app id filter, blank values ignored
+   * @param catalogId optional catalog id filter, blank values ignored
+   * @param reviewerKeyId optional reviewer key id filter, blank values ignored
+   * @param kind optional event-kind filter
+   */
+  public AppReviewTransparencyQuery {
+    if (limit <= 0) {
+      limit = DEFAULT_LIMIT;
+    }
+    limit = Math.min(limit, MAX_LIMIT);
+    cursor = blankToNull(cursor);
+    appId = blankToNull(appId);
+    catalogId = blankToNull(catalogId);
+    reviewerKeyId = blankToNull(reviewerKeyId);
+  }
+
+  boolean includes(AppReviewTransparencyRecord transparencyRecord) {
+    Objects.requireNonNull(transparencyRecord, "transparencyRecord");
+    return matchesFilter(appId, transparencyRecord.appId())
+        && matchesFilter(catalogId, transparencyRecord.catalogId())
+        && matchesFilter(reviewerKeyId, transparencyRecord.reviewerKeyId())
+        && (kind == null || kind == transparencyRecord.kind());
+  }
+
+  long cursorSequence() {
+    if (cursor == null) {
+      return 0L;
+    }
+    try {
+      return Long.parseLong(cursor);
+    } catch (NumberFormatException _) {
+      return 0L;
+    }
+  }
+
+  private static boolean matchesFilter(String expected, String actual) {
+    return expected == null || expected.equals(actual);
+  }
+
+  private static String blankToNull(String value) {
+    return value == null || value.isBlank() ? null : value.trim();
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyRecord.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyRecord.java
@@ -1,0 +1,855 @@
+package network.crypta.platform.appcatalog;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * One redacted local review transparency log record.
+ *
+ * <p>Records are hash-chained over canonical fields. They intentionally contain only display-safe
+ * review identifiers, policy metadata, artifact digest/size, evidence digest/URI, and trust
+ * outcomes. They never include raw public keys, private keys, local paths, request bodies, browser
+ * sessions, process tokens, or receipt signatures.
+ *
+ * <p>This record is both the in-memory value and the JSONL persistence contract for the local
+ * transparency log. Store implementations assign sequence, creation time, previous hash, and record
+ * hash when appending a draft. Verification recomputes the canonical text from these normalized
+ * fields, so parser validation must fail closed for unsupported fields, malformed values, and type
+ * mismatches instead of silently normalizing tampered lines.
+ *
+ * <p>The format is local to one host. A valid hash chain proves that the local log file is
+ * internally consistent; it does not prove global publication or consensus. Callers should pair a
+ * record with the current {@link AppReviewTrustDecision} when explaining why an installation or
+ * update is trusted, cautioned, rejected, or blocked.
+ *
+ * @param schemaVersion local record schema version, currently {@link #SCHEMA_VERSION}
+ * @param sequence one-based append sequence, or {@code 0} for an unchained draft
+ * @param recordId stable record identifier, assigned from kind and sequence when absent
+ * @param createdAt append time assigned by the store, or {@code null} for drafts
+ * @param kind stable event kind describing why this record was written
+ * @param subjectType redacted subject category such as {@code app}
+ * @param appId app id from the receipt, entry, or update candidate
+ * @param appVersion app version from the receipt, entry, or update candidate
+ * @param catalogId local catalog id associated with the evaluated candidate
+ * @param artifactSha256 lowercase SHA-256 artifact digest when known
+ * @param artifactSizeBytes artifact size in bytes when known
+ * @param reviewerKeyId reviewer key id from the receipt or local decision
+ * @param reviewerKeyStatus local lifecycle status for the reviewer key when known
+ * @param policyId review policy id from the receipt or local trust decision
+ * @param policyVersion review policy version from the receipt or local trust decision
+ * @param receiptStatus independent receipt verdict when a receipt exists
+ * @param trustStatus local review trust status after policy and lifecycle evaluation
+ * @param trusted whether local verification trusted the receipt
+ * @param positive whether local verification found a positive trusted review
+ * @param requiresAcknowledgement whether local policy requires operator acknowledgement
+ * @param blocksInstall whether local policy blocks manual install
+ * @param blocksUpdate whether local policy blocks manual update
+ * @param blocksPolicyApply whether local policy blocks policy-driven apply
+ * @param evidenceSha256 lowercase SHA-256 digest for external evidence when supplied
+ * @param evidenceUri evidence URI from the receipt or trust decision when supplied
+ * @param previousRecordHash hash of the previous record, or an empty genesis value
+ * @param recordHash SHA-256 hash over canonical record fields and previous hash
+ * @param warnings bounded display-safe warnings associated with the event
+ */
+public record AppReviewTransparencyRecord(
+    int schemaVersion,
+    long sequence,
+    String recordId,
+    Instant createdAt,
+    AppReviewTransparencyEventKind kind,
+    String subjectType,
+    String appId,
+    String appVersion,
+    String catalogId,
+    String artifactSha256,
+    Long artifactSizeBytes,
+    String reviewerKeyId,
+    String reviewerKeyStatus,
+    String policyId,
+    String policyVersion,
+    String receiptStatus,
+    String trustStatus,
+    Boolean trusted,
+    Boolean positive,
+    Boolean requiresAcknowledgement,
+    Boolean blocksInstall,
+    Boolean blocksUpdate,
+    Boolean blocksPolicyApply,
+    String evidenceSha256,
+    String evidenceUri,
+    String previousRecordHash,
+    String recordHash,
+    List<String> warnings) {
+  /**
+   * Current local log record schema.
+   *
+   * <p>The parser accepts only this value. Unsupported future or malformed schema versions fail
+   * closed during log verification so older binaries do not accidentally validate records whose
+   * canonical form they do not understand.
+   */
+  public static final int SCHEMA_VERSION = 1;
+
+  private static final int MAX_FIELD_CHARS = 512;
+  private static final int MAX_WARNING_CHARS = 256;
+  private static final String SCHEMA_VERSION_FIELD = "schemaVersion";
+  private static final String SEQUENCE_FIELD = "sequence";
+  private static final String RECORD_ID_FIELD = "recordId";
+  private static final String CREATED_AT_FIELD = "createdAt";
+  private static final String KIND_FIELD = "kind";
+  private static final String SUBJECT_TYPE_FIELD = "subjectType";
+  private static final String APP_ID_FIELD = "appId";
+  private static final String APP_VERSION_FIELD = "appVersion";
+  private static final String CATALOG_ID_FIELD = "catalogId";
+  private static final String ARTIFACT_SHA256_FIELD = "artifactSha256";
+  private static final String ARTIFACT_SIZE_BYTES_FIELD = "artifactSizeBytes";
+  private static final String REVIEWER_KEY_ID_FIELD = "reviewerKeyId";
+  private static final String REVIEWER_KEY_STATUS_FIELD = "reviewerKeyStatus";
+  private static final String POLICY_ID_FIELD = "policyId";
+  private static final String POLICY_VERSION_FIELD = "policyVersion";
+  private static final String RECEIPT_STATUS_FIELD = "receiptStatus";
+  private static final String TRUST_STATUS_FIELD = "trustStatus";
+  private static final String TRUSTED_FIELD = "trusted";
+  private static final String POSITIVE_FIELD = "positive";
+  private static final String REQUIRES_ACKNOWLEDGEMENT_FIELD = "requiresAcknowledgement";
+  private static final String BLOCKS_INSTALL_FIELD = "blocksInstall";
+  private static final String BLOCKS_UPDATE_FIELD = "blocksUpdate";
+  private static final String BLOCKS_POLICY_APPLY_FIELD = "blocksPolicyApply";
+  private static final String EVIDENCE_SHA256_FIELD = "evidenceSha256";
+  private static final String EVIDENCE_URI_FIELD = "evidenceUri";
+  private static final String PREVIOUS_RECORD_HASH_FIELD = "previousRecordHash";
+  private static final String RECORD_HASH_FIELD = "recordHash";
+  private static final String WARNINGS_FIELD = "warnings";
+  private static final List<String> JSON_FIELD_NAMES =
+      List.of(
+          SCHEMA_VERSION_FIELD,
+          SEQUENCE_FIELD,
+          RECORD_ID_FIELD,
+          CREATED_AT_FIELD,
+          KIND_FIELD,
+          SUBJECT_TYPE_FIELD,
+          APP_ID_FIELD,
+          APP_VERSION_FIELD,
+          CATALOG_ID_FIELD,
+          ARTIFACT_SHA256_FIELD,
+          ARTIFACT_SIZE_BYTES_FIELD,
+          REVIEWER_KEY_ID_FIELD,
+          REVIEWER_KEY_STATUS_FIELD,
+          POLICY_ID_FIELD,
+          POLICY_VERSION_FIELD,
+          RECEIPT_STATUS_FIELD,
+          TRUST_STATUS_FIELD,
+          TRUSTED_FIELD,
+          POSITIVE_FIELD,
+          REQUIRES_ACKNOWLEDGEMENT_FIELD,
+          BLOCKS_INSTALL_FIELD,
+          BLOCKS_UPDATE_FIELD,
+          BLOCKS_POLICY_APPLY_FIELD,
+          EVIDENCE_SHA256_FIELD,
+          EVIDENCE_URI_FIELD,
+          PREVIOUS_RECORD_HASH_FIELD,
+          RECORD_HASH_FIELD,
+          WARNINGS_FIELD);
+
+  /**
+   * Creates a normalized record.
+   *
+   * <p>The constructor validates bounded single-line text, lowercase SHA-256 fields, non-negative
+   * sizes and sequences, and immutable warning lists. It accepts nullable optional fields because
+   * different event kinds naturally carry different evidence, but malformed non-null values fail
+   * closed before they can enter the hash chain.
+   */
+  public AppReviewTransparencyRecord {
+    if (schemaVersion != SCHEMA_VERSION) {
+      throw AppCatalogSidecars.invalidEntry(
+          "unsupported review transparency schemaVersion: " + schemaVersion);
+    }
+    if (sequence < 0L) {
+      throw AppCatalogSidecars.invalidEntry("review transparency sequence must be >= 0");
+    }
+    recordId = optionalSingleLine(recordId, "review transparency record id", MAX_FIELD_CHARS);
+    Objects.requireNonNull(kind, "kind");
+    subjectType = optionalSingleLine(subjectType, "review transparency subject type", 64);
+    appId = optionalSingleLine(appId, "review transparency app id", MAX_FIELD_CHARS);
+    appVersion = optionalSingleLine(appVersion, "review transparency app version", MAX_FIELD_CHARS);
+    catalogId = optionalSingleLine(catalogId, "review transparency catalog id", MAX_FIELD_CHARS);
+    artifactSha256 =
+        artifactSha256 == null
+            ? null
+            : AppCatalogSidecars.requireLowercaseSha256(
+                artifactSha256, "review transparency artifactSha256");
+    if (artifactSizeBytes != null && artifactSizeBytes < 0L) {
+      throw AppCatalogSidecars.invalidEntry("review transparency artifactSizeBytes must be >= 0");
+    }
+    reviewerKeyId =
+        optionalSingleLine(reviewerKeyId, "review transparency reviewer key id", MAX_FIELD_CHARS);
+    reviewerKeyStatus =
+        optionalSingleLine(
+            reviewerKeyStatus, "review transparency reviewer key status", MAX_FIELD_CHARS);
+    policyId = optionalSingleLine(policyId, "review transparency policy id", MAX_FIELD_CHARS);
+    policyVersion =
+        optionalSingleLine(policyVersion, "review transparency policy version", MAX_FIELD_CHARS);
+    receiptStatus =
+        optionalSingleLine(receiptStatus, "review transparency receipt status", MAX_FIELD_CHARS);
+    trustStatus =
+        optionalSingleLine(trustStatus, "review transparency trust status", MAX_FIELD_CHARS);
+    evidenceSha256 =
+        evidenceSha256 == null
+            ? null
+            : AppCatalogSidecars.requireLowercaseSha256(
+                evidenceSha256, "review transparency evidenceSha256");
+    evidenceUri = optionalSingleLine(evidenceUri, "review transparency evidence URI", 1024);
+    previousRecordHash = normalizeHash(previousRecordHash, PREVIOUS_RECORD_HASH_FIELD);
+    recordHash = normalizeHash(recordHash, RECORD_HASH_FIELD);
+    warnings =
+        warnings == null
+            ? List.of()
+            : warnings.stream()
+                .map(
+                    value ->
+                        AppCatalogSidecars.requireBoundedSingleLine(
+                            value,
+                            "review transparency warning",
+                            AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+                            MAX_WARNING_CHARS))
+                .toList();
+  }
+
+  /**
+   * Builds a record from a catalog entry and review trust decision.
+   *
+   * <p>The draft uses catalog-entry app and artifact fields for gate/evaluation records and uses
+   * the embedded receipt payload only for the receipt-status field. Receipt observation records are
+   * created separately by {@link AppReviewTransparencyLog} so mismatched receipts can be tied to
+   * their own payload instead of inheriting publisher-controlled entry fields.
+   *
+   * @param kind event kind for the local evaluation or gate decision
+   * @param catalogId catalog id associated with the entry being evaluated
+   * @param entry catalog entry whose metadata and optional receipt were checked
+   * @param decision local trust decision produced by the verifier and policy
+   * @param warnings extra bounded warnings to include with decision warnings
+   * @return unchained redacted record draft ready for store append
+   */
+  public static AppReviewTransparencyRecord fromCatalogDecision(
+      AppReviewTransparencyEventKind kind,
+      String catalogId,
+      AppCatalogEntry entry,
+      AppReviewTrustDecision decision,
+      List<String> warnings) {
+    Objects.requireNonNull(entry, "entry");
+    Objects.requireNonNull(decision, "decision");
+    return new AppReviewTransparencyRecord(
+        SCHEMA_VERSION,
+        0L,
+        null,
+        null,
+        kind,
+        "app",
+        entry.appId(),
+        entry.version(),
+        catalogId,
+        entry.bundleSha256(),
+        entry.bundleSizeBytes(),
+        decision.reviewerKeyId(),
+        decision.reviewerKeyStatus(),
+        decision.policyId(),
+        decision.policyVersion(),
+        entry
+            .reviewReceipt()
+            .map(receipt -> receipt.payload().status().catalogValue())
+            .orElse(null),
+        decision.status().jsonValue(),
+        decision.trusted(),
+        decision.positive(),
+        decision.requiresAcknowledgement(),
+        decision.blocksInstall(),
+        decision.blocksUpdate(),
+        decision.blocksPolicyApply(),
+        decision.evidenceSha256(),
+        decision.evidenceUri() == null ? null : decision.evidenceUri().toString(),
+        null,
+        null,
+        warnings);
+  }
+
+  /**
+   * Builds a record from an app-update candidate review-trust map.
+   *
+   * <p>This factory is used by scheduler and update code that already carries a JSON-compatible
+   * {@code reviewTrust} object. It copies only the stable display-safe keys used by API surfaces
+   * and leaves missing values as {@code null}. The constructor still validates digests, warnings,
+   * and bounded strings before the draft can be appended.
+   *
+   * @param kind event kind for the update or policy gate
+   * @param appId app id for the update candidate
+   * @param appVersion candidate target version displayed to the operator
+   * @param catalogId catalog id that supplied the candidate, when known
+   * @param artifactSha256 lowercase SHA-256 digest of the candidate artifact
+   * @param artifactSizeBytes candidate artifact size in bytes
+   * @param reviewTrust JSON-compatible review trust map from API or scheduler code
+   * @param warnings bounded event warnings to include on the record
+   * @return unchained redacted record draft ready for store append
+   */
+  public static AppReviewTransparencyRecord fromReviewTrustMap(
+      AppReviewTransparencyEventKind kind,
+      String appId,
+      String appVersion,
+      String catalogId,
+      String artifactSha256,
+      long artifactSizeBytes,
+      Map<String, Object> reviewTrust,
+      List<String> warnings) {
+    Objects.requireNonNull(reviewTrust, "reviewTrust");
+    return new AppReviewTransparencyRecord(
+        SCHEMA_VERSION,
+        0L,
+        null,
+        null,
+        kind,
+        "app",
+        appId,
+        appVersion,
+        catalogId,
+        artifactSha256,
+        artifactSizeBytes,
+        stringValue(reviewTrust.get(REVIEWER_KEY_ID_FIELD)),
+        stringValue(reviewTrust.get(REVIEWER_KEY_STATUS_FIELD)),
+        stringValue(reviewTrust.get(POLICY_ID_FIELD)),
+        stringValue(reviewTrust.get(POLICY_VERSION_FIELD)),
+        null,
+        stringValue(reviewTrust.get("status")),
+        optionalBooleanValue(reviewTrust.get(TRUSTED_FIELD)).orElse(null),
+        optionalBooleanValue(reviewTrust.get(POSITIVE_FIELD)).orElse(null),
+        optionalBooleanValue(reviewTrust.get(REQUIRES_ACKNOWLEDGEMENT_FIELD)).orElse(null),
+        optionalBooleanValue(reviewTrust.get(BLOCKS_INSTALL_FIELD)).orElse(null),
+        optionalBooleanValue(reviewTrust.get(BLOCKS_UPDATE_FIELD)).orElse(null),
+        optionalBooleanValue(reviewTrust.get(BLOCKS_POLICY_APPLY_FIELD)).orElse(null),
+        stringValue(reviewTrust.get(EVIDENCE_SHA256_FIELD)),
+        stringValue(reviewTrust.get(EVIDENCE_URI_FIELD)),
+        null,
+        null,
+        warnings);
+  }
+
+  AppReviewTransparencyRecord withChain(long sequence, String previousHash, Instant createdAt) {
+    String assignedRecordId =
+        recordId == null || recordId.isBlank() ? kind.jsonValue() + ":" + sequence : recordId;
+    AppReviewTransparencyRecord chained =
+        new AppReviewTransparencyRecord(
+            schemaVersion,
+            sequence,
+            assignedRecordId,
+            createdAt,
+            kind,
+            subjectType,
+            appId,
+            appVersion,
+            catalogId,
+            artifactSha256,
+            artifactSizeBytes,
+            reviewerKeyId,
+            reviewerKeyStatus,
+            policyId,
+            policyVersion,
+            receiptStatus,
+            trustStatus,
+            trusted,
+            positive,
+            requiresAcknowledgement,
+            blocksInstall,
+            blocksUpdate,
+            blocksPolicyApply,
+            evidenceSha256,
+            evidenceUri,
+            previousHash == null ? "" : previousHash,
+            null,
+            warnings);
+    return new AppReviewTransparencyRecord(
+        chained.schemaVersion,
+        chained.sequence,
+        chained.recordId,
+        chained.createdAt,
+        chained.kind,
+        chained.subjectType,
+        chained.appId,
+        chained.appVersion,
+        chained.catalogId,
+        chained.artifactSha256,
+        chained.artifactSizeBytes,
+        chained.reviewerKeyId,
+        chained.reviewerKeyStatus,
+        chained.policyId,
+        chained.policyVersion,
+        chained.receiptStatus,
+        chained.trustStatus,
+        chained.trusted,
+        chained.positive,
+        chained.requiresAcknowledgement,
+        chained.blocksInstall,
+        chained.blocksUpdate,
+        chained.blocksPolicyApply,
+        chained.evidenceSha256,
+        chained.evidenceUri,
+        chained.previousRecordHash,
+        chained.computeRecordHash(),
+        chained.warnings);
+  }
+
+  String computeRecordHash() {
+    MessageDigest digest = AppCatalogSidecars.newArtifactSha256Digest();
+    digest.update(canonicalBytes());
+    return AppCatalogSidecars.lowercaseHex(digest.digest());
+  }
+
+  byte[] canonicalBytes() {
+    return canonicalText().getBytes(StandardCharsets.UTF_8);
+  }
+
+  String canonicalText() {
+    StringBuilder builder = new StringBuilder();
+    appendCanonical(builder, SCHEMA_VERSION_FIELD, Integer.toString(schemaVersion));
+    appendCanonical(builder, SEQUENCE_FIELD, Long.toString(sequence));
+    appendCanonical(builder, RECORD_ID_FIELD, recordId);
+    appendCanonical(builder, CREATED_AT_FIELD, createdAt == null ? null : createdAt.toString());
+    appendCanonical(builder, KIND_FIELD, kind.jsonValue());
+    appendCanonical(builder, SUBJECT_TYPE_FIELD, subjectType);
+    appendCanonical(builder, APP_ID_FIELD, appId);
+    appendCanonical(builder, APP_VERSION_FIELD, appVersion);
+    appendCanonical(builder, CATALOG_ID_FIELD, catalogId);
+    appendCanonical(builder, ARTIFACT_SHA256_FIELD, artifactSha256);
+    appendCanonical(builder, ARTIFACT_SIZE_BYTES_FIELD, artifactSizeBytes);
+    appendCanonical(builder, REVIEWER_KEY_ID_FIELD, reviewerKeyId);
+    appendCanonical(builder, REVIEWER_KEY_STATUS_FIELD, reviewerKeyStatus);
+    appendCanonical(builder, POLICY_ID_FIELD, policyId);
+    appendCanonical(builder, POLICY_VERSION_FIELD, policyVersion);
+    appendCanonical(builder, RECEIPT_STATUS_FIELD, receiptStatus);
+    appendCanonical(builder, TRUST_STATUS_FIELD, trustStatus);
+    appendCanonical(builder, TRUSTED_FIELD, trusted);
+    appendCanonical(builder, POSITIVE_FIELD, positive);
+    appendCanonical(builder, REQUIRES_ACKNOWLEDGEMENT_FIELD, requiresAcknowledgement);
+    appendCanonical(builder, BLOCKS_INSTALL_FIELD, blocksInstall);
+    appendCanonical(builder, BLOCKS_UPDATE_FIELD, blocksUpdate);
+    appendCanonical(builder, BLOCKS_POLICY_APPLY_FIELD, blocksPolicyApply);
+    appendCanonical(builder, EVIDENCE_SHA256_FIELD, evidenceSha256);
+    appendCanonical(builder, EVIDENCE_URI_FIELD, evidenceUri);
+    appendCanonical(builder, PREVIOUS_RECORD_HASH_FIELD, previousRecordHash);
+    appendCanonical(builder, WARNINGS_FIELD, canonicalWarnings(warnings));
+    return builder.toString();
+  }
+
+  /**
+   * Converts this record to JSON-compatible values.
+   *
+   * <p>The map preserves field order for deterministic JSONL output and test assertions. All fields
+   * are already redacted and normalized by the record constructor; this method does not expose
+   * public key bytes, private key material, local paths, browser sessions, request bodies, receipt
+   * signatures, or process tokens.
+   *
+   * @return redacted transparency record with stable JSON field names
+   */
+  public Map<String, Object> toJsonValue() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(24);
+    json.put(SCHEMA_VERSION_FIELD, schemaVersion);
+    json.put(SEQUENCE_FIELD, sequence);
+    json.put(RECORD_ID_FIELD, recordId);
+    json.put(CREATED_AT_FIELD, createdAt == null ? null : createdAt.toString());
+    json.put(KIND_FIELD, kind.jsonValue());
+    json.put(SUBJECT_TYPE_FIELD, subjectType);
+    json.put(APP_ID_FIELD, appId);
+    json.put(APP_VERSION_FIELD, appVersion);
+    json.put(CATALOG_ID_FIELD, catalogId);
+    json.put(ARTIFACT_SHA256_FIELD, artifactSha256);
+    json.put(ARTIFACT_SIZE_BYTES_FIELD, artifactSizeBytes);
+    json.put(REVIEWER_KEY_ID_FIELD, reviewerKeyId);
+    json.put(REVIEWER_KEY_STATUS_FIELD, reviewerKeyStatus);
+    json.put(POLICY_ID_FIELD, policyId);
+    json.put(POLICY_VERSION_FIELD, policyVersion);
+    json.put(RECEIPT_STATUS_FIELD, receiptStatus);
+    json.put(TRUST_STATUS_FIELD, trustStatus);
+    json.put(TRUSTED_FIELD, trusted);
+    json.put(POSITIVE_FIELD, positive);
+    json.put(REQUIRES_ACKNOWLEDGEMENT_FIELD, requiresAcknowledgement);
+    json.put(BLOCKS_INSTALL_FIELD, blocksInstall);
+    json.put(BLOCKS_UPDATE_FIELD, blocksUpdate);
+    json.put(BLOCKS_POLICY_APPLY_FIELD, blocksPolicyApply);
+    json.put(EVIDENCE_SHA256_FIELD, evidenceSha256);
+    json.put(EVIDENCE_URI_FIELD, evidenceUri);
+    json.put(PREVIOUS_RECORD_HASH_FIELD, previousRecordHash);
+    json.put(RECORD_HASH_FIELD, recordHash);
+    json.put(WARNINGS_FIELD, warnings);
+    return json;
+  }
+
+  String toJsonLine() {
+    return Json.write(toJsonValue());
+  }
+
+  static AppReviewTransparencyRecord parseJsonLine(String line) {
+    Map<String, Object> json = Json.parse(line);
+    rejectUnknownJsonFields(json);
+    return new AppReviewTransparencyRecord(
+        intValue(json.get(SCHEMA_VERSION_FIELD)),
+        longValue(json.get(SEQUENCE_FIELD)),
+        stringValue(json.get(RECORD_ID_FIELD)),
+        instantValue(json.get(CREATED_AT_FIELD)),
+        AppReviewTransparencyEventKind.parse(stringValue(json.get(KIND_FIELD))),
+        stringValue(json.get(SUBJECT_TYPE_FIELD)),
+        stringValue(json.get(APP_ID_FIELD)),
+        stringValue(json.get(APP_VERSION_FIELD)),
+        stringValue(json.get(CATALOG_ID_FIELD)),
+        stringValue(json.get(ARTIFACT_SHA256_FIELD)),
+        longObjectValue(json.get(ARTIFACT_SIZE_BYTES_FIELD)),
+        stringValue(json.get(REVIEWER_KEY_ID_FIELD)),
+        stringValue(json.get(REVIEWER_KEY_STATUS_FIELD)),
+        stringValue(json.get(POLICY_ID_FIELD)),
+        stringValue(json.get(POLICY_VERSION_FIELD)),
+        stringValue(json.get(RECEIPT_STATUS_FIELD)),
+        stringValue(json.get(TRUST_STATUS_FIELD)),
+        optionalBooleanValue(json.get(TRUSTED_FIELD)).orElse(null),
+        optionalBooleanValue(json.get(POSITIVE_FIELD)).orElse(null),
+        optionalBooleanValue(json.get(REQUIRES_ACKNOWLEDGEMENT_FIELD)).orElse(null),
+        optionalBooleanValue(json.get(BLOCKS_INSTALL_FIELD)).orElse(null),
+        optionalBooleanValue(json.get(BLOCKS_UPDATE_FIELD)).orElse(null),
+        optionalBooleanValue(json.get(BLOCKS_POLICY_APPLY_FIELD)).orElse(null),
+        stringValue(json.get(EVIDENCE_SHA256_FIELD)),
+        stringValue(json.get(EVIDENCE_URI_FIELD)),
+        stringValue(json.get(PREVIOUS_RECORD_HASH_FIELD)),
+        stringValue(json.get(RECORD_HASH_FIELD)),
+        stringListValue(json.get(WARNINGS_FIELD)));
+  }
+
+  private static void rejectUnknownJsonFields(Map<String, Object> json) {
+    for (String fieldName : json.keySet()) {
+      if (!JSON_FIELD_NAMES.contains(fieldName)) {
+        throw AppCatalogSidecars.invalidEntry(
+            "unknown review transparency record field: " + fieldName);
+      }
+    }
+  }
+
+  private static void appendCanonical(StringBuilder builder, String key, Object value) {
+    builder.append(key).append('=').append(value == null ? "" : value).append('\n');
+  }
+
+  private static String canonicalWarnings(List<String> warnings) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(warnings.size()).append(':');
+    for (String warning : warnings) {
+      String value = Objects.requireNonNullElse(warning, "");
+      builder.append(value.getBytes(StandardCharsets.UTF_8).length).append(':').append(value);
+    }
+    return builder.toString();
+  }
+
+  private static String optionalSingleLine(String value, String fieldName, int maxChars) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    return AppCatalogSidecars.requireBoundedSingleLine(
+        value, fieldName, AppCatalogSidecars.INVALID_CATALOG_ENTRY, maxChars);
+  }
+
+  private static String normalizeHash(String value, String fieldName) {
+    if (value == null || value.isBlank()) {
+      return value == null ? null : "";
+    }
+    return AppCatalogSidecars.requireLowercaseSha256(value, "review transparency " + fieldName);
+  }
+
+  private static String stringValue(Object value) {
+    return value == null ? null : value.toString();
+  }
+
+  private static Optional<Boolean> optionalBooleanValue(Object value) {
+    if (value == null) {
+      return Optional.empty();
+    }
+    if (value instanceof Boolean booleanValue) {
+      return Optional.of(booleanValue);
+    }
+    throw AppCatalogSidecars.invalidEntry("review transparency boolean field must be true/false");
+  }
+
+  private static int intValue(Object value) {
+    if (value instanceof Number number) {
+      long longValue = number.longValue();
+      if (longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE) {
+        throw AppCatalogSidecars.invalidEntry("review transparency integer field is out of range");
+      }
+      return Math.toIntExact(longValue);
+    }
+    try {
+      return Integer.parseInt(Objects.requireNonNull(value, "integer value").toString());
+    } catch (NumberFormatException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+          "invalid review transparency integer field",
+          exception);
+    }
+  }
+
+  private static long longValue(Object value) {
+    if (value instanceof Number number) {
+      return number.longValue();
+    }
+    return Long.parseLong(Objects.requireNonNull(value, "long value").toString());
+  }
+
+  private static Long longObjectValue(Object value) {
+    return value == null ? null : longValue(value);
+  }
+
+  private static Instant instantValue(Object value) {
+    if (value == null) {
+      return null;
+    }
+    try {
+      return Instant.parse(value.toString());
+    } catch (DateTimeParseException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+          "invalid review transparency createdAt: " + value,
+          exception);
+    }
+  }
+
+  private static List<String> stringListValue(Object value) {
+    if (!(value instanceof List<?> items)) {
+      return List.of();
+    }
+    List<String> strings = new ArrayList<>(items.size());
+    for (Object item : items) {
+      strings.add(item == null ? "" : item.toString());
+    }
+    return strings;
+  }
+
+  private static final class Json {
+    private Json() {}
+
+    static String write(Map<String, Object> json) {
+      StringBuilder builder = new StringBuilder("{");
+      boolean first = true;
+      for (Map.Entry<String, Object> entry : json.entrySet()) {
+        if (!first) {
+          builder.append(',');
+        }
+        first = false;
+        builder.append('"').append(escape(entry.getKey())).append('"').append(':');
+        writeValue(builder, entry.getValue());
+      }
+      return builder.append('}').toString();
+    }
+
+    static Map<String, Object> parse(String raw) {
+      Parser parser = new Parser(raw);
+      Map<String, Object> values = parser.parseObject();
+      parser.expectEnd();
+      return values;
+    }
+
+    private static void writeValue(StringBuilder builder, Object value) {
+      if (value == null) {
+        builder.append("null");
+      } else if (value instanceof Number || value instanceof Boolean) {
+        builder.append(value);
+      } else if (value instanceof List<?> list) {
+        builder.append('[');
+        boolean first = true;
+        for (Object item : list) {
+          if (!first) {
+            builder.append(',');
+          }
+          first = false;
+          writeValue(builder, item == null ? null : item.toString());
+        }
+        builder.append(']');
+      } else {
+        builder.append('"').append(escape(value.toString())).append('"');
+      }
+    }
+
+    private static String escape(String value) {
+      StringBuilder builder = new StringBuilder(value.length());
+      for (int index = 0; index < value.length(); index++) {
+        char character = value.charAt(index);
+        switch (character) {
+          case '"' -> builder.append("\\\"");
+          case '\\' -> builder.append("\\\\");
+          case '\n' -> builder.append("\\n");
+          case '\r' -> builder.append("\\r");
+          case '\t' -> builder.append("\\t");
+          default -> builder.append(character);
+        }
+      }
+      return builder.toString();
+    }
+  }
+
+  private static final class Parser {
+    private final String text;
+    private int index;
+
+    private Parser(String text) {
+      this.text = Objects.requireNonNull(text, "text").trim();
+    }
+
+    private Map<String, Object> parseObject() {
+      expect('{');
+      LinkedHashMap<String, Object> values = new LinkedHashMap<>();
+      skipWhitespace();
+      if (peek('}')) {
+        index++;
+        return values;
+      }
+      while (true) {
+        String key = parseString();
+        skipWhitespace();
+        expect(':');
+        Object value = parseValue();
+        if (values.containsKey(key)) {
+          throw AppCatalogSidecars.invalidEntry(
+              "duplicate review transparency record field: " + key);
+        }
+        values.put(key, value);
+        skipWhitespace();
+        if (peek('}')) {
+          index++;
+          return values;
+        }
+        expect(',');
+      }
+    }
+
+    private Object parseValue() {
+      skipWhitespace();
+      if (peek('"')) {
+        return parseString();
+      }
+      if (peek('[')) {
+        return parseArray();
+      }
+      if (consumeLiteral("null")) {
+        return null;
+      }
+      if (consumeLiteral("true")) {
+        return Boolean.TRUE;
+      }
+      if (consumeLiteral("false")) {
+        return Boolean.FALSE;
+      }
+      return parseNumber();
+    }
+
+    private List<String> parseArray() {
+      expect('[');
+      List<String> values = new ArrayList<>();
+      skipWhitespace();
+      if (peek(']')) {
+        index++;
+        return values;
+      }
+      while (true) {
+        Object value = parseValue();
+        values.add(value == null ? null : value.toString());
+        skipWhitespace();
+        if (peek(']')) {
+          index++;
+          return values;
+        }
+        expect(',');
+      }
+    }
+
+    private String parseString() {
+      expect('"');
+      StringBuilder builder = new StringBuilder();
+      while (index < text.length()) {
+        char character = text.charAt(index++);
+        if (character == '"') {
+          return builder.toString();
+        }
+        if (character != '\\') {
+          builder.append(character);
+          continue;
+        }
+        if (index >= text.length()) {
+          throw AppCatalogSidecars.invalidEntry("invalid JSON escape in transparency log");
+        }
+        char escaped = text.charAt(index++);
+        switch (escaped) {
+          case '"' -> builder.append('"');
+          case '\\' -> builder.append('\\');
+          case 'n' -> builder.append('\n');
+          case 'r' -> builder.append('\r');
+          case 't' -> builder.append('\t');
+          default ->
+              throw AppCatalogSidecars.invalidEntry("invalid JSON escape in transparency log");
+        }
+      }
+      throw AppCatalogSidecars.invalidEntry("unterminated JSON string in transparency log");
+    }
+
+    private Number parseNumber() {
+      int start = index;
+      if (peek('-')) {
+        index++;
+      }
+      while (index < text.length() && Character.isDigit(text.charAt(index))) {
+        index++;
+      }
+      if (start == index) {
+        throw AppCatalogSidecars.invalidEntry("invalid JSON value in transparency log");
+      }
+      try {
+        return Long.parseLong(text.substring(start, index));
+      } catch (NumberFormatException exception) {
+        throw new AppCatalogException(
+            AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+            "invalid JSON number in transparency log",
+            exception);
+      }
+    }
+
+    private boolean consumeLiteral(String literal) {
+      if (!text.startsWith(literal, index)) {
+        return false;
+      }
+      index += literal.length();
+      return true;
+    }
+
+    private void expect(char expected) {
+      skipWhitespace();
+      if (index >= text.length() || text.charAt(index) != expected) {
+        throw AppCatalogSidecars.invalidEntry("invalid JSON transparency log record");
+      }
+      index++;
+    }
+
+    private void expectEnd() {
+      skipWhitespace();
+      if (index != text.length()) {
+        throw AppCatalogSidecars.invalidEntry("trailing data after JSON transparency log record");
+      }
+    }
+
+    private boolean peek(char expected) {
+      skipWhitespace();
+      return index < text.length() && text.charAt(index) == expected;
+    }
+
+    private void skipWhitespace() {
+      while (index < text.length() && Character.isWhitespace(text.charAt(index))) {
+        index++;
+      }
+    }
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyStore.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyStore.java
@@ -1,0 +1,79 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+
+/**
+ * Persistence boundary for local review transparency records.
+ *
+ * <p>Stores are responsible for assigning append metadata and preserving the local hash chain.
+ * Callers normally use {@link AppReviewTransparencyLog}, which wraps this interface with
+ * best-effort behavior for install and update paths. Direct store callers, including tests and CLI
+ * verification code, receive {@link IOException} when storage cannot be read or written.
+ *
+ * <p>Implementations must keep records redacted. They should never persist private reviewer keys,
+ * raw public key bytes, local browser sessions, process tokens, scratch paths, request bodies, or
+ * receipt signatures. The file-backed implementation writes JSONL records; the in-memory
+ * implementation mirrors the same sequencing and verification rules for deterministic tests.
+ */
+public interface AppReviewTransparencyStore {
+  /**
+   * Appends one record draft and assigns sequence/hash-chain metadata.
+   *
+   * <p>The supplied record is expected to have draft values for sequence, timestamps, and hash
+   * fields. The store reads the current chain head, assigns the next sequence, sets the previous
+   * hash, computes the record hash, persists the result, and returns the chained record. Receipt
+   * observation records may be de-duplicated by stable record id.
+   *
+   * @param recordDraft unchained redacted record draft to append
+   * @return chained record that was persisted or matched by de-duplication
+   * @throws IOException if the backing store cannot be read or written
+   */
+  AppReviewTransparencyRecord append(AppReviewTransparencyRecord recordDraft) throws IOException;
+
+  /**
+   * Reads one bounded page.
+   *
+   * <p>Stores should apply cursor, limit, and filter constraints after reading records in sequence
+   * order. Implementations may treat a {@code null} query as {@link
+   * AppReviewTransparencyQuery#defaultQuery()} to match facade behavior.
+   *
+   * @param query bounded query with cursor and optional filters
+   * @return matching redacted page in ascending sequence order
+   * @throws IOException if records cannot be read from the backing store
+   */
+  AppReviewTransparencyPage page(AppReviewTransparencyQuery query) throws IOException;
+
+  /**
+   * Recomputes the local hash chain.
+   *
+   * <p>Verification checks sequence continuity, previous-hash linkage, and each record hash over
+   * the canonical fields understood by the current schema. A failed result should be redacted and
+   * must not include local paths or raw record bodies.
+   *
+   * @return verification result with record count and latest verified hash
+   * @throws IOException if records cannot be read from the backing store
+   */
+  AppReviewTransparencyVerificationResult verify() throws IOException;
+
+  /**
+   * Returns the number of stored records.
+   *
+   * <p>The count is a summary helper for governance status and should reflect the number of
+   * non-blank persisted records that parse successfully.
+   *
+   * @return number of stored transparency records
+   * @throws IOException if records cannot be read from the backing store
+   */
+  long recordCount() throws IOException;
+
+  /**
+   * Returns the latest record hash, or {@code null} when empty.
+   *
+   * <p>The latest hash is the current local chain head. It is display-safe but not a global
+   * checkpoint, and callers must still verify the chain before treating it as integrity evidence.
+   *
+   * @return latest local record hash, or {@code null} for an empty store
+   * @throws IOException if records cannot be read from the backing store
+   */
+  String latestRecordHash() throws IOException;
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyVerificationResult.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTransparencyVerificationResult.java
@@ -1,0 +1,73 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Result of recomputing a local review transparency log hash chain.
+ *
+ * <p>The result is the display-safe output of transparency-log verification. It reports whether the
+ * local sequence and hash chain are internally consistent, how many records were considered, the
+ * latest verified hash when available, and a redacted failure reason. It intentionally omits local
+ * file paths, raw JSONL lines, key material, receipt signatures, request bodies, and process state.
+ *
+ * <p>A successful result proves only local integrity for the records understood by this binary. It
+ * is not a global transparency checkpoint and does not make a review decision trusted by itself.
+ * Callers still need the corresponding {@link AppReviewTrustDecision} and reviewer-key governance
+ * state to explain install or update trust.
+ *
+ * @param verified whether the local chain recomputed successfully
+ * @param recordCount number of records inspected or known at failure time
+ * @param latestRecordHash latest verified record hash, or {@code null} when unavailable
+ * @param error redacted failure reason, or {@code null} for successful verification
+ */
+public record AppReviewTransparencyVerificationResult(
+    boolean verified, long recordCount, String latestRecordHash, String error) {
+  /**
+   * Returns a successful verification result.
+   *
+   * <p>The latest hash may be {@code null} for an empty log. Callers should use {@link #verified()}
+   * rather than hash presence alone when rendering status.
+   *
+   * @param recordCount number of records that verified successfully
+   * @param latestRecordHash latest verified hash, or {@code null} for an empty log
+   * @return success result with no error text
+   */
+  public static AppReviewTransparencyVerificationResult verified(
+      long recordCount, String latestRecordHash) {
+    return new AppReviewTransparencyVerificationResult(true, recordCount, latestRecordHash, null);
+  }
+
+  /**
+   * Returns a failed verification result.
+   *
+   * <p>The error string should be stable and redacted so it can be shown in API, CLI, Web Shell,
+   * and release-certification output. It must not include local paths or raw record content.
+   *
+   * @param recordCount number of records known or attempted at failure time
+   * @param latestRecordHash latest hash verified before failure, when available
+   * @param error display-safe failure reason
+   * @return failed verification result with redacted error text
+   */
+  public static AppReviewTransparencyVerificationResult failed(
+      long recordCount, String latestRecordHash, String error) {
+    return new AppReviewTransparencyVerificationResult(false, recordCount, latestRecordHash, error);
+  }
+
+  /**
+   * Converts this result to JSON-compatible values.
+   *
+   * <p>The field names match Platform API governance responses and developer CLI output. The map is
+   * safe to serialize directly because this record never stores filesystem paths or raw log data.
+   *
+   * @return JSON-compatible verification summary
+   */
+  public Map<String, Object> toJsonValue() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(4);
+    json.put("verified", verified);
+    json.put("recordCount", recordCount);
+    json.put("latestRecordHash", latestRecordHash);
+    json.put("error", error);
+    return json;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTrustDecision.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTrustDecision.java
@@ -34,8 +34,10 @@ import java.util.Objects;
  * @param blocksPolicyApply whether local policy blocks policy-driven apply
  * @param reviewerKeyId display-safe reviewer key id, when known
  * @param reviewerDisplayName display-safe reviewer name, when configured
+ * @param reviewerKeyStatus local reviewer-key lifecycle status, when the key is known
  * @param policyId receipt policy id, when known
  * @param policyVersion receipt policy version, when known
+ * @param policyVersionStatus local policy-version governance status, when known
  * @param reviewedAt receipt reviewed-at instant, when known
  * @param expiresAt receipt expiry instant, when known
  * @param evidenceSha256 evidence digest, when supplied
@@ -53,8 +55,10 @@ public record AppReviewTrustDecision(
     boolean blocksPolicyApply,
     String reviewerKeyId,
     String reviewerDisplayName,
+    String reviewerKeyStatus,
     String policyId,
     String policyVersion,
+    String policyVersionStatus,
     Instant reviewedAt,
     Instant expiresAt,
     String evidenceSha256,
@@ -77,8 +81,10 @@ public record AppReviewTrustDecision(
    * @param blocksPolicyApply whether local policy blocks automatic policy-driven apply
    * @param reviewerKeyId reviewer key id from the receipt payload, when available
    * @param reviewerDisplayName reviewer display name from local trust configuration, when available
+   * @param reviewerKeyStatus local reviewer-key lifecycle status, when available
    * @param policyId review policy id from the receipt payload, when available
    * @param policyVersion review policy version from the receipt payload, when available
+   * @param policyVersionStatus local policy-version governance status, when available
    * @param reviewedAt receipt review timestamp, when available
    * @param expiresAt receipt expiry timestamp, when available
    * @param evidenceSha256 receipt evidence digest, when supplied
@@ -102,7 +108,7 @@ public record AppReviewTrustDecision(
    * @return safe review trust JSON object without key bytes, private material, paths, or tokens
    */
   public Map<String, Object> toJsonValue() {
-    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(17);
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(19);
     json.put("status", status.jsonValue());
     json.put("trusted", trusted);
     json.put("positive", positive);
@@ -112,8 +118,10 @@ public record AppReviewTrustDecision(
     json.put("blocksPolicyApply", blocksPolicyApply);
     json.put("reviewerKeyId", reviewerKeyId);
     json.put("reviewerDisplayName", reviewerDisplayName);
+    json.put("reviewerKeyStatus", reviewerKeyStatus);
     json.put("policyId", policyId);
     json.put("policyVersion", policyVersion);
+    json.put("policyVersionStatus", policyVersionStatus);
     json.put("policyMode", policyMode.jsonValue());
     json.put("reviewedAt", reviewedAt == null ? null : reviewedAt.toString());
     json.put("expiresAt", expiresAt == null ? null : expiresAt.toString());

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTrustStatus.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/AppReviewTrustStatus.java
@@ -54,6 +54,44 @@ public enum AppReviewTrustStatus {
   UNKNOWN_REVIEWER("unknown_reviewer"),
 
   /**
+   * The receipt names a locally known reviewer key that is retired for the receipt timestamp.
+   *
+   * <p>Retired keys may authenticate historical receipts inside their validity window, but receipts
+   * outside that window fail closed with this status.
+   */
+  RETIRED_REVIEWER("retired_reviewer"),
+
+  /**
+   * The receipt names a locally known reviewer key that has been revoked.
+   *
+   * <p>Revoked keys fail closed for all receipts, including historical receipts. This status is
+   * deliberately distinct from {@link #UNKNOWN_REVIEWER} so operators can see revoked-key evidence.
+   */
+  REVOKED_REVIEWER("revoked_reviewer"),
+
+  /**
+   * The receipt was produced before the reviewer key's configured validity window.
+   *
+   * <p>The review timestamp, not the local wall clock, is used for this lifecycle decision.
+   */
+  REVIEWER_NOT_YET_VALID("reviewer_not_yet_valid"),
+
+  /**
+   * The receipt was produced after the reviewer key's configured active validity window.
+   *
+   * <p>For active keys this usually means the receipt was signed after the local key validity end.
+   */
+  REVIEWER_EXPIRED("reviewer_expired"),
+
+  /**
+   * The receipt policy id or policy version does not match the trusted reviewer-key constraint.
+   *
+   * <p>The reviewer key is known locally, but local governance does not accept this key for the
+   * receipt's policy metadata.
+   */
+  REVIEW_POLICY_MISMATCH("review_policy_mismatch"),
+
+  /**
    * The receipt signature is missing, malformed, or does not verify over canonical payload bytes.
    *
    * <p>The receipt might still parse structurally, but the node cannot authenticate the payload

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/FileAppReviewTransparencyStore.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/FileAppReviewTransparencyStore.java
@@ -1,0 +1,204 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * File-backed JSONL store for the local review transparency log.
+ *
+ * <p>The store persists one redacted {@link AppReviewTransparencyRecord} per line. Each append
+ * reads the current file, de-duplicates receipt-observation records by stable record id, assigns
+ * the next sequence number, links the previous hash, computes the new record hash, and appends a
+ * canonical JSON object. Verification reparses the file and recomputes the same canonical chain.
+ *
+ * <p>The configured path is host-owned state. API, Web Shell, CLI, and release-certification
+ * surfaces expose record counts, hashes, and redacted errors instead of filesystem paths or raw
+ * JSONL lines. The store methods are synchronized because callers may share one store instance
+ * across request handlers.
+ *
+ * @param logFile host-owned JSONL log file path
+ */
+public record FileAppReviewTransparencyStore(Path logFile) implements AppReviewTransparencyStore {
+  /**
+   * Default log file name below the review transparency directory.
+   *
+   * <p>Runtime composition may place this file under the catalog store root or another host-owned
+   * state directory. The name is stable for CLI verification and release-certification fixtures.
+   */
+  public static final String LOG_FILE_NAME = "review-transparency-log.jsonl";
+
+  public FileAppReviewTransparencyStore {
+    logFile = Objects.requireNonNull(logFile, "logFile").toAbsolutePath().normalize();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The file-backed implementation appends a single JSON object plus the platform line
+   * separator. Missing parent directories are created lazily on the first write. If a matching
+   * receipt observation already exists, the existing record is returned and the file is left
+   * unchanged.
+   */
+  @Override
+  public synchronized AppReviewTransparencyRecord append(AppReviewTransparencyRecord recordDraft)
+      throws IOException {
+    List<AppReviewTransparencyRecord> records = readAll();
+    for (AppReviewTransparencyRecord existing : records) {
+      if (Objects.equals(existing.recordId(), recordDraft.recordId())
+          && existing.kind() == AppReviewTransparencyEventKind.REVIEW_RECEIPT_OBSERVED) {
+        return existing;
+      }
+    }
+    String previousHash = records.isEmpty() ? "" : records.getLast().recordHash();
+    AppReviewTransparencyRecord appended =
+        recordDraft.withChain(records.size() + 1L, previousHash, Instant.now());
+    Files.createDirectories(logFile.getParent());
+    Files.writeString(
+        logFile,
+        appended.toJsonLine() + System.lineSeparator(),
+        StandardOpenOption.CREATE,
+        StandardOpenOption.APPEND);
+    return appended;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Records are read from the JSONL file in stored order, filtered after the cursor, and
+   * returned in ascending sequence order. A missing file is treated as an empty log.
+   */
+  @Override
+  public synchronized AppReviewTransparencyPage page(AppReviewTransparencyQuery query)
+      throws IOException {
+    AppReviewTransparencyQuery checkedQuery =
+        query == null ? AppReviewTransparencyQuery.defaultQuery() : query;
+    long cursor = checkedQuery.cursorSequence();
+    List<AppReviewTransparencyRecord> page = new ArrayList<>();
+    String nextCursor = null;
+    for (AppReviewTransparencyRecord transparencyRecord : readAll()) {
+      if (transparencyRecord.sequence() > cursor && checkedQuery.includes(transparencyRecord)) {
+        if (page.size() >= checkedQuery.limit()) {
+          nextCursor = Long.toString(page.getLast().sequence());
+          break;
+        }
+        page.add(transparencyRecord);
+      }
+    }
+    return new AppReviewTransparencyPage(page, nextCursor);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Malformed persisted records return a redacted failed result rather than leaking the bad line
+   * or the local file path. IO failures are still surfaced to direct callers.
+   */
+  @Override
+  public synchronized AppReviewTransparencyVerificationResult verify() throws IOException {
+    try {
+      return verifyRecords(readAll());
+    } catch (AppCatalogException _) {
+      return AppReviewTransparencyVerificationResult.failed(
+          0L, null, "invalid review transparency record");
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The count reflects non-blank persisted JSONL records that parse successfully. A missing file
+   * counts as zero records.
+   */
+  @Override
+  public synchronized long recordCount() throws IOException {
+    return readAll().size();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The latest hash is read from the final parsed record. A missing or empty file has no chain
+   * head and returns {@code null}.
+   */
+  @Override
+  public synchronized String latestRecordHash() throws IOException {
+    List<AppReviewTransparencyRecord> records = readAll();
+    return records.isEmpty() ? null : records.getLast().recordHash();
+  }
+
+  /**
+   * Verifies a standalone log file.
+   *
+   * <p>This helper is used by developer tooling and release-certification checks when they receive
+   * an explicit JSONL path. The returned result follows the same redaction rules as instance
+   * verification and does not expose the supplied path.
+   *
+   * @param logFile host-owned JSONL log file to verify
+   * @return redacted verification result for the standalone file
+   * @throws IOException if the log file cannot be read by the current process
+   */
+  public static AppReviewTransparencyVerificationResult verifyFile(Path logFile)
+      throws IOException {
+    return new FileAppReviewTransparencyStore(logFile).verify();
+  }
+
+  static AppReviewTransparencyVerificationResult verifyRecords(
+      List<AppReviewTransparencyRecord> records) {
+    String previousHash = "";
+    long expectedSequence = 1L;
+    for (AppReviewTransparencyRecord transparencyRecord : records) {
+      if (transparencyRecord.sequence() != expectedSequence) {
+        return AppReviewTransparencyVerificationResult.failed(
+            records.size(), previousHash, "record sequence gap at " + expectedSequence);
+      }
+      if (!previousHash.equals(transparencyRecord.previousRecordHash())) {
+        return AppReviewTransparencyVerificationResult.failed(
+            records.size(),
+            previousHash,
+            "previous hash mismatch at " + transparencyRecord.sequence());
+      }
+      String recomputedHash = transparencyRecord.computeRecordHash();
+      if (!recomputedHash.equals(transparencyRecord.recordHash())) {
+        return AppReviewTransparencyVerificationResult.failed(
+            records.size(),
+            previousHash,
+            "record hash mismatch at " + transparencyRecord.sequence());
+      }
+      previousHash = transparencyRecord.recordHash();
+      expectedSequence++;
+    }
+    return AppReviewTransparencyVerificationResult.verified(records.size(), previousHash);
+  }
+
+  private List<AppReviewTransparencyRecord> readAll() throws IOException {
+    if (!Files.isRegularFile(logFile)) {
+      return List.of();
+    }
+    List<AppReviewTransparencyRecord> records = new ArrayList<>();
+    for (String line : Files.readAllLines(logFile)) {
+      if (!line.isBlank()) {
+        records.add(parseRecordLine(line));
+      }
+    }
+    return List.copyOf(records);
+  }
+
+  private static AppReviewTransparencyRecord parseRecordLine(String line) {
+    try {
+      return AppReviewTransparencyRecord.parseJsonLine(line);
+    } catch (AppCatalogException exception) {
+      throw exception;
+    } catch (RuntimeException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+          "invalid review transparency record",
+          exception);
+    }
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/InMemoryAppReviewTransparencyStore.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/InMemoryAppReviewTransparencyStore.java
@@ -1,0 +1,113 @@
+package network.crypta.platform.appcatalog;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * In-memory transparency store used by tests and no-filesystem embeddings.
+ *
+ * <p>The store mirrors the file-backed sequencing, receipt-observation de-duplication, previous
+ * hash linking, and verification logic without touching the filesystem. It is useful for unit
+ * tests, API handler fixtures, and controlled embeddings that need governance behavior but do not
+ * want durable local state.
+ *
+ * <p>Records live only for the lifetime of this object. A successful verification result from this
+ * store proves that the in-memory chain is internally consistent, not that release-candidate
+ * evidence was persisted. Methods are synchronized so a shared test fixture behaves predictably
+ * when accessed from multiple request paths.
+ */
+public final class InMemoryAppReviewTransparencyStore implements AppReviewTransparencyStore {
+  private final List<AppReviewTransparencyRecord> records = new ArrayList<>();
+
+  /**
+   * Creates an empty in-memory transparency store.
+   *
+   * <p>The store starts with no records and assigns sequence {@code 1} to the first appended draft.
+   * It keeps all state in this object and does not create local files or directories.
+   */
+  public InMemoryAppReviewTransparencyStore() {
+    // State is initialized by the field declaration; the public constructor exists for doclint.
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The in-memory implementation assigns the next sequence and hash-chain fields immediately.
+   * Duplicate receipt observation records return the existing record and leave the list unchanged.
+   */
+  @Override
+  public synchronized AppReviewTransparencyRecord append(AppReviewTransparencyRecord recordDraft)
+      throws IOException {
+    for (AppReviewTransparencyRecord existing : records) {
+      if (Objects.equals(existing.recordId(), recordDraft.recordId())
+          && existing.kind() == AppReviewTransparencyEventKind.REVIEW_RECEIPT_OBSERVED) {
+        return existing;
+      }
+    }
+    String previousHash = records.isEmpty() ? "" : records.getLast().recordHash();
+    AppReviewTransparencyRecord appended =
+        recordDraft.withChain(records.size() + 1L, previousHash, Instant.now());
+    records.add(appended);
+    return appended;
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Filtering and cursor handling match {@link FileAppReviewTransparencyStore}. The returned
+   * page contains immutable snapshots of the currently stored records.
+   */
+  @Override
+  public synchronized AppReviewTransparencyPage page(AppReviewTransparencyQuery query) {
+    AppReviewTransparencyQuery checkedQuery =
+        query == null ? AppReviewTransparencyQuery.defaultQuery() : query;
+    long cursor = checkedQuery.cursorSequence();
+    List<AppReviewTransparencyRecord> page = new ArrayList<>();
+    String nextCursor = null;
+    for (AppReviewTransparencyRecord transparencyRecord : records) {
+      if (transparencyRecord.sequence() > cursor && checkedQuery.includes(transparencyRecord)) {
+        if (page.size() >= checkedQuery.limit()) {
+          nextCursor = Long.toString(page.getLast().sequence());
+          break;
+        }
+        page.add(transparencyRecord);
+      }
+    }
+    return new AppReviewTransparencyPage(page, nextCursor);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Verification delegates to the shared record-chain verifier so in-memory tests exercise the
+   * same canonical hash behavior as persisted JSONL logs.
+   */
+  @Override
+  public synchronized AppReviewTransparencyVerificationResult verify() {
+    return FileAppReviewTransparencyStore.verifyRecords(records);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The count reflects records currently held by this store instance.
+   */
+  @Override
+  public synchronized long recordCount() {
+    return records.size();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The latest hash is the hash of the final in-memory record, or {@code null} when no records
+   * have been appended.
+   */
+  @Override
+  public synchronized String latestRecordHash() {
+    return records.isEmpty() ? null : records.getLast().recordHash();
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/StoredCatalogSource.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/StoredCatalogSource.java
@@ -10,6 +10,7 @@ import java.time.Instant;
  * source URI, local lifecycle timestamps, and the exact fetched catalog/signature bytes that still
  * need to be verified against the current trusted-key policy before exposure.
  *
+ * @param catalogId normalized catalog id for the stored source directory
  * @param source validated source URI used for refresh operations
  * @param addedAt local timestamp when the source was first persisted
  * @param refreshedAt local timestamp when sidecars were last fetched and verified
@@ -17,6 +18,7 @@ import java.time.Instant;
  * @param fetchedCatalog exact catalog and signature bytes cached by the source store
  */
 record StoredCatalogSource(
+    String catalogId,
     AppCatalogSource source,
     Instant addedAt,
     Instant refreshedAt,

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerKey.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerKey.java
@@ -35,14 +35,16 @@ import network.crypta.platform.appdist.AppBundleSignature;
  * @param algorithm signature algorithm supported by the key
  * @param publicKey public verification key used for Ed25519 receipt signatures
  * @param displayName optional operator-facing reviewer name for API and UI summaries
- * @param policyId optional review policy id this reviewer key is trusted for
+ * @param policyConstraint optional review policy id/version this reviewer key is trusted for
+ * @param lifecycle local lifecycle governance metadata for this key
  */
 public record TrustedReviewerKey(
     String keyId,
     String algorithm,
     PublicKey publicKey,
     Optional<String> displayName,
-    Optional<String> policyId) {
+    TrustedReviewerPolicyConstraint policyConstraint,
+    TrustedReviewerKeyLifecycle lifecycle) {
   /**
    * Signature algorithm accepted for review receipt signatures.
    *
@@ -56,7 +58,6 @@ public record TrustedReviewerKey(
       Pattern.compile("-----BEGIN [^-]+-----|-----END [^-]+-----");
   private static final int MAX_KEY_ID_CHARS = 128;
   private static final int MAX_DISPLAY_NAME_CHARS = 128;
-  private static final int MAX_POLICY_ID_CHARS = 128;
 
   /**
    * Creates an Ed25519 reviewer key from base64-encoded X.509 bytes or PEM text.
@@ -74,7 +75,42 @@ public record TrustedReviewerKey(
    */
   public static TrustedReviewerKey ed25519(
       String keyId, String publicKeyMaterial, String displayName, String policyId) {
-    return ed25519(keyId, decodeBase64KeyMaterial(publicKeyMaterial), displayName, policyId);
+    return ed25519(
+        keyId,
+        decodeBase64KeyMaterial(publicKeyMaterial),
+        displayName,
+        policyId,
+        null,
+        TrustedReviewerKeyLifecycle.ACTIVE);
+  }
+
+  /**
+   * Creates an Ed25519 reviewer key from base64-encoded X.509 bytes or PEM text with lifecycle
+   * governance metadata.
+   *
+   * @param keyId stable reviewer key id expected in receipt payloads
+   * @param publicKeyMaterial X.509 public key bytes as base64 or PEM text
+   * @param displayName display name exposed in review-trust summaries, or {@code null} when omitted
+   * @param policyId review policy id this key is trusted for, or {@code null} when omitted
+   * @param policyVersion review policy version this key is trusted for, or {@code null} when
+   *     omitted
+   * @param lifecycle reviewer-key lifecycle metadata
+   * @return decoded trusted reviewer key
+   */
+  public static TrustedReviewerKey ed25519(
+      String keyId,
+      String publicKeyMaterial,
+      String displayName,
+      String policyId,
+      String policyVersion,
+      TrustedReviewerKeyLifecycle lifecycle) {
+    return ed25519(
+        keyId,
+        decodeBase64KeyMaterial(publicKeyMaterial),
+        displayName,
+        policyId,
+        policyVersion,
+        lifecycle);
   }
 
   /**
@@ -92,6 +128,29 @@ public record TrustedReviewerKey(
    */
   public static TrustedReviewerKey ed25519(
       String keyId, byte[] publicKeyBytes, String displayName, String policyId) {
+    return ed25519(
+        keyId, publicKeyBytes, displayName, policyId, null, TrustedReviewerKeyLifecycle.ACTIVE);
+  }
+
+  /**
+   * Creates an Ed25519 reviewer key from X.509 key bytes with lifecycle governance metadata.
+   *
+   * @param keyId stable reviewer key id expected in receipt payloads
+   * @param publicKeyBytes X.509 SubjectPublicKeyInfo key bytes
+   * @param displayName display name exposed in review-trust summaries, or {@code null} when omitted
+   * @param policyId review policy id this key is trusted for, or {@code null} when omitted
+   * @param policyVersion review policy version this key is trusted for, or {@code null} when
+   *     omitted
+   * @param lifecycle reviewer-key lifecycle metadata
+   * @return decoded trusted reviewer key
+   */
+  public static TrustedReviewerKey ed25519(
+      String keyId,
+      byte[] publicKeyBytes,
+      String displayName,
+      String policyId,
+      String policyVersion,
+      TrustedReviewerKeyLifecycle lifecycle) {
     try {
       PublicKey publicKey =
           KeyFactory.getInstance(SIGNATURE_ALGORITHM)
@@ -101,7 +160,8 @@ public record TrustedReviewerKey(
           SIGNATURE_ALGORITHM,
           publicKey,
           Optional.ofNullable(displayName),
-          Optional.ofNullable(policyId));
+          TrustedReviewerPolicyConstraint.of(policyId, policyVersion),
+          Objects.requireNonNullElse(lifecycle, TrustedReviewerKeyLifecycle.ACTIVE));
     } catch (GeneralSecurityException | IllegalArgumentException exception) {
       throw new AppCatalogException(
           AppCatalogSidecars.INVALID_CATALOG_ENTRY,
@@ -135,15 +195,35 @@ public record TrustedReviewerKey(
                     "reviewer display name",
                     AppCatalogSidecars.INVALID_CATALOG_ENTRY,
                     MAX_DISPLAY_NAME_CHARS));
-    Objects.requireNonNull(policyId, "policyId");
-    policyId =
-        policyId.map(
-            value ->
-                AppCatalogSidecars.requireBoundedSingleLine(
-                    value,
-                    "reviewer policy id",
-                    AppCatalogSidecars.INVALID_CATALOG_ENTRY,
-                    MAX_POLICY_ID_CHARS));
+    Objects.requireNonNull(policyConstraint, "policyConstraint");
+    Objects.requireNonNull(lifecycle, "lifecycle");
+  }
+
+  /**
+   * Returns the optional policy id constraint for source compatibility with older callers.
+   *
+   * @return configured policy id, when constrained
+   */
+  public Optional<String> policyId() {
+    return policyConstraint.policyId();
+  }
+
+  /**
+   * Returns the optional policy version constraint.
+   *
+   * @return configured policy version, when constrained
+   */
+  public Optional<String> policyVersion() {
+    return policyConstraint.policyVersion();
+  }
+
+  /**
+   * Returns the local lifecycle status.
+   *
+   * @return active, retired, or revoked
+   */
+  public TrustedReviewerKeyStatus status() {
+    return lifecycle.status();
   }
 
   private static byte[] decodeBase64KeyMaterial(String material) {

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerKeyLifecycle.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerKeyLifecycle.java
@@ -1,0 +1,191 @@
+package network.crypta.platform.appcatalog;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Local lifecycle governance metadata for a trusted reviewer key.
+ *
+ * <p>The lifecycle is intentionally small: it models active, retired, and revoked state; optional
+ * validity bounds for receipt review timestamps; revocation metadata; and key rotation links. The
+ * verifier uses only redacted metadata from this record when explaining trust decisions.
+ *
+ * <p>This state belongs to the local trusted-reviewer registry. It is not supplied by a remote
+ * catalog and does not make a receipt trusted by itself. A lifecycle can only allow evaluation to
+ * continue; signature verification, app/artifact binding, receipt expiry, and policy constraints
+ * still have to pass. Revoked keys fail closed, while retired keys require an explicit historical
+ * window before any receipt can remain trusted.
+ *
+ * <p>Instances are immutable and safe to expose through redacted summaries after public key
+ * material has been removed by the caller. Rotation ids are explanatory links for operators and do
+ * not create transitive trust between keys.
+ *
+ * @param status local lifecycle state for the reviewer key
+ * @param validFrom optional inclusive start instant for receipt review timestamps
+ * @param validUntil optional exclusive end instant for receipt review timestamps
+ * @param revokedAt optional instant when a revoked key was recorded locally
+ * @param revocationReason optional bounded reason explaining local revocation
+ * @param rotatesFrom optional predecessor reviewer key id
+ * @param rotatesTo optional successor reviewer key id
+ */
+public record TrustedReviewerKeyLifecycle(
+    TrustedReviewerKeyStatus status,
+    Optional<Instant> validFrom,
+    Optional<Instant> validUntil,
+    Optional<Instant> revokedAt,
+    Optional<String> revocationReason,
+    Optional<String> rotatesFrom,
+    Optional<String> rotatesTo) {
+  private static final int MAX_REASON_CHARS = 256;
+  private static final int MAX_ROTATION_ID_CHARS = 128;
+
+  /**
+   * Active key with no explicit validity window.
+   *
+   * <p>This is the compatibility default for v1 registries and programmatic test keys. Production
+   * v2 registries should prefer explicit windows so operators can audit reviewer rotations.
+   */
+  public static final TrustedReviewerKeyLifecycle ACTIVE =
+      new TrustedReviewerKeyLifecycle(
+          TrustedReviewerKeyStatus.ACTIVE,
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty(),
+          Optional.empty());
+
+  /**
+   * Creates lifecycle metadata from nullable registry values.
+   *
+   * <p>Registry loaders use this factory because properties files naturally produce nullable
+   * values. A missing status defaults to {@link TrustedReviewerKeyStatus#ACTIVE} for v1
+   * compatibility. Optional text fields are validated by the canonical constructor after conversion
+   * to {@link Optional}.
+   *
+   * @param status configured key lifecycle status, or {@code null} for active
+   * @param validFrom optional inclusive validity start for reviewed-at timestamps
+   * @param validUntil optional exclusive validity end for reviewed-at timestamps
+   * @param revokedAt optional local revocation instant
+   * @param revocationReason optional bounded single-line revocation reason
+   * @param rotatesFrom optional predecessor reviewer key id
+   * @param rotatesTo optional successor reviewer key id
+   * @return validated immutable lifecycle metadata
+   */
+  public static TrustedReviewerKeyLifecycle of(
+      TrustedReviewerKeyStatus status,
+      Instant validFrom,
+      Instant validUntil,
+      Instant revokedAt,
+      String revocationReason,
+      String rotatesFrom,
+      String rotatesTo) {
+    return new TrustedReviewerKeyLifecycle(
+        Objects.requireNonNullElse(status, TrustedReviewerKeyStatus.ACTIVE),
+        Optional.ofNullable(validFrom),
+        Optional.ofNullable(validUntil),
+        Optional.ofNullable(revokedAt),
+        Optional.ofNullable(revocationReason),
+        Optional.ofNullable(rotatesFrom),
+        Optional.ofNullable(rotatesTo));
+  }
+
+  /**
+   * Creates validated lifecycle metadata.
+   *
+   * <p>The constructor enforces a valid time window, requires revocation metadata to appear only on
+   * revoked keys, bounds revocation and rotation text, and preserves empty optionals as absent
+   * values. It intentionally records warnings rather than rejecting retired keys without {@code
+   * validUntil}; the verifier then fails those receipts closed at trust-evaluation time.
+   */
+  public TrustedReviewerKeyLifecycle {
+    Objects.requireNonNull(status, "status");
+    Objects.requireNonNull(validFrom, "validFrom");
+    Objects.requireNonNull(validUntil, "validUntil");
+    Objects.requireNonNull(revokedAt, "revokedAt");
+    Objects.requireNonNull(revocationReason, "revocationReason");
+    Objects.requireNonNull(rotatesFrom, "rotatesFrom");
+    Objects.requireNonNull(rotatesTo, "rotatesTo");
+    if (validFrom.isPresent()
+        && validUntil.isPresent()
+        && !validFrom.get().isBefore(validUntil.get())) {
+      throw AppCatalogSidecars.invalidEntry("reviewer valid.until must be after valid.from");
+    }
+    if (status != TrustedReviewerKeyStatus.REVOKED
+        && (revokedAt.isPresent() || revocationReason.isPresent())) {
+      throw AppCatalogSidecars.invalidEntry("reviewer revocation metadata requires status=revoked");
+    }
+    revocationReason =
+        revocationReason.map(
+            value ->
+                AppCatalogSidecars.requireBoundedSingleLine(
+                    value,
+                    "reviewer revocation reason",
+                    AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+                    MAX_REASON_CHARS));
+    rotatesFrom = rotatesFrom.map(TrustedReviewerKeyLifecycle::validateRotationId);
+    rotatesTo = rotatesTo.map(TrustedReviewerKeyLifecycle::validateRotationId);
+  }
+
+  /**
+   * Evaluates lifecycle acceptability for a receipt review timestamp.
+   *
+   * <p>The returned status is the first lifecycle-specific reason a receipt cannot be trusted.
+   * Revocation wins over all timestamp checks. A retired key without an explicit end of validity is
+   * rejected because there is no safe historical window. Passing this method only means lifecycle
+   * governance allows signature and policy checks to continue.
+   *
+   * @param reviewedAt timestamp from the independent receipt payload
+   * @return lifecycle trust failure, or empty when later verifier checks may proceed
+   */
+  public Optional<AppReviewTrustStatus> trustFailureAt(Instant reviewedAt) {
+    Objects.requireNonNull(reviewedAt, "reviewedAt");
+    if (status == TrustedReviewerKeyStatus.REVOKED) {
+      return Optional.of(AppReviewTrustStatus.REVOKED_REVIEWER);
+    }
+    if (validFrom.isPresent() && reviewedAt.isBefore(validFrom.get())) {
+      return Optional.of(AppReviewTrustStatus.REVIEWER_NOT_YET_VALID);
+    }
+    if (status == TrustedReviewerKeyStatus.RETIRED && validUntil.isEmpty()) {
+      return Optional.of(AppReviewTrustStatus.RETIRED_REVIEWER);
+    }
+    if (validUntil.isPresent() && !reviewedAt.isBefore(validUntil.get())) {
+      return Optional.of(
+          status == TrustedReviewerKeyStatus.RETIRED
+              ? AppReviewTrustStatus.RETIRED_REVIEWER
+              : AppReviewTrustStatus.REVIEWER_EXPIRED);
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns display-safe validation warnings about lifecycle metadata.
+   *
+   * <p>Warnings are intended for registry summaries and operator diagnostics. They are not used to
+   * downgrade trust by themselves; the verifier has explicit fail-closed checks for revoked and
+   * retired-key edge cases.
+   *
+   * @return warnings suitable for API, CLI, and certification summaries
+   */
+  public List<String> warnings() {
+    List<String> warnings = new ArrayList<>();
+    if (status == TrustedReviewerKeyStatus.REVOKED && revokedAt.isEmpty()) {
+      warnings.add("Revoked reviewer key has no revokedAt timestamp.");
+    }
+    if (status == TrustedReviewerKeyStatus.RETIRED && validUntil.isEmpty()) {
+      warnings.add("Retired reviewer key has no validUntil timestamp.");
+    }
+    return List.copyOf(warnings);
+  }
+
+  private static String validateRotationId(String value) {
+    return AppCatalogSidecars.requireBoundedSingleLine(
+        value,
+        "reviewer rotation key id",
+        AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+        MAX_ROTATION_ID_CHARS);
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerKeyStatus.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerKeyStatus.java
@@ -1,0 +1,85 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Locale;
+
+/**
+ * Local lifecycle status for a trusted reviewer key.
+ *
+ * <p>The status is operator-controlled local governance state. It is not read from catalogs or
+ * receipt payloads, and it never grants trust by itself; receipt signatures, policy constraints,
+ * artifact binding, and receipt expiry still have to verify.
+ *
+ * <p>The three states describe how the verifier should treat receipts that name a configured key
+ * id. Active keys may verify current receipts inside their validity window. Retired keys can only
+ * verify historical receipts inside an explicit window. Revoked keys fail closed for every receipt
+ * and remain visible as governance evidence instead of being downgraded to unknown reviewers.
+ *
+ * <p>The lowercase values returned by {@link #jsonValue()} are stable across registry files, API
+ * responses, Web Shell badges, CLI output, and release-certification reports.
+ */
+public enum TrustedReviewerKeyStatus {
+  /**
+   * Key may sign current receipts within its configured validity window.
+   *
+   * <p>An active key still has to match the receipt policy constraint and verify the receipt
+   * signature. Active status alone does not trust catalog publishers or app bundles.
+   */
+  ACTIVE("active"),
+
+  /**
+   * Key is no longer current, but may authenticate historical receipts inside its window.
+   *
+   * <p>A retired key without an explicit validity end is not accepted for positive trust because
+   * the verifier cannot determine the historical boundary safely.
+   */
+  RETIRED("retired"),
+
+  /**
+   * Key is revoked and must fail closed for every receipt.
+   *
+   * <p>Revocation is distinct from an unknown key. Operator surfaces should show that the key is
+   * known locally but rejected by governance policy.
+   */
+  REVOKED("revoked");
+
+  private final String jsonValue;
+
+  TrustedReviewerKeyStatus(String jsonValue) {
+    this.jsonValue = jsonValue;
+  }
+
+  /**
+   * Parses a registry status value.
+   *
+   * <p>Registry parsing accepts the stable lowercase values case-insensitively after validating
+   * that the input is a bounded single line. Unsupported values fail closed so a malformed trust
+   * registry cannot silently create active reviewer keys.
+   *
+   * @param raw configured status text from a trusted-reviewer registry
+   * @return matching local lifecycle status
+   */
+  public static TrustedReviewerKeyStatus parse(String raw) {
+    String value =
+        AppCatalogSidecars.requireNonBlankSingleLine(
+                raw, "reviewer key status", AppCatalogSidecars.INVALID_CATALOG_ENTRY)
+            .toLowerCase(Locale.ROOT);
+    for (TrustedReviewerKeyStatus status : values()) {
+      if (status.jsonValue.equals(value)) {
+        return status;
+      }
+    }
+    throw AppCatalogSidecars.invalidEntry("unsupported reviewer key status: " + raw);
+  }
+
+  /**
+   * Returns the stable lowercase value used in API, CLI, docs, and audit summaries.
+   *
+   * <p>Use this value for persisted registry summaries and JSON responses. Enum names are not part
+   * of the external review-governance contract.
+   *
+   * @return stable lowercase JSON-facing status value
+   */
+  public String jsonValue() {
+    return jsonValue;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerKeySummary.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerKeySummary.java
@@ -1,0 +1,103 @@
+package network.crypta.platform.appcatalog;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Redacted JSON-facing summary for one trusted reviewer key.
+ *
+ * <p>This summary intentionally excludes public key bytes and all file provenance. It contains only
+ * display-safe governance metadata needed by operators, Web Shell, CLI inspection, and
+ * release-certification evidence.
+ *
+ * <p>The summary is derived from an in-process {@link TrustedReviewerKey}, which still contains
+ * public verifier material. Callers should convert to this type before returning reviewer
+ * governance data through Platform API, Web Shell, CLI, logs, or certification reports. The summary
+ * preserves policy and lifecycle information so operators can explain why a receipt was trusted,
+ * historical, revoked, or rejected by local governance.
+ *
+ * <p>Nullable fields stay present in the JSON output. That lets clients distinguish an omitted
+ * lifecycle window or policy version from an unknown key, without exposing registry paths or raw
+ * sidecar contents.
+ *
+ * @param keyId stable local reviewer key id
+ * @param displayName optional operator-facing reviewer display name
+ * @param algorithm signature algorithm name, currently {@code Ed25519}
+ * @param status local lifecycle status for the key
+ * @param policyId accepted review policy id, or {@code null} for unconstrained keys
+ * @param policyVersion accepted review policy version, or {@code null} when unconstrained
+ * @param validFrom optional inclusive validity start instant
+ * @param validUntil optional exclusive validity end instant
+ * @param revokedAt optional local revocation instant
+ * @param revocationReason optional display-safe revocation reason
+ * @param rotatesFrom optional predecessor reviewer key id
+ * @param rotatesTo optional successor reviewer key id
+ */
+public record TrustedReviewerKeySummary(
+    String keyId,
+    String displayName,
+    String algorithm,
+    TrustedReviewerKeyStatus status,
+    String policyId,
+    String policyVersion,
+    Instant validFrom,
+    Instant validUntil,
+    Instant revokedAt,
+    String revocationReason,
+    String rotatesFrom,
+    String rotatesTo) {
+  /**
+   * Builds a redacted summary from a trusted reviewer key.
+   *
+   * <p>The conversion copies display-safe lifecycle and policy fields only. It deliberately drops
+   * public key bytes, registry file paths, and any source provenance so the result can be
+   * serialized by operator-facing endpoints.
+   *
+   * @param key trusted reviewer key that remains usable for in-process verification
+   * @return summary without raw key material or local file provenance
+   */
+  public static TrustedReviewerKeySummary from(TrustedReviewerKey key) {
+    TrustedReviewerKeyLifecycle lifecycle = key.lifecycle();
+    TrustedReviewerPolicyConstraint constraint = key.policyConstraint();
+    return new TrustedReviewerKeySummary(
+        key.keyId(),
+        key.displayName().orElse(null),
+        key.algorithm(),
+        lifecycle.status(),
+        constraint.policyId().orElse(null),
+        constraint.policyVersion().orElse(null),
+        lifecycle.validFrom().orElse(null),
+        lifecycle.validUntil().orElse(null),
+        lifecycle.revokedAt().orElse(null),
+        lifecycle.revocationReason().orElse(null),
+        lifecycle.rotatesFrom().orElse(null),
+        lifecycle.rotatesTo().orElse(null));
+  }
+
+  /**
+   * Converts this summary to stable JSON-compatible values.
+   *
+   * <p>The map uses stable field names consumed by Platform API, Web Shell, developer CLI, and
+   * release-certification evidence. Timestamp values are rendered as ISO-8601 instants and optional
+   * fields remain present with {@code null} values.
+   *
+   * @return redacted key summary with lifecycle and policy metadata
+   */
+  public Map<String, Object> toJsonValue() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(12);
+    json.put("keyId", keyId);
+    json.put("displayName", displayName);
+    json.put("algorithm", algorithm);
+    json.put("status", status.jsonValue());
+    json.put("policyId", policyId);
+    json.put("policyVersion", policyVersion);
+    json.put("validFrom", validFrom == null ? null : validFrom.toString());
+    json.put("validUntil", validUntil == null ? null : validUntil.toString());
+    json.put("revokedAt", revokedAt == null ? null : revokedAt.toString());
+    json.put("revocationReason", revocationReason);
+    json.put("rotatesFrom", rotatesFrom);
+    json.put("rotatesTo", rotatesTo);
+    return json;
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerKeys.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerKeys.java
@@ -2,9 +2,12 @@ package network.crypta.platform.appcatalog;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,12 +39,19 @@ import java.util.regex.Pattern;
 public final class TrustedReviewerKeys {
   private static final Pattern REVIEWER_PROPERTY_PATTERN =
       Pattern.compile(
-          "reviewer\\.(\\d+)\\.(id|algorithm|public\\.key\\.base64|display\\.name|policy\\.id)");
-  private static final TrustedReviewerKeys EMPTY = new TrustedReviewerKeys(Map.of());
+          "reviewer\\.(\\d+)\\.(id|algorithm|public\\.key\\.base64|display\\.name|policy\\.id|"
+              + "policy\\.version|status|valid\\.from|valid\\.until|revoked\\.at|"
+              + "revocation\\.reason|rotates\\.from|rotates\\.to)");
+  private static final TrustedReviewerKeys EMPTY = new TrustedReviewerKeys(1, Map.of());
+  private static final String DUPLICATE_KEY_ID_MESSAGE_PREFIX =
+      "duplicate trusted reviewer key id: ";
+  private static final String REVIEWER_ENTRY_PREFIX = "reviewer.";
 
+  private final int registryVersion;
   private final Map<String, TrustedReviewerKey> keysById;
 
-  private TrustedReviewerKeys(Map<String, TrustedReviewerKey> keysById) {
+  private TrustedReviewerKeys(int registryVersion, Map<String, TrustedReviewerKey> keysById) {
+    this.registryVersion = registryVersion;
     this.keysById = Map.copyOf(keysById);
   }
 
@@ -62,11 +72,10 @@ public final class TrustedReviewerKeys {
       TrustedReviewerKey trustedKey = Objects.requireNonNull(key, "key");
       TrustedReviewerKey previous = byId.putIfAbsent(trustedKey.keyId(), trustedKey);
       if (previous != null) {
-        throw AppCatalogSidecars.invalidEntry(
-            "duplicate trusted reviewer key id: " + trustedKey.keyId());
+        throw AppCatalogSidecars.invalidEntry(DUPLICATE_KEY_ID_MESSAGE_PREFIX + trustedKey.keyId());
       }
     }
-    return new TrustedReviewerKeys(byId);
+    return new TrustedReviewerKeys(1, byId);
   }
 
   /**
@@ -100,9 +109,9 @@ public final class TrustedReviewerKeys {
    *
    * <p>The file supports {@code trusted.reviewers.version=1} and contiguous {@code reviewer.N.*}
    * entries with {@code id}, {@code algorithm}, {@code public.key.base64}, and optional {@code
-   * display.name} and {@code policy.id} fields. Indexes may start at either {@code 0} or {@code 1}
-   * so operator examples can use human-friendly numbering while tests can mirror existing app-key
-   * fixtures.
+   * display.name} and {@code policy.id} fields. Version {@code 2} also accepts policy-version and
+   * lifecycle governance fields. Indexes may start at either {@code 0} or {@code 1} so operator
+   * examples can use human-friendly numbering while tests can mirror existing app-key fixtures.
    *
    * <p>Only the Ed25519 review receipt algorithm is accepted. Unknown properties, unsupported
    * algorithms, duplicate ids, and incomplete key entries fail the whole load rather than producing
@@ -123,13 +132,13 @@ public final class TrustedReviewerKeys {
     Map<String, String> properties =
         AppCatalogSidecars.parseKeyValueSidecar(
             AppCatalogSidecars.utf8(bytes), "trusted reviewer keys file");
-    validateVersion(properties.remove("trusted.reviewers.version"));
+    int version = validateVersion(properties.remove("trusted.reviewers.version"));
     SortedMap<Integer, TrustedReviewerKeyBuilder> builders = readBuilders(properties);
     if (!properties.isEmpty()) {
       throw AppCatalogSidecars.invalidEntry(
           "unsupported trusted reviewer keys property: " + properties.keySet().iterator().next());
     }
-    return buildKeys(builders);
+    return buildKeys(version, builders);
   }
 
   /**
@@ -160,6 +169,52 @@ public final class TrustedReviewerKeys {
   }
 
   /**
+   * Returns the trusted-reviewer registry format version.
+   *
+   * @return registry version parsed from the properties file, or {@code 1} for programmatic keys
+   */
+  public int registryVersion() {
+    return registryVersion;
+  }
+
+  /**
+   * Returns configured reviewer keys without exposing public key material through JSON helpers.
+   *
+   * <p>The returned key objects still contain public verifier material for in-process verification,
+   * so callers must use {@link #summaries()} for API, Web Shell, CLI, or certification output.
+   *
+   * @return configured reviewer keys sorted by key id for deterministic output
+   */
+  public List<TrustedReviewerKey> all() {
+    return keysById.values().stream()
+        .sorted(Comparator.comparing(TrustedReviewerKey::keyId))
+        .toList();
+  }
+
+  /**
+   * Returns redacted reviewer-key summaries.
+   *
+   * @return key summaries sorted by key id
+   */
+  public List<TrustedReviewerKeySummary> summaries() {
+    return all().stream().map(TrustedReviewerKeySummary::from).toList();
+  }
+
+  /**
+   * Returns a redacted summary of the registry.
+   *
+   * @return registry version, lifecycle counts, and warnings
+   */
+  public TrustedReviewerRegistrySummary summary() {
+    LinkedHashMap<String, Integer> counts = LinkedHashMap.newLinkedHashMap(3);
+    counts.put("active", count(TrustedReviewerKeyStatus.ACTIVE));
+    counts.put("retired", count(TrustedReviewerKeyStatus.RETIRED));
+    counts.put("revoked", count(TrustedReviewerKeyStatus.REVOKED));
+    return new TrustedReviewerRegistrySummary(
+        !isEmpty(), registryVersion, counts, registryWarnings());
+  }
+
+  /**
    * Returns a new registry with one additional reviewer key.
    *
    * <p>The existing registry is not modified. This is used by configuration loading to combine a
@@ -174,21 +229,50 @@ public final class TrustedReviewerKeys {
     TrustedReviewerKey trustedKey = Objects.requireNonNull(key, "key");
     TrustedReviewerKey previous = combined.putIfAbsent(trustedKey.keyId(), trustedKey);
     if (previous != null) {
-      throw AppCatalogSidecars.invalidEntry(
-          "duplicate trusted reviewer key id: " + trustedKey.keyId());
+      throw AppCatalogSidecars.invalidEntry(DUPLICATE_KEY_ID_MESSAGE_PREFIX + trustedKey.keyId());
     }
-    return new TrustedReviewerKeys(combined);
+    return new TrustedReviewerKeys(registryVersion, combined);
   }
 
-  private static void validateVersion(String versionText) {
+  private int count(TrustedReviewerKeyStatus status) {
+    int count = 0;
+    for (TrustedReviewerKey key : keysById.values()) {
+      if (key.status() == status) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  private List<String> registryWarnings() {
+    List<String> warnings = new ArrayList<>();
+    for (TrustedReviewerKey key : all()) {
+      warnings.addAll(
+          key.lifecycle().warnings().stream()
+              .map(warning -> key.keyId() + ": " + warning)
+              .toList());
+      key.lifecycle()
+          .rotatesFrom()
+          .filter(id -> !keysById.containsKey(id))
+          .ifPresent(_ -> warnings.add(key.keyId() + ": rotatesFrom key is not configured."));
+      key.lifecycle()
+          .rotatesTo()
+          .filter(id -> !keysById.containsKey(id))
+          .ifPresent(_ -> warnings.add(key.keyId() + ": rotatesTo key is not configured."));
+    }
+    return List.copyOf(warnings);
+  }
+
+  private static int validateVersion(String versionText) {
     if (versionText == null) {
       throw AppCatalogSidecars.invalidEntry("missing trusted.reviewers.version");
     }
     try {
       int version = Integer.parseInt(versionText);
-      if (version != 1) {
+      if (version != 1 && version != 2) {
         throw AppCatalogSidecars.invalidEntry("unsupported trusted.reviewers.version: " + version);
       }
+      return version;
     } catch (NumberFormatException exception) {
       throw new AppCatalogException(
           AppCatalogSidecars.INVALID_CATALOG_ENTRY,
@@ -215,9 +299,9 @@ public final class TrustedReviewerKeys {
   }
 
   private static TrustedReviewerKeys buildKeys(
-      SortedMap<Integer, TrustedReviewerKeyBuilder> builders) {
+      int version, SortedMap<Integer, TrustedReviewerKeyBuilder> builders) {
     if (builders.isEmpty()) {
-      return empty();
+      return new TrustedReviewerKeys(version, Map.of());
     }
     int start = builders.firstKey();
     if (start != 0 && start != 1) {
@@ -230,12 +314,20 @@ public final class TrustedReviewerKeys {
       if (builder == null) {
         throw AppCatalogSidecars.invalidEntry("trusted reviewer keys must use contiguous indexes");
       }
-      keys.add(buildKey(builder, index));
+      keys.add(buildKey(version, builder, index));
     }
-    return of(keys);
+    Map<String, TrustedReviewerKey> byId = new LinkedHashMap<>();
+    for (TrustedReviewerKey key : keys) {
+      TrustedReviewerKey previous = byId.putIfAbsent(key.keyId(), key);
+      if (previous != null) {
+        throw AppCatalogSidecars.invalidEntry(DUPLICATE_KEY_ID_MESSAGE_PREFIX + key.keyId());
+      }
+    }
+    return new TrustedReviewerKeys(version, byId);
   }
 
-  private static TrustedReviewerKey buildKey(TrustedReviewerKeyBuilder builder, int index) {
+  private static TrustedReviewerKey buildKey(
+      int registryVersion, TrustedReviewerKeyBuilder builder, int index) {
     if (builder.id == null || builder.algorithm == null || builder.publicKeyBase64 == null) {
       throw AppCatalogSidecars.invalidEntry("trusted reviewer key " + index + " is incomplete");
     }
@@ -243,8 +335,48 @@ public final class TrustedReviewerKeys {
       throw AppCatalogSidecars.invalidEntry(
           "unsupported trusted reviewer key algorithm: " + builder.algorithm);
     }
+    if (registryVersion == 1 && builder.hasV2Fields()) {
+      throw AppCatalogSidecars.invalidEntry(
+          "trusted reviewer key " + index + " uses v2 fields in a v1 registry");
+    }
+    TrustedReviewerKeyStatus status =
+        builder.status == null
+            ? TrustedReviewerKeyStatus.ACTIVE
+            : TrustedReviewerKeyStatus.parse(builder.status);
+    TrustedReviewerKeyLifecycle lifecycle =
+        TrustedReviewerKeyLifecycle.of(
+            status,
+            parseOptionalInstant(builder.validFrom, reviewerFieldName(index, "valid.from")),
+            parseOptionalInstant(builder.validUntil, reviewerFieldName(index, "valid.until")),
+            parseOptionalInstant(builder.revokedAt, reviewerFieldName(index, "revoked.at")),
+            builder.revocationReason,
+            builder.rotatesFrom,
+            builder.rotatesTo);
     return TrustedReviewerKey.ed25519(
-        builder.id, builder.publicKeyBase64, builder.displayName, builder.policyId);
+        builder.id,
+        builder.publicKeyBase64,
+        builder.displayName,
+        builder.policyId,
+        builder.policyVersion,
+        lifecycle);
+  }
+
+  private static Instant parseOptionalInstant(String value, String fieldName) {
+    if (value == null) {
+      return null;
+    }
+    try {
+      return Instant.parse(value);
+    } catch (DateTimeParseException exception) {
+      throw new AppCatalogException(
+          AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+          "invalid " + fieldName + ": " + value,
+          exception);
+    }
+  }
+
+  private static String reviewerFieldName(int index, String fieldName) {
+    return REVIEWER_ENTRY_PREFIX + index + "." + fieldName;
   }
 
   private static int parseIndex(String rawIndex, String propertyName) {
@@ -265,6 +397,14 @@ public final class TrustedReviewerKeys {
       case "public.key.base64" -> builder.publicKeyBase64 = value;
       case "display.name" -> builder.displayName = value;
       case "policy.id" -> builder.policyId = value;
+      case "policy.version" -> builder.policyVersion = value;
+      case "status" -> builder.status = value;
+      case "valid.from" -> builder.validFrom = value;
+      case "valid.until" -> builder.validUntil = value;
+      case "revoked.at" -> builder.revokedAt = value;
+      case "revocation.reason" -> builder.revocationReason = value;
+      case "rotates.from" -> builder.rotatesFrom = value;
+      case "rotates.to" -> builder.rotatesTo = value;
       default -> throw new IllegalArgumentException("unsupported trusted reviewer key field");
     }
   }
@@ -275,5 +415,24 @@ public final class TrustedReviewerKeys {
     private String publicKeyBase64;
     private String displayName;
     private String policyId;
+    private String policyVersion;
+    private String status;
+    private String validFrom;
+    private String validUntil;
+    private String revokedAt;
+    private String revocationReason;
+    private String rotatesFrom;
+    private String rotatesTo;
+
+    private boolean hasV2Fields() {
+      return policyVersion != null
+          || status != null
+          || validFrom != null
+          || validUntil != null
+          || revokedAt != null
+          || revocationReason != null
+          || rotatesFrom != null
+          || rotatesTo != null;
+    }
   }
 }

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerPolicyConstraint.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerPolicyConstraint.java
@@ -1,0 +1,100 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Local policy constraint attached to one trusted reviewer key.
+ *
+ * <p>Receipts already carry policy id and version metadata. This constraint lets a local registry
+ * say which policy id, and optionally which policy version, a key may authenticate. It is a local
+ * governance rule, not signed catalog metadata.
+ *
+ * <p>The constraint is evaluated after the receipt names a configured reviewer key and before the
+ * verifier reports positive trust. A missing policy id means the key accepts any policy, but a
+ * configured version requires a configured id so operators cannot accidentally trust every policy
+ * with the same version number. This keeps small registry mistakes from broadening trust.
+ *
+ * <p>Instances are immutable and contain only bounded text. They are safe to expose through
+ * redacted reviewer summaries because they do not include key bytes, signatures, registry paths, or
+ * receipt bodies.
+ *
+ * @param policyId optional accepted receipt policy id
+ * @param policyVersion optional accepted receipt policy version
+ */
+public record TrustedReviewerPolicyConstraint(
+    Optional<String> policyId, Optional<String> policyVersion) {
+  private static final int MAX_POLICY_ID_CHARS = 128;
+  private static final int MAX_POLICY_VERSION_CHARS = 64;
+
+  /**
+   * Constraint that accepts any receipt policy id and version.
+   *
+   * <p>This value preserves v1 registry behavior. New v2 registries should normally configure an
+   * explicit policy id, and optionally a version, so local governance can explain policy trust.
+   */
+  @SuppressWarnings("unused")
+  public static final TrustedReviewerPolicyConstraint ANY =
+      new TrustedReviewerPolicyConstraint(Optional.empty(), Optional.empty());
+
+  /**
+   * Creates a constraint from nullable registry values.
+   *
+   * <p>Registry loaders use this factory for properties-file values. Blank validation and
+   * single-line bounds are enforced by the canonical constructor after nullable values are
+   * converted to optionals.
+   *
+   * @param policyId optional policy id from the reviewer registry
+   * @param policyVersion optional policy version from the reviewer registry
+   * @return validated policy constraint for one reviewer key
+   */
+  public static TrustedReviewerPolicyConstraint of(String policyId, String policyVersion) {
+    return new TrustedReviewerPolicyConstraint(
+        Optional.ofNullable(policyId), Optional.ofNullable(policyVersion));
+  }
+
+  /**
+   * Creates a validated constraint.
+   *
+   * <p>Policy ids and versions are bounded single-line strings. A version without an id is rejected
+   * because policy versions are meaningful only within a policy namespace.
+   */
+  public TrustedReviewerPolicyConstraint {
+    Objects.requireNonNull(policyId, "policyId");
+    Objects.requireNonNull(policyVersion, "policyVersion");
+    policyId =
+        policyId.map(
+            value ->
+                AppCatalogSidecars.requireBoundedSingleLine(
+                    value,
+                    "reviewer policy id",
+                    AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+                    MAX_POLICY_ID_CHARS));
+    policyVersion =
+        policyVersion.map(
+            value ->
+                AppCatalogSidecars.requireBoundedSingleLine(
+                    value,
+                    "reviewer policy version",
+                    AppCatalogSidecars.INVALID_CATALOG_ENTRY,
+                    MAX_POLICY_VERSION_CHARS));
+    if (policyVersion.isPresent() && policyId.isEmpty()) {
+      throw AppCatalogSidecars.invalidEntry("reviewer policy.version requires policy.id");
+    }
+  }
+
+  /**
+   * Returns whether this constraint accepts a receipt policy id/version pair.
+   *
+   * <p>Unconfigured fields are wildcards. Configured fields must match exactly because policy ids
+   * and versions are part of the local governance contract and are not normalized by this method.
+   *
+   * @param receiptPolicyId policy id from the independent receipt payload
+   * @param receiptPolicyVersion policy version from the independent receipt payload
+   * @return {@code true} when every configured constraint matches the receipt
+   */
+  public boolean matches(String receiptPolicyId, String receiptPolicyVersion) {
+    return policyId.map(value -> value.equals(receiptPolicyId)).orElse(true)
+        && policyVersion.map(value -> value.equals(receiptPolicyVersion)).orElse(true);
+  }
+}

--- a/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerRegistrySummary.java
+++ b/platform-appcatalog/src/main/java/network/crypta/platform/appcatalog/TrustedReviewerRegistrySummary.java
@@ -1,0 +1,45 @@
+package network.crypta.platform.appcatalog;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Redacted summary of the local trusted-reviewer registry.
+ *
+ * <p>The summary exposes registry version, lifecycle counts, and parser/governance warnings. It
+ * does not expose the registry path or any public/private key material.
+ *
+ * <p>This value is used by governance API responses, Web Shell status panels, developer CLI
+ * inspection, and release-certification evidence. It answers whether local reviewer trust is
+ * configured and how many keys are active, retired, or revoked without exposing the underlying
+ * sidecar file or verifier bytes.
+ *
+ * <p>Warnings are display-safe configuration findings such as missing rotation targets or retired
+ * keys without historical windows. They help operators correct local governance state, but the
+ * verifier still uses explicit fail-closed trust statuses for receipt evaluation.
+ *
+ * @param configured whether at least one local reviewer key is configured
+ * @param version trusted-reviewer registry format version that was loaded
+ * @param counts lifecycle counts keyed by stable lowercase status values
+ * @param warnings display-safe registry and lifecycle warnings
+ */
+public record TrustedReviewerRegistrySummary(
+    boolean configured, int version, Map<String, Integer> counts, List<String> warnings) {
+  /**
+   * Converts this registry summary to JSON-compatible values.
+   *
+   * <p>The map preserves stable field names for API, CLI, and certification output. It contains no
+   * public key bytes, private keys, local registry paths, or raw properties-file content.
+   *
+   * @return redacted registry summary with counts and warnings
+   */
+  public Map<String, Object> toJsonValue() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(4);
+    json.put("configured", configured);
+    json.put("version", version);
+    json.put("counts", counts);
+    json.put("warnings", warnings);
+    return json;
+  }
+}

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogSourceStoreTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogSourceStoreTest.java
@@ -143,7 +143,6 @@ class AppCatalogSourceStoreTest {
     Instant failedAt = REFRESHED_AT.plusSeconds(60);
 
     store.recordRefreshFailure(
-        "core",
         beforeFailure,
         failedAt,
         new AppCatalogException(AppCatalogSidecars.CATALOG_FETCH_FAILED, "fetch failed"));
@@ -171,7 +170,6 @@ class AppCatalogSourceStoreTest {
     String unsafeMessage = "fetch failed\nwith\ttabs\r" + "x".repeat(600);
 
     store.recordRefreshFailure(
-        "core",
         beforeFailure,
         REFRESHED_AT.plusSeconds(60),
         new AppCatalogException(AppCatalogSidecars.CATALOG_FETCH_FAILED, unsafeMessage));

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppReviewReceiptTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppReviewReceiptTest.java
@@ -1,5 +1,6 @@
 package network.crypta.platform.appcatalog;
 
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -14,8 +15,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -111,6 +115,134 @@ class AppReviewReceiptTest {
 
     assertEquals(AppReviewTrustStatus.UNKNOWN_REVIEWER, decision.status());
     assertFalse(decision.trusted());
+  }
+
+  @Test
+  void evaluate_whenReviewerKeyIsRevoked_expectRevokedReviewer() throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    TrustedReviewerKeyLifecycle lifecycle =
+        TrustedReviewerKeyLifecycle.of(
+            TrustedReviewerKeyStatus.REVOKED,
+            null,
+            null,
+            Instant.parse("2026-05-02T00:00:00Z"),
+            "Key compromise.",
+            null,
+            null);
+
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry(receipt, AppCatalogReviewMetadata.EMPTY),
+            trustedKeys(REVIEWER_KEY_ID, keyPair, POLICY_VERSION, lifecycle),
+            AppReviewPolicy.DEFAULT,
+            REVIEWED_AT);
+
+    assertEquals(AppReviewTrustStatus.REVOKED_REVIEWER, decision.status());
+    assertFalse(decision.trusted());
+    assertEquals("revoked", decision.reviewerKeyStatus());
+  }
+
+  @Test
+  void evaluate_whenRetiredReviewerCoversReviewedAt_expectTrustedHistoricalReview()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    TrustedReviewerKeyLifecycle lifecycle =
+        TrustedReviewerKeyLifecycle.of(
+            TrustedReviewerKeyStatus.RETIRED,
+            Instant.parse("2026-04-01T00:00:00Z"),
+            Instant.parse("2026-06-01T00:00:00Z"),
+            null,
+            null,
+            null,
+            null);
+
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry(receipt, AppCatalogReviewMetadata.EMPTY),
+            trustedKeys(REVIEWER_KEY_ID, keyPair, POLICY_VERSION, lifecycle),
+            AppReviewPolicy.DEFAULT,
+            REVIEWED_AT);
+
+    assertEquals(AppReviewTrustStatus.TRUSTED_REVIEWED, decision.status());
+    assertTrue(decision.trusted());
+    assertEquals("retired", decision.reviewerKeyStatus());
+    assertEquals("retired", decision.policyVersionStatus());
+  }
+
+  @Test
+  void evaluate_whenRetiredReviewerNoLongerCoversReviewedAt_expectRetiredReviewer()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    TrustedReviewerKeyLifecycle lifecycle =
+        TrustedReviewerKeyLifecycle.of(
+            TrustedReviewerKeyStatus.RETIRED,
+            Instant.parse("2026-04-01T00:00:00Z"),
+            REVIEWED_AT,
+            null,
+            null,
+            null,
+            null);
+
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry(receipt, AppCatalogReviewMetadata.EMPTY),
+            trustedKeys(REVIEWER_KEY_ID, keyPair, POLICY_VERSION, lifecycle),
+            AppReviewPolicy.DEFAULT,
+            REVIEWED_AT);
+
+    assertEquals(AppReviewTrustStatus.RETIRED_REVIEWER, decision.status());
+    assertFalse(decision.trusted());
+  }
+
+  @Test
+  void evaluate_whenRetiredReviewerHasNoValidityEnd_expectRetiredReviewer() throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    TrustedReviewerKeyLifecycle lifecycle =
+        TrustedReviewerKeyLifecycle.of(
+            TrustedReviewerKeyStatus.RETIRED,
+            Instant.parse("2026-04-01T00:00:00Z"),
+            null,
+            null,
+            null,
+            null,
+            null);
+
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry(receipt, AppCatalogReviewMetadata.EMPTY),
+            trustedKeys(REVIEWER_KEY_ID, keyPair, POLICY_VERSION, lifecycle),
+            AppReviewPolicy.DEFAULT,
+            REVIEWED_AT);
+
+    assertEquals(AppReviewTrustStatus.RETIRED_REVIEWER, decision.status());
+    assertFalse(decision.trusted());
+  }
+
+  @Test
+  void evaluate_whenPolicyVersionDoesNotMatchReviewerConstraint_expectPolicyMismatch()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry(receipt, AppCatalogReviewMetadata.EMPTY),
+            trustedKeys(REVIEWER_KEY_ID, keyPair, "2", TrustedReviewerKeyLifecycle.ACTIVE),
+            AppReviewPolicy.DEFAULT,
+            REVIEWED_AT);
+
+    assertEquals(AppReviewTrustStatus.REVIEW_POLICY_MISMATCH, decision.status());
+    assertFalse(decision.trusted());
+    assertEquals("rejected", decision.policyVersionStatus());
   }
 
   @Test
@@ -309,6 +441,438 @@ class AppReviewReceiptTest {
     assertEquals(TrustedReviewerKey.SIGNATURE_ALGORITHM, key.algorithm());
     assertEquals(Optional.of("Crypta First-Party Review"), key.displayName());
     assertEquals(Optional.of(POLICY_ID), key.policyId());
+    assertEquals(TrustedReviewerKeyStatus.ACTIVE, key.status());
+  }
+
+  @Test
+  void trustedReviewerKeysLoad_whenV2LifecycleConfigured_expectParsesStatuses() throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    Path trustedReviewers = tempDir.resolve("trusted-reviewers-v2.properties");
+    Files.writeString(
+        trustedReviewers,
+        lines(
+            "trusted.reviewers.version=2",
+            reviewerProperties("reviewer.1", keyPair, "active-reviewer"),
+            "reviewer.1.policy.version=1",
+            "reviewer.1.status=active",
+            "reviewer.1.valid.from=2026-04-01T00:00:00Z",
+            "reviewer.1.valid.until=2026-07-01T00:00:00Z",
+            "reviewer.1.rotates.from=retired-reviewer",
+            reviewerProperties("reviewer.2", keyPair, "retired-reviewer"),
+            "reviewer.2.policy.version=1",
+            "reviewer.2.status=retired",
+            "reviewer.2.valid.from=2026-01-01T00:00:00Z",
+            "reviewer.2.valid.until=2026-04-01T00:00:00Z",
+            "reviewer.2.rotates.to=active-reviewer",
+            reviewerProperties("reviewer.3", keyPair, "revoked-reviewer"),
+            "reviewer.3.policy.version=1",
+            "reviewer.3.status=revoked",
+            "reviewer.3.revoked.at=2026-05-01T00:00:00Z",
+            "reviewer.3.revocation.reason=Key compromise."),
+        StandardCharsets.UTF_8);
+
+    TrustedReviewerKeys keys = TrustedReviewerKeys.load(trustedReviewers);
+
+    assertEquals(2, keys.registryVersion());
+    assertEquals(
+        TrustedReviewerKeyStatus.ACTIVE, keys.find("active-reviewer").orElseThrow().status());
+    assertEquals(
+        TrustedReviewerKeyStatus.RETIRED, keys.find("retired-reviewer").orElseThrow().status());
+    assertEquals(
+        TrustedReviewerKeyStatus.REVOKED, keys.find("revoked-reviewer").orElseThrow().status());
+    assertFalse(keys.summaries().getFirst().toJsonValue().containsKey("publicKey"));
+  }
+
+  @Test
+  void trustedReviewerKeysLoad_whenPolicyVersionOmitsPolicyId_expectInvalidCatalogEntry()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    Path trustedReviewers = tempDir.resolve("trusted-reviewers-version-only.properties");
+    Files.writeString(
+        trustedReviewers,
+        lines(
+            "trusted.reviewers.version=2",
+            "reviewer.1.id=version-only-reviewer",
+            "reviewer.1.algorithm=Ed25519",
+            "reviewer.1.public.key.base64="
+                + Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()),
+            "reviewer.1.policy.version=1",
+            "reviewer.1.status=active"),
+        StandardCharsets.UTF_8);
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> TrustedReviewerKeys.load(trustedReviewers));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_ENTRY, exception.errorCode());
+    assertTrue(exception.getMessage().contains("policy.version requires policy.id"));
+  }
+
+  @Test
+  void transparencyLog_whenReceiptObservedTwice_expectReceiptObservationDeduplicated()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    AppCatalogEntry entry = entry(receipt, AppCatalogReviewMetadata.EMPTY);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, trustedKeys(keyPair), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+    AppReviewTransparencyLog log = AppReviewTransparencyLog.inMemory();
+
+    log.recordCatalogDecision(
+        AppReviewTransparencyEventKind.REVIEW_GATE_INSTALL, "core", entry, decision, List.of());
+    log.recordCatalogDecision(
+        AppReviewTransparencyEventKind.REVIEW_GATE_INSTALL, "core", entry, decision, List.of());
+
+    AppReviewTransparencyPage observed =
+        log.page(
+            new AppReviewTransparencyQuery(
+                10,
+                null,
+                null,
+                null,
+                null,
+                AppReviewTransparencyEventKind.REVIEW_RECEIPT_OBSERVED));
+    assertEquals(1, observed.records().size());
+    assertTrue(log.verify().verified());
+  }
+
+  @Test
+  void transparencyLog_whenMismatchedReceiptObserved_expectReceiptPayloadBinding()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    String receiptAppId = "other-app";
+    String receiptVersion = "9.9.9";
+    String receiptSha256 = "b".repeat(64);
+    long receiptSize = 4321L;
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(
+            payloadWithBinding(receiptAppId, receiptVersion, receiptSha256, receiptSize),
+            keyPair.getPrivate());
+    AppCatalogEntry entry = entry(receipt, AppCatalogReviewMetadata.EMPTY);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, trustedKeys(keyPair), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+    AppReviewTransparencyLog log = AppReviewTransparencyLog.inMemory();
+
+    log.recordCatalogDecision(
+        AppReviewTransparencyEventKind.REVIEW_GATE_INSTALL, "core", entry, decision, List.of());
+
+    AppReviewTransparencyPage observed =
+        log.page(
+            new AppReviewTransparencyQuery(
+                10,
+                null,
+                null,
+                null,
+                null,
+                AppReviewTransparencyEventKind.REVIEW_RECEIPT_OBSERVED));
+    assertEquals(AppReviewTrustStatus.APP_MISMATCH, decision.status());
+    assertEquals(1, observed.records().size());
+    AppReviewTransparencyRecord observedRecord = observed.records().getFirst();
+    assertEquals(receiptAppId, observedRecord.appId());
+    assertEquals(receiptVersion, observedRecord.appVersion());
+    assertEquals(receiptSha256, observedRecord.artifactSha256());
+    assertEquals(receiptSize, observedRecord.artifactSizeBytes());
+  }
+
+  @Test
+  void
+      transparencyRecordFromCatalogDecision_whenReceiptAndPublisherStatusesDiffer_expectReceiptStatus()
+          throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REJECTED), keyPair.getPrivate());
+    AppCatalogReviewMetadata publisherReview =
+        new AppCatalogReviewMetadata(
+            AppCatalogReviewStatus.REVIEWED, Optional.of("Publisher says reviewed."));
+    AppCatalogEntry entry = entry(receipt, publisherReview);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, trustedKeys(keyPair), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+
+    AppReviewTransparencyRecord transparencyRecord =
+        AppReviewTransparencyRecord.fromCatalogDecision(
+            AppReviewTransparencyEventKind.REVIEW_TRUST_EVALUATED,
+            "core",
+            entry,
+            decision,
+            List.of());
+
+    assertEquals(AppReviewTrustStatus.TRUSTED_REJECTED, decision.status());
+    assertEquals("rejected", transparencyRecord.receiptStatus());
+  }
+
+  @Test
+  void transparencyRecordFromCatalogDecision_whenOnlyPublisherReviewExists_expectNoReceiptStatus() {
+    AppCatalogReviewMetadata publisherReview =
+        new AppCatalogReviewMetadata(
+            AppCatalogReviewStatus.REVIEWED, Optional.of("Publisher says reviewed."));
+    AppCatalogEntry entry = entryWithoutReceipt(publisherReview);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, TrustedReviewerKeys.empty(), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+
+    AppReviewTransparencyRecord transparencyRecord =
+        AppReviewTransparencyRecord.fromCatalogDecision(
+            AppReviewTransparencyEventKind.REVIEW_TRUST_EVALUATED,
+            "core",
+            entry,
+            decision,
+            List.of());
+
+    assertEquals(AppReviewTrustStatus.PUBLISHER_CLAIM_ONLY, decision.status());
+    assertNull(transparencyRecord.receiptStatus());
+  }
+
+  @Test
+  void transparencyStoreVerify_whenRecordIsTampered_expectVerificationFailure() throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    AppCatalogEntry entry = entry(receipt, AppCatalogReviewMetadata.EMPTY);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, trustedKeys(keyPair), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+    Path logFile = tempDir.resolve("review-transparency-log.jsonl");
+    FileAppReviewTransparencyStore store = new FileAppReviewTransparencyStore(logFile);
+    store.append(
+        AppReviewTransparencyRecord.fromCatalogDecision(
+            AppReviewTransparencyEventKind.REVIEW_TRUST_EVALUATED,
+            "core",
+            entry,
+            decision,
+            List.of()));
+    String tampered = Files.readString(logFile).replace("trusted_reviewed", "trusted_rejected");
+    Files.writeString(logFile, tampered, StandardCharsets.UTF_8);
+
+    AppReviewTransparencyVerificationResult result = store.verify();
+
+    assertFalse(result.verified());
+    assertTrue(result.error().contains("hash mismatch"));
+  }
+
+  @Test
+  void transparencyStoreVerify_whenRecordHasUnknownField_expectVerificationFailure()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    AppCatalogEntry entry = entry(receipt, AppCatalogReviewMetadata.EMPTY);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, trustedKeys(keyPair), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+    Path logFile = tempDir.resolve("review-transparency-log.jsonl");
+    FileAppReviewTransparencyStore store = new FileAppReviewTransparencyStore(logFile);
+    store.append(
+        AppReviewTransparencyRecord.fromCatalogDecision(
+            AppReviewTransparencyEventKind.REVIEW_TRUST_EVALUATED,
+            "core",
+            entry,
+            decision,
+            List.of()));
+    String original = Files.readString(logFile, StandardCharsets.UTF_8).stripTrailing();
+    String tampered =
+        original.substring(0, original.length() - 1)
+            + ",\"unexpected\":\"value\"}"
+            + System.lineSeparator();
+    Files.writeString(logFile, tampered, StandardCharsets.UTF_8);
+
+    AppReviewTransparencyVerificationResult result = store.verify();
+
+    assertFalse(result.verified());
+    assertTrue(result.error().contains("invalid review transparency record"));
+  }
+
+  @Test
+  void transparencyStoreVerify_whenRecordHasTrailingData_expectVerificationFailure()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    AppCatalogEntry entry = entry(receipt, AppCatalogReviewMetadata.EMPTY);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, trustedKeys(keyPair), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+    Path logFile = tempDir.resolve("review-transparency-log.jsonl");
+    FileAppReviewTransparencyStore store = new FileAppReviewTransparencyStore(logFile);
+    store.append(
+        AppReviewTransparencyRecord.fromCatalogDecision(
+            AppReviewTransparencyEventKind.REVIEW_TRUST_EVALUATED,
+            "core",
+            entry,
+            decision,
+            List.of()));
+    String tampered =
+        Files.readString(logFile, StandardCharsets.UTF_8).stripTrailing()
+            + " trailing"
+            + System.lineSeparator();
+    Files.writeString(logFile, tampered, StandardCharsets.UTF_8);
+
+    AppReviewTransparencyVerificationResult result = store.verify();
+
+    assertFalse(result.verified());
+    assertTrue(result.error().contains("invalid review transparency record"));
+  }
+
+  @Test
+  void transparencyStoreVerify_whenWarningListShapeIsTampered_expectVerificationFailure()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    AppCatalogEntry entry = entry(receipt, AppCatalogReviewMetadata.EMPTY);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, trustedKeys(keyPair), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+    Path logFile = tempDir.resolve("review-transparency-log.jsonl");
+    FileAppReviewTransparencyStore store = new FileAppReviewTransparencyStore(logFile);
+    store.append(
+        AppReviewTransparencyRecord.fromCatalogDecision(
+            AppReviewTransparencyEventKind.REVIEW_TRUST_EVALUATED,
+            "core",
+            entry,
+            decision,
+            List.of("a", "b")));
+    String original = Files.readString(logFile, StandardCharsets.UTF_8);
+    String tampered = original.replace("\"warnings\":[\"a\",\"b\"]", "\"warnings\":[\"a|b\"]");
+    assertNotEquals(original, tampered);
+    Files.writeString(logFile, tampered, StandardCharsets.UTF_8);
+
+    AppReviewTransparencyVerificationResult result = store.verify();
+
+    assertFalse(result.verified());
+    assertTrue(result.error().contains("hash mismatch"));
+  }
+
+  @Test
+  void transparencyStoreVerify_whenBooleanFieldHasStringValue_expectVerificationFailure()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    AppCatalogEntry entry = entry(receipt, AppCatalogReviewMetadata.EMPTY);
+    Path logFile = tempDir.resolve("review-transparency-log.jsonl");
+    FileAppReviewTransparencyStore store =
+        storeWithReceiptObservationForBooleanTamper(logFile, entry);
+    String original = Files.readString(logFile, StandardCharsets.UTF_8);
+    String tampered = original.replace("\"trusted\":null", "\"trusted\":\"true\"");
+    assertNotEquals(original, tampered);
+    Files.writeString(logFile, tampered, StandardCharsets.UTF_8);
+
+    AppReviewTransparencyVerificationResult result = store.verify();
+
+    assertFalse(result.verified());
+    assertTrue(result.error().contains("invalid review transparency record"));
+  }
+
+  @Test
+  void transparencyStoreVerify_whenSchemaVersionIsOutOfRange_expectVerificationFailure()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    AppCatalogEntry entry = entry(receipt, AppCatalogReviewMetadata.EMPTY);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, trustedKeys(keyPair), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+    Path logFile = tempDir.resolve("review-transparency-log.jsonl");
+    FileAppReviewTransparencyStore store = new FileAppReviewTransparencyStore(logFile);
+    store.append(
+        AppReviewTransparencyRecord.fromCatalogDecision(
+            AppReviewTransparencyEventKind.REVIEW_TRUST_EVALUATED,
+            "core",
+            entry,
+            decision,
+            List.of()));
+    String original = Files.readString(logFile, StandardCharsets.UTF_8);
+    String tampered = original.replace("\"schemaVersion\":1", "\"schemaVersion\":4294967297");
+    assertNotEquals(original, tampered);
+    Files.writeString(logFile, tampered, StandardCharsets.UTF_8);
+
+    AppReviewTransparencyVerificationResult result = store.verify();
+
+    assertFalse(result.verified());
+    assertTrue(result.error().contains("invalid review transparency record"));
+  }
+
+  @Test
+  void transparencyLogRecordCatalogDecision_whenExistingLogIsMalformed_expectBestEffort()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    AppCatalogEntry entry = entry(receipt, AppCatalogReviewMetadata.EMPTY);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, trustedKeys(keyPair), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+    Path logFile = tempDir.resolve("review-transparency-log.jsonl");
+    Files.writeString(logFile, "{}" + System.lineSeparator(), StandardCharsets.UTF_8);
+    AppReviewTransparencyLog log = AppReviewTransparencyLog.fileBacked(logFile);
+
+    assertDoesNotThrow(
+        () ->
+            log.recordCatalogDecision(
+                AppReviewTransparencyEventKind.REVIEW_GATE_INSTALL,
+                "core",
+                entry,
+                decision,
+                List.of()));
+  }
+
+  @Test
+  void transparencyLogRecordCatalogDecision_whenExistingReceiptRecordHasNullId_expectBestEffort()
+      throws Exception {
+    KeyPair keyPair = reviewerKeyPair();
+    AppReviewReceipt receipt =
+        AppReviewReceiptSigner.sign(payload(AppReviewReceiptStatus.REVIEWED), keyPair.getPrivate());
+    AppCatalogEntry entry = entry(receipt, AppCatalogReviewMetadata.EMPTY);
+    AppReviewTrustDecision decision =
+        AppReviewReceiptVerifier.evaluate(
+            entry, trustedKeys(keyPair), AppReviewPolicy.DEFAULT, REVIEWED_AT);
+    Path logFile = tempDir.resolve("review-transparency-log.jsonl");
+    AppReviewTransparencyRecord existing =
+        new AppReviewTransparencyRecord(
+            AppReviewTransparencyRecord.SCHEMA_VERSION,
+            1L,
+            null,
+            REVIEWED_AT,
+            AppReviewTransparencyEventKind.REVIEW_RECEIPT_OBSERVED,
+            "app",
+            APP_ID,
+            APP_VERSION,
+            "core",
+            ARTIFACT_SHA256,
+            ARTIFACT_SIZE,
+            REVIEWER_KEY_ID,
+            null,
+            POLICY_ID,
+            POLICY_VERSION,
+            "reviewed",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            "",
+            "0".repeat(64),
+            List.of());
+    Files.writeString(
+        logFile, existing.toJsonLine() + System.lineSeparator(), StandardCharsets.UTF_8);
+    AppReviewTransparencyLog log = AppReviewTransparencyLog.fileBacked(logFile);
+
+    assertDoesNotThrow(
+        () ->
+            log.recordCatalogDecision(
+                AppReviewTransparencyEventKind.REVIEW_GATE_INSTALL,
+                "core",
+                entry,
+                decision,
+                List.of()));
   }
 
   @Test
@@ -370,12 +934,17 @@ class AppReviewReceiptTest {
   }
 
   private static AppReviewReceiptPayload payloadWithBinding(String appId, String sha256) {
+    return payloadWithBinding(appId, APP_VERSION, sha256, ARTIFACT_SIZE);
+  }
+
+  private static AppReviewReceiptPayload payloadWithBinding(
+      String appId, String appVersion, String sha256, long artifactSize) {
     return new AppReviewReceiptPayload(
         AppReviewReceiptPayload.RECEIPT_VERSION,
         appId,
-        APP_VERSION,
+        appVersion,
         sha256,
-        ARTIFACT_SIZE,
+        artifactSize,
         Optional.empty(),
         POLICY_ID,
         POLICY_VERSION,
@@ -425,9 +994,55 @@ class AppReviewReceiptTest {
   }
 
   private static TrustedReviewerKeys trustedKeys(String keyId, KeyPair keyPair) {
+    return trustedKeys(keyId, keyPair, null, TrustedReviewerKeyLifecycle.ACTIVE);
+  }
+
+  private static TrustedReviewerKeys trustedKeys(
+      String keyId, KeyPair keyPair, String policyVersion, TrustedReviewerKeyLifecycle lifecycle) {
     return TrustedReviewerKeys.of(
         TrustedReviewerKey.ed25519(
-            keyId, keyPair.getPublic().getEncoded(), "Crypta First-Party Review", POLICY_ID));
+            keyId,
+            keyPair.getPublic().getEncoded(),
+            "Crypta First-Party Review",
+            POLICY_ID,
+            policyVersion,
+            lifecycle));
+  }
+
+  private static FileAppReviewTransparencyStore storeWithReceiptObservationForBooleanTamper(
+      Path logFile, AppCatalogEntry entry) throws IOException {
+    FileAppReviewTransparencyStore store = new FileAppReviewTransparencyStore(logFile);
+    store.append(
+        new AppReviewTransparencyRecord(
+            AppReviewTransparencyRecord.SCHEMA_VERSION,
+            0L,
+            "receipt:test-boolean-type",
+            null,
+            AppReviewTransparencyEventKind.REVIEW_RECEIPT_OBSERVED,
+            "app",
+            entry.appId(),
+            entry.version(),
+            "core",
+            entry.bundleSha256(),
+            entry.bundleSizeBytes(),
+            REVIEWER_KEY_ID,
+            null,
+            POLICY_ID,
+            POLICY_VERSION,
+            "reviewed",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            List.of()));
+    return store;
   }
 
   private static KeyPair reviewerKeyPair() throws Exception {
@@ -439,8 +1054,12 @@ class AppReviewReceiptTest {
   }
 
   private static String reviewerProperties(String prefix, KeyPair keyPair) {
+    return reviewerProperties(prefix, keyPair, REVIEWER_KEY_ID);
+  }
+
+  private static String reviewerProperties(String prefix, KeyPair keyPair, String keyId) {
     return lines(
-        prefix + ".id=" + REVIEWER_KEY_ID,
+        prefix + ".id=" + keyId,
         prefix + ".algorithm=Ed25519",
         prefix
             + ".public.key.base64="

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/CryptaAppCli.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/CryptaAppCli.java
@@ -14,6 +14,7 @@ import java.security.PrivateKey;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Locale;
@@ -39,7 +40,10 @@ import network.crypta.platform.appcatalog.AppReviewReceiptPayload;
 import network.crypta.platform.appcatalog.AppReviewReceiptSigner;
 import network.crypta.platform.appcatalog.AppReviewReceiptStatus;
 import network.crypta.platform.appcatalog.AppReviewReceiptVerifier;
+import network.crypta.platform.appcatalog.AppReviewTransparencyVerificationResult;
 import network.crypta.platform.appcatalog.AppReviewTrustDecision;
+import network.crypta.platform.appcatalog.FileAppReviewTransparencyStore;
+import network.crypta.platform.appcatalog.TrustedReviewerKey;
 import network.crypta.platform.appcatalog.TrustedReviewerKeys;
 import network.crypta.platform.appdist.AppBundlePackager;
 import network.crypta.platform.appdist.AppDistributionException;
@@ -90,6 +94,8 @@ import picocli.CommandLine;
       CryptaAppCli.PublishUskCommand.class
     })
 public final class CryptaAppCli implements Runnable {
+  private static final String WARNING_PREFIX = "Warning: ";
+
   private CommandSpec spec;
 
   /**
@@ -417,7 +423,8 @@ public final class CryptaAppCli implements Runnable {
         super.commandLine()
             .getErr()
             .println(
-                "Warning: unknown app permission(s): "
+                WARNING_PREFIX
+                    + "unknown app permission(s): "
                     + String.join(", ", validation.permissionLint().unknownPermissions()));
       }
       CompatibilityVerificationResult compatibility =
@@ -681,7 +688,12 @@ public final class CryptaAppCli implements Runnable {
   @Command(
       name = "review",
       description = "Sign and verify independent app review receipts.",
-      subcommands = {ReviewSignCommand.class, ReviewVerifyCommand.class})
+      subcommands = {
+        ReviewSignCommand.class,
+        ReviewVerifyCommand.class,
+        ReviewKeysCommand.class,
+        ReviewTransparencyCommand.class
+      })
   static final class ReviewCommand extends SpecAwareCommand implements Runnable {
     @Override
     public void run() {
@@ -846,6 +858,239 @@ public final class CryptaAppCli implements Runnable {
                   + decision.reviewerKeyId());
       return CommandLine.ExitCode.OK;
     }
+  }
+
+  /** Parent command for trusted reviewer-key lifecycle tooling. */
+  @Command(
+      name = "keys",
+      description = "Inspect and validate trusted reviewer-key lifecycle registries.",
+      subcommands = {
+        ReviewKeysInspectCommand.class,
+        ReviewKeysMigrateCommand.class,
+        ReviewKeysVerifyLifecycleCommand.class
+      })
+  static final class ReviewKeysCommand extends SpecAwareCommand implements Runnable {
+    @Override
+    public void run() {
+      super.commandLine().usage(super.commandLine().getOut());
+    }
+  }
+
+  /** Implements {@code crypta-app review keys inspect}. */
+  @Command(name = "inspect", description = "Inspect a redacted trusted reviewer-key registry.")
+  static final class ReviewKeysInspectCommand extends SpecAwareCommand
+      implements Callable<Integer> {
+    @Option(
+        names = "--trusted-reviewer-keys-file",
+        required = true,
+        description = "Trusted reviewer keys properties file.")
+    private Path trustedReviewerKeysFile;
+
+    @Override
+    public Integer call() throws Exception {
+      TrustedReviewerKeys keys = TrustedReviewerKeys.load(trustedReviewerKeysFile);
+      PrintWriter out = super.commandLine().getOut();
+      out.println(
+          "Trusted reviewer registry: version="
+              + keys.registryVersion()
+              + " configured="
+              + !keys.isEmpty());
+      for (var summary : keys.summaries()) {
+        out.println(
+            "Reviewer key: "
+                + summary.keyId()
+                + " status="
+                + summary.status().jsonValue()
+                + " algorithm="
+                + summary.algorithm()
+                + " policy="
+                + nullToDash(summary.policyId())
+                + "/"
+                + nullToDash(summary.policyVersion())
+                + " displayName="
+                + nullToDash(summary.displayName()));
+      }
+      List<String> warnings = keys.summary().warnings();
+      out.println("Warnings: " + warnings.size());
+      for (String warning : warnings) {
+        out.println(WARNING_PREFIX + warning);
+      }
+      return CommandLine.ExitCode.OK;
+    }
+  }
+
+  /** Implements {@code crypta-app review keys migrate}. */
+  @Command(name = "migrate", description = "Migrate a trusted reviewer-key registry to v2.")
+  static final class ReviewKeysMigrateCommand extends SpecAwareCommand
+      implements Callable<Integer> {
+    @Option(
+        names = "--trusted-reviewer-keys-file",
+        required = true,
+        description = "Trusted reviewer keys properties file.")
+    private Path trustedReviewerKeysFile;
+
+    @Option(names = "--output", required = true, description = "Output v2 registry file.")
+    private Path output;
+
+    @Option(names = "--overwrite", description = "Replace an existing output file.")
+    private boolean overwrite;
+
+    @Override
+    public Integer call() throws Exception {
+      TrustedReviewerKeys keys = TrustedReviewerKeys.load(trustedReviewerKeysFile);
+      Path normalizedOutput = output.toAbsolutePath().normalize();
+      if (Files.exists(normalizedOutput) && !overwrite) {
+        throw new AppDistributionException("trusted reviewer output already exists: " + output);
+      }
+      Files.createDirectories(normalizedOutput.getParent());
+      Files.writeString(normalizedOutput, serializeV2ReviewerKeys(keys), StandardCharsets.UTF_8);
+      super.commandLine()
+          .getOut()
+          .println("Migrated trusted reviewer registry to v2: keys=" + keys.summaries().size());
+      return CommandLine.ExitCode.OK;
+    }
+
+    private static String serializeV2ReviewerKeys(TrustedReviewerKeys keys) {
+      StringBuilder builder = new StringBuilder("trusted.reviewers.version=2\n\n");
+      int index = 1;
+      for (TrustedReviewerKey key : keys.all()) {
+        int reviewerIndex = index;
+        appendReviewerProperty(builder, reviewerIndex, "id", key.keyId());
+        appendReviewerProperty(builder, reviewerIndex, "algorithm", key.algorithm());
+        appendReviewerProperty(
+            builder,
+            reviewerIndex,
+            "public.key.base64",
+            Base64.getEncoder().encodeToString(key.publicKey().getEncoded()));
+        key.displayName()
+            .ifPresent(
+                value -> appendReviewerProperty(builder, reviewerIndex, "display.name", value));
+        key.policyId()
+            .ifPresent(value -> appendReviewerProperty(builder, reviewerIndex, "policy.id", value));
+        key.policyVersion()
+            .ifPresent(
+                value -> appendReviewerProperty(builder, reviewerIndex, "policy.version", value));
+        appendReviewerProperty(builder, reviewerIndex, "status", key.status().jsonValue());
+        key.lifecycle()
+            .validFrom()
+            .ifPresent(
+                value ->
+                    appendReviewerProperty(builder, reviewerIndex, "valid.from", value.toString()));
+        key.lifecycle()
+            .validUntil()
+            .ifPresent(
+                value ->
+                    appendReviewerProperty(
+                        builder, reviewerIndex, "valid.until", value.toString()));
+        key.lifecycle()
+            .revokedAt()
+            .ifPresent(
+                value ->
+                    appendReviewerProperty(builder, reviewerIndex, "revoked.at", value.toString()));
+        key.lifecycle()
+            .revocationReason()
+            .ifPresent(
+                value ->
+                    appendReviewerProperty(builder, reviewerIndex, "revocation.reason", value));
+        key.lifecycle()
+            .rotatesFrom()
+            .ifPresent(
+                value -> appendReviewerProperty(builder, reviewerIndex, "rotates.from", value));
+        key.lifecycle()
+            .rotatesTo()
+            .ifPresent(
+                value -> appendReviewerProperty(builder, reviewerIndex, "rotates.to", value));
+        builder.append('\n');
+        index++;
+      }
+      return builder.toString();
+    }
+
+    private static void appendReviewerProperty(
+        StringBuilder builder, int index, String field, String value) {
+      builder
+          .append("reviewer.")
+          .append(index)
+          .append('.')
+          .append(field)
+          .append('=')
+          .append(value)
+          .append('\n');
+    }
+  }
+
+  /** Implements {@code crypta-app review keys verify-lifecycle}. */
+  @Command(
+      name = "verify-lifecycle",
+      description = "Validate reviewer-key lifecycle metadata without printing key material.")
+  static final class ReviewKeysVerifyLifecycleCommand extends SpecAwareCommand
+      implements Callable<Integer> {
+    @Option(
+        names = "--trusted-reviewer-keys-file",
+        required = true,
+        description = "Trusted reviewer keys properties file.")
+    private Path trustedReviewerKeysFile;
+
+    @Override
+    public Integer call() throws Exception {
+      TrustedReviewerKeys keys = TrustedReviewerKeys.load(trustedReviewerKeysFile);
+      List<String> warnings = keys.summary().warnings();
+      PrintWriter out = super.commandLine().getOut();
+      out.println(
+          "Reviewer key lifecycle valid: keys="
+              + keys.summaries().size()
+              + " warnings="
+              + warnings.size());
+      for (String warning : warnings) {
+        out.println(WARNING_PREFIX + warning);
+      }
+      return CommandLine.ExitCode.OK;
+    }
+  }
+
+  /** Parent command for local review transparency-log tooling. */
+  @Command(
+      name = "transparency",
+      description = "Inspect local review transparency logs.",
+      subcommands = {ReviewTransparencyVerifyCommand.class})
+  static final class ReviewTransparencyCommand extends SpecAwareCommand implements Runnable {
+    @Override
+    public void run() {
+      super.commandLine().usage(super.commandLine().getOut());
+    }
+  }
+
+  /** Implements {@code crypta-app review transparency verify}. */
+  @Command(name = "verify", description = "Verify a local review transparency-log hash chain.")
+  static final class ReviewTransparencyVerifyCommand extends SpecAwareCommand
+      implements Callable<Integer> {
+    @Option(names = "--log-file", required = true, description = "Review transparency JSONL log.")
+    private Path logFile;
+
+    @Override
+    public Integer call() throws Exception {
+      if (!Files.isRegularFile(logFile)) {
+        throw new AppDistributionException("review transparency log file not found");
+      }
+      AppReviewTransparencyVerificationResult result =
+          FileAppReviewTransparencyStore.verifyFile(logFile);
+      if (!result.verified()) {
+        throw new AppDistributionException(
+            "review transparency log verification failed: " + result.error());
+      }
+      super.commandLine()
+          .getOut()
+          .println(
+              "Verified review transparency log: records="
+                  + result.recordCount()
+                  + " latestHash="
+                  + nullToDash(result.latestRecordHash()));
+      return CommandLine.ExitCode.OK;
+    }
+  }
+
+  private static String nullToDash(String value) {
+    return value == null || value.isBlank() ? "-" : value;
   }
 
   /**
@@ -1090,7 +1335,7 @@ public final class CryptaAppCli implements Runnable {
       for (String permission : result.missingRationales()) {
         super.commandLine()
             .getErr()
-            .println("Warning: missing permission rationale for " + permission);
+            .println(WARNING_PREFIX + "missing permission rationale for " + permission);
       }
       super.commandLine()
           .getOut()
@@ -1313,7 +1558,7 @@ public final class CryptaAppCli implements Runnable {
       CommandLine commandLine, CompatibilityVerificationResult result) {
     for (CompatibilityFinding finding : result.findings()) {
       String prefix =
-          finding.severity() == CompatibilityFindingSeverity.ERROR ? "Error: " : "Warning: ";
+          finding.severity() == CompatibilityFindingSeverity.ERROR ? "Error: " : WARNING_PREFIX;
       commandLine.getErr().println(prefix + finding.message());
     }
   }

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/CryptaAppCliTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/CryptaAppCliTest.java
@@ -1750,6 +1750,18 @@ class CryptaAppCliTest {
   }
 
   @Test
+  void reviewTransparencyVerify_whenLogFileIsMissing_expectFailure() {
+    Path missingLog = tempDir.resolve("missing-review-transparency-log.jsonl");
+
+    CliResult result =
+        runCli("review", "transparency", "verify", "--log-file", missingLog.toString());
+
+    assertEquals(CommandLine.ExitCode.SOFTWARE, result.exitCode());
+    assertTrue(result.err().contains("review transparency log file not found"));
+    assertFalse(result.out().contains("Verified review transparency log"));
+  }
+
+  @Test
   void catalogSignAndVerify_whenCatalogCliRoundTrips_expectSuccess() throws Exception {
     Path appDir = tempDir.resolve("sample-app");
     Path outputZip = tempDir.resolve("sample-app.zip");

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -1511,7 +1511,14 @@
     if (trust.positive === true && trust.trusted === true) {
       return "is-success";
     }
-    if (status.includes("reject") || status.includes("mismatch") || status.includes("expired") || status.includes("invalid")) {
+    if (
+      status.includes("reject")
+      || status.includes("mismatch")
+      || status.includes("expired")
+      || status.includes("invalid")
+      || status.includes("revoked")
+      || status.includes("policy")
+    ) {
       return "is-error";
     }
     return "is-warning";
@@ -2373,6 +2380,9 @@
       typeof data.identityVaultError === "string" ? data.identityVaultError : "";
     const vaultIdentities = Array.isArray(identityVault.identities) ? identityVault.identities : [];
     const vaultGrants = Array.isArray(identityVault.grants) ? identityVault.grants : [];
+    const reviewGovernance = recordValue(data.reviewGovernance);
+    const reviewerKeys = recordValue(data.reviewerKeys);
+    const transparencyVerification = recordValue(data.reviewTransparencyVerification);
     const runningApps = apps.filter((app) => app && typeof app === "object" && app.running).length;
     const summaryEntries = [
       ["Installed apps", `${apps.length}`],
@@ -2381,18 +2391,33 @@
       ["Recommended catalogs", `${recommendedCatalogs.length}`],
       ["Vault identities", `${vaultIdentities.length}`],
       ["Identity grants", `${vaultGrants.length}`],
+      ["Review log verified", transparencyVerification.verified === false ? "No" : "Yes"],
+      ["Reviewer keys", `${Array.isArray(reviewerKeys.keys) ? reviewerKeys.keys.length : 0}`],
       ["Scope", formPassword ? "Shell-native" : "Read-only"],
       ...topLevelFieldEntries(data, [
         "apps",
         "catalogs",
         "recommendedCatalogs",
         "identityVault",
+        "reviewGovernance",
+        "reviewerKeys",
+        "reviewTransparencyLog",
+        "reviewTransparencyVerification",
         "catalogError",
         "recommendedCatalogError",
         "identityVaultError",
+        "reviewGovernanceError",
       ]),
     ];
     sections.apps.append(summaryCard("Apps summary", summaryEntries, apps.length ? "" : "is-warning"));
+
+    renderReviewGovernance(
+      reviewGovernance,
+      reviewerKeys,
+      recordValue(data.reviewTransparencyLog),
+      transparencyVerification,
+      typeof data.reviewGovernanceError === "string" ? data.reviewGovernanceError : "",
+    );
 
     if (apps.length) {
       const list = document.createElement("div");
@@ -2408,6 +2433,81 @@
     renderIdentityVault(identityVault, identityVaultError, apps);
     renderRecommendedCatalogs(recommendedCatalogs, recommendedCatalogError, catalogs);
     renderCatalogs(catalogs, catalogError);
+  }
+
+  function renderReviewGovernance(governance, reviewerKeys, transparencyLog, verification, error) {
+    sections.apps.append(text("h3", "app-card-title", "Review governance"));
+    if (error) {
+      sections.apps.append(text("p", "error-state", `Review governance unavailable: ${error}`));
+      return;
+    }
+    const registry = recordValue(governance.trustedReviewerRegistry);
+    const counts = recordValue(registry.counts);
+    const log = recordValue(governance.transparencyLog);
+    const keys = Array.isArray(reviewerKeys.keys) ? reviewerKeys.keys : [];
+    sections.apps.append(
+      summaryCard(
+        "Governance summary",
+        [
+          ["Review policy mode", normalizedStatus(governance.reviewPolicyMode, "Advisory")],
+          ["Registry version", scalar(registry.version)],
+          ["Active reviewers", scalar(counts.active || 0)],
+          ["Retired reviewers", scalar(counts.retired || 0)],
+          ["Revoked reviewers", scalar(counts.revoked || 0)],
+          ["Transparency records", scalar(log.recordCount || transparencyLog.records?.length || 0)],
+          ["Transparency verified", verification.verified === false ? "No" : "Yes"],
+          ["Latest hash", scalar(log.latestRecordHash || verification.latestRecordHash)],
+        ],
+        verification.verified === false ? "is-error" : "",
+      ),
+    );
+    if (keys.length) {
+      const list = document.createElement("div");
+      list.className = "app-card-list";
+      keys.forEach((key) => {
+        const card = document.createElement("article");
+        card.className = "app-card";
+        const header = document.createElement("div");
+        header.className = "app-card-header";
+        const heading = document.createElement("div");
+        heading.className = "app-card-heading";
+        heading.append(
+          text("h4", "catalog-app-title", scalar(key.displayName || key.keyId)),
+          text("p", "app-card-subtitle", scalar(key.keyId)),
+        );
+        const pills = document.createElement("div");
+        pills.className = "app-card-pills";
+        pills.append(createPill(normalizedStatus(key.status, "Active"), reviewerKeyTone(key.status)));
+        pills.append(createPill(scalar(key.algorithm)));
+        header.append(heading, pills);
+        card.append(header);
+        card.append(
+          definitionList([
+            ["Policy", [key.policyId, key.policyVersion].filter((value) => value).join(" ") || "Any"],
+            ["Valid from", formatIsoTimestamp(key.validFrom)],
+            ["Valid until", formatIsoTimestamp(key.validUntil)],
+            ["Rotates from", scalar(key.rotatesFrom)],
+            ["Rotates to", scalar(key.rotatesTo)],
+            ["Revoked at", formatIsoTimestamp(key.revokedAt)],
+          ]),
+        );
+        list.append(card);
+      });
+      sections.apps.append(list);
+    } else {
+      sections.apps.append(text("p", "empty-state", "No trusted reviewer keys are configured."));
+    }
+  }
+
+  function reviewerKeyTone(status) {
+    const normalized = typeof status === "string" ? status.toLowerCase() : "";
+    if (normalized === "active") {
+      return "is-success";
+    }
+    if (normalized === "revoked") {
+      return "is-error";
+    }
+    return "is-warning";
   }
 
   function renderIdentityVault(identityVault, identityVaultError, apps) {
@@ -2808,6 +2908,9 @@
   function catalogReviewDetailsNode(app) {
     const review = recordValue(app.review);
     const reviewTrust = recordValue(app.reviewTrust);
+    const reviewHistory = recordValue(app.reviewHistory);
+    const historyLog = recordValue(reviewHistory.transparencyLog);
+    const historyRecords = Array.isArray(historyLog.records) ? historyLog.records : [];
     const reviewer =
       reviewTrust.reviewerDisplayName || reviewTrust.reviewerKeyId || "Unavailable";
     const policy = [reviewTrust.policyId, reviewTrust.policyVersion].filter((entry) => entry).join(" ");
@@ -2825,7 +2928,9 @@
         ["Trusted review receipt", reviewTrustLabel(reviewTrust)],
         ["Trusted reviewer", scalar(reviewer)],
         ["Reviewer key id", scalar(reviewTrust.reviewerKeyId)],
+        ["Reviewer key status", normalizedStatus(reviewTrust.reviewerKeyStatus, "Unavailable")],
         ["Review policy", scalar(policy)],
+        ["Policy version status", normalizedStatus(reviewTrust.policyVersionStatus, "Unavailable")],
         ["Policy mode", normalizedStatus(reviewTrust.policyMode, "Advisory")],
         ["Reviewed at", formatIsoTimestamp(reviewTrust.reviewedAt)],
         ["Expires at", formatIsoTimestamp(reviewTrust.expiresAt)],
@@ -2833,6 +2938,10 @@
         ["Evidence URI", metadataLinkNode(reviewTrust.evidenceUri)],
         ["Install handling", reviewTrust.blocksInstall ? "Blocked" : reviewTrust.requiresAcknowledgement ? "Acknowledgement required" : "Allowed"],
         ["Update handling", reviewTrust.blocksUpdate ? "Blocked" : reviewTrust.requiresAcknowledgement ? "Acknowledgement required" : "Allowed"],
+        ["Installed version", scalar(reviewHistory.installedVersion || app.installedVersion)],
+        ["Catalog version", scalar(reviewHistory.catalogVersion || app.version)],
+        ["Transparency entries", scalar(historyRecords.length)],
+        ["Latest transparency hash", scalar(historyRecords.length ? historyRecords[historyRecords.length - 1].recordHash : null)],
         ["Warnings", reviewTrustWarnings(reviewTrust)],
       ]),
     );
@@ -4059,6 +4168,27 @@
         error instanceof Error ? error.message : typeof error === "string" ? error : "Unknown error";
     }
 
+    let reviewGovernance = {};
+    let reviewerKeys = {};
+    let reviewTransparencyLog = {};
+    let reviewTransparencyVerification = {};
+    let reviewGovernanceError = "";
+    try {
+      const [governanceSnapshot, keysSnapshot, logSnapshot, verifySnapshot] = await Promise.all([
+        loadOptionalJson(apiUrl("app-review/governance")),
+        loadOptionalJson(apiUrl("app-review/reviewer-keys")),
+        loadOptionalJson(apiUrl("app-review/transparency-log?limit=8")),
+        loadOptionalJson(apiUrl("app-review/transparency-log/verify")),
+      ]);
+      reviewGovernance = recordValue(governanceSnapshot && governanceSnapshot.governance);
+      reviewerKeys = recordValue(keysSnapshot && keysSnapshot.reviewerKeys);
+      reviewTransparencyLog = recordValue(logSnapshot && logSnapshot.transparencyLog);
+      reviewTransparencyVerification = recordValue(verifySnapshot && verifySnapshot.verification);
+    } catch (error) {
+      reviewGovernanceError =
+        error instanceof Error ? error.message : typeof error === "string" ? error : "Unknown error";
+    }
+
     if (loadGeneration !== appsLoadGeneration) {
       return;
     }
@@ -4070,6 +4200,11 @@
       recommendedCatalogError,
       identityVault,
       identityVaultError,
+      reviewGovernance,
+      reviewerKeys,
+      reviewTransparencyLog,
+      reviewTransparencyVerification,
+      reviewGovernanceError,
     });
   }
 
@@ -4140,11 +4275,31 @@
     }
     try {
       const apps = await loadJson(apiUrl(`app-catalogs/${encodeURIComponent(catalog.catalogId)}/apps`));
-      return { ...catalog, apps: apps && Array.isArray(apps.apps) ? apps.apps : [] };
+      const catalogApps = apps && Array.isArray(apps.apps) ? apps.apps : [];
+      const appsWithHistory = await Promise.all(
+        catalogApps.map((app) => loadCatalogAppReviewHistory(catalog.catalogId, app)),
+      );
+      return { ...catalog, apps: appsWithHistory };
     } catch (error) {
       const appsError =
         error instanceof Error ? error.message : typeof error === "string" ? error : "Unknown error";
       return { ...catalog, apps: [], appsError };
+    }
+  }
+
+  async function loadCatalogAppReviewHistory(catalogId, app) {
+    if (!app || typeof app !== "object" || typeof app.appId !== "string") {
+      return app;
+    }
+    try {
+      const snapshot = await loadOptionalJson(
+        apiUrl(
+          `app-catalogs/${encodeURIComponent(catalogId)}/apps/${encodeURIComponent(app.appId)}/review-history`,
+        ),
+      );
+      return { ...app, reviewHistory: snapshot && snapshot.reviewHistory };
+    } catch (_) {
+      return app;
     }
   }
 

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -1845,6 +1845,282 @@ def collect_app_review_policy_evidence(settings: Settings) -> EvidenceItem:
     return EvidenceItem("app-review.policy", "pass", True, "App-review policy gates passed deterministic evidence checks.", source, details)
 
 
+def collect_app_review_governance_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    appcatalog_dir = workspace / "platform-appcatalog/src/main/java/network/crypta/platform/appcatalog"
+    api_routes = workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppRoutes.java"
+    api_handler = workspace / "platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java"
+    shell = workspace / "platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js"
+    status_text = read_source(appcatalog_dir / "TrustedReviewerKeyStatus.java")
+    lifecycle_text = read_source(appcatalog_dir / "TrustedReviewerKeyLifecycle.java")
+    verifier_text = read_source(appcatalog_dir / "AppReviewReceiptVerifier.java")
+    routes_text = read_source(api_routes)
+    handler_text = read_source(api_handler)
+    shell_text = read_source(shell)
+    checks = {
+        "reviewerLifecycleStatuses": all(value in status_text for value in ("ACTIVE", "RETIRED", "REVOKED")),
+        "policyVersionConstraint": "TrustedReviewerPolicyConstraint" in read_source(appcatalog_dir / "TrustedReviewerPolicyConstraint.java"),
+        "lifecycleTrustStatuses": all(
+            value in verifier_text
+            for value in (
+                "REVOKED_REVIEWER",
+                "RETIRED_REVIEWER",
+                "REVIEWER_NOT_YET_VALID",
+                "REVIEWER_EXPIRED",
+                "REVIEW_POLICY_MISMATCH",
+            )
+        ),
+        "governanceRoutes": (
+            "routeAppReviewRequest" in routes_text
+            and "app-review" in routes_text
+            and "reviewer-keys" in routes_text
+            and "transparency-log" in routes_text
+        ),
+        "redactedReviewerSummaries": (
+            "TrustedReviewerKeySummary" in handler_text
+            and "publicKey" not in read_source(appcatalog_dir / "TrustedReviewerKeySummary.java")
+        ),
+        "webShellGovernance": (
+            "Review governance" in shell_text
+            and "reviewerKeyStatus" in shell_text
+            and "policyVersionStatus" in shell_text
+        ),
+        "lifecycleValidation": (
+            "revocation metadata requires status=revoked" in lifecycle_text
+            and "reviewer valid.until must be after valid.from" in lifecycle_text
+        ),
+    }
+    errors = [key for key, passed in checks.items() if not passed]
+    details = {
+        "checks": checks,
+        "sources": {
+            "status": display_path(appcatalog_dir / "TrustedReviewerKeyStatus.java", workspace),
+            "lifecycle": display_path(appcatalog_dir / "TrustedReviewerKeyLifecycle.java", workspace),
+            "verifier": display_path(appcatalog_dir / "AppReviewReceiptVerifier.java", workspace),
+            "apiRoutes": display_path(api_routes, workspace),
+            "apiHandler": display_path(api_handler, workspace),
+            "webShell": display_path(shell, workspace),
+        },
+    }
+    if errors:
+        return EvidenceItem(
+            "app-review.governance",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "App-review governance evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "app-review.governance",
+        "pass",
+        True,
+        "App-review governance evidence passed deterministic source checks.",
+        source,
+        details,
+    )
+
+
+def collect_app_review_reviewer_key_lifecycle_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    appcatalog_dir = workspace / "platform-appcatalog/src/main/java/network/crypta/platform/appcatalog"
+    tests = workspace / "platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppReviewReceiptTest.java"
+    keys_text = read_source(appcatalog_dir / "TrustedReviewerKeys.java")
+    tests_text = read_source(tests)
+    checks = {
+        "v2Parser": (
+            "trusted.reviewers.version" in keys_text
+            and "policy.version" in keys_text
+            and "valid.from" in keys_text
+            and "revoked.at" in keys_text
+        ),
+        "duplicateIdsFailClosed": "duplicate trusted reviewer key id" in keys_text,
+        "strictInstants": "Instant.parse(value)" in keys_text,
+        "revokedReviewerTest": "evaluate_whenReviewerKeyIsRevoked_expectRevokedReviewer" in tests_text,
+        "retiredReviewerTest": "evaluate_whenRetiredReviewerCoversReviewedAt_expectTrustedHistoricalReview" in tests_text,
+        "retiredReviewerRequiresWindowTest": "evaluate_whenRetiredReviewerHasNoValidityEnd_expectRetiredReviewer" in tests_text,
+        "policyMismatchTest": "evaluate_whenPolicyVersionDoesNotMatchReviewerConstraint_expectPolicyMismatch" in tests_text,
+        "policyVersionRequiresPolicyIdTest": "trustedReviewerKeysLoad_whenPolicyVersionOmitsPolicyId_expectInvalidCatalogEntry" in tests_text,
+        "redactedSummaryTest": "publicKey" in tests_text and "containsKey" in tests_text,
+    }
+    errors = [key for key, passed in checks.items() if not passed]
+    details = {
+        "checks": checks,
+        "sources": {
+            "trustedReviewerKeys": display_path(appcatalog_dir / "TrustedReviewerKeys.java", workspace),
+            "tests": display_path(tests, workspace),
+        },
+    }
+    if errors:
+        return EvidenceItem(
+            "app-review.reviewer-key-lifecycle",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "Reviewer-key lifecycle evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "app-review.reviewer-key-lifecycle",
+        "pass",
+        True,
+        "Reviewer-key lifecycle parser and verifier evidence passed.",
+        source,
+        details,
+    )
+
+
+def collect_app_review_transparency_log_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    appcatalog_dir = workspace / "platform-appcatalog/src/main/java/network/crypta/platform/appcatalog"
+    record_text = read_source(appcatalog_dir / "AppReviewTransparencyRecord.java")
+    store_text = read_source(appcatalog_dir / "FileAppReviewTransparencyStore.java")
+    log_text = read_source(appcatalog_dir / "AppReviewTransparencyLog.java")
+    manager_text = read_source(appcatalog_dir / "AppCatalogManager.java")
+    tests_text = read_source(workspace / "platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppReviewReceiptTest.java")
+    checks = {
+        "hashChain": (
+            "previousRecordHash" in record_text
+            and "recordHash" in record_text
+            and "computeRecordHash" in record_text
+            and "verifyRecords" in store_text
+        ),
+        "redactedFields": (
+            "privateKey" not in record_text
+            and "processToken" not in record_text
+            and "browserSession" not in record_text
+            and "signature.value" not in record_text
+        ),
+        "receiptObservationDedup": "REVIEW_RECEIPT_OBSERVED" in log_text and "receiptFingerprint" in log_text,
+        "receiptObservationPayloadBindingTest": "transparencyLog_whenMismatchedReceiptObserved_expectReceiptPayloadBinding" in tests_text,
+        "gateReceiptStatusTest": "transparencyRecordFromCatalogDecision_whenReceiptAndPublisherStatusesDiffer_expectReceiptStatus" in tests_text,
+        "publisherOnlyNoReceiptStatusTest": "transparencyRecordFromCatalogDecision_whenOnlyPublisherReviewExists_expectNoReceiptStatus" in tests_text,
+        "managerOwnedStore": "reviewTransparencyLog" in manager_text,
+        "rejectUnknownFields": "rejectUnknownJsonFields" in record_text,
+        "rejectTrailingData": "expectEnd()" in record_text,
+        "tamperTest": "transparencyStoreVerify_whenRecordIsTampered_expectVerificationFailure" in tests_text,
+        "unknownFieldTest": "transparencyStoreVerify_whenRecordHasUnknownField_expectVerificationFailure" in tests_text,
+        "trailingDataTest": "transparencyStoreVerify_whenRecordHasTrailingData_expectVerificationFailure" in tests_text,
+        "warningListTamperTest": "transparencyStoreVerify_whenWarningListShapeIsTampered_expectVerificationFailure" in tests_text,
+        "booleanTypeTamperTest": "transparencyStoreVerify_whenBooleanFieldHasStringValue_expectVerificationFailure" in tests_text,
+        "schemaVersionRangeTest": "transparencyStoreVerify_whenSchemaVersionIsOutOfRange_expectVerificationFailure" in tests_text,
+        "bestEffortMalformedLogTest": "transparencyLogRecordCatalogDecision_whenExistingLogIsMalformed_expectBestEffort" in tests_text,
+        "bestEffortNullRecordIdTest": "transparencyLogRecordCatalogDecision_whenExistingReceiptRecordHasNullId_expectBestEffort" in tests_text,
+        "dedupTest": "transparencyLog_whenReceiptObservedTwice_expectReceiptObservationDeduplicated" in tests_text,
+    }
+    errors = [key for key, passed in checks.items() if not passed]
+    details = {
+        "checks": checks,
+        "sources": {
+            "record": display_path(appcatalog_dir / "AppReviewTransparencyRecord.java", workspace),
+            "store": display_path(appcatalog_dir / "FileAppReviewTransparencyStore.java", workspace),
+            "log": display_path(appcatalog_dir / "AppReviewTransparencyLog.java", workspace),
+            "manager": display_path(appcatalog_dir / "AppCatalogManager.java", workspace),
+        },
+    }
+    if errors:
+        return EvidenceItem(
+            "app-review.transparency-log",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "Review transparency-log evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "app-review.transparency-log",
+        "pass",
+        True,
+        "Review transparency-log hash-chain and redaction evidence passed.",
+        source,
+        details,
+    )
+
+
+def collect_app_review_history_api_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    routes = workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppRoutes.java"
+    handler = workspace / "platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java"
+    shell = workspace / "platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js"
+    routes_text = read_source(routes)
+    handler_text = read_source(handler)
+    shell_text = read_source(shell)
+    checks = {
+        "reviewHistoryRoute": "review-history" in routes_text and "reviewHistory(" in handler_text,
+        "governanceEndpoint": "governance()" in handler_text,
+        "reviewerKeysEndpoint": "reviewerKeys()" in handler_text,
+        "transparencyEndpoint": "transparencyLog(" in handler_text and "verifyTransparencyLog" in handler_text,
+        "shellHistoryFetch": "loadCatalogAppReviewHistory" in shell_text,
+        "shellTrustDelta": "trustDelta" in handler_text and "Installed version" in shell_text,
+    }
+    errors = [key for key, passed in checks.items() if not passed]
+    details = {
+        "checks": checks,
+        "sources": {
+            "routes": display_path(routes, workspace),
+            "handler": display_path(handler, workspace),
+            "webShell": display_path(shell, workspace),
+        },
+    }
+    if errors:
+        return EvidenceItem(
+            "app-review.review-history-api",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "Review-history API evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "app-review.review-history-api",
+        "pass",
+        True,
+        "Review-history and governance API evidence passed.",
+        source,
+        details,
+    )
+
+
+def collect_app_review_first_party_chain_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    smoke_text = read_source(workspace / "tools/release-certification/app_platform_smoke.py")
+    docs_text = read_source(workspace / "docs/app-review-governance.md")
+    checks = {
+        "firstPartyCatalogEvidence": "collect_app_review_first_party_catalog_evidence" in smoke_text,
+        "reviewReceiptVerify": "review_verify_args" in smoke_text and "trustedPositiveReceipts" in smoke_text,
+        "governanceEvidenceRequired": "app-review.governance" in smoke_text,
+        "transparencyEvidenceRequired": "app-review.transparency-log" in smoke_text,
+        "docsExplainLocalLog": (
+            "tamper-evident" in docs_text.lower()
+            and "not a global public" in docs_text.lower()
+        ),
+    }
+    errors = [key for key, passed in checks.items() if not passed]
+    details = {"checks": checks}
+    if errors:
+        return EvidenceItem(
+            "app-review.first-party-review-chain",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "First-party app-review chain evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "app-review.first-party-review-chain",
+        "pass",
+        True,
+        "First-party app-review chain evidence passed deterministic checks.",
+        source,
+        details,
+    )
+
+
 def write_first_party_review_descriptor(
     descriptor: Path,
     spec: dict[str, Any],
@@ -4545,6 +4821,8 @@ def build_summary(settings: Settings, evidence: list[EvidenceItem]) -> dict[str,
             "appProcessTokensRedacted": True,
             "browserSessionTokensRedacted": True,
             "signatureValuesRedacted": True,
+            "reviewerKeyMaterialRedacted": True,
+            "reviewTransparencyPathsExcluded": True,
             "rawUpdateRollbackOutputsExcluded": True,
             "absolutePathsSanitized": True,
         },
@@ -4573,7 +4851,12 @@ def run(settings: Settings) -> tuple[dict[str, Any], int]:
         collect_first_party_beta_catalog_evidence(settings),
         collect_app_review_receipt_evidence(settings),
         collect_app_review_policy_evidence(settings),
+        collect_app_review_governance_evidence(settings),
+        collect_app_review_reviewer_key_lifecycle_evidence(settings),
+        collect_app_review_transparency_log_evidence(settings),
+        collect_app_review_history_api_evidence(settings),
         collect_app_review_first_party_catalog_evidence(settings, sample_paths),
+        collect_app_review_first_party_chain_evidence(settings),
         collect_app_ui_design_system_evidence(settings),
         collect_app_ui_lint_evidence(settings, cli if isinstance(cli, Path) else None),
         collect_app_ui_first_party_adoption_evidence(settings),

--- a/tools/release-certification/fixtures/self-test-app-platform-smoke.json
+++ b/tools/release-certification/fixtures/self-test-app-platform-smoke.json
@@ -305,6 +305,107 @@
     },
     {
       "details": {
+        "checks": {
+          "governanceEndpoint": true,
+          "reviewHistoryEndpoint": true,
+          "reviewerKeysEndpoint": true,
+          "transparencyEndpoint": true,
+          "webShellSurface": true
+        },
+        "redaction": {
+          "browserSessionsExcluded": true,
+          "localPathsExcluded": true,
+          "rawPublicKeysExcluded": true,
+          "reviewerPrivateKeysExcluded": true,
+          "tokensExcluded": true
+        }
+      },
+      "id": "app-review.governance",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "App-review governance API, Web Shell, and redaction evidence passed."
+    },
+    {
+      "details": {
+        "checks": {
+          "activeStatus": true,
+          "policyVersionConstraint": true,
+          "policyVersionRequiresPolicyIdTest": true,
+          "retiredReviewerRequiresWindowTest": true,
+          "retiredStatus": true,
+          "revokedFailClosed": true,
+          "revokedStatus": true,
+          "v1Compatibility": true,
+          "v2RegistryParser": true
+        },
+        "redaction": {
+          "rawPublicKeysExcluded": true,
+          "reviewerPrivateKeysExcluded": true
+        }
+      },
+      "id": "app-review.reviewer-key-lifecycle",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Reviewer-key lifecycle parser and fail-closed evidence passed."
+    },
+    {
+      "details": {
+        "checks": {
+          "dedupTest": true,
+          "bestEffortMalformedLogTest": true,
+          "bestEffortNullRecordIdTest": true,
+          "booleanTypeTamperTest": true,
+          "gateReceiptStatusTest": true,
+          "hashChain": true,
+          "publisherOnlyNoReceiptStatusTest": true,
+          "receiptObservationPayloadBindingTest": true,
+          "redactedRecord": true,
+          "rejectTrailingData": true,
+          "rejectUnknownFields": true,
+          "schemaVersionRangeTest": true,
+          "tamperTest": true,
+          "trailingDataTest": true,
+          "unknownFieldTest": true,
+          "warningListTamperTest": true,
+          "verifyEndpoint": true
+        },
+        "redaction": {
+          "browserSessionsExcluded": true,
+          "localPathsExcluded": true,
+          "rawPublicKeysExcluded": true,
+          "tokensExcluded": true
+        }
+      },
+      "id": "app-review.transparency-log",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Review transparency-log hash-chain and redaction evidence passed."
+    },
+    {
+      "details": {
+        "checks": {
+          "historyEndpoint": true,
+          "readOnlyRoutes": true,
+          "reviewTrustCombined": true,
+          "transparencyHistoryCombined": true
+        },
+        "redaction": {
+          "localPathsExcluded": true,
+          "rawPublicKeysExcluded": true,
+          "tokensExcluded": true
+        }
+      },
+      "id": "app-review.review-history-api",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Review-history API evidence passed."
+    },
+    {
+      "details": {
         "firstPartyApps": [
           "queue-manager",
           "publisher",
@@ -347,6 +448,27 @@
       "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
       "status": "pass",
       "summary": "First-party catalog review receipt evidence covered all first-party apps."
+    },
+    {
+      "details": {
+        "checks": {
+          "firstPartyCatalogEvidence": true,
+          "governanceEvidenceRequired": true,
+          "historyApiEvidenceRequired": true,
+          "reviewerLifecycleEvidenceRequired": true,
+          "transparencyEvidenceRequired": true
+        },
+        "redaction": {
+          "catalogScratchPathsExcluded": true,
+          "localEvidencePathsExcluded": true,
+          "reviewerPrivateKeysExcluded": true
+        }
+      },
+      "id": "app-review.first-party-review-chain",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "First-party review-chain governance evidence passed."
     },
     {
       "details": {

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -869,7 +869,12 @@ def app_platform_evidence(
         "app-catalog.first-party-beta",
         "app-review.trusted-receipts",
         "app-review.policy",
+        "app-review.governance",
+        "app-review.reviewer-key-lifecycle",
+        "app-review.transparency-log",
+        "app-review.review-history-api",
         "app-review.first-party-catalog",
+        "app-review.first-party-review-chain",
         "app-ui.design-system",
         "app-ui.lint",
         "app-ui.first-party-adoption",
@@ -1731,12 +1736,24 @@ def evaluate_app_ui_quality_gate(
 
 
 def evaluate_app_review_trust_gate(
-    current: dict[str, dict[str, Any]], previous: dict[str, dict[str, Any]], metadata: dict[str, Any], mode: str
+    current: dict[str, dict[str, Any]],
+    previous: dict[str, dict[str, Any]],
+    metadata: dict[str, Any],
+    mode: str,
 ) -> GateResult:
     failures: list[str] = []
     warnings: list[str] = []
     details: dict[str, Any] = {}
-    for evidence_id in ("app-review.trusted-receipts", "app-review.policy", "app-review.first-party-catalog"):
+    for evidence_id in (
+        "app-review.trusted-receipts",
+        "app-review.policy",
+        "app-review.governance",
+        "app-review.reviewer-key-lifecycle",
+        "app-review.transparency-log",
+        "app-review.review-history-api",
+        "app-review.first-party-catalog",
+        "app-review.first-party-review-chain",
+    ):
         status = evidence_status(current.get(evidence_id))
         previous_status = evidence_status(previous.get(evidence_id))
         details[evidence_id] = {"currentStatus": status, "previousStatus": previous_status}
@@ -2469,7 +2486,12 @@ def render_report(summary: dict[str, Any]) -> str:
         "app-catalog.first-party-beta",
         "app-review.trusted-receipts",
         "app-review.policy",
+        "app-review.governance",
+        "app-review.reviewer-key-lifecycle",
+        "app-review.transparency-log",
+        "app-review.review-history-api",
         "app-review.first-party-catalog",
+        "app-review.first-party-review-chain",
         "app-ui.design-system",
         "app-ui.lint",
         "app-ui.first-party-adoption",
@@ -2948,6 +2970,15 @@ def run_self_test(repo_root: Path) -> None:
         assert evidence_by_id["app-platform.trust-statement-signing"][
             "requiredForReleaseCandidate"
         ] is True
+        for evidence_id in (
+            "app-review.governance",
+            "app-review.reviewer-key-lifecycle",
+            "app-review.transparency-log",
+            "app-review.review-history-api",
+            "app-review.first-party-review-chain",
+        ):
+            assert evidence_by_id[evidence_id]["status"] == "pass", evidence_by_id
+            assert evidence_by_id[evidence_id]["requiredForReleaseCandidate"] is True
         assert evidence_by_id["reference-app.profile-publisher"]["status"] == "pass", evidence_by_id
         assert evidence_by_id["reference-app.feed-reader"]["status"] == "pass", evidence_by_id
         assert evidence_by_id["reference-app.trust-graph"]["status"] == "pass", evidence_by_id
@@ -3640,7 +3671,58 @@ def run_self_test(repo_root: Path) -> None:
             "trusted-review-fail-cert", app_platform_summary=trusted_review_fail_path
         )
         assert trusted_review_fail_exit_code == 1, trusted_review_fail_summary
-        assert gate_by_id(trusted_review_fail_summary, "ecosystem.app-review-trust")["status"] == "fail"
+        assert (
+            gate_by_id(trusted_review_fail_summary, "ecosystem.app-review-trust")["status"]
+            == "fail"
+        )
+
+        missing_review_governance_ids = {
+            "app-review.governance",
+            "app-review.reviewer-key-lifecycle",
+            "app-review.transparency-log",
+            "app-review.review-history-api",
+            "app-review.first-party-review-chain",
+        }
+        missing_review_governance_path = write_app_summary_variant(
+            "missing-review-governance",
+            lambda value: value.update(
+                {
+                    "evidence": [
+                        item
+                        for item in value["evidence"]
+                        if item.get("id") not in missing_review_governance_ids
+                    ]
+                }
+            ),
+        )
+        missing_review_governance_items = app_platform_evidence(
+            missing_review_governance_path, workspace, out_dir, "release-candidate"
+        )
+        missing_review_governance_by_id = {
+            item.id: item for item in missing_review_governance_items
+        }
+        for evidence_id in missing_review_governance_ids:
+            assert (
+                missing_review_governance_by_id[evidence_id].status == "missing"
+            ), missing_review_governance_by_id
+        (
+            missing_review_governance_summary,
+            missing_review_governance_exit_code,
+        ) = run_with_previous(
+            "missing-review-governance-cert",
+            app_platform_summary=missing_review_governance_path,
+        )
+        assert missing_review_governance_exit_code == 1, missing_review_governance_summary
+        missing_review_governance_gate = gate_by_id(
+            missing_review_governance_summary, "ecosystem.app-review-trust"
+        )
+        assert (
+            missing_review_governance_gate["status"] == "fail"
+        ), missing_review_governance_gate
+        for evidence_id in missing_review_governance_ids:
+            assert (
+                evidence_id in missing_review_governance_gate["details"]["failureEvidenceIds"]
+            ), missing_review_governance_gate
 
         rollback_fail_path = write_app_summary_variant(
             "rollback-fail",


### PR DESCRIPTION
## Summary
- Adds reviewer-key lifecycle governance for app review receipts, including v2 trusted reviewer registry metadata, active/retired/revoked semantics, policy-version trust constraints, and redacted registry summaries.
- Adds a host-owned, redacted, hash-chained app review transparency log with verification, install/update/apply gate events, and review-history integration.
- Exposes governance, reviewer-key, transparency-log, and review-history surfaces through Platform API, Web Shell, `crypta-app`, release-certification evidence, and operator docs.

## Testing
- `./gradlew spotlessApply`
- `./gradlew :platform-appcatalog:test :platform-api:test :platform-devtools:test :test --tests 'network.crypta.platform.api.PlatformApiRouterTest'`
- `python3 tools/release-certification/app_platform_smoke.py --self-test`
- `python3 tools/release-certification/release_certification.py --self-test`