### PR TITLE
feat(app-platform): Add beta docs closeout

### DIFF
--- a/.agents/skills/cryptad-architecture/SKILL.md
+++ b/.agents/skills/cryptad-architecture/SKILL.md
@@ -84,6 +84,9 @@ Use this skill when you need to:
     catalog writer/descriptors, Crypta catalog source handling, app-store/API compatibility
     metadata, independent app-review receipts, artifact verification, safe ZIP extraction, and
     verified staging)
+  - `:platform-trustgraph` → `network.crypta.platform.trustgraph` (Trust Graph Preview statement
+    parsing, canonicalization, verification, process-local store/anchor behavior, and deterministic
+    direct-anchor scoring)
   - `:platform-devtools` → `network.crypta.platform.devtools` (standalone `crypta-app` developer
     CLI for staged-bundle, UI lint, mock dev server, offline tests, catalog-authoring, developer
     keys, publication plans, API snapshot, and compatibility verification workflows)
@@ -123,6 +126,10 @@ Use this skill when you need to:
   - `:apps:feed-reader` → staged Feed Reader content-fetch reference AppHost bundle with a static
     UI under an isolated app origin when available, using bounded Crypta content fetch and
     app-generated feed document insertion
+  - `:apps:trust-graph` → staged Trust Graph Preview local trust-service reference AppHost bundle
+    with a static UI under an isolated app origin when available, using `trust.read`,
+    `trust.write`, bounded content fetch, AppVault trust-statement signing, and app-generated trust
+    statement insertion
 - The runtime boundary is split intentionally:
   - `:runtime-spi` exposes small JDK-only ports plus immutable config, alert, queue, peer, wizard,
     updater, and shell DTOs.
@@ -157,7 +164,8 @@ Use this skill when you need to:
   `:platform-design-system` owns canonical local app UI assets, `:platform-sdk-js` owns the
   browser SDK resource, `:platform-appdist` owns signed local bundle distribution,
   `:platform-appcatalog` owns signed catalog sources, trusted app-review receipts, and verified
-  staging, `:platform-devtools` owns the standalone app developer CLI and offline UI linter,
+  staging, `:platform-trustgraph` owns local trust statement parsing and deterministic preview
+  scoring, `:platform-devtools` owns the standalone app developer CLI and offline UI linter,
   `:platform-web-shell` owns the browser-facing
   node-management shell, `:runtime-alerts` owns the extracted alert/feed model subset,
   `:runtime-node` owns the
@@ -387,6 +395,10 @@ Use this skill when you need to:
   compatibility metadata, verifies independent app-review receipts against trusted reviewer keys
   and local review policy, validates artifact size and SHA-256, safely extracts ZIP bundles, and
   delegates verified staged bundles to AppHost install/update flows.
+- `:platform-trustgraph` owns `network.crypta.platform.trustgraph`, the local Trust Graph Preview
+  model and scoring layer. It parses bounded trust statement documents, canonicalizes and verifies
+  statement payloads, stores process-local anchors/statements, and computes deterministic direct
+  trust scores without changing peer protocols or claiming full Web of Trust behavior.
 - `:platform-devtools` owns `network.crypta.platform.devtools`, the standalone `crypta-app` CLI. It
   wires app template scaffolding, bundle validation, signing, packaging, verification, permission
   linting, offline UI linting, mock dev serving, offline app tests, developer key generation,
@@ -520,6 +532,7 @@ Use this skill when you need to:
 - `:platform-sdk-js`: browser SDK resource under `network/crypta/platform/sdk/js`
 - `:platform-appdist`: `network.crypta.platform.appdist`
 - `:platform-appcatalog`: `network.crypta.platform.appcatalog`
+- `:platform-trustgraph`: `network.crypta.platform.trustgraph`
 - `:platform-devtools`: `network.crypta.platform.devtools`
 - `:platform-web-shell`: `network.crypta.platform.webshell`
 - `:runtime-alerts`: `network.crypta.runtime.alerts`, including the detached

--- a/.agents/skills/cryptad-build-test/SKILL.md
+++ b/.agents/skills/cryptad-build-test/SKILL.md
@@ -23,13 +23,15 @@ Use this skill when you need to:
   `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:kernel-content`,
   `:kernel-transport`, `:kernel-routing`, `:runtime-spi`, `:platform-api`,
   `:platform-apphost`, `:platform-app-ui`, `:platform-appvault`, `:platform-appdist`,
-  `:platform-appcatalog`, `:platform-design-system`, `:platform-devtools`, `:platform-sdk-js`,
-  `:platform-web-shell`, `:runtime-alerts`, `:runtime-node`, `:adapter-fcp`,
+  `:platform-appcatalog`, `:platform-trustgraph`, `:platform-design-system`,
+  `:platform-devtools`, `:platform-sdk-js`, `:platform-web-shell`, `:runtime-alerts`,
+  `:runtime-node`, `:adapter-fcp`,
   `:bridge-fcp-runtime`, `:bridge-http-runtime`,
   `:adapter-http-legacy-admin`, `:adapter-http-legacy-browse`, `:thirdparty-onion`,
   `:thirdparty-legacy`, and `:launcher-desktop`.
 - First-party app bundle projects live under `:apps:queue-manager`, `:apps:publisher`,
-  `:apps:site-publisher`, `:apps:profile-publisher`, and `:apps:feed-reader`.
+  `:apps:site-publisher`, `:apps:profile-publisher`, `:apps:feed-reader`, and
+  `:apps:trust-graph`.
 - The extracted leaf projects compile separately, but `buildJar`, `run`, `runLauncher`,
   `assembleCryptadDist`, and jpackage tasks are still rooted at `:cryptad`.
 - `:foundation-support` owns the current stable generic support subset under
@@ -109,6 +111,9 @@ Use this skill when you need to:
   verification, `crypta:` catalog source fetching, app-store/API compatibility metadata,
   independent app-review receipt trust metadata, artifact download, safe ZIP extraction, and
   verified staging code plus focused tests under `platform-appcatalog/src/test/java`.
+- `:platform-trustgraph` owns Trust Graph Preview statement parsing, canonicalization,
+  verification, process-local store/anchor behavior, and deterministic scoring plus focused tests
+  under `platform-trustgraph/src/test/java`.
 - `:platform-design-system` owns the canonical local app UI CSS/JS resources plus safe
   asset-listing, hashing, and bundle-copy helpers. Its focused tests live under
   `platform-design-system/src/test/java`.
@@ -178,6 +183,7 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew :platform-appvault:test`
   - `./gradlew :platform-appdist:test`
   - `./gradlew :platform-appcatalog:test`
+  - `./gradlew :platform-trustgraph:test`
   - `./gradlew :platform-design-system:test`
   - `./gradlew :platform-devtools:test`
   - `./gradlew :platform-sdk-js:test`
@@ -248,6 +254,8 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew :platform-appdist:compileJava`
 - Compile the app catalog leaf when you touched `network.crypta.platform.appcatalog`:
   - `./gradlew :platform-appcatalog:compileJava`
+- Compile the Trust Graph Preview leaf when you touched `network.crypta.platform.trustgraph`:
+  - `./gradlew :platform-trustgraph:compileJava`
 - Compile the developer app CLI leaf when you touched `network.crypta.platform.devtools`:
   - `./gradlew :platform-devtools:compileJava`
 - Process and test the Platform SDK resource leaf when you touched
@@ -278,7 +286,7 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
 ## First-party app bundle checks
 - Stage first-party app bundles, especially after changing `:platform-sdk-js` or
   `:platform-design-system` because Queue Manager, Publisher, Site Publisher, Profile Publisher,
-  and Feed Reader copy those assets into staged static UI bundles:
+  Feed Reader, and Trust Graph Preview copy those assets into staged static UI bundles:
   - `./gradlew stageFirstPartyApps`
 - Run app project tests:
   - `./gradlew :apps:queue-manager:test`
@@ -286,6 +294,7 @@ When running ./gradlew test via OpenCode bash, set timeout ≥ 15 minutes (≥ 9
   - `./gradlew :apps:site-publisher:test`
   - `./gradlew :apps:profile-publisher:test`
   - `./gradlew :apps:feed-reader:test`
+  - `./gradlew :apps:trust-graph:test`
 - Sign and verify staged bundles only when signing/trusted-key inputs are available:
   - `./gradlew signFirstPartyApps`
   - `./gradlew verifyFirstPartyApps`

--- a/.agents/skills/cryptad-interop-performance-gates/SKILL.md
+++ b/.agents/skills/cryptad-interop-performance-gates/SKILL.md
@@ -42,8 +42,8 @@ INTEROP_MODE=extended INTEROP_SKIP_BUILD=1 tools/interop/run-hyphanet-interop-sm
 
 - The performance gate records lightweight packaged-node startup, local FCP/Platform API timing,
   distribution size, Web Shell asset size, SDK asset size, and first-party static app source and
-  staged-bundle size signals for Queue Manager, Publisher, Site Publisher, Profile Publisher, and
-  Feed Reader. It is not a broad benchmark suite.
+  staged-bundle size signals for Queue Manager, Publisher, Site Publisher, Profile Publisher, Feed
+  Reader, and Trust Graph Preview. It is not a broad benchmark suite.
 - The runner requires Python 3.12 or newer.
 - Normal local commands:
 
@@ -76,14 +76,19 @@ build/release-certification/artifacts/
   for the Platform API contract, app-vault capability docs, signed catalogs, trusted app-review
   receipts, app-owned UI origin behavior, app UI design-system/lint evidence, Site Publisher
   reference-content coverage, Profile Publisher identity-profile coverage, Feed Reader
-  content-fetch coverage, generated document insert/content-fetch redaction coverage,
+  content-fetch coverage, Trust Graph Preview coverage, generated document insert/content-fetch and
+  trust redaction coverage, app-review governance/reviewer-key/transparency-log evidence,
   legacy-admin retirement/removal evidence, sandbox provider selection, and app-update
   lifecycle/scheduler/rollback.
+- `tools/release-certification/app_platform_docs_check.py` produces deterministic app-platform
+  beta docs evidence for the developer portal, tutorials, beta program, issue templates, relative
+  Markdown links, and docs redaction checks.
 - The wrapper resolves relative `--out-dir` values under the repository root, then runs the
   app-platform smoke collector before aggregation.
 - Normal local commands:
 
 ```bash
+python3 tools/release-certification/app_platform_docs_check.py --self-test
 python3 tools/release-certification/release_certification.py --self-test
 python3 tools/release-certification/app_platform_smoke.py --self-test
 tools/release-certification/run-release-certification.sh
@@ -93,21 +98,31 @@ tools/release-certification/run-release-certification.sh --mode release-candidat
 - Release-candidate mode fails when required evidence is missing, skipped, malformed, wrong-mode,
   or failing unless a release-manager waiver is recorded. Required app-platform evidence now
   includes `app-platform.first-party`, `app-platform.devtools-cli`,
-  `app-platform.developer-beta-toolkit`, `app-platform.signed-bundles`, `catalog.smoke`,
+  `app-platform.developer-beta-toolkit`, `app-platform.docs-portal`,
+  `app-platform.beta-program`, `app-platform.beta-tutorials`,
+  `app-platform.docs-redaction`, `app-platform.signed-bundles`, `catalog.smoke`,
   `app-catalog.first-party-beta`, `platform-api.contract`, `app-vault.capabilities`,
   `app-platform.identity-profile-publish`, `app-platform.generated-document-insert`,
-  `app-platform.content-fetch`, `app-ui.design-system`, `app-ui.lint`,
+  `app-platform.content-fetch`, `app-platform.trust-graph-preview`,
+  `app-platform.trust-statement-signing`, `app-ui.design-system`, `app-ui.lint`,
   `app-ui.first-party-adoption`, `app-ui.smoke`, `reference-apps.content`,
-  `reference-app.profile-publisher`, `reference-app.feed-reader`, `legacy.retirement`,
-  `legacy-admin.removal-wave-1`, `apphost.sandbox-provider`, `app-update.lifecycle`,
-  `app-update.scheduler`, `app-update.rollback`, `app-review.trusted-receipts`,
-  `app-review.policy`, and `app-review.first-party-catalog`.
+  `reference-app.profile-publisher`, `reference-app.feed-reader`, `reference-app.trust-graph`,
+  `legacy.retirement`, `legacy-admin.removal-wave-1`, `legacy-admin.removal-wave-2`,
+  `apphost.sandbox-provider`, `app-update.lifecycle`, `app-update.scheduler`,
+  `app-update.rollback`, `app-review.trusted-receipts`, `app-review.policy`,
+  `app-review.governance`, `app-review.reviewer-key-lifecycle`,
+  `app-review.transparency-log`, `app-review.review-history-api`,
+  `app-review.first-party-catalog`, `app-review.first-party-review-chain`, and
+  `release-certification.ecosystem-matrix`.
 - Do not publish private signing keys, form passwords, app tokens, browser-session tokens, raw
   reviewer keys, raw trusted reviewer public key bytes, raw request bodies, raw feed bodies, raw
-  update/rollback command output, private insert URIs, non-localhost endpoint metadata, catalog
-  scratch paths, staged bundle paths, rollback backup paths, UI lint report paths, or other
-  unsanitized local paths. The aggregator filters `artifacts/private-insert-uris.json` even when
-  interop summaries reference it.
+  trust documents from real users, raw update/rollback command output, private insert URIs,
+  non-localhost endpoint metadata, catalog scratch paths, staged bundle paths, rollback backup
+  paths, UI lint report paths, or other unsanitized local paths. The aggregator filters
+  `artifacts/private-insert-uris.json` even when interop summaries reference it.
+- Treat docs redaction findings as non-waivable blockers. Link-only or presence-only docs gaps can
+  be waived by a release manager when policy allows, but raw secret/path findings must keep the
+  evidence and matrix row failing.
 
 ## CI and release notes
 

--- a/.agents/skills/cryptad-packaging/SKILL.md
+++ b/.agents/skills/cryptad-packaging/SKILL.md
@@ -25,8 +25,9 @@ Use this skill when working on:
   `:foundation-config`, `:foundation-fs`, `:foundation-compat`, `:kernel-content`,
   `:kernel-transport`, `:kernel-routing`, `:runtime-spi`, `:platform-api`,
   `:platform-apphost`, `:platform-app-ui`, `:platform-appvault`, `:platform-appdist`,
-  `:platform-appcatalog`, `:platform-design-system`, `:platform-devtools`, `:platform-sdk-js`,
-  `:platform-web-shell`, `:runtime-alerts`, `:runtime-node`, `:adapter-fcp`,
+  `:platform-appcatalog`, `:platform-trustgraph`, `:platform-design-system`,
+  `:platform-devtools`, `:platform-sdk-js`, `:platform-web-shell`, `:runtime-alerts`,
+  `:runtime-node`, `:adapter-fcp`,
   `:bridge-fcp-runtime`, `:bridge-http-runtime`, `:adapter-http-legacy-admin`,
   `:adapter-http-legacy-browse`, `:thirdparty-onion`,
   `:thirdparty-legacy`, and `:launcher-desktop`.
@@ -58,6 +59,9 @@ Use this skill when working on:
   verification, Crypta catalog source fetching, app-store/API compatibility metadata parsing,
   independent app-review receipt trust metadata, artifact download, safe ZIP extraction, and
   verified staging support.
+- The `:platform-trustgraph` JAR contributes local Trust Graph Preview statement parsing,
+  canonicalization, verification, process-local store/anchor behavior, and deterministic scoring
+  used by Platform API trust routes.
 - The `:platform-design-system` JAR contributes canonical local static app UI assets and helper
   APIs used by first-party app staging and the standalone developer CLI. It is packaged as a normal
   leaf artifact but the CSS/JS bytes are copied into app bundles, not loaded from a daemon-hosted
@@ -92,9 +96,10 @@ Use this skill when working on:
 - Packaging does not have separate entrypoints per leaf project; it still assembles a single daemon
   artifact and distribution layout from the root build.
 - First-party app projects such as `:apps:queue-manager`, `:apps:publisher`,
-  `:apps:site-publisher`, `:apps:profile-publisher`, and `:apps:feed-reader` provide staged app
-  bundles through their `stageApp`, `signApp`, and `verifyApp` tasks. Those bundles are release
-  artifacts and AppHost install inputs; they are not daemon entrypoints inside `build/cryptad-dist`.
+  `:apps:site-publisher`, `:apps:profile-publisher`, `:apps:feed-reader`, and
+  `:apps:trust-graph` provide staged app bundles through their `stageApp`, `signApp`, and
+  `verifyApp` tasks. Those bundles are release artifacts and AppHost install inputs; they are not
+  daemon entrypoints inside `build/cryptad-dist`.
   Their static UI staging copies the current `:platform-sdk-js` browser resource and canonical
   `:platform-design-system` assets into each bundle's `static/` assets.
 

--- a/.agents/skills/cryptad-platform-apps/SKILL.md
+++ b/.agents/skills/cryptad-platform-apps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cryptad-platform-apps
-description: "Work on Cryptad's app platform: Platform API v1/contract, AppHost runtime/rollback, signed app bundles/catalogs, trusted app-review receipts, app-update lifecycle, app-owned static UI, browser sessions, the browser SDK, the app UI design system/linter, developer CLI, app permissions/audit, sandbox providers, and legacy admin retirement routing."
+description: "Work on Cryptad's app platform: Platform API v1/contract, AppHost runtime/rollback, signed app bundles/catalogs, trusted app-review receipts, Trust Graph Preview, app-update lifecycle, app-owned static UI, browser sessions, the browser SDK, the app UI design system/linter, developer CLI, app permissions/audit, sandbox providers, beta docs evidence, and legacy admin retirement routing."
 ---
 
 # Cryptad platform apps
@@ -11,6 +11,10 @@ Use this skill before touching app-platform code, docs, or tests.
 
 Load only the docs needed for the change:
 
+- App ecosystem beta entry point: `docs/app-platform-developer-portal.md`
+- Offline beta tutorials: `docs/app-platform-beta-tutorials.md`
+- Beta limitations and safety boundaries: `docs/app-platform-beta-known-limitations.md`
+- Beta program, submission, feedback, and closeout runbook: `docs/app-platform-beta-program.md`
 - Platform API and shell surface: `docs/platform-api-surface.md`
 - Platform API compatibility contract: `docs/platform-api-contract.md`
 - Signed bundles and first-party app tasks: `docs/app-distribution.md`
@@ -21,6 +25,7 @@ Load only the docs needed for the change:
 - App UI design-system assets and offline UI lint: `docs/app-ui-design-system.md`
 - Browser SDK behavior: `docs/platform-sdk-js.md`
 - Feed Reader and content-fetch reference app: `docs/feed-reader-reference-app.md`
+- Trust Graph Preview reference app and local trust-service API: `docs/trust-graph-preview.md`
 - App secret and identity vault: `docs/app-secret-and-identity-vault.md`
 - AppHost runtime/log/token boundary: `docs/apphost-runtime-hardening.md`
 - App-token permission matrix and audit model: `docs/app-permissions-and-audit.md`
@@ -32,8 +37,9 @@ Load only the docs needed for the change:
 - `:platform-api` owns the transport-neutral Platform API v1 router, route families,
   deterministic compatibility contract, app-token authorization decisions, browser-session
   authorization decisions, capabilities, app-vault route handlers, generated app-document queue
-  staging, bounded content fetch routing, bounded app audit log, and the local app-update lifecycle
-  service plus scheduler above AppHost/catalog/vault/runtime primitives.
+  staging, bounded content fetch routing, local Trust Graph Preview route handlers, bounded app
+  audit log, and the local app-update lifecycle service plus scheduler above
+  AppHost/catalog/vault/trust/runtime primitives.
 - `:platform-apphost` owns installed app layout, manifest parsing, app process lifecycle,
   per-launch `CRYPTAD_APP_TOKEN`, runtime status, process-log capture/redaction, and restart
   attempts, durable previous-bundle rollback records, plus sandbox policy/status reporting,
@@ -46,7 +52,8 @@ Load only the docs needed for the change:
 - `:platform-design-system` owns canonical local app UI CSS/JS assets and safe asset metadata/copy
   helpers used by scaffolds, first-party staging, UI lint, and release evidence.
 - `:platform-appvault` owns app secret and identity vault storage records, metadata/grant value
-  types, local wrapping-key provider, audit/redaction helpers, and deterministic vault tests.
+  types, local wrapping-key provider, bounded profile/trust statement signing helpers,
+  audit/redaction helpers, and deterministic vault tests.
 - `:platform-appdist` owns local signed bundle digests, signatures, trusted-key verification,
   deterministic bundle packaging, manifest sandbox/quota fields, and first-party
   signing/verification tooling.
@@ -54,7 +61,12 @@ Load only the docs needed for the change:
   verification, `crypta:` catalog-source URI handling, safe ZIP extraction, and verified staging
   into AppHost install/update flows, plus optional review/API compatibility metadata, independent
   app-review receipts, trusted reviewer-key loading, review policy modes, and review trust
-  decisions used by app update review.
+  decisions used by app update review, reviewer-key lifecycle parsing, local review transparency
+  logging, governance snapshots, and review-history API support.
+- `:platform-trustgraph` owns the Trust Graph Preview statement model, strict JSON parser,
+  canonical payload and signature helpers, process-local anchor/store abstractions, and
+  deterministic direct-anchor scoring. It is a local preview library, not a peer protocol or full
+  Web of Trust implementation.
 - `:platform-devtools` owns the standalone `crypta-app` CLI for scaffolding, validating, signing,
   packaging, verifying, catalog-authoring, API contract snapshotting, compatibility verification,
   mock dev serving, offline app tests, developer key generation, and dry-run publication planning
@@ -69,6 +81,7 @@ Load only the docs needed for the change:
 - `:apps:site-publisher` stages the first-party content reference static UI bundle.
 - `:apps:profile-publisher` stages the first-party identity-profile reference static UI bundle.
 - `:apps:feed-reader` stages the first-party feed reader and publisher reference static UI bundle.
+- `:apps:trust-graph` stages the first-party Trust Graph Preview reference static UI bundle.
 
 ## Guardrails
 
@@ -87,8 +100,12 @@ Load only the docs needed for the change:
   reject `file:`, arbitrary HTTP(S), loopback/LAN URLs, and absolute local paths before calling the
   runtime fetch port.
 - App-generated document insert routes accept generated document bytes, not local source paths.
-  Keep raw generated documents, raw feed/profile bodies, private insert URIs, raw signatures, and
-  request bodies out of audit entries, logs, and release evidence.
+  Keep raw generated documents, raw feed/profile/trust bodies, private insert URIs, raw
+  signatures, and request bodies out of audit entries, logs, and release evidence.
+- Trust Graph Preview is local preview scoring and bounded statement import/sign/publish support.
+  Do not claim full Web of Trust compatibility, old plugin compatibility, global moderation,
+  background crawling, daemon-core identity sharing, or protocol/network behavior changes. Trust
+  evidence must stay bounded and redacted; do not record raw trust documents from real users.
 - Audit entries are bounded and process-local. Do not add query strings, request bodies, form
   passwords, tokens, absolute filesystem paths, or large payloads.
 - Static UI routes must serve only immutable installed-bundle files. Reject traversal, encoded path
@@ -100,6 +117,9 @@ Load only the docs needed for the change:
   the explicit development-only escape hatch.
 - Trusted app-review receipts are independent reviewer evidence. Do not treat publisher advisory
   `review.status`, app signing keys, or catalog signing keys as reviewer trust.
+- Reviewer governance is local trusted-key configuration plus a local tamper-evident transparency
+  log. Do not present catalog-listed reviewer keys as automatically trusted, and do not describe
+  the local transparency log as a global public log.
 - `crypta:` catalog sources still require signed catalog verification. They do not make catalog
   artifacts trusted, and catalog entry bundle artifacts remain limited to the schemes documented in
   `docs/app-catalogs.md`.
@@ -125,9 +145,10 @@ Load only the docs needed for the change:
 - Legacy admin retirement changes must update both the code map
   (`LegacyAdminRetirementRegistry`) and `docs/legacy-retirement-plan.md`.
 - Release-certification evidence must not expose private signing keys, app process tokens,
-  browser-session tokens, form passwords, raw request bodies, raw feed bodies, private insert URIs,
-  non-localhost endpoint metadata, or unsanitized local paths. Optional live AppHost smoke reads the
-  form password from `CRYPTAD_CERT_FORM_PASSWORD`; do not pass it as a command-line argument.
+  browser-session tokens, form passwords, raw request bodies, raw feed bodies, raw trust documents,
+  private insert URIs, non-localhost endpoint metadata, or unsanitized local paths. Optional live
+  AppHost smoke reads the form password from `CRYPTAD_CERT_FORM_PASSWORD`; do not pass it as a
+  command-line argument.
 
 ## Release certification smoke
 
@@ -138,8 +159,12 @@ Load only the docs needed for the change:
   evidence, bounded content-fetch evidence, signed bundle evidence, signed catalog evidence,
   first-party beta catalog metadata, trusted app-review receipt evidence, sandbox-provider
   evidence, app-update lifecycle/scheduler/rollback evidence, Site Publisher/Profile
-  Publisher/Feed Reader reference-app evidence, legacy-admin retirement state, and optional
-  localhost-only live AppHost lifecycle evidence.
+  Publisher/Feed Reader/Trust Graph Preview reference-app evidence, app-review governance and
+  local transparency-log evidence, legacy-admin retirement state, and optional localhost-only live
+  AppHost lifecycle evidence.
+- `tools/release-certification/app_platform_docs_check.py` is the deterministic docs evidence
+  collector for the app ecosystem beta portal, tutorials, beta program, issue templates, internal
+  Markdown links, and docs redaction checks.
 - `pr` mode must stay fast and offline-safe. It must not require a live node, signing keys, Hyphanet
   downloads, or production credentials.
 - `release-candidate` mode treats missing required signed bundle/catalog/app-platform evidence as
@@ -157,6 +182,7 @@ Use `$cryptad-build-test` for Gradle rules and timeouts. Common focused checks:
 ./gradlew :platform-app-ui:test
 ./gradlew :platform-appdist:test
 ./gradlew :platform-appcatalog:test
+./gradlew :platform-trustgraph:test
 ./gradlew :platform-design-system:test
 ./gradlew :platform-appvault:test
 ./gradlew :platform-devtools:test
@@ -168,7 +194,9 @@ Use `$cryptad-build-test` for Gradle rules and timeouts. Common focused checks:
 ./gradlew :apps:site-publisher:test
 ./gradlew :apps:profile-publisher:test
 ./gradlew :apps:feed-reader:test
+./gradlew :apps:trust-graph:test
 ./gradlew stageFirstPartyApps
+python3 tools/release-certification/app_platform_docs_check.py --self-test
 python3 tools/release-certification/app_platform_smoke.py --self-test
 ```
 
@@ -181,10 +209,12 @@ When changing `crypta-app` command wiring or distribution behavior, also run
 
 When changing signed bundle/catalog, app-review receipts, static UI, design-system assets, UI lint,
 SDK, Platform API contract, AppHost lifecycle, app-vault capabilities, generated document inserts,
-content fetch, app-update lifecycle/scheduler/rollback, sandbox-provider evidence, reference
-content/profile/feed apps, or legacy-admin retirement evidence behavior, also run:
+content fetch, Trust Graph Preview, app-update lifecycle/scheduler/rollback, sandbox-provider
+evidence, reference content/profile/feed/trust apps, app platform beta docs evidence, or
+legacy-admin retirement evidence behavior, also run:
 
 ```bash
+python3 tools/release-certification/app_platform_docs_check.py --self-test
 python3 tools/release-certification/app_platform_smoke.py --self-test
 tools/release-certification/run-release-certification.sh --mode pr --skip-gradle --skip-git-metadata
 ```

--- a/.agents/skills/cryptad-release-workflow/SKILL.md
+++ b/.agents/skills/cryptad-release-workflow/SKILL.md
@@ -31,10 +31,12 @@ Build: 2
 - Use `docs/cryptad-release-workflow-and-runbook.md` as the detailed release-readiness source of
   truth. Current release gates include the release certification report, first-party app
   staging/signing/verification, first-party beta catalog and trusted app-review receipt smoke,
-  app-owned UI design-system/lint smoke, app-vault capability evidence, generated-document insert
-  evidence, content-fetch evidence, Site Publisher/Profile Publisher/Feed Reader reference-app
-  evidence, app-update lifecycle/scheduler/rollback evidence, `crypta-app` developer beta toolkit
-  smoke, legacy-admin retirement/removal evidence, Hyphanet interop smoke/soak evidence, and the
+  app-review governance/reviewer-key/transparency-log evidence, app-owned UI design-system/lint
+  smoke, app-vault capability evidence, generated-document insert evidence, content-fetch evidence,
+  Trust Graph Preview evidence, Site Publisher/Profile Publisher/Feed Reader/Trust Graph Preview
+  reference-app evidence, app platform beta docs/program evidence, app-update
+  lifecycle/scheduler/rollback evidence, `crypta-app` developer beta toolkit smoke,
+  legacy-admin retirement/removal evidence, Hyphanet interop smoke/soak evidence, and the
   packaged-node performance smoke.
 
 ---
@@ -101,17 +103,18 @@ git push origin v<build-number>
 - [ ] Signed catalog, first-party beta catalog, trusted app-review receipt, Platform API contract,
       app-vault capability, generated-document insert, content-fetch, app UI design-system/lint,
       app-owned UI smoke, Site Publisher reference-content, Profile Publisher identity-profile,
-      Feed Reader content-fetch, AppHost sandbox-provider, app-update lifecycle, app-update
-      scheduler, app-update rollback, developer beta toolkit, and legacy-admin retirement/removal
-      evidence are present in the certification summary.
+      Feed Reader content-fetch, Trust Graph Preview, app-review governance/reviewer-key lifecycle
+      and transparency-log, app platform beta docs/program/redaction, AppHost sandbox-provider,
+      app-update lifecycle, app-update scheduler, app-update rollback, developer beta toolkit, and
+      legacy-admin retirement/removal evidence are present in the certification summary.
 - [ ] Hyphanet interop smoke passed or CI evidence recorded; extended interop captured when
       compatibility-sensitive behavior changed.
 - [ ] Performance smoke passed or scheduled/manual CI evidence recorded when release readiness or
       performance-sensitive changes require it.
 - [ ] Release record excludes `artifacts/private-insert-uris.json`, private signing keys, private
       reviewer keys, form passwords, app tokens, browser-session tokens, raw request bodies, raw
-      feed bodies, private insert URIs, raw trusted reviewer public key bytes, and unsanitized
-      local paths.
+      feed bodies, raw trust documents, private insert URIs, raw trusted reviewer public key bytes,
+      and unsanitized local paths.
 - [ ] Tag `v<build-number>` created.
 - [ ] Merged to `main` with `--no-ff` (no squash), then back-merged to `develop` with `--no-ff`.
 - [ ] Branches and tag pushed.

--- a/.agents/skills/cryptad-style-docs/SKILL.md
+++ b/.agents/skills/cryptad-style-docs/SKILL.md
@@ -18,8 +18,9 @@ Use this skill when you:
 - Java sources go under `src/*/java/` (for example `src/main/java`, `src/test/java`).
 - For extracted production leaves such as `:runtime-node`, `:kernel-content`, `:platform-api`,
   `:platform-apphost`, `:platform-app-ui`, `:platform-appvault`, `:platform-design-system`,
-  `:platform-appdist`, `:platform-appcatalog`, `:platform-devtools`, `:platform-web-shell`, and
-  the adapter modules, keep `package-info.java` in each production package you add or move.
+  `:platform-appdist`, `:platform-appcatalog`, `:platform-trustgraph`, `:platform-devtools`,
+  `:platform-web-shell`, and the adapter modules, keep `package-info.java` in each production
+  package you add or move.
   Boundary tests currently enforce this for the runtime, kernel, platform, FCP, and HTTP leaves,
   and the adapter packages follow the same convention.
 - Resource-owned leaves such as `:platform-sdk-js` still keep Java tests under `src/test/java`.

--- a/.github/ISSUE_TEMPLATE/app-platform-beta-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/app-platform-beta-feedback.yml
@@ -1,0 +1,82 @@
+name: App platform beta feedback
+description: Report beta feedback for Crypta app platform docs, devtools, catalogs, apps, updates, or review flows.
+title: "[app-platform-beta] "
+labels:
+  - app-platform
+  - beta-feedback
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not paste private keys, reviewer private keys, seed phrases, private insert URIs, browser session tokens, AppHost process tokens, form passwords, authorization headers, cookies, request bodies, raw feed bodies, raw trust documents, raw receipt signatures, or local absolute paths.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Install/catalog issue
+        - Update/rollback issue
+        - Platform API compatibility issue
+        - AppVault/identity issue
+        - Content fetch/insert issue
+        - Trust Graph Preview issue
+        - UI/design-system issue
+        - Legacy replacement issue
+        - Documentation issue
+    validations:
+      required: true
+  - type: input
+    id: cryptad-version
+    attributes:
+      label: Cryptad version/build
+      placeholder: "Example: 1481 or commit SHA"
+    validations:
+      required: true
+  - type: input
+    id: platform-api-contract
+    attributes:
+      label: Platform API contract version
+      placeholder: "Example: 7"
+    validations:
+      required: true
+  - type: input
+    id: app-id-version
+    attributes:
+      label: App id/version
+      placeholder: "Example: feed-reader 1.0.0"
+  - type: input
+    id: catalog-source
+    attributes:
+      label: Catalog id/source class, redacted
+      placeholder: "Example: crypta-first-party-beta, crypta:USK@<catalog-key>/cryptad-app-catalog.properties"
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Use offline or loopback-only steps where possible. Redact local paths and private values.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Redacted evidence
+      description: Paste redacted release-certification evidence, `crypta-app test` JSON summaries, or short sanitized excerpts only.
+  - type: checkboxes
+    id: redaction-confirmation
+    attributes:
+      label: Redaction confirmation
+      options:
+        - label: I confirm this report does not include secrets, private URIs, tokens, request bodies, raw user documents, raw signatures, or unredacted local absolute paths.
+          required: true

--- a/.github/ISSUE_TEMPLATE/app-submission-beta.yml
+++ b/.github/ISSUE_TEMPLATE/app-submission-beta.yml
@@ -1,0 +1,110 @@
+name: App submission beta
+description: Propose a Crypta app for beta review.
+title: "[app-submission-beta] "
+labels:
+  - app-platform
+  - app-submission
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Do not paste private keys, reviewer private keys, seed phrases, private insert URIs, browser session tokens, AppHost process tokens, form passwords, authorization headers, cookies, request bodies, raw feed bodies, raw trust documents, raw receipt signatures, or local absolute paths.
+  - type: input
+    id: app-id-name-version
+    attributes:
+      label: App id/name/version
+      placeholder: "Example: hello-crypta / Hello Crypta / 0.1.0"
+    validations:
+      required: true
+  - type: input
+    id: lineage
+    attributes:
+      label: Template or reference app lineage
+      placeholder: "Example: static-basic, queue-dashboard, publisher, vault-profile, or custom"
+  - type: textarea
+    id: capabilities
+    attributes:
+      label: Requested capabilities
+      description: List capability names from the manifest.
+      placeholder: "queue.read, queue.write"
+    validations:
+      required: true
+  - type: textarea
+    id: rationales
+    attributes:
+      label: Permission rationales
+      description: Explain why each requested capability is needed.
+    validations:
+      required: true
+  - type: input
+    id: api-range
+    attributes:
+      label: API min/max tested version
+      placeholder: "Example: minimum 1, maximum tested 7"
+    validations:
+      required: true
+  - type: input
+    id: bundle-digest
+    attributes:
+      label: Signed bundle digest
+      placeholder: "Lowercase SHA-256 digest, no private material"
+    validations:
+      required: true
+  - type: textarea
+    id: catalog-entry
+    attributes:
+      label: Catalog entry digest or descriptor excerpt
+      description: Include only safe descriptor fields such as app id, version, digest, size, capability names, and redacted URIs.
+    validations:
+      required: true
+  - type: dropdown
+    id: review-receipt
+    attributes:
+      label: Review receipt status
+      options:
+        - Not included
+        - Included and pending reviewer trust configuration
+        - Included and verified by local trusted reviewer key
+        - Rejected or requires changes
+    validations:
+      required: true
+  - type: input
+    id: ui-lint
+    attributes:
+      label: UI lint status
+      placeholder: "Example: crypta-app ui lint --strict passed"
+    validations:
+      required: true
+  - type: input
+    id: compatibility
+    attributes:
+      label: Compatibility status
+      placeholder: "Example: crypta-app compat verify --strict passed against contract v7"
+    validations:
+      required: true
+  - type: textarea
+    id: update-policy
+    attributes:
+      label: Update policy expectations
+      description: Describe permission deltas, review requirements, and whether manual review is expected.
+  - type: textarea
+    id: limitations
+    attributes:
+      label: Known limitations
+      description: Be explicit about beta limits and unsupported behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: security-notes
+    attributes:
+      label: Security notes
+      description: Describe data handling, capability boundaries, and redaction-sensitive areas.
+    validations:
+      required: true
+  - type: checkboxes
+    id: redaction-confirmation
+    attributes:
+      label: Redaction confirmation
+      options:
+        - label: I confirm this submission does not include private keys, tokens, private URIs, request bodies, raw user documents, raw signatures, or unredacted local absolute paths.
+          required: true

--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ Cryptad now uses a partial multi-project Gradle build.
   remote/local/Crypta catalog fetching, app-store metadata parsing, artifact digest checks, safe
   ZIP extraction, reviewer-key lifecycle governance, local review transparency logging, and
   verified staging for AppHost install/update flows.
+- `:platform-trustgraph` owns the local Trust Graph Preview statement model, strict JSON parsing,
+  canonicalization, verification, process-local anchor/store behavior, and deterministic direct
+  scoring. It is a local preview service, not the old Web of Trust plugin or a network protocol
+  change.
 - `:platform-devtools` owns the standalone `crypta-app` developer CLI for scaffolding, validating,
   UI linting, signing, packaging, verifying, catalog-authoring, API contract snapshotting, and
   compatibility verification for standalone staged bundles.
@@ -581,9 +585,14 @@ Key docs:
 - [App-owned static UI](docs/app-owned-ui.md)
 - [App UI design system](docs/app-ui-design-system.md)
 - [Platform JavaScript SDK](docs/platform-sdk-js.md)
+- [Feed Reader reference app](docs/feed-reader-reference-app.md)
+- [Trust Graph Preview](docs/trust-graph-preview.md)
 - [AppHost runtime hardening](docs/apphost-runtime-hardening.md)
 - [App permissions and audit](docs/app-permissions-and-audit.md)
 - [App secret and identity vault](docs/app-secret-and-identity-vault.md)
+- [App review governance](docs/app-review-governance.md)
+- [App update lifecycle](docs/app-update-lifecycle.md)
+- [App platform beta known limitations](docs/app-platform-beta-known-limitations.md)
 - [Legacy admin retirement plan](docs/legacy-retirement-plan.md)
 - [Release certification](docs/release-certification.md)
 
@@ -637,6 +646,7 @@ require a live node.
 Fast self-tests:
 
 ```bash
+python3 tools/release-certification/app_platform_docs_check.py --self-test
 python3 tools/release-certification/release_certification.py --self-test
 python3 tools/release-certification/app_platform_smoke.py --self-test
 ```
@@ -715,6 +725,7 @@ leaf ownership and import rules:
 ./gradlew :platform-appcatalog:test
 ./gradlew :platform-devtools:test
 ./gradlew :platform-sdk-js:test
+./gradlew :platform-trustgraph:test
 ./gradlew :platform-web-shell:test
 ./gradlew :kernel-content:test
 ./gradlew :kernel-transport:test
@@ -745,7 +756,7 @@ Additional root and mixed verification slices remain available:
 
 Platform checks now live in `:platform-api`, `:platform-apphost`, `:platform-app-ui`,
 `:platform-appvault`, `:platform-design-system`, `:platform-appdist`, `:platform-appcatalog`,
-`:platform-devtools`, `:platform-sdk-js`, and `:platform-web-shell`.
+`:platform-devtools`, `:platform-sdk-js`, `:platform-trustgraph`, and `:platform-web-shell`.
 
 ## Code Quality
 
@@ -1034,8 +1045,8 @@ Root build also includes:
 - `:platform-api`: transport-neutral Platform API v1 built on top of `:runtime-spi` and
   `:platform-apphost`, currently mounted under `/api/v1/` through the legacy HTTP admin adapter.
   Its current family-level surface covers node, connectivity, queue, peers, config, security
-  levels, updates, wizard/welcome, alerts, diagnostics, apps, app catalogs, app vault routes, and
-  the platform compatibility contract.
+  levels, updates, wizard/welcome, alerts, diagnostics, apps, app catalogs, app vault routes, local
+  Trust Graph Preview routes, and the platform compatibility contract.
 - `:platform-apphost`: transport-neutral out-of-process AppHost v1 core for installed local apps.
   Local staged and verified catalog app updates now flow through this core. It also reports sandbox
   provider status, selects the Linux bubblewrap provider for enforced restricted-process launches
@@ -1057,6 +1068,8 @@ Root build also includes:
 - `:platform-appcatalog`: signed catalog source parsing, catalog writing, signature verification,
   app-store metadata parsing, Crypta catalog source fetching, artifact digest checks, safe ZIP
   extraction, and verified staging for AppHost install/update flows.
+- `:platform-trustgraph`: local Trust Graph Preview statement parsing, canonicalization,
+  verification, process-local store/anchor behavior, and deterministic direct-anchor scoring.
 - `:platform-devtools`: standalone `crypta-app` developer CLI for scaffolding, validating,
   UI linting, signing, packaging, verifying, catalog-authoring, API contract snapshotting, and
   compatibility verification for standalone staged bundles.
@@ -1161,7 +1174,7 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
     `:kernel-transport`, `:kernel-routing`, `:runtime-spi`, `:runtime-alerts`,
     `:platform-api`, `:platform-apphost`, `:platform-app-ui`, `:platform-appvault`,
     `:platform-design-system`, `:platform-appdist`, `:platform-appcatalog`,
-    `:platform-devtools`, `:platform-sdk-js`,
+    `:platform-trustgraph`, `:platform-devtools`, `:platform-sdk-js`,
     `:platform-web-shell`,
     `:runtime-node`,
     `:adapter-fcp`, `:bridge-fcp-runtime`, `:bridge-http-runtime`,
@@ -1316,7 +1329,8 @@ Tip: Keep the Spotless formatter at the intended version (currently `googleJavaF
   browser SDK resource for app-owned static UI; `:platform-appdist` provides the local app bundle
   digest, signing, packaging, and verification tooling; `:platform-appcatalog` provides signed
   catalog source, app-store metadata, Crypta catalog fetching, artifact verification, and safe ZIP
-  staging support; `:platform-devtools` provides the standalone `crypta-app` developer CLI,
+  staging support; `:platform-trustgraph` provides local trust statement parsing and deterministic
+  preview scoring; `:platform-devtools` provides the standalone `crypta-app` developer CLI,
   including offline UI linting, API contract, and compatibility checks;
   `:platform-web-shell` provides the browser-facing Web Shell v1 node-management assets and
   bootstrap contract; `:runtime-node`

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ data, and serves applications.
 - [Quick Start](#quick-start)
 - [Building](#building)
 - [Signed App Bundles](#signed-app-bundles)
+- [App Platform Beta](#app-platform-beta)
 - [Developer App CLI](#developer-app-cli)
 - [Platform Closeout & API Surface](#platform-closeout--api-surface)
 - [Trust Graph Preview](#trust-graph-preview)
@@ -433,6 +434,18 @@ process/browser, lifecycle, audit, and redaction rules. Profile publishing uses
 See [docs/app-distribution.md](docs/app-distribution.md) for the full workflow and exact signing
 inputs.
 
+## App Platform Beta
+
+The app ecosystem beta is documented through
+[docs/app-platform-developer-portal.md](docs/app-platform-developer-portal.md). Start there for
+the current Platform API contract version, first-party app map, offline beta tutorials, known
+limitations, beta feedback and app submission workflow, and release-manager closeout path.
+
+The beta is offline-first for developer tests and dry-run publication planning. It does not create
+a public production app store, does not auto-install recommended catalog apps, does not require
+public Crypta network access for tests, and does not change FNP, FCP, Hyphanet/Freenet
+compatibility behavior, or retained FProxy browse behavior.
+
 ## Developer App CLI
 
 Standalone app authors can use `crypta-app` for staged bundle scaffolding, validation, signing,
@@ -495,11 +508,13 @@ into the generated catalog entry so Platform API responses can expose `reviewTru
 legacy advisory `review` object.
 
 First-party apps can keep using `:apps:queue-manager`, `:apps:publisher`,
-`:apps:site-publisher`, `:apps:profile-publisher`, and `:apps:feed-reader` `stageApp`, `signApp`, and `verifyApp`
-tasks. See
-[docs/app-dev-cli.md](docs/app-dev-cli.md) for the standalone CLI flow and
-[docs/app-catalogs.md](docs/app-catalogs.md) for catalog entry descriptors and verification. The
-PR-225 beta toolkit sidecar walkthrough is in
+`:apps:site-publisher`, `:apps:profile-publisher`, `:apps:feed-reader`, and
+`:apps:trust-graph` `stageApp`, `signApp`, and `verifyApp` tasks. See
+[docs/app-platform-developer-portal.md](docs/app-platform-developer-portal.md) for the beta
+developer portal, [docs/app-platform-beta-tutorials.md](docs/app-platform-beta-tutorials.md) for
+copyable offline flows, [docs/app-dev-cli.md](docs/app-dev-cli.md) for the standalone CLI flow,
+and [docs/app-catalogs.md](docs/app-catalogs.md) for catalog entry descriptors and verification.
+The developer beta toolkit walkthrough is in
 [docs/developer-beta-toolkit.md](docs/developer-beta-toolkit.md).
 
 ## Platform Closeout & API Surface
@@ -555,9 +570,14 @@ Key docs:
 - [Phase 3 Platform Primacy closeout](docs/phase-3-platform-primacy-closeout.md)
 - [Platform API and Web Shell surface](docs/platform-api-surface.md)
 - [Platform API compatibility contract](docs/platform-api-contract.md)
+- [App platform developer portal](docs/app-platform-developer-portal.md)
+- [App platform beta tutorials](docs/app-platform-beta-tutorials.md)
+- [App platform beta program](docs/app-platform-beta-program.md)
 - [Developer app CLI](docs/app-dev-cli.md)
+- [Developer beta toolkit](docs/developer-beta-toolkit.md)
 - [Signed App Distribution](docs/app-distribution.md)
 - [Signed app catalogs](docs/app-catalogs.md)
+- [First-party beta app catalog](docs/first-party-beta-catalog.md)
 - [App-owned static UI](docs/app-owned-ui.md)
 - [App UI design system](docs/app-ui-design-system.md)
 - [Platform JavaScript SDK](docs/platform-sdk-js.md)
@@ -920,7 +940,7 @@ xattr -dr com.apple.quarantine "build/jpackage/Crypta.app"
 - See launcher logs by running the Mach‑O launcher in Terminal:
 
 ```bash
-build/jpackage/Crypta.app/Contents/MacOS/Crypta 2>&1 | tee /tmp/crypta-run.log
+build/jpackage/Crypta.app/Contents/MacOS/Crypta 2>&1 | tee build/crypta-run.log
 ```
 
 - Run the embedded JRE directly to isolate classpath issues:

--- a/docs/app-catalogs.md
+++ b/docs/app-catalogs.md
@@ -557,7 +557,8 @@ signed-bundle verification, so those files are not installed as app payload.
 Cryptad exposes a recommended first-party beta catalog descriptor for the Web Shell and Platform
 API. The descriptor is an onboarding hint, not an app store ranking system and not a trust bypass.
 It is visible even when packaging has not configured a source, so operators can see why the catalog
-is unavailable.
+is unavailable. See [first-party-beta-catalog.md](first-party-beta-catalog.md) for the full
+maintainer publication flow and operator onboarding guidance.
 
 Recommended catalog configuration:
 

--- a/docs/app-dev-cli.md
+++ b/docs/app-dev-cli.md
@@ -611,7 +611,7 @@ review keys outside the repository.
 
    ```properties
    artifact.path=/abs/path/to/queue-manager.zip
-   bundle.uri=crypta:CHK@<artifact-key>
+   bundle.uri=crypta:CHK@...
    summary=Manage local Crypta transfer queues.
    name=Queue Manager
    permissions=queue.read,queue.write

--- a/docs/app-dev-cli.md
+++ b/docs/app-dev-cli.md
@@ -18,9 +18,10 @@ API or signed catalog source handling described in [app-catalogs.md](app-catalog
 First-party repo apps can keep using their existing Gradle tasks. See
 [First-party Gradle workflow](#first-party-gradle-workflow).
 
-For the PR-225 beta sidecar workflow, including `init --template queue-dashboard`, the mock
-development server, strict beta test wrapper, local key generation, and `publish-usk --dry-run`,
-see [developer-beta-toolkit.md](developer-beta-toolkit.md).
+For the beta sidecar workflow, including `init --template queue-dashboard`, the mock development
+server, strict beta test wrapper, local key generation, and `publish-usk --dry-run`, see
+[developer-beta-toolkit.md](developer-beta-toolkit.md). For the full beta portal and submission
+path, see [app-platform-developer-portal.md](app-platform-developer-portal.md).
 
 ## Build and run the command
 
@@ -636,9 +637,15 @@ operator flow.
 
 ## Related docs
 
-- [developer-beta-toolkit.md](developer-beta-toolkit.md) gives the PR-225 beta toolkit walkthrough
-  for queue-dashboard scaffolding, mock dev runs, strict tests, key generation, signing, cataloging,
+- [app-platform-developer-portal.md](app-platform-developer-portal.md) is the app ecosystem beta
+  entry point.
+- [app-platform-beta-tutorials.md](app-platform-beta-tutorials.md) gives copyable offline beta
+  tutorials.
+- [developer-beta-toolkit.md](developer-beta-toolkit.md) gives the beta toolkit walkthrough for
+  queue-dashboard scaffolding, mock dev runs, strict tests, key generation, signing, cataloging,
   and dry-run USK publication.
+- [first-party-beta-catalog.md](first-party-beta-catalog.md) covers first-party catalog publication
+  and Web Shell onboarding.
 - [app-distribution.md](app-distribution.md) describes the signed bundle sidecars, manifest fields,
   and first-party Gradle tasks.
 - [app-ui-design-system.md](app-ui-design-system.md) describes canonical app UI assets and

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -408,7 +408,8 @@ Verify Trust Graph Preview with the matching public key:
 
 Stage, sign, and verify all first-party apps:
 
-The root first-party tasks include Site Publisher, Profile Publisher, and Feed Reader.
+The root first-party tasks include Site Publisher, Profile Publisher, Feed Reader, and Trust Graph
+Preview.
 
 ```bash
 ./gradlew \

--- a/docs/app-distribution.md
+++ b/docs/app-distribution.md
@@ -71,13 +71,15 @@ signed bundle and are validated during structure checks. They must not point at 
 distribution sidecars, absolute paths, traversal segments, Windows drive prefixes, empty segments,
 colons, or control characters. Existing shell-panel entries remain valid.
 
-The repo-owned Queue Manager, legacy Publisher, Site Publisher, Profile Publisher, and Feed Reader
-bundles use `app.ui.mode=static` and `app.ui.entry=static/index.html`, so installed copies open
-through isolated app origins when available. Queue Manager and legacy Publisher remain
-compatibility fallbacks for the current retirement map. Site Publisher is the content reference app
-for local publishing workflows, Profile Publisher is the identity-profile reference app for
-vault-backed profile-document publishing, and Feed Reader is the bounded content-fetch reference
-app for feed reading and generated feed publication.
+The repo-owned Queue Manager, legacy Publisher, Site Publisher, Profile Publisher, Feed Reader, and
+Trust Graph Preview bundles use `app.ui.mode=static` and `app.ui.entry=static/index.html`, so
+installed copies open through isolated app origins when available. Queue Manager and legacy
+Publisher remain compatibility fallbacks for the current retirement map. Site Publisher is the
+content reference app for local publishing workflows, Profile Publisher is the identity-profile
+reference app for vault-backed profile-document publishing, Feed Reader is the bounded
+content-fetch reference app for feed reading and generated feed publication, and Trust Graph
+Preview is the local trust-service reference app for trust statements, anchors, and preview
+scoring.
 
 See [app-owned-ui.md](app-owned-ui.md) for the `/apps/{appId}/` route contract, first-party
 bootstrap JSON, static asset security boundary, and API summary fields. See
@@ -241,6 +243,9 @@ Per app:
 - `:apps:feed-reader:stageApp`
 - `:apps:feed-reader:signApp`
 - `:apps:feed-reader:verifyApp`
+- `:apps:trust-graph:stageApp`
+- `:apps:trust-graph:signApp`
+- `:apps:trust-graph:verifyApp`
 
 Root convenience tasks:
 
@@ -315,6 +320,12 @@ Stage the Feed Reader reference app:
 ./gradlew :apps:feed-reader:stageApp
 ```
 
+Stage the Trust Graph Preview reference app:
+
+```bash
+./gradlew :apps:trust-graph:stageApp
+```
+
 Sign it with a local development key pair:
 
 ```bash
@@ -347,6 +358,14 @@ Sign Feed Reader with the same local development key pair:
   -PcryptadAppSigningPrivateKeyFile=/abs/path/to/dev-app-signing-private.pem
 ```
 
+Sign Trust Graph Preview with the same local development key pair:
+
+```bash
+./gradlew :apps:trust-graph:signApp \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPrivateKeyFile=/abs/path/to/dev-app-signing-private.pem
+```
+
 Verify it with the matching public key:
 
 ```bash
@@ -375,6 +394,14 @@ Verify Feed Reader with the matching public key:
 
 ```bash
 ./gradlew :apps:feed-reader:verifyApp \
+  -PcryptadAppSigningKeyId=dev-local \
+  -PcryptadAppSigningPublicKeyFile=/abs/path/to/dev-app-signing-public.pem
+```
+
+Verify Trust Graph Preview with the matching public key:
+
+```bash
+./gradlew :apps:trust-graph:verifyApp \
   -PcryptadAppSigningKeyId=dev-local \
   -PcryptadAppSigningPublicKeyFile=/abs/path/to/dev-app-signing-public.pem
 ```

--- a/docs/app-owned-ui.md
+++ b/docs/app-owned-ui.md
@@ -276,8 +276,9 @@ Queue Manager and legacy Publisher are also the primary replacements for the leg
 insert admin pages in the current retirement map. Site Publisher is the content reference app for
 new app-platform publishing flows. Profile Publisher is the identity-profile reference app for
 vault-backed profile-document publishing. Feed Reader is the bounded content-fetch reference app
-for reading feed snapshots and publishing generated feed documents. The full legacy map is
-maintained in [legacy-retirement-plan.md](legacy-retirement-plan.md).
+for reading feed snapshots and publishing generated feed documents. Trust Graph Preview is the
+local trust-service reference app for local trust statements, anchors, and preview scoring. The
+full legacy map is maintained in [legacy-retirement-plan.md](legacy-retirement-plan.md).
 
 ## Platform API summary fields
 
@@ -430,6 +431,27 @@ feed snapshots without local source-path authority, and `queue.read` to show upl
 keeps source lists and fetched content in memory by default and must not persist raw feed bodies,
 raw request bodies, private insert URIs, app process tokens, browser-session tokens, form
 passwords, or local paths.
+
+Trust Graph Preview reference app bundle:
+
+```properties
+manifest.version=1
+app.id=trust-graph
+app.name=Trust Graph Preview
+app.version=1.0.0
+app.exec=bin/trust-graph.sh
+app.ui.mode=static
+app.ui.entry=static/index.html
+app.permissions=trust.read,trust.write,content.fetch,content.insert.app-document,queue.read,queue.write,vault.identities.read,vault.identities.create,vault.identities.use
+quota.data.bytes=1048576
+quota.cache.bytes=2097152
+```
+
+Trust Graph Preview needs `trust.read` and `trust.write` for local preview state, `content.fetch`
+for bounded Crypta trust documents selected by the user, `content.insert.app-document` plus queue
+capabilities for generated statement publication, and `vault.identities.*` for app-owned trust
+identity creation and bounded trust-statement signing. It is not full Web of Trust, a moderation
+system, a background crawler, or old plugin compatibility.
 
 Transitional shell-panel bundle:
 

--- a/docs/app-platform-beta-known-limitations.md
+++ b/docs/app-platform-beta-known-limitations.md
@@ -1,0 +1,110 @@
+# App platform beta known limitations
+
+This page records conservative limits and safety boundaries for the Crypta app ecosystem beta.
+
+## General beta limits
+
+- This is an app ecosystem beta, not a public production app store.
+- First-party beta catalog support does not imply automatic app installation.
+- Recommended catalog metadata is an onboarding hint, not ranking, endorsement, or trust by itself.
+- Developer tooling supports offline and dry-run publication planning. Live insertion depends on
+  existing content and queue mechanisms plus the operator's deployment configuration.
+- `crypta-app dev`, `crypta-app test`, release self-tests, and docs certification do not depend on
+  the public Crypta network.
+- The beta does not require Docker, Node.js, npm, external network access, signing secrets, or
+  public Crypta network access for its offline tests.
+- The beta does not modify FNP, FCP, wire protocol, or Hyphanet/Freenet network compatibility
+  behavior.
+- FProxy browse remains retained.
+
+## Security boundaries
+
+- App UI origin isolation is based on app-owned origins and browser sessions. It is not permission
+  to bypass server-side Platform API capability checks.
+- Browser app sessions are local browser credentials for static UI calls. Do not treat them as
+  long-lived secrets, do not persist them in app local storage, and do not confuse them with
+  AppHost process tokens.
+- AppHost process tokens must never be exposed through bootstrap JSON, Web Shell state, app UI,
+  release evidence, logs, diagnostics, or bug reports.
+- AppVault protects app-owned identity and secret material through bounded routes. It does not
+  expose private keys, seed material, or raw signing keys to apps.
+- `vault.identities.create` creates app-owned identity material. `vault.identities.use` permits
+  bounded signing operations such as profile-document or trust-statement signing without exporting
+  private material.
+- `content.fetch` is bounded Crypta-content fetch. It is not arbitrary HTTP, LAN, local file, or
+  loopback fetch.
+- App-generated document insert stages bytes under Cryptad control. It must not expose absolute
+  staging paths, local source paths, raw request bodies, raw profile/feed/trust documents, or
+  private insert URIs.
+- Trust Graph Preview is a local preview. It is not full Web of Trust, old plugin compatibility,
+  global moderation, or a background crawler.
+- Review governance uses local trust configuration plus a local tamper-evident transparency log.
+  It is not a global public transparency log.
+- Sandbox provider support depends on platform and provider availability. Linux bubblewrap support
+  can provide an enforced provider on supported systems, but the docs and evidence must not claim
+  hard isolation beyond the implemented provider status, tests, quotas, and runtime checks.
+
+## Update and rollback limits
+
+- Background scheduler behavior is policy-driven.
+- Manual update policy detects candidates but does not stage or apply automatically.
+- `stage` may stage eligible verified candidates according to policy.
+- `apply_when_stopped` may apply only when the app is already stopped and catalog, bundle, review,
+  compatibility, permission-delta, and health gates pass.
+- Permission additions should block unattended apply unless the current implementation explicitly
+  supports a stricter approved path.
+- Rollback restores the immutable installed bundle. It does not promise to roll back app data,
+  cache, run state, external network state, or every user-visible app state.
+- Health checks and rollback records are safety mechanisms, not a guarantee that every update
+  failure can be undone.
+
+## Review and catalog limits
+
+- Signed catalog, signed bundle, artifact digest, review receipt, and reviewer trust are separate
+  layers.
+- A valid catalog signature authenticates catalog bytes and publisher metadata only.
+- A valid bundle signature authenticates the extracted app bundle payload only.
+- A review receipt is independent reviewer evidence. It is trusted only when it verifies against
+  local trusted reviewer-key configuration and policy.
+- A catalog listing a reviewer key must not automatically establish local reviewer trust unless the
+  local implementation explicitly configures that key as trusted.
+- Publisher-advisory `review.status` and `review.note` fields do not replace trusted review
+  receipts.
+- Unknown, revoked, expired, retired, missing, or mismatched reviewer states must be displayed
+  honestly and must not be rendered as trusted positive review.
+- `crypta:` catalog transport is not a trust boundary. Catalog bytes, catalog signatures, app
+  artifacts, artifact digests, bundle signatures, review receipts, reviewer key lifecycle state,
+  and permission/API compatibility still need their own checks.
+
+## Data handling and redaction
+
+Do not paste or commit:
+
+- Private signing keys or reviewer private keys.
+- Seed phrases, recovery phrases, or private identity material.
+- Private insert URIs.
+- Browser session tokens, app process tokens, form passwords, authorization headers, cookies, or
+  request bodies.
+- Raw feed bodies, raw trust documents from real users, raw profile documents, or raw receipt
+  signatures.
+- Local absolute paths, catalog scratch paths, staging paths, rollback backup paths, or host private
+  configuration paths unless they are already redacted.
+
+Safe placeholders include:
+
+```text
+<redacted>
+<token-redacted>
+/abs/path/outside/repo/dev-private.der
+crypta:CHK@<artifact-key>
+crypta:USK@<catalog-key>/cryptad-app-catalog.properties
+```
+
+Release certification and issue templates should record statuses, relative repo paths, digests,
+app ids, capability names, evidence ids, and redacted summaries instead of raw payloads.
+
+## Non-goals
+
+The beta does not introduce a live public app store, live public-network test dependency, global
+transparency log, full Web of Trust, durable feed subscription daemon, new sandbox provider, new
+update scheduler policy, legacy route removal wave 3, or any FNP/FCP/wire protocol change.

--- a/docs/app-platform-beta-program.md
+++ b/docs/app-platform-beta-program.md
@@ -1,0 +1,177 @@
+# App platform beta program
+
+This page defines the app ecosystem beta program, app submission expectations, feedback workflow,
+and Phase 7 closeout runbook.
+
+## Purpose
+
+The beta is for proving that external app developers and release managers can complete an offline,
+reproducible app flow:
+
+```text
+scaffold app -> run mock dev server -> run offline tests -> sign bundle -> pack artifact
+-> create catalog entry -> create/sign/verify catalog -> produce dry-run USK publication plan
+-> review submission -> certify release readiness
+```
+
+The beta is not a public production app store, does not auto-install recommended catalog apps, and
+does not introduce public network dependencies into tests.
+
+## Participants
+
+| Role | What they test |
+| --- | --- |
+| App developers | Templates, manifest permissions, UI lint, SDK helpers, signing, packing, catalog entries, and `crypta-app test` output. |
+| Reviewers | Manifest validation, capability rationale, review receipt evidence, reviewer key lifecycle, local transparency log behavior, and redaction. |
+| Release managers | First-party catalog readiness, reference app coverage, update scheduler and rollback evidence, legacy retirement status, docs readiness, and the ecosystem certification matrix. |
+| Operators | First-party/reference app install, update review, rollback behavior, Web Shell onboarding, and beta feedback. |
+
+## App proposal checklist
+
+An app proposal should include:
+
+- App id, display name, and app version.
+- `cryptad-app.properties` manifest.
+- Requested capabilities and permission rationales.
+- Platform API contract `api.minimumVersion` and `api.maximumTestedVersion`.
+- UI lint output, preferably from `crypta-app ui lint --strict --json`.
+- API compatibility output, preferably from `crypta-app compat verify --strict`.
+- `crypta-app test --strict --json` output.
+- Signed bundle digest and signing key id.
+- Catalog entry descriptor or a safe excerpt with artifact digest, size, app id, version, and
+  permission rationales.
+- Optional review receipt status and reviewer policy id/version.
+- Update policy expectations and permission-delta notes.
+- Known risks and beta limitations.
+- Security notes and redaction confirmation.
+
+Do not include private keys, reviewer private keys, private insert URIs, session tokens, form
+passwords, raw request bodies, raw feed bodies, raw trust documents from real users, raw receipt
+signatures, or local absolute paths.
+
+## Review expectations
+
+Reviewers should check:
+
+- Manifest parsing and bundle validation.
+- Capability and permission rationale fit.
+- Platform API compatibility range and optional capability metadata.
+- UI safety: local resources, SDK/bootstrap ordering, permission disclosure, accessibility basics,
+  and design-system use.
+- Static asset safety and absence of remote runtime dependencies unless explicitly reviewed.
+- Redaction: no private keys, tokens, request bodies, private URIs, raw user documents, raw
+  signatures, or local absolute paths.
+- Signed bundle verification and artifact digest consistency.
+- Catalog entry metadata, signed catalog behavior, and review receipt handling.
+- Reviewer key lifecycle status: active, retired, revoked, expired, unknown, or mismatched.
+- Local transparency log behavior when review evidence is recorded.
+- Update behavior, permission additions, compatibility gates, and rollback scope.
+
+Review receipts are independent of catalog signatures and bundle signatures. Catalog publisher
+metadata does not create reviewer trust by itself.
+
+## Feedback categories
+
+Use the closest category when filing beta feedback:
+
+- Install/catalog issue.
+- Update/rollback issue.
+- Platform API compatibility issue.
+- AppVault/identity issue.
+- Content fetch/insert issue.
+- Trust Graph Preview issue.
+- UI/design-system issue.
+- Legacy replacement issue.
+- Documentation issue.
+
+Use `.github/ISSUE_TEMPLATE/app-platform-beta-feedback.yml` when filing general feedback and
+`.github/ISSUE_TEMPLATE/app-submission-beta.yml` when proposing an app for beta review.
+
+## Bug report redaction
+
+Do not include:
+
+- Private keys or reviewer private keys.
+- Seed phrases or private identity material.
+- Private insert URIs.
+- Browser session tokens, AppHost process tokens, form passwords, authorization headers, cookies,
+  or request bodies.
+- Raw trust documents, raw feed bodies, raw profile documents, or raw receipt signatures.
+- Local absolute paths unless already redacted.
+
+Acceptable replacements:
+
+```text
+<redacted>
+<token-redacted>
+crypta:CHK@<artifact-key>
+crypta:USK@<catalog-key>/cryptad-app-catalog.properties
+```
+
+## Maintainer closeout runbook
+
+Use this runbook to decide whether the ecosystem beta is ready for a release candidate.
+
+1. Run the normal build and test commands for the release scope.
+
+   ```bash
+   ./gradlew test
+   ```
+
+2. Build the developer CLI and run app-platform smoke self-tests.
+
+   ```bash
+   ./gradlew :platform-devtools:installDist
+   python3 tools/release-certification/app_platform_smoke.py --self-test
+   ```
+
+3. Run release certification self-tests.
+
+   ```bash
+   python3 tools/release-certification/release_certification.py --self-test
+   ```
+
+4. Run release certification in the mode that matches the release stage.
+
+   ```bash
+   tools/release-certification/run-release-certification.sh --mode pr --skip-gradle --skip-git-metadata
+   tools/release-certification/run-release-certification.sh --mode nightly --out-dir build/release-certification
+   tools/release-certification/run-release-certification.sh --mode release-candidate --out-dir build/release-certification
+   ```
+
+5. Inspect the release summary and report.
+
+   ```text
+   build/release-certification/release-certification-summary.json
+   build/release-certification/release-certification-report.md
+   build/release-certification/ecosystem-certification-matrix.json
+   build/release-certification/ecosystem-certification-matrix.md
+   build/release-certification/app-platform-smoke/summary.json
+   build/release-certification/app-platform-smoke/app-platform-smoke-report.md
+   ```
+
+6. Confirm the app-review governance evidence passes: review receipts, reviewer key lifecycle,
+   local transparency log, review-history API, and first-party review chain.
+7. Confirm legacy retirement evidence passes and FProxy browse remains retained.
+8. Confirm docs evidence passes: portal, beta tutorials, beta program, known limitations, issue
+   templates, internal links, and redaction checks.
+9. Confirm the ecosystem certification matrix includes `app-platform-beta-docs-and-program` and no
+   active blocker remains unless a release manager recorded an explicit waiver.
+10. Publish release notes with the known beta limitations and any accepted waivers or residual
+    risks.
+
+Release-candidate mode should require docs and beta evidence unless a release-manager waiver
+explicitly accepts a docs-only gap. Do not waive redaction failures.
+
+## Phase 7 closeout statement
+
+The Phase 7 closeout story is:
+
+```text
+first-party catalog + developer toolkit + reference apps + trust graph preview
++ review governance + legacy wave 2 + ecosystem certification matrix
+-> documented and certified as Ecosystem Beta readiness
+```
+
+The closeout evidence must be redacted and reproducible. It should show that docs are present,
+linked, current with the source code, and honest about beta limits.

--- a/docs/app-platform-beta-program.md
+++ b/docs/app-platform-beta-program.md
@@ -122,6 +122,7 @@ Use this runbook to decide whether the ecosystem beta is ready for a release can
 
    ```bash
    ./gradlew :platform-devtools:installDist
+   python3 tools/release-certification/app_platform_docs_check.py --self-test
    python3 tools/release-certification/app_platform_smoke.py --self-test
    ```
 

--- a/docs/app-platform-beta-tutorials.md
+++ b/docs/app-platform-beta-tutorials.md
@@ -15,9 +15,9 @@ export CRYPTA_APP="$PWD/platform-devtools/build/install/crypta-app/bin/crypta-ap
 ```
 
 Keep local development keys outside the repository. The examples below use `$HOME/.crypta-dev/keys`
-and placeholder Crypta URIs such as `crypta:CHK@<artifact-key>` and
-`crypta:USK@<catalog-key>/cryptad-app-catalog.properties`. They are placeholders, not usable
-public network keys.
+and URI-safe placeholder Crypta URIs such as `crypta:CHK@...` and
+`crypta:USK@.../cryptad-app-catalog.properties`. They are placeholders, not usable public network
+keys.
 
 ## Tutorial 1: static app from template
 
@@ -144,14 +144,14 @@ mkdir -p dist/apps dist/catalog
   --overwrite
 ```
 
-Create a catalog entry descriptor. The `crypta:CHK@<artifact-key>` value is a placeholder for the
-public immutable artifact URI returned by a reviewed insertion workflow:
+Create a catalog entry descriptor. The `crypta:CHK@...` value is a placeholder for the public
+immutable artifact URI returned by a reviewed insertion workflow:
 
 ```bash
 "$CRYPTA_APP" catalog entry \
   --bundle-dir build/dev-apps/queue-dashboard \
   --artifact dist/apps/queue-dashboard-0.1.0.zip \
-  --bundle-uri "crypta:CHK@<artifact-key>" \
+  --bundle-uri "crypta:CHK@..." \
   --output dist/catalog/queue-dashboard-entry.properties \
   --summary "Inspect and manage local transfer queue state." \
   --homepage "https://example.invalid/apps/queue-dashboard" \
@@ -192,7 +192,7 @@ Write an offline Crypta USK publication plan:
 "$CRYPTA_APP" publish-usk \
   --catalog-file dist/catalog/cryptad-app-catalog.properties \
   --catalog-signature-file dist/catalog/cryptad-app-catalog.signature \
-  --catalog-source "crypta:USK@<catalog-key>/cryptad-app-catalog.properties" \
+  --catalog-source "crypta:USK@.../cryptad-app-catalog.properties" \
   --output dist/catalog/publish-plan.md \
   --dry-run
 ```

--- a/docs/app-platform-beta-tutorials.md
+++ b/docs/app-platform-beta-tutorials.md
@@ -1,0 +1,258 @@
+# App platform beta tutorials
+
+Use these offline-first tutorials to create, test, sign, pack, catalog, and review a beta app
+without reading Cryptad internals.
+
+## Prerequisites
+
+Run from the repository root with Java 25 or newer. The flows use the Gradle wrapper and the
+installed `crypta-app` launcher:
+
+```bash
+./gradlew :platform-devtools:installDist
+export CRYPTA_APP="$PWD/platform-devtools/build/install/crypta-app/bin/crypta-app"
+"$CRYPTA_APP" --help
+```
+
+Keep local development keys outside the repository. The examples below use `$HOME/.crypta-dev/keys`
+and placeholder Crypta URIs such as `crypta:CHK@<artifact-key>` and
+`crypta:USK@<catalog-key>/cryptad-app-catalog.properties`. They are placeholders, not usable
+public network keys.
+
+## Tutorial 1: static app from template
+
+Create a minimal static app bundle:
+
+```bash
+"$CRYPTA_APP" init \
+  --dir build/dev-apps/hello-crypta \
+  --template static-basic \
+  --app-id hello-crypta \
+  --name "Hello Crypta" \
+  --version 0.1.0
+```
+
+Run the local development server:
+
+```bash
+"$CRYPTA_APP" dev --bundle-dir build/dev-apps/hello-crypta
+```
+
+`crypta-app dev` binds to `127.0.0.1` by default and uses mock Platform API fixtures. It does not
+talk to the public Crypta network, install the app into AppHost, fetch signed catalogs, or prove
+live-node permission grants. Use `--fixture-dir` for custom mock JSON fixtures and
+`--allow-non-loopback` only for deliberate local-network testing.
+
+In another terminal, run the offline test suite:
+
+```bash
+"$CRYPTA_APP" test \
+  --bundle-dir build/dev-apps/hello-crypta \
+  --strict \
+  --json build/dev-apps/hello-crypta-test.json
+```
+
+The JSON report uses deterministic, path-redacted output suitable for beta submissions and release
+evidence.
+
+## Tutorial 2: queue dashboard or publisher template
+
+Create a queue-dashboard app with the template's default queue capabilities:
+
+```bash
+"$CRYPTA_APP" init \
+  --dir build/dev-apps/queue-dashboard \
+  --template queue-dashboard \
+  --app-id queue-dashboard \
+  --name "Queue Dashboard" \
+  --version 0.1.0
+```
+
+The `queue-dashboard` template declares `queue.read` and `queue.write`. Add any extra capability
+deliberately with repeated `--permission <capability>` options and update the visible permission
+rationale before signing.
+
+Create a publisher app instead when you want a content-insert example:
+
+```bash
+"$CRYPTA_APP" init \
+  --dir build/dev-apps/local-publisher \
+  --template publisher \
+  --app-id local-publisher \
+  --name "Local Publisher" \
+  --version 0.1.0
+```
+
+The `publisher` template declares `content.insert`, `queue.read`, and `queue.write`.
+
+Run strict offline checks:
+
+```bash
+"$CRYPTA_APP" test \
+  --bundle-dir build/dev-apps/queue-dashboard \
+  --strict \
+  --json build/dev-apps/queue-dashboard-test.json
+```
+
+`crypta-app test` runs the app developer checks without network access. It covers staged bundle
+validation, manifest and Platform API compatibility checks, static asset safety, UI lint for static
+bundles, API compatibility output, and a dev-server smoke check when the bundle can be served by the
+mock loopback server.
+
+## Tutorial 3: sign, pack, catalog, and offline USK publication plan
+
+Generate separate local development keys for bundle and catalog signing:
+
+```bash
+mkdir -p "$HOME/.crypta-dev/keys"
+
+"$CRYPTA_APP" keys generate \
+  --key-id dev-local-bundle \
+  --private-key-file "$HOME/.crypta-dev/keys/dev-local-bundle-private.der" \
+  --public-key-file "$HOME/.crypta-dev/keys/dev-local-bundle-public.der" \
+  --trusted-keys-file "$HOME/.crypta-dev/keys/trusted-app-keys.properties" \
+  --overwrite
+
+"$CRYPTA_APP" keys generate \
+  --key-id dev-local-catalog \
+  --private-key-file "$HOME/.crypta-dev/keys/dev-local-catalog-private.der" \
+  --public-key-file "$HOME/.crypta-dev/keys/dev-local-catalog-public.der" \
+  --overwrite
+```
+
+Sign and verify the staged bundle:
+
+```bash
+"$CRYPTA_APP" sign \
+  --bundle-dir build/dev-apps/queue-dashboard \
+  --key-id dev-local-bundle \
+  --private-key-file "$HOME/.crypta-dev/keys/dev-local-bundle-private.der"
+
+"$CRYPTA_APP" verify \
+  --bundle-dir build/dev-apps/queue-dashboard \
+  --trusted-keys-file "$HOME/.crypta-dev/keys/trusted-app-keys.properties"
+```
+
+Pack the signed staged bundle:
+
+```bash
+mkdir -p dist/apps dist/catalog
+
+"$CRYPTA_APP" pack \
+  --bundle-dir build/dev-apps/queue-dashboard \
+  --output dist/apps/queue-dashboard-0.1.0.zip \
+  --overwrite
+```
+
+Create a catalog entry descriptor. The `crypta:CHK@<artifact-key>` value is a placeholder for the
+public immutable artifact URI returned by a reviewed insertion workflow:
+
+```bash
+"$CRYPTA_APP" catalog entry \
+  --bundle-dir build/dev-apps/queue-dashboard \
+  --artifact dist/apps/queue-dashboard-0.1.0.zip \
+  --bundle-uri "crypta:CHK@<artifact-key>" \
+  --output dist/catalog/queue-dashboard-entry.properties \
+  --summary "Inspect and manage local transfer queue state." \
+  --homepage "https://example.invalid/apps/queue-dashboard" \
+  --source "https://example.invalid/src/queue-dashboard" \
+  --license "MIT" \
+  --category productivity \
+  --minimum-crypta-version 1481 \
+  --permission-rationale "queue.read=Reads local queue state." \
+  --permission-rationale "queue.write=Cancels or reprioritizes selected queue entries." \
+  --strict \
+  --overwrite
+```
+
+Create, sign, and verify the catalog:
+
+```bash
+"$CRYPTA_APP" catalog create \
+  --catalog-file dist/catalog/cryptad-app-catalog.properties \
+  --catalog-id dev-queue-dashboard \
+  --name "Development Queue Dashboard Catalog" \
+  --entry dist/catalog/queue-dashboard-entry.properties \
+  --overwrite
+
+"$CRYPTA_APP" catalog sign \
+  --catalog-file dist/catalog/cryptad-app-catalog.properties \
+  --key-id dev-local-catalog \
+  --private-key-file "$HOME/.crypta-dev/keys/dev-local-catalog-private.der"
+
+"$CRYPTA_APP" catalog verify \
+  --catalog-file dist/catalog/cryptad-app-catalog.properties \
+  --trusted-key-id dev-local-catalog \
+  --trusted-public-key-file "$HOME/.crypta-dev/keys/dev-local-catalog-public.der"
+```
+
+Write an offline Crypta USK publication plan:
+
+```bash
+"$CRYPTA_APP" publish-usk \
+  --catalog-file dist/catalog/cryptad-app-catalog.properties \
+  --catalog-signature-file dist/catalog/cryptad-app-catalog.signature \
+  --catalog-source "crypta:USK@<catalog-key>/cryptad-app-catalog.properties" \
+  --output dist/catalog/publish-plan.md \
+  --dry-run
+```
+
+`crypta-app publish-usk --dry-run` writes a plan. It does not insert catalog bytes, signature
+bytes, or app ZIP artifacts into the public Crypta network. Live insertion remains a separate
+reviewed publishing workflow that uses the existing content and queue mechanisms.
+
+## Tutorial 4: reference app map
+
+The first-party apps are reference points for the beta. Their current manifests declare these key
+capabilities:
+
+| App | Demonstrates | Key capabilities |
+| --- | --- | --- |
+| Queue Manager | Queue read/write and operator queue flow. | `queue.read`, `queue.write` |
+| Publisher | Content insert workflow. | `content.insert`, `queue.read`, `queue.write` |
+| Site Publisher | Static site publishing pattern. | `content.insert`, `queue.read`, `queue.write` |
+| Profile Publisher | AppVault identity, bounded profile document signing, and app-generated document insert. | `vault.identities.read`, `vault.identities.create`, `vault.identities.use`, `content.insert.app-document`, `queue.read`, `queue.write` |
+| Feed Reader & Publisher | Bounded content fetch plus feed snapshot publish. | `content.fetch`, `content.insert.app-document`, `queue.read`, `queue.write` |
+| Trust Graph Preview | Local trust statement import, score, sign, and publish preview. | `trust.read`, `trust.write`, `content.fetch`, `content.insert.app-document`, `vault.identities.read`, `vault.identities.create`, `vault.identities.use`, `queue.read`, `queue.write` |
+
+Use the detailed docs before copying a reference pattern:
+
+- [feed-reader-reference-app.md](feed-reader-reference-app.md)
+- [trust-graph-preview.md](trust-graph-preview.md)
+- [app-secret-and-identity-vault.md](app-secret-and-identity-vault.md)
+- [platform-api-contract.md](platform-api-contract.md)
+
+## Tutorial 5: Web Shell onboarding path
+
+The first-party beta catalog appears in Web Shell as a recommended catalog when the runtime or
+package configuration provides the catalog source and trusted key hint. Recommended catalog means
+"available for explicit operator onboarding." It is not automatic app installation.
+
+The high-level operator flow is:
+
+1. Open the Web Shell Apps area.
+2. Inspect the recommended first-party beta catalog entry.
+3. Confirm the catalog source and trusted catalog key configuration.
+4. Add the catalog recommendation.
+5. Refresh the signed catalog source.
+6. Inspect each app entry, permissions, review trust, API compatibility, and version delta.
+7. Install or update individual apps explicitly.
+
+These checks still apply:
+
+- The catalog source signature and trusted catalog key must verify.
+- Signed bundle verification and artifact SHA-256 checks remain separate from catalog trust.
+- App review trust and reviewer governance still apply; a review receipt is independent evidence.
+- Reviewer trust follows the reviewer key lifecycle and local transparency log records described in
+  the governance docs; a catalog listing does not make an unknown reviewer locally trusted.
+- Platform API compatibility and permission-delta gates still apply.
+- The background update scheduler policy governs check, stage, and apply behavior.
+- Manual policy detects candidates but does not stage or apply updates automatically.
+- Rollback is a bounded safety mechanism after an update is staged or applied; it is not a promise
+  that every app state can be restored.
+- The ecosystem certification matrix records this docs/tutorial evidence for release managers.
+- FProxy browse remains retained; Web Shell catalog onboarding does not remove legacy browse routes.
+
+See [first-party-beta-catalog.md](first-party-beta-catalog.md),
+[app-catalogs.md](app-catalogs.md), [app-review-governance.md](app-review-governance.md), and
+[app-update-lifecycle.md](app-update-lifecycle.md).

--- a/docs/app-platform-developer-portal.md
+++ b/docs/app-platform-developer-portal.md
@@ -126,6 +126,7 @@ Phase 7 closeout treats these workstreams as one ecosystem beta readiness story:
 Release candidates should run the normal build/test gates plus release certification:
 
 ```bash
+python3 tools/release-certification/app_platform_docs_check.py --self-test
 python3 tools/release-certification/release_certification.py --self-test
 python3 tools/release-certification/app_platform_smoke.py --self-test
 tools/release-certification/run-release-certification.sh --mode release-candidate --out-dir build/release-certification

--- a/docs/app-platform-developer-portal.md
+++ b/docs/app-platform-developer-portal.md
@@ -1,0 +1,163 @@
+# App platform developer portal
+
+This page is the entry point for app developers, reviewers, operators, and release managers working
+with the Crypta app ecosystem beta.
+
+## Scope
+
+The app platform beta covers offline app authoring, signed bundle and catalog workflows, local
+review evidence, first-party reference apps, and release certification. It is not a public
+production app store and it does not change FNP, FCP, Hyphanet/Freenet compatibility behavior, or
+retained FProxy browse behavior.
+
+Use this portal first, then follow the detailed source-of-truth pages for the area you are touching:
+
+| Area | Source of truth |
+| --- | --- |
+| Copyable beta tutorials | [app-platform-beta-tutorials.md](app-platform-beta-tutorials.md) |
+| Known beta limits and safety boundaries | [app-platform-beta-known-limitations.md](app-platform-beta-known-limitations.md) |
+| Beta submission, feedback, and closeout runbook | [app-platform-beta-program.md](app-platform-beta-program.md) |
+| Developer CLI reference | [app-dev-cli.md](app-dev-cli.md) |
+| Developer beta toolkit flow | [developer-beta-toolkit.md](developer-beta-toolkit.md) |
+| Signed app bundles | [app-distribution.md](app-distribution.md) |
+| Signed catalogs and catalog sources | [app-catalogs.md](app-catalogs.md) |
+| First-party beta catalog | [first-party-beta-catalog.md](first-party-beta-catalog.md) |
+| Platform API contract | [platform-api-contract.md](platform-api-contract.md) |
+| Platform API route surface | [platform-api-surface.md](platform-api-surface.md) |
+| Browser SDK | [platform-sdk-js.md](platform-sdk-js.md) |
+| App-owned UI and isolated origins | [app-owned-ui.md](app-owned-ui.md) |
+| App UI design system and lint | [app-ui-design-system.md](app-ui-design-system.md) |
+| Permissions and audit | [app-permissions-and-audit.md](app-permissions-and-audit.md) |
+| AppVault secret and identity material | [app-secret-and-identity-vault.md](app-secret-and-identity-vault.md) |
+| AppHost runtime hardening | [apphost-runtime-hardening.md](apphost-runtime-hardening.md) |
+| App update lifecycle and rollback | [app-update-lifecycle.md](app-update-lifecycle.md) |
+| App review governance | [app-review-governance.md](app-review-governance.md) |
+| Feed Reader reference app | [feed-reader-reference-app.md](feed-reader-reference-app.md) |
+| Trust Graph Preview | [trust-graph-preview.md](trust-graph-preview.md) |
+| Legacy HTTP boundary | [legacy-http-boundary.md](legacy-http-boundary.md) |
+| Legacy retirement plan | [legacy-retirement-plan.md](legacy-retirement-plan.md) |
+| Release certification | [release-certification.md](release-certification.md) |
+| Security reporting and data handling | [SECURITY.md](SECURITY.md) |
+
+## Platform API versions
+
+Cryptad exposes the current local Platform API transport under `/api/v1`. That route family is
+separate from the integer app compatibility contract version used by manifests, catalogs,
+developer tooling, and release certification.
+
+The current source declares:
+
+```text
+PlatformApiContract.CURRENT_API_VERSION = "v1"
+PlatformApiContract.CURRENT_CONTRACT_VERSION = 7
+```
+
+In docs, manifests, and catalog descriptors:
+
+- `/api/v1` identifies the transport route family.
+- `contractVersion=7` identifies the Platform API compatibility contract snapshot.
+- `api.minimumVersion` and `api.maximumTestedVersion` compare against the integer contract
+  version, not against the URL route prefix or the Cryptad build number.
+
+Use [platform-api-contract.md](platform-api-contract.md) for compatibility rules and
+[platform-api-surface.md](platform-api-surface.md) for route families.
+
+## First-party app set
+
+The current first-party app ecosystem beta includes these repo-owned bundles:
+
+| App | App id | Role |
+| --- | --- | --- |
+| Queue Manager | `queue-manager` | Queue read/write operator workflow. |
+| Publisher | `publisher` | Legacy publisher replacement for content insert workflows. |
+| Site Publisher | `site-publisher` | Static-site content publishing reference pattern. |
+| Profile Publisher | `profile-publisher` | AppVault identity/profile signing plus generated app-document insert. |
+| Feed Reader & Publisher | `feed-reader` | Bounded `content.fetch` plus generated feed snapshot publication. |
+| Trust Graph Preview | `trust-graph` | Local trust statement import, scoring, signing, and publication preview. |
+
+See [first-party-beta-catalog.md](first-party-beta-catalog.md),
+[feed-reader-reference-app.md](feed-reader-reference-app.md), and
+[trust-graph-preview.md](trust-graph-preview.md) for app-specific notes.
+
+## Developer path
+
+Start with the offline workflow. The first three commands do not require a live Crypta node, public
+network access, signing secrets, Docker, Node.js, or npm:
+
+```bash
+./gradlew :platform-devtools:installDist
+export CRYPTA_APP="$PWD/platform-devtools/build/install/crypta-app/bin/crypta-app"
+"$CRYPTA_APP" --help
+```
+
+Then follow this path:
+
+| Step | Command or doc |
+| --- | --- |
+| Scaffold an app from a template | `crypta-app init --template static-basic|queue-dashboard|publisher|vault-profile` in [app-platform-beta-tutorials.md](app-platform-beta-tutorials.md) |
+| Run local UI against mock Platform API fixtures | `crypta-app dev --bundle-dir <bundle>` in [developer-beta-toolkit.md](developer-beta-toolkit.md) |
+| Run offline checks | `crypta-app test --bundle-dir <bundle> --strict --json <report.json>` |
+| Generate local development signing keys | `crypta-app keys generate` |
+| Sign and verify the staged bundle | `crypta-app sign`, then `crypta-app verify` |
+| Pack a deterministic ZIP artifact | `crypta-app pack` |
+| Create a catalog entry descriptor | `crypta-app catalog entry` |
+| Create, sign, and verify a catalog | `crypta-app catalog create`, `crypta-app catalog sign`, `crypta-app catalog verify` |
+| Produce an offline USK publication plan | `crypta-app publish-usk --dry-run` |
+| Submit app proposal or beta feedback | [app-platform-beta-program.md](app-platform-beta-program.md) |
+
+`crypta-app dev` is loopback-only by default and serves a mock Platform API. It does not install
+the app, fetch catalogs, talk to the public Crypta network, or prove live-node permission grants.
+
+## Release manager path
+
+Phase 7 closeout treats these workstreams as one ecosystem beta readiness story:
+
+| Readiness area | Evidence and docs |
+| --- | --- |
+| First-party catalog | [first-party-beta-catalog.md](first-party-beta-catalog.md), `app-catalog.first-party-beta`, `catalog.smoke` |
+| Developer toolkit | [developer-beta-toolkit.md](developer-beta-toolkit.md), `app-platform.devtools-cli`, `app-platform.developer-beta-toolkit` |
+| Reference apps | [feed-reader-reference-app.md](feed-reader-reference-app.md), [trust-graph-preview.md](trust-graph-preview.md), `reference-app.*` evidence |
+| Review governance | [app-review-governance.md](app-review-governance.md), `review receipt`, `reviewer key lifecycle`, `transparency log` evidence |
+| Updates and rollback | [app-update-lifecycle.md](app-update-lifecycle.md), `background update scheduler`, `rollback` evidence |
+| Legacy admin status | [legacy-retirement-plan.md](legacy-retirement-plan.md), `legacy-admin.removal-wave-1`, `legacy-admin.removal-wave-2`; FProxy browse remains retained |
+| Ecosystem matrix | [release-certification.md](release-certification.md), `ecosystem certification matrix` |
+| Docs and beta program | This portal, [app-platform-beta-tutorials.md](app-platform-beta-tutorials.md), [app-platform-beta-known-limitations.md](app-platform-beta-known-limitations.md), [app-platform-beta-program.md](app-platform-beta-program.md) |
+
+Release candidates should run the normal build/test gates plus release certification:
+
+```bash
+python3 tools/release-certification/release_certification.py --self-test
+python3 tools/release-certification/app_platform_smoke.py --self-test
+tools/release-certification/run-release-certification.sh --mode release-candidate --out-dir build/release-certification
+```
+
+The generated release summary, release report, app-platform smoke report, review transparency-log
+evidence, legacy retirement evidence, and ecosystem certification matrix are the closeout record.
+
+## Security entry points
+
+The beta security model is capability-based and local-node enforced. Browser origin isolation,
+signed catalogs, signed bundles, review receipts, and AppVault routes are separate layers.
+
+Start here:
+
+- [app-platform-beta-known-limitations.md](app-platform-beta-known-limitations.md) for conservative
+  beta boundaries.
+- [app-owned-ui.md](app-owned-ui.md) and [platform-sdk-js.md](platform-sdk-js.md) for browser
+  sessions and static UI origins.
+- [app-permissions-and-audit.md](app-permissions-and-audit.md) for capability checks and redacted
+  audit behavior.
+- [app-secret-and-identity-vault.md](app-secret-and-identity-vault.md) for AppVault routes and
+  identity/private-material limits.
+- [app-catalogs.md](app-catalogs.md) and [app-review-governance.md](app-review-governance.md) for
+  signed catalogs, trusted reviewer keys, local review transparency logs, and review policy modes.
+- [app-update-lifecycle.md](app-update-lifecycle.md) for manual, stage, and apply-when-stopped
+  update behavior plus rollback scope.
+- [SECURITY.md](SECURITY.md) for security reporting.
+
+## Feedback and submissions
+
+Use [app-platform-beta-program.md](app-platform-beta-program.md) for proposal requirements,
+feedback categories, redaction rules, and the maintainer closeout runbook. GitHub issue forms are
+available for app platform beta feedback and app submission proposals when GitHub issue templates
+are enabled for the repository.

--- a/docs/app-ui-design-system.md
+++ b/docs/app-ui-design-system.md
@@ -151,9 +151,9 @@ a release blocker by default.
 
 `:platform-design-system` owns the canonical asset bytes and metadata helpers. `crypta-app init
 --ui-mode static` copies those assets into new standalone scaffolds. The repo-owned Queue Manager,
-Publisher, Site Publisher, Profile Publisher, and Feed Reader Gradle `stageApp` tasks copy the same
-assets into `static/crypta-ui/` during staging instead of duplicating them in
-`apps/*/src/staged`.
+Publisher, Site Publisher, Profile Publisher, Feed Reader, and Trust Graph Preview Gradle
+`stageApp` tasks copy the same assets into `static/crypta-ui/` during staging instead of
+duplicating them in `apps/*/src/staged`.
 
 Release certification records three UI-specific evidence ids:
 

--- a/docs/cryptad-release-workflow-and-runbook.md
+++ b/docs/cryptad-release-workflow-and-runbook.md
@@ -1,8 +1,8 @@
 # Cryptad Release Workflow and Runbook
 
-> Updated May 1, 2026, to cover the release certification report that aggregates interop,
-> performance, app-platform, catalog, app-owned UI, legacy-admin retirement, and CI evidence for a
-> release candidate.
+> Updated May 23, 2026, to cover the release certification report that aggregates interop,
+> performance, app-platform, beta documentation, app-review governance, catalog, app-owned UI,
+> legacy-admin retirement, and CI evidence for a release candidate.
 
 ## Overview
 - Purpose: publish a Cryptad release so running nodes discover a new `info/<edition>` descriptor, download OS-specific installers, and guide operators through installation without self-replacing the running JAR.
@@ -71,6 +71,10 @@ Treat these as release blockers, in order:
    evidence coverage, ecosystem gate coverage, first-party app coverage, docs coverage, waivers,
    and row-level regressions. The workflow is documented in
    [release-certification.md](release-certification.md).
+   Confirm `app-platform.docs-portal`, `app-platform.beta-program`,
+   `app-platform.beta-tutorials`, `app-platform.docs-redaction`, and the
+   `app-platform-beta-docs-and-program` matrix row are present. Docs-only gaps require an explicit
+   release-manager waiver; redaction findings must remain blockers.
 3. **First-party app staging** - stage repo-owned AppHost bundles with the app module tasks or `./gradlew stageFirstPartyApps`. The app workflow source of truth is [app-distribution.md](app-distribution.md).
 4. **First-party app signing and verification** - sign with the intended release or staging key inputs, then verify with the matching trusted public key inputs. Gate promotion on successful `./gradlew signFirstPartyApps` and `./gradlew verifyFirstPartyApps` runs. Keep private signing keys outside the repository.
 5. **App catalog smoke, when catalog sources ship** - verify each signed catalog source refreshes,
@@ -89,11 +93,14 @@ Treat these as release blockers, in order:
    design-system assets, strict UI lint summaries, and visible permission disclosure. The route
    contract is documented in [app-owned-ui.md](app-owned-ui.md); the design-system/lint contract is
    documented in [app-ui-design-system.md](app-ui-design-system.md).
-8. **App-vault and reference-app evidence** - verify the release certification report includes
+8. **App-vault, trust graph, and reference-app evidence** - verify the release certification report
+   includes
    `app-vault.capabilities`, `app-platform.identity-profile-publish`,
    `app-platform.generated-document-insert`, `app-platform.content-fetch`,
-   `reference-apps.content`, `reference-app.profile-publisher`, and
-   `reference-app.feed-reader`. Site Publisher is the content-oriented reference app;
+   `app-platform.trust-graph-preview`, `app-platform.trust-statement-signing`,
+   `reference-apps.content`, `reference-app.profile-publisher`, `reference-app.feed-reader`, and
+   `reference-app.trust-graph`. Site Publisher is the
+   content-oriented reference app;
    release evidence must prove its staged bundle, SDK usage, design-system adoption, permission
    disclosure, content/queue helper usage, and absence of vault/identity permissions. Profile
    Publisher is the identity-profile reference app; evidence must prove browser-safe app-owned
@@ -104,11 +111,20 @@ Treat these as release blockers, in order:
    `POST /api/v1/content/fetch`, SDK feed-helper usage, generated-feed publication permissions,
    and redaction of raw feed bodies, raw request bodies, tokens, form passwords, private insert
    URIs, and local paths.
+   Trust Graph Preview is the local trust-service reference app; evidence must prove Platform API
+   v7 trust routes, `trust.read`, `trust.write`, bounded AppVault trust-statement signing, SDK
+   trust-helper usage, generated trust-statement publication permissions, and redaction of raw
+   trust documents, raw request bodies, tokens, form passwords, private insert URIs, and local
+   paths.
 9. **Trusted app-review receipt evidence** - verify the release certification report includes
-   `app-review.trusted-receipts`, `app-review.policy`, and `app-review.first-party-catalog` when
-   first-party catalog evidence is part of the candidate. Review receipt evidence is independent of
-   app and catalog signing keys. Keep reviewer private keys outside the checkout and out of release
-   artifacts. The catalog/review contract is documented in [app-catalogs.md](app-catalogs.md).
+   `app-review.trusted-receipts`, `app-review.policy`, `app-review.governance`,
+   `app-review.reviewer-key-lifecycle`, `app-review.transparency-log`,
+   `app-review.review-history-api`, `app-review.first-party-catalog`, and
+   `app-review.first-party-review-chain` when first-party catalog evidence is part of the
+   candidate. Review receipt evidence is independent of app and catalog signing keys. Keep
+   reviewer private keys outside the checkout and out of release artifacts. The catalog/review
+   contract is documented in [app-catalogs.md](app-catalogs.md) and
+   [app-review-governance.md](app-review-governance.md).
 10. **AppHost sandbox-provider evidence** - verify the release certification report includes
    `apphost.sandbox-provider`. The evidence is deterministic and does not require live bubblewrap in
    normal CI; it must prove the bubblewrap provider contract, required-sandbox fail-closed behavior,
@@ -263,8 +279,8 @@ Treat these as release blockers, in order:
   maintainer-reviewed baseline update. Environment-sensitive startup, FCP, and Platform API timing
   regressions should be investigated on comparable hardware before promotion. CI uploads
   `summary.json` and `artifacts/` from the scheduled/manual `performance-smoke` job.
-- Generate the release certification report after the interop, performance, and app-platform
-  evidence exists:
+- Generate the release certification report after the interop, performance, app-platform,
+  app-review, and beta documentation evidence exists:
   ```bash
   tools/release-certification/run-release-certification.sh \
     --mode release-candidate \
@@ -278,17 +294,20 @@ Treat these as release blockers, in order:
   `build/release-certification/history-comparison.json`. Then inspect
   `build/release-certification/ecosystem-certification-matrix.md` for row status, previous
   status, regression status, release blockers, waiver ids, coverage checks, and recommendations.
-  Missing required evidence, failed required evidence, missing signed bundle/catalog/review evidence, missing app UI
-  design-system/lint evidence, missing `apphost.sandbox-provider` evidence, required evidence
+  Missing required evidence, failed required evidence, missing signed bundle/catalog/review
+  evidence, missing app UI design-system/lint evidence, missing beta documentation evidence,
+  failing docs redaction, missing `apphost.sandbox-provider` evidence, required evidence
   regressions, or failing ecosystem gates block release-candidate promotion unless a release
-  manager records an explicit waiver. If the previous summary predates PR-231 and the matrix
+  manager records an explicit waiver for a waivable gap. If the previous summary predates PR-231
+  and the matrix
   reports `previousMatrixPresent=false`, record that baseline transition in the release log and
   continue only after the row-level evidence and gate coverage checks pass or have explicit
-  waivers. Do not attach `artifacts/private-insert-uris.json`, private
-  signing keys, private reviewer keys, form passwords, app tokens, browser session tokens, raw
-  request bodies, raw trusted reviewer public key bytes, or unsanitized local paths to the release
-  record. CI uploads contain sanitized certification artifacts only; preserve raw local or CI gate
-  failure directories separately when deeper diagnostics are needed.
+  waivers. Do not attach `artifacts/private-insert-uris.json`, private signing keys, private
+  reviewer keys, form passwords, app tokens, browser session tokens, raw request bodies, raw feed
+  bodies, raw trust documents, private insert URIs, raw trusted reviewer public key bytes, or
+  unsanitized local paths to the release record. CI uploads contain sanitized certification
+  artifacts only; preserve raw local or CI gate failure directories separately when deeper
+  diagnostics are needed.
 
 ## Production Rollout
 - Publish descriptor and artifacts to the production USK.

--- a/docs/developer-beta-toolkit.md
+++ b/docs/developer-beta-toolkit.md
@@ -191,7 +191,7 @@ crypta-app catalog entry \
   --bundle-dir build/dev-apps/queue-dashboard \
   --output dist/catalog/queue-dashboard-entry.properties \
   --artifact dist/apps/queue-dashboard-0.1.0.zip \
-  --bundle-uri "crypta:CHK@<artifact-key>" \
+  --bundle-uri "crypta:CHK@..." \
   --summary "Inspect and manage local transfer queue state." \
   --homepage "https://example.invalid/apps/queue-dashboard" \
   --source "https://example.invalid/src/queue-dashboard" \
@@ -212,7 +212,7 @@ using the shape in [app-dev-cli.md](app-dev-cli.md#catalog-descriptor-and-flow):
 
 ```properties
 artifact.path=/abs/path/to/dist/apps/queue-dashboard-0.1.0.zip
-bundle.uri=crypta:CHK@<artifact-key>
+bundle.uri=crypta:CHK@...
 summary=Inspect and manage local transfer queue state.
 name=Queue Dashboard
 version=0.1.0
@@ -319,7 +319,7 @@ Prepare a dry-run catalog publication plan:
 crypta-app publish-usk \
   --catalog-file dist/catalog/cryptad-app-catalog.properties \
   --catalog-signature-file dist/catalog/cryptad-app-catalog.signature \
-  --catalog-source "crypta:USK@<public-key>/apps/dev-queue-dashboard/cryptad-app-catalog.properties" \
+  --catalog-source "crypta:USK@.../apps/dev-queue-dashboard/cryptad-app-catalog.properties" \
   --output dist/catalog/publish-plan.md \
   --dry-run
 ```

--- a/docs/developer-beta-toolkit.md
+++ b/docs/developer-beta-toolkit.md
@@ -1,14 +1,13 @@
 # Developer beta toolkit
 
-This guide describes the PR-225 developer beta toolkit workflow for building, testing, signing,
+This guide describes the developer beta toolkit workflow for building, testing, signing,
 cataloging, and dry-run publishing a standalone Crypta app bundle.
 
 ## Scope
 
-Use this page with a `crypta-app` launcher built from a PR-225-compatible `:platform-devtools`
-tree. Older launchers may expose only the base commands documented in
-[app-dev-cli.md](app-dev-cli.md). Run `crypta-app --help` and the subcommand help before relying on
-beta flags in automation.
+Use this page with a current `crypta-app` launcher built from `:platform-devtools`. Older launchers
+may expose only the base commands documented in [app-dev-cli.md](app-dev-cli.md). Run
+`crypta-app --help` and the subcommand help before relying on beta flags in automation.
 
 The beta toolkit is for developer-owned app bundles outside the first-party `apps/*` Gradle
 projects. It can scaffold a queue dashboard template, run a mock development server, execute
@@ -422,11 +421,21 @@ become failures with `--strict`.
 
 ## Related docs
 
+- [app-platform-developer-portal.md](app-platform-developer-portal.md) is the app ecosystem beta
+  entry point.
+- [app-platform-beta-tutorials.md](app-platform-beta-tutorials.md) gives copyable offline beta
+  tutorials.
+- [app-platform-beta-known-limitations.md](app-platform-beta-known-limitations.md) records beta
+  limits and safety boundaries.
+- [app-platform-beta-program.md](app-platform-beta-program.md) covers app submission, feedback, and
+  release closeout.
 - [app-dev-cli.md](app-dev-cli.md) documents the base standalone CLI workflow.
 - [app-distribution.md](app-distribution.md) documents signed bundle sidecars and runtime trusted
   key inputs.
 - [app-catalogs.md](app-catalogs.md) documents catalog format, source transport, artifact
   verification, and review trust.
+- [first-party-beta-catalog.md](first-party-beta-catalog.md) covers first-party catalog
+  publication and Web Shell onboarding.
 - [app-ui-design-system.md](app-ui-design-system.md) documents static UI assets and offline lint.
 - [platform-sdk-js.md](platform-sdk-js.md) documents the browser SDK and browser session handling.
 - [app-permissions-and-audit.md](app-permissions-and-audit.md) documents process principals,

--- a/docs/first-party-beta-catalog.md
+++ b/docs/first-party-beta-catalog.md
@@ -212,3 +212,23 @@ passwords, private insert URIs, raw request bodies, raw feed bodies, raw trust s
 from real users, private keys, raw public key bytes, raw receipt signatures, transparency-log
 paths, or absolute staging paths. It does not fetch a public Crypta network catalog during normal
 unit tests.
+
+## Related docs
+
+- [app-platform-developer-portal.md](app-platform-developer-portal.md) is the app ecosystem beta
+  entry point.
+- [app-platform-beta-tutorials.md](app-platform-beta-tutorials.md) gives offline developer flows
+  for template, signing, catalog, and dry-run publication work.
+- [app-platform-beta-known-limitations.md](app-platform-beta-known-limitations.md) records beta
+  safety boundaries.
+- [app-platform-beta-program.md](app-platform-beta-program.md) covers app submission, feedback, and
+  release closeout.
+- [app-catalogs.md](app-catalogs.md) documents signed catalog formats and runtime install/update.
+- [app-dev-cli.md](app-dev-cli.md) documents the standalone `crypta-app` CLI.
+- [app-review-governance.md](app-review-governance.md) documents review receipts, reviewer keys,
+  and the local transparency log.
+- [app-update-lifecycle.md](app-update-lifecycle.md) documents candidate detection, scheduler
+  policy, manual apply, and rollback scope.
+- [release-certification.md](release-certification.md) documents release-candidate evidence and
+  the ecosystem certification matrix.
+- [SECURITY.md](SECURITY.md) documents security reporting and sensitive data handling.

--- a/docs/phase-3-platform-primacy-closeout.md
+++ b/docs/phase-3-platform-primacy-closeout.md
@@ -85,6 +85,10 @@ The Phase 3 platform path is split across focused modules:
   staged bundles declare `app.ui.mode=static`, fetch bounded Crypta feed documents through
   `content.fetch`, publish generated feed snapshots through the app-document insert route, and keep
   USK follow behavior scoped to the open browser tab.
+- `apps/trust-graph` owns the Trust Graph Preview first-party local trust-service reference app
+  bundle. Current staged bundles declare `app.ui.mode=static`, use `trust.read` and `trust.write`
+  for local preview state, fetch bounded Crypta trust statement documents through `content.fetch`,
+  and publish generated trust statements through the app-document insert route.
 - `:adapter-fcp` owns the detached FCP protocol adapter surface. It remains a compatibility and
   automation protocol, separate from Platform API.
 - `:bridge-fcp-runtime` owns the concrete runtime bindings for FCP.
@@ -197,9 +201,11 @@ Phase 4 candidates were plans, not PR-194 implementation scope. Current status:
 - Standalone developer tooling has landed through the `crypta-app` CLI for scaffolding,
   validation, signing, packaging, verification, and catalog authoring.
 - The first content-oriented reference app has landed as Site Publisher, the first
-  identity-profile reference app has landed as Profile Publisher, and the first feed/content-fetch
-  reference app has landed as Feed Reader. Broader first-party app catalog depth beyond Queue
-  Manager, Publisher, Site Publisher, Profile Publisher, and Feed Reader remains future work.
+  identity-profile reference app has landed as Profile Publisher, the first feed/content-fetch
+  reference app has landed as Feed Reader, and the first local trust-service preview reference app
+  has landed as Trust Graph Preview. Broader first-party app catalog depth beyond Queue Manager,
+  Publisher, Site Publisher, Profile Publisher, Feed Reader, and Trust Graph Preview remains future
+  work.
 - App permission enforcement and app-origin audit landed after this Phase 3 closeout; see
   [app-permissions-and-audit.md](app-permissions-and-audit.md).
 - Legacy admin and browse retirement plan.

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -102,6 +102,10 @@ Release-candidate mode requires these evidence ids:
 | `app-platform.first-party` | App-platform smoke summary. | The first-party staged apps, including Queue Manager, Publisher, Site Publisher, Profile Publisher, Feed Reader, and Trust Graph Preview, have valid manifests, launchers, static UI assets, and SDK wiring. |
 | `app-platform.devtools-cli` | App-platform smoke summary. | `crypta-app init`, `validate`, and `pack` work for a generated sample app. |
 | `app-platform.developer-beta-toolkit` | App-platform smoke summary. | Developer beta toolkit command, template, mock-dev, offline-test, catalog entry, dry-run publication, docs, and self-test evidence is present. |
+| `app-platform.docs-portal` | App-platform docs check. | The developer portal, required docs, known limitations page, portal links, and README portal link are present. |
+| `app-platform.beta-program` | App-platform docs check. | The beta program doc and app platform beta feedback/submission issue templates are present. |
+| `app-platform.beta-tutorials` | App-platform docs check. | Offline beta tutorials cover the required `crypta-app` commands, first-party app map, Platform API capabilities, review governance, update/rollback, and retained FProxy browse concepts. |
+| `app-platform.docs-redaction` | App-platform docs check. | Local Markdown links resolve without network access, and docs/templates pass obvious secret, token, private key, cookie, form-password, and local-path redaction checks. |
 | `app-platform.signed-bundles` | App-platform smoke summary. | First-party and sample bundle signing/verification evidence exists with configured non-production or release signing inputs. |
 | `catalog.smoke` | App-platform smoke summary. | Signed catalog create/sign/verify evidence exists and records digest, catalog id, and app id without private key material. |
 | `app-catalog.first-party-beta` | App-platform smoke summary. | Recommended first-party beta catalog descriptor, Platform API/Web Shell onboarding, CHK artifact transport tests, first-party metadata docs, and configuration readiness reporting are present without a live public-network fetch. |
@@ -167,6 +171,14 @@ require a live local node or operator form password.
 catalog key hints are configured in the certification environment, but it does not fetch a public
 Crypta catalog during normal tests. It uses source checks, documentation checks, and deterministic
 `platform-appcatalog` tests for `crypta:CHK@` artifact support.
+
+`app-platform.docs-portal`, `app-platform.beta-program`,
+`app-platform.beta-tutorials`, and `app-platform.docs-redaction` are deterministic local docs
+evidence. They check that the app platform developer portal, beta tutorials, known limitations,
+beta program, required source docs, issue templates, README link, critical concept coverage,
+relative Markdown links, and obvious secret/redaction rules are present without fetching external
+URLs. Missing docs or redaction failures block release-candidate mode unless a release manager
+records an explicit waiver for a docs-only gap; redaction failures should not be waived.
 
 `platform-api.contract` is generated offline with `crypta-app api snapshot`. In
 release-candidate mode, snapshot generation failure, contract parse failure, missing contract
@@ -335,7 +347,8 @@ The first-party app coverage is intentionally split. `queue-manager`, `publisher
 bundle set are grouped under the first-party app bundle row. `site-publisher` is covered by the
 reference content row. `profile-publisher`, `feed-reader`, and `trust-graph` each have their own
 rows because they validate distinct identity publishing, content fetch, and trust graph preview
-behavior.
+behavior. The `app-platform-beta-docs-and-program` row records Phase 7 docs portal, tutorials,
+beta program, issue-template, link, and redaction readiness.
 
 In `release-candidate` mode, unmapped required evidence, unmapped ecosystem gates, missing docs,
 or failed redaction make the matrix fail. In `pr` and `nightly` mode, coverage gaps warn unless

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -38,6 +38,7 @@ library.
 Run self-tests first:
 
 ```bash
+python3 tools/release-certification/app_platform_docs_check.py --self-test
 python3 tools/release-certification/release_certification.py --self-test
 python3 tools/release-certification/app_platform_smoke.py --self-test
 ```
@@ -377,8 +378,9 @@ evidence or missing profile-document route evidence.
 Sandbox gates warn when enforced evidence regresses to best-effort, and block in
 `release-candidate` mode when enforced evidence is required but absent. Reference-content gates
 block if Site Publisher evidence disappears, Profile Publisher evidence disappears, Feed Reader
-evidence disappears, generated document insert evidence disappears, content-fetch evidence
-disappears, or a reference app no longer proves its required helper usage. Legacy
+evidence disappears, Trust Graph Preview evidence disappears, generated document insert evidence
+disappears, content-fetch evidence disappears, trust-statement signing evidence disappears, or a
+reference app no longer proves its required helper usage. Legacy
 retirement gates block missing removal-wave evidence, including
 `legacy-admin.removal-wave-2`, or failed retained browse safety evidence and warn on removed-route
 count changes without update-note metadata.
@@ -461,6 +463,7 @@ The report, matrix, and copied artifacts must not contain:
 - the host/operator form password;
 - raw request bodies;
 - raw feed bodies;
+- raw trust statement documents or trust-document bodies from real users;
 - raw app-vault secret values, identity private keys, identity seeds, or recovery phrases;
 - raw profile-document signatures or signed profile-document payloads;
 - raw update or rollback command output;

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -81,6 +81,10 @@ performance.smoke
 app-platform.first-party
 app-platform.devtools-cli
 app-platform.developer-beta-toolkit
+app-platform.docs-portal
+app-platform.beta-program
+app-platform.beta-tutorials
+app-platform.docs-redaction
 app-platform.signed-bundles
 catalog.smoke
 app-catalog.first-party-beta
@@ -119,8 +123,12 @@ release-certification.ecosystem-matrix
 
 The app-platform, app-review, reference-app, legacy-retirement, and matrix evidence ids above use
 deterministic source checks, fixtures, and fake/offline tests; they do not require a live node or
-host-installed bubblewrap in normal CI. `app-catalog.first-party-beta` reports source/key
-configuration readiness but does not fetch the public Crypta catalog. `app-review.first-party-catalog`
+host-installed bubblewrap in normal CI. `app-platform.docs-portal`,
+`app-platform.beta-program`, `app-platform.beta-tutorials`, and
+`app-platform.docs-redaction` run a deterministic local docs check for required docs, concept
+coverage, issue templates, internal Markdown links, README/portal links, and obvious secret leaks.
+`app-catalog.first-party-beta` reports source/key configuration readiness but does not fetch the
+public Crypta catalog. `app-review.first-party-catalog`
 also runs offline, but release-candidate mode requires explicit reviewer key inputs so the runner
 can pack every staged first-party app and sign, verify, and embed a matching first-party review
 receipt for each catalog entry. `interop.extended` and `apphost.live` are recorded as optional
@@ -193,7 +201,8 @@ Matrix coverage is self-checked on every run:
 `queue-manager`, `publisher`, and the shared staged-bundle set are grouped under the first-party
 app bundle row. `site-publisher` is covered by the reference content row, while
 `profile-publisher`, `feed-reader`, and `trust-graph` have app-specific rows for their distinct
-networked app-layer behavior.
+networked app-layer behavior. The `app-platform-beta-docs-and-program` row records Phase 7 docs
+portal, tutorials, beta program, issue-template, link, and redaction readiness.
 
 In `release-candidate` mode, unmapped required evidence, unmapped ecosystem gates, missing docs,
 or failed redaction make the matrix fail. In `pr` and `nightly` mode, coverage gaps are warnings

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -11,6 +11,7 @@ network.
 Run the Python-only self-tests:
 
 ```bash
+python3 tools/release-certification/app_platform_docs_check.py --self-test
 python3 tools/release-certification/release_certification.py --self-test
 python3 tools/release-certification/app_platform_smoke.py --self-test
 ```
@@ -293,7 +294,7 @@ inputs are present, signed catalog authoring/verification, AppHost
 sandbox-provider evidence, app-update lifecycle/scheduler/rollback evidence, independent
 app-review receipt evidence, Profile Publisher identity-profile publishing evidence,
 app-generated document insert evidence, content-fetch evidence, Feed Reader reference-app evidence,
-and the legacy-admin retirement map.
+Trust Graph Preview evidence, app-review governance evidence, and the legacy-admin retirement map.
 
 Signing inputs use the documented first-party app environment variables:
 
@@ -351,6 +352,7 @@ Certification outputs must remain suitable for release-candidate evidence.  Do n
 - the host/operator form password;
 - raw request bodies;
 - raw feed bodies;
+- raw trust statement documents or trust-document bodies from real users;
 - raw app-vault secret values, identity private keys, identity seeds, or recovery phrases;
 - raw profile-document signatures or signed profile-document payloads;
 - raw update or rollback command output;

--- a/tools/release-certification/app_platform_docs_check.py
+++ b/tools/release-certification/app_platform_docs_check.py
@@ -282,9 +282,11 @@ def normalize_doc_link_target(raw_target: str) -> str:
 
 
 def resolve_doc_link_target(workspace_root: Path, markdown_file: Path, target: str) -> Path:
+    if target.startswith("/"):
+        return (workspace_root / target.lstrip("/")).resolve()
     target_path = Path(target)
     if target_path.is_absolute():
-        return (workspace_root / target_path.relative_to("/")).resolve()
+        return target_path.resolve()
     return (markdown_file.parent / target_path).resolve()
 
 

--- a/tools/release-certification/app_platform_docs_check.py
+++ b/tools/release-certification/app_platform_docs_check.py
@@ -971,9 +971,8 @@ def main() -> int:
     if args.output:
         write_json(args.output, output_summary)
     else:
-        # The summary is recursively redacted before stdout emission.
-        # codeql[py/clear-text-logging-sensitive-data]
-        print(json.dumps(output_summary, indent=2, sort_keys=True))
+        status_text = "passed" if summary["status"] == "pass" else "failed"
+        print(f"app-platform docs check {status_text}; use --output for redacted JSON details")
     return 0 if summary["status"] == "pass" else 1
 
 

--- a/tools/release-certification/app_platform_docs_check.py
+++ b/tools/release-certification/app_platform_docs_check.py
@@ -139,6 +139,20 @@ REDACTION_ALLOWLIST_EXACT_PATHS = (
 PRIVATE_KEY_BLOCK_RE = re.compile(
     r"-----BEGIN [A-Z0-9 -]*PRIVATE KEY(?: BLOCK)?-----", re.IGNORECASE
 )
+PRIVATE_KEY_ASSIGNMENT_NAME_RE = (
+    r"(?:"
+    r"(?:[A-Z0-9]+_)*PRIVATE_KEY(?:_BASE64)?"
+    r"|[A-Za-z0-9]*PrivateKey(?:Base64)?"
+    r")"
+)
+PRIVATE_KEY_ASSIGNMENT_RE = re.compile(
+    r"(?<![\w-])(?:-P)?[\"']?"
+    + PRIVATE_KEY_ASSIGNMENT_NAME_RE
+    + r"[\"']?\s*[:=]\s*"
+    r"(?![\"']?(?:<[^>]+>|redacted|\.\.\.)[\"']?(?:$|[\s,}\]`\\]))"
+    r"(?:[\"'][^\"'<>\r\n]{16,}[\"']|[A-Za-z0-9._~+/=-]{16,})",
+    re.IGNORECASE,
+)
 SEED_PHRASE_RE = re.compile(
     r"\bseed phrase\s*[:=]\s*(?!<redacted>)(?:[a-z]{3,}\s+){3,}[a-z]{3,}\b",
     re.IGNORECASE,
@@ -166,7 +180,12 @@ PARTIAL_REDACTION_RE = re.compile(
     r"(?<![\w-])(?:[\"']?Authorization[\"']?\s*:\s*[\"']?(?:[A-Za-z][A-Za-z0-9._~-]*\s+)?|"
     r"(?:Cookie|Set-Cookie|X-Crypta-App-Session)\s*:|"
     r"[\"']?(?:CRYPTAD_APP_TOKEN|browserSessionToken|appProcessToken|"
-    r"formPassword|CRYPTAD_CERT_FORM_PASSWORD)[\"']?\s*[:=]|"
+    r"formPassword|CRYPTAD_CERT_FORM_PASSWORD|"
+    + PRIVATE_KEY_ASSIGNMENT_NAME_RE
+    + r")[\"']?\s*[:=]|"
+    r"(?:-P)[\"']?"
+    + PRIVATE_KEY_ASSIGNMENT_NAME_RE
+    + r"[\"']?\s*[:=]|"
     r"--form-password(?:=|\s+))"
     r"\s*[\"']?(?:<[^>\r\n]+>|redacted|\.\.\.)[\"']?"
     r"(?!\s*(?:$|[\r\n,}\]`\\]))(?=[^\r\n]*[A-Za-z0-9])",
@@ -217,6 +236,7 @@ CRYPTA_APP_ALIAS_RE = re.compile(
 )
 REDACTION_CHECKS = (
     ("private-key-block", PRIVATE_KEY_BLOCK_RE),
+    ("private-key-assignment", PRIVATE_KEY_ASSIGNMENT_RE),
     ("seed-phrase", SEED_PHRASE_RE),
     ("authorization-header", AUTHORIZATION_HEADER_RE),
     ("cookie", COOKIE_RE),
@@ -354,9 +374,18 @@ def redaction_files_to_check(workspace_root: Path) -> list[Path]:
 def allowed_absolute_path(value: str) -> bool:
     normalized = unquote(value).replace("\\", "/")
     normalized_without_trailing_slash = normalized.rstrip("/")
-    return normalized.startswith(REDACTION_ALLOWLIST_PATH_PREFIXES) or (
+    return any(
+        allowed_path_prefix_match(normalized, prefix)
+        for prefix in REDACTION_ALLOWLIST_PATH_PREFIXES
+    ) or (
         normalized_without_trailing_slash in REDACTION_ALLOWLIST_EXACT_PATHS
     )
+
+
+def allowed_path_prefix_match(value: str, prefix: str) -> bool:
+    if prefix.endswith("/"):
+        return value.startswith(prefix)
+    return value == prefix or value.startswith(f"{prefix}/")
 
 
 def file_uri_path_value(raw_path: str) -> str:
@@ -755,6 +784,33 @@ def run_self_test(repo_root: Path) -> None:
     assert "private-key-block" in redaction_findings_for_text(
         "-----BEGIN ENCRYPTED PRIVATE KEY-----"
     )
+    assert "private-key-assignment" in redaction_findings_for_text(
+        "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64=MC4CAQAwBQYDK2VwBCIEIAabcdefghijklmnop"
+    )
+    assert "private-key-assignment" in redaction_findings_for_text(
+        '"reviewerPrivateKey": "MC4CAQAwBQYDK2VwBCIEIAabcdefghijklmnop"'
+    )
+    assert "private-key-assignment" in redaction_findings_for_text(
+        "-PcryptadAppSigningPrivateKeyBase64=MC4CAQAwBQYDK2VwBCIEIAabcdefghijklmnop"
+    )
+    assert "private-key-assignment" not in redaction_findings_for_text(
+        "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64=..."
+    )
+    assert "private-key-assignment" not in redaction_findings_for_text(
+        '"reviewerPrivateKey": "<redacted>"'
+    )
+    assert "private-key-assignment" not in redaction_findings_for_text(
+        "-PcryptadAppSigningPrivateKeyBase64=..."
+    )
+    assert "private-key-assignment" not in redaction_findings_for_text(
+        "-PcryptadAppSigningPrivateKeyFile=/abs/path/to/dev-app-signing-private.pem"
+    )
+    assert "partial-redaction" in redaction_findings_for_text(
+        "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64=<redacted> MC4CAQAwBQYDK2Vw"
+    )
+    assert "partial-redaction" in redaction_findings_for_text(
+        "-PcryptadAppSigningPrivateKeyBase64=<redacted> MC4CAQAwBQYDK2Vw"
+    )
     assert "form-password" in redaction_findings_for_text("formPassword=hunter2")
     assert "form-password" in redaction_findings_for_text("formPassword: hunter2")
     assert "form-password" in redaction_findings_for_text('"formPassword": "hunter2"')
@@ -848,10 +904,22 @@ def run_self_test(repo_root: Path) -> None:
     assert "local-absolute-path" in redaction_findings_for_text(
         "file:///app/secrets/private.pem"
     )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "/content-secret/dev-private.pem"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "file:///content-secret/dev-private.pem"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text("/welcome-back/key.pem")
     assert "local-absolute-path" not in redaction_findings_for_text("/app/node")
     assert "local-absolute-path" not in redaction_findings_for_text("/app/node/")
     assert "local-absolute-path" not in redaction_findings_for_text("file:///app/node")
     assert "local-absolute-path" not in redaction_findings_for_text("file:///app/node/")
+    assert "local-absolute-path" not in redaction_findings_for_text("/content")
+    assert "local-absolute-path" not in redaction_findings_for_text("/content/")
+    assert "local-absolute-path" not in redaction_findings_for_text("/content/fetch")
+    assert "local-absolute-path" not in redaction_findings_for_text("/welcome")
+    assert "local-absolute-path" not in redaction_findings_for_text("/welcome/")
     assert "local-absolute-path" not in redaction_findings_for_text(
         "/abs/path/outside/repo/dev-private.der"
     )

--- a/tools/release-certification/app_platform_docs_check.py
+++ b/tools/release-certification/app_platform_docs_check.py
@@ -424,6 +424,18 @@ def safe_broken_link_target(target: str) -> str:
     return target
 
 
+def safe_summary_for_output(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: safe_summary_for_output(child) for key, child in value.items()}
+    if isinstance(value, list):
+        return [safe_summary_for_output(child) for child in value]
+    if isinstance(value, str) and (
+        has_disallowed_local_path(value) or has_sensitive_redaction_material(value)
+    ):
+        return REDACTED_BROKEN_LINK_TARGET
+    return value
+
+
 def redaction_findings(workspace_root: Path) -> list[dict[str, str]]:
     findings: list[dict[str, str]] = []
     for path in redaction_files_to_check(workspace_root):
@@ -719,11 +731,9 @@ def run_self_test(repo_root: Path) -> None:
             "issue": "local-absolute-path",
         } in unsafe_link_evidence["details"]["redactionFindings"], unsafe_link
         sensitive_uri_target = "USK@abcdefghijklmno,qrstuvwxyz0123456789ABCDEFG/private/doc.md"
-        sensitive_password_target = "formPassword=hunter2.md"
         portal_linked_doc.write_text(
             read_text(repo_root / "docs/app-owned-ui.md")
-            + f"\n[Sensitive URI link]({sensitive_uri_target})\n"
-            + f"[Sensitive password link]({sensitive_password_target})\n",
+            + f"\n[Sensitive URI link]({sensitive_uri_target})\n",
             encoding="utf-8",
         )
         sensitive_links = run_check(temp_root)
@@ -735,14 +745,9 @@ def run_self_test(repo_root: Path) -> None:
         } in sensitive_link_evidence["details"]["brokenLinks"], sensitive_links
         sensitive_links_encoded = json.dumps(sensitive_links, sort_keys=True)
         assert sensitive_uri_target not in sensitive_links_encoded, sensitive_links
-        assert sensitive_password_target not in sensitive_links_encoded, sensitive_links
         assert {
             "path": "docs/app-owned-ui.md",
             "issue": "private-insert-uri",
-        } in sensitive_link_evidence["details"]["redactionFindings"], sensitive_links
-        assert {
-            "path": "docs/app-owned-ui.md",
-            "issue": "form-password",
         } in sensitive_link_evidence["details"]["redactionFindings"], sensitive_links
     assert redaction_findings_for_text("Authorization: Bearer concrete-token-value") == [
         "authorization-header"
@@ -962,10 +967,13 @@ def main() -> int:
         print("app-platform docs check self-test passed")
         return 0
     summary = run_check(workspace_root)
+    output_summary = safe_summary_for_output(summary)
     if args.output:
-        write_json(args.output, summary)
+        write_json(args.output, output_summary)
     else:
-        print(json.dumps(summary, indent=2, sort_keys=True))
+        # The summary is recursively redacted before stdout emission.
+        # codeql[py/clear-text-logging-sensitive-data]
+        print(json.dumps(output_summary, indent=2, sort_keys=True))
     return 0 if summary["status"] == "pass" else 1
 
 

--- a/tools/release-certification/app_platform_docs_check.py
+++ b/tools/release-certification/app_platform_docs_check.py
@@ -1,0 +1,892 @@
+#!/usr/bin/env python3
+"""Check app-platform beta docs, links, templates, and redaction rules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+
+SCHEMA_VERSION = 1
+TOOL_NAME = "app-platform-docs-check"
+EVIDENCE_IDS = (
+    "app-platform.docs-portal",
+    "app-platform.beta-program",
+    "app-platform.beta-tutorials",
+    "app-platform.docs-redaction",
+)
+
+REQUIRED_DOCS = (
+    "docs/app-platform-developer-portal.md",
+    "docs/app-platform-beta-tutorials.md",
+    "docs/app-platform-beta-known-limitations.md",
+    "docs/app-platform-beta-program.md",
+    "docs/developer-beta-toolkit.md",
+    "docs/app-catalogs.md",
+    "docs/app-dev-cli.md",
+    "docs/platform-api-contract.md",
+    "docs/platform-api-surface.md",
+    "docs/platform-sdk-js.md",
+    "docs/app-permissions-and-audit.md",
+    "docs/app-secret-and-identity-vault.md",
+    "docs/app-review-governance.md",
+    "docs/app-update-lifecycle.md",
+    "docs/first-party-beta-catalog.md",
+    "docs/feed-reader-reference-app.md",
+    "docs/trust-graph-preview.md",
+    "docs/release-certification.md",
+    "docs/SECURITY.md",
+)
+
+NEW_DOCS = (
+    "docs/app-platform-developer-portal.md",
+    "docs/app-platform-beta-tutorials.md",
+    "docs/app-platform-beta-known-limitations.md",
+    "docs/app-platform-beta-program.md",
+)
+
+ISSUE_TEMPLATES = (
+    ".github/ISSUE_TEMPLATE/app-platform-beta-feedback.yml",
+    ".github/ISSUE_TEMPLATE/app-submission-beta.yml",
+)
+
+REQUIRED_PORTAL_LINKS = tuple(
+    path for path in REQUIRED_DOCS if path != "docs/app-platform-developer-portal.md"
+) + (
+    "docs/app-distribution.md",
+    "docs/app-owned-ui.md",
+    "docs/app-ui-design-system.md",
+    "docs/apphost-runtime-hardening.md",
+    "docs/legacy-http-boundary.md",
+    "docs/legacy-retirement-plan.md",
+)
+
+REQUIRED_CONCEPTS = (
+    "crypta-app init",
+    "crypta-app dev",
+    "crypta-app test",
+    "crypta-app keys generate",
+    "crypta-app sign",
+    "crypta-app verify",
+    "crypta-app pack",
+    "crypta-app catalog entry",
+    "crypta-app catalog create",
+    "crypta-app catalog sign",
+    "crypta-app catalog verify",
+    "crypta-app publish-usk",
+    "content.fetch",
+    "content.insert.app-document",
+    "vault.identities.create",
+    "vault.identities.use",
+    "trust.read",
+    "trust.write",
+    "review receipt",
+    "reviewer key lifecycle",
+    "transparency log",
+    "background update scheduler",
+    "rollback",
+    "ecosystem certification matrix",
+    "FProxy browse remains retained",
+)
+
+REDACTION_ALLOWLIST_PATH_PREFIXES = (
+    "/abs/path/",
+    "/api/",
+    "/app/",
+    "/apps/",
+    "/downloads/",
+    "/uploads/",
+    "/insertfile/",
+    "/insert-browse/",
+    "/friends/",
+    "/addfriend/",
+    "/strangers/",
+    "/connectivity/",
+    "/alerts/",
+    "/config/",
+    "/core-update/",
+    "/stats/",
+    "/welcome",
+    "/wizard",
+    "/help",
+    "/chat",
+    "/content",
+    "/filterfile",
+    "/diagnostics",
+    "/docs/",
+    "/.well-known/",
+    "/static/",
+    "/src/",
+    "/app-catalogs/",
+)
+
+REDACTION_ALLOWLIST_EXACT_PATHS = (
+    "/etc/systemd/system/cryptad.service",
+    "/opt/cryptad",
+    "/opt/cryptad/Crypta",
+    "/usr/share/applications/crypta.desktop",
+    "/usr/share/wayland-sessions",
+    "/usr/share/xsessions",
+    "/var/lib/cryptad",
+)
+
+PRIVATE_KEY_BLOCK_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 -]*PRIVATE KEY(?: BLOCK)?-----", re.IGNORECASE
+)
+SEED_PHRASE_RE = re.compile(
+    r"\bseed phrase\s*[:=]\s*(?!<redacted>)(?:[a-z]{3,}\s+){3,}[a-z]{3,}\b",
+    re.IGNORECASE,
+)
+AUTHORIZATION_HEADER_RE = re.compile(
+    r"(?<![\w-])[\"']?Authorization[\"']?\s*:\s*[\"']?"
+    r"(?!(?:<[^>\r\n]+>|redacted|\.\.\.)(?:[\"']?\s*(?:$|[\r\n,}\]`])))"
+    r"(?:"
+    r"[A-Za-z][A-Za-z0-9._~-]*\s+"
+    r"(?!(?:<[^>\r\n]+>|redacted|\.\.\.)(?:[\"']?\s*(?:$|[\r\n,}\]`])))"
+    r"[A-Za-z0-9._~+/=:,-]{4,}"
+    r"|[A-Za-z0-9._~+/=-]{8,}"
+    r")",
+    re.IGNORECASE,
+)
+COOKIE_RE = re.compile(
+    r"\b(?:Cookie|Set-Cookie)\s*:\s*(?!<redacted>|<token-redacted>|$)[^\n<]{4,}",
+    re.IGNORECASE,
+)
+APP_SESSION_RE = re.compile(
+    r"\bX-Crypta-App-Session\s*:\s*(?!<redacted>|<token-redacted>)[A-Za-z0-9._~+/=-]{8,}",
+    re.IGNORECASE,
+)
+PARTIAL_REDACTION_RE = re.compile(
+    r"(?<![\w-])(?:[\"']?Authorization[\"']?\s*:\s*[\"']?(?:[A-Za-z][A-Za-z0-9._~-]*\s+)?|"
+    r"(?:Cookie|Set-Cookie|X-Crypta-App-Session)\s*:|"
+    r"[\"']?(?:CRYPTAD_APP_TOKEN|browserSessionToken|appProcessToken|"
+    r"formPassword|CRYPTAD_CERT_FORM_PASSWORD)[\"']?\s*[:=]|"
+    r"--form-password(?:=|\s+))"
+    r"\s*[\"']?(?:<[^>\r\n]+>|redacted|\.\.\.)[\"']?"
+    r"(?!\s*(?:$|[\r\n,}\]`\\]))(?=[^\r\n]*[A-Za-z0-9])",
+    re.IGNORECASE,
+)
+TOKEN_ASSIGNMENT_RE = re.compile(
+    r"\b[\"']?(?:CRYPTAD_APP_TOKEN|browserSessionToken|appProcessToken)[\"']?\s*[:=]\s*"
+    r"(?![\"']?(?:<[^>]+>|\.\.\.|redacted|<redacted>|<token-redacted>)[\"']?(?:$|[\s,}\]`]))"
+    r"(?:[\"'][^\"'<>\r\n]{8,}[\"']|[A-Za-z0-9._~+/=-]{8,})",
+    re.IGNORECASE,
+)
+FORM_PASSWORD_RE = re.compile(
+    r"(?:\b[\"']?(?:formPassword|CRYPTAD_CERT_FORM_PASSWORD)[\"']?\s*[:=]|"
+    r"(?<![\w-])--form-password(?:=|\s+))\s*"
+    r"(?![\"']?(?:<[^>]+>|redacted|\.\.\.)[\"']?(?:$|[\s,}\]`\\]))"
+    r"(?:[\"'][^\"'<>\r\n]{4,}[\"']|[^&,\s`'\"<>{}\[\]]{4,})",
+    re.IGNORECASE,
+)
+PRIVATE_INSERT_URI_RE = re.compile(
+    r"\b(?:crypta:|freenet:)?(?:SSK|USK)@"
+    r"(?!<|\.\.\.)"
+    r"(?=[A-Za-z0-9~_-]{8})"
+    r"[A-Za-z0-9~_,=-]+(?:/[^\s`'\"<>)]*)?",
+    re.IGNORECASE,
+)
+LOCAL_ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_:/.\->])(?:"
+    r"/(?!/)(?:[A-Za-z0-9._~+-]+/)+[A-Za-z0-9._~+-]+/?"
+    r"|[A-Za-z]:[\\/][^\s`'\"<>)]*)"
+)
+UNC_ABSOLUTE_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_:/.\->\\])"
+    r"\\\\[^\\/\s`'\"<>|:*?]+\\[^\\/\s`'\"<>|:*?]+"
+    r"(?:\\[^\\\s`'\"<>|:*?]+)*"
+)
+FILE_URI_RE = re.compile(
+    r"\bfile:(?://(?P<authority>[^/\s`'\"<>)]*))?"
+    r"(?P<path>/[^\s`'\"<>)]*|[A-Za-z]:[\\/][^\s`'\"<>)]*)",
+    re.IGNORECASE,
+)
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+MARKDOWN_LINK_DESTINATION_RE = re.compile(
+    r"^(?:<(?P<angle>[^<>\r\n]*)>|(?P<bare>\S+))"
+    r"(?:\s+(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|\([^)\r\n]*\)))?\s*$"
+)
+CRYPTA_APP_ALIAS_RE = re.compile(
+    r'(?:"\$(?:CRYPTA_APP|\{CRYPTA_APP\})"|\$(?:CRYPTA_APP|\{CRYPTA_APP\}))'
+)
+REDACTION_CHECKS = (
+    ("private-key-block", PRIVATE_KEY_BLOCK_RE),
+    ("seed-phrase", SEED_PHRASE_RE),
+    ("authorization-header", AUTHORIZATION_HEADER_RE),
+    ("cookie", COOKIE_RE),
+    ("app-session-token", APP_SESSION_RE),
+    ("partial-redaction", PARTIAL_REDACTION_RE),
+    ("token-assignment", TOKEN_ASSIGNMENT_RE),
+    ("form-password", FORM_PASSWORD_RE),
+    ("private-insert-uri", PRIVATE_INSERT_URI_RE),
+)
+REDACTED_BROKEN_LINK_TARGET = "<redacted-sensitive-link-target>"
+
+
+def display_path(path: str | Path) -> str:
+    return str(path).replace("\\", "/")
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def required_file_status(workspace_root: Path, paths: tuple[str, ...]) -> dict[str, bool]:
+    return {
+        path: (workspace_root / path).is_file() and bool(read_text(workspace_root / path).strip())
+        for path in paths
+    }
+
+
+def normalize_crypta_app_aliases(text: str) -> str:
+    return CRYPTA_APP_ALIAS_RE.sub("crypta-app", text)
+
+
+def tutorial_doc_concept_text(workspace_root: Path) -> str:
+    return normalize_crypta_app_aliases(
+        read_text(workspace_root / "docs/app-platform-beta-tutorials.md")
+    )
+
+
+def missing_concepts(text: str) -> list[str]:
+    lowered = text.lower()
+    return sorted(concept for concept in REQUIRED_CONCEPTS if concept.lower() not in lowered)
+
+
+def normalize_doc_link_target(raw_target: str) -> str:
+    target = raw_target.strip()
+    if not target or target.startswith("#"):
+        return ""
+    destination = MARKDOWN_LINK_DESTINATION_RE.match(target)
+    if not destination:
+        return ""
+    target = (destination.group("angle") or destination.group("bare") or "").strip()
+    if not target or target.startswith("#"):
+        return ""
+    parsed = urlparse(target)
+    if parsed.scheme or parsed.netloc:
+        return ""
+    path = unquote(parsed.path)
+    if not path.endswith(".md"):
+        return ""
+    return path
+
+
+def resolve_doc_link_target(workspace_root: Path, markdown_file: Path, target: str) -> Path:
+    target_path = Path(target)
+    if target_path.is_absolute():
+        return (workspace_root / target_path.relative_to("/")).resolve()
+    return (markdown_file.parent / target_path).resolve()
+
+
+def markdown_link_targets(workspace_root: Path, markdown_file: Path) -> set[str]:
+    targets: set[str] = set()
+    text = read_text(markdown_file)
+    for match in MARKDOWN_LINK_RE.finditer(text):
+        target = normalize_doc_link_target(match.group(1))
+        if not target:
+            continue
+        resolved = resolve_doc_link_target(workspace_root, markdown_file, target)
+        try:
+            relative = resolved.relative_to(workspace_root.resolve())
+        except ValueError:
+            continue
+        targets.add(display_path(relative))
+    return targets
+
+
+def markdown_files_to_check(workspace_root: Path) -> list[Path]:
+    files = [workspace_root / path for path in NEW_DOCS]
+    files.extend(workspace_root / path for path in (*REQUIRED_DOCS, *REQUIRED_PORTAL_LINKS))
+    files.append(workspace_root / "README.md")
+    return sorted({path for path in files if path.is_file()})
+
+
+def broken_markdown_links(workspace_root: Path) -> list[dict[str, str]]:
+    broken: list[dict[str, str]] = []
+    for markdown_file in markdown_files_to_check(workspace_root):
+        text = read_text(markdown_file)
+        for match in MARKDOWN_LINK_RE.finditer(text):
+            target = normalize_doc_link_target(match.group(1))
+            if not target:
+                continue
+            resolved = resolve_doc_link_target(workspace_root, markdown_file, target)
+            try:
+                resolved.relative_to(workspace_root.resolve())
+            except ValueError:
+                broken.append(
+                    {
+                        "source": display_path(markdown_file.relative_to(workspace_root)),
+                        "target": safe_broken_link_target(target),
+                        "reason": "outside-repo",
+                    }
+                )
+                continue
+            if not resolved.is_file():
+                broken.append(
+                    {
+                        "source": display_path(markdown_file.relative_to(workspace_root)),
+                        "target": safe_broken_link_target(target),
+                        "reason": "missing",
+                    }
+                )
+    return broken
+
+
+def redaction_files_to_check(workspace_root: Path) -> list[Path]:
+    files = [workspace_root / path for path in (*REQUIRED_DOCS, *REQUIRED_PORTAL_LINKS)]
+    files.extend(workspace_root / path for path in ISSUE_TEMPLATES)
+    files.append(workspace_root / "README.md")
+    return sorted({path for path in files if path.is_file()})
+
+
+def allowed_absolute_path(value: str) -> bool:
+    normalized = unquote(value).replace("\\", "/")
+    normalized_without_trailing_slash = normalized.rstrip("/")
+    return normalized.startswith(REDACTION_ALLOWLIST_PATH_PREFIXES) or (
+        normalized_without_trailing_slash in REDACTION_ALLOWLIST_EXACT_PATHS
+    )
+
+
+def file_uri_path_value(raw_path: str) -> str:
+    value = unquote(raw_path).replace("\\", "/")
+    if re.match(r"^/[A-Za-z]:/", value):
+        return value[1:]
+    return value
+
+
+def has_disallowed_local_path(text: str) -> bool:
+    for match in FILE_URI_RE.finditer(text):
+        authority = match.group("authority")
+        if authority and authority.lower() != "localhost":
+            return True
+        value = file_uri_path_value(match.group("path"))
+        if not allowed_absolute_path(value):
+            return True
+    for match in LOCAL_ABSOLUTE_PATH_RE.finditer(text):
+        value = match.group(0)
+        if not allowed_absolute_path(value):
+            return True
+    for match in UNC_ABSOLUTE_PATH_RE.finditer(text):
+        value = match.group(0)
+        if not allowed_absolute_path(value):
+            return True
+    return False
+
+
+def has_sensitive_redaction_material(text: str) -> bool:
+    return any(pattern.search(text) for _, pattern in REDACTION_CHECKS)
+
+
+def safe_broken_link_target(target: str) -> str:
+    if has_disallowed_local_path(target) or has_sensitive_redaction_material(target):
+        return REDACTED_BROKEN_LINK_TARGET
+    return target
+
+
+def redaction_findings(workspace_root: Path) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    for path in redaction_files_to_check(workspace_root):
+        relative = display_path(path.relative_to(workspace_root))
+        text = read_text(path)
+        for issue, pattern in REDACTION_CHECKS:
+            if pattern.search(text):
+                findings.append({"path": relative, "issue": issue})
+        if has_disallowed_local_path(text):
+            findings.append({"path": relative, "issue": "local-absolute-path"})
+    return findings
+
+
+def portal_link_status(workspace_root: Path) -> dict[str, bool]:
+    targets = markdown_link_targets(
+        workspace_root, workspace_root / "docs/app-platform-developer-portal.md"
+    )
+    return {path: path in targets for path in REQUIRED_PORTAL_LINKS}
+
+
+def readme_links_portal(workspace_root: Path) -> bool:
+    return "docs/app-platform-developer-portal.md" in markdown_link_targets(
+        workspace_root, workspace_root / "README.md"
+    )
+
+
+def evidence_item(
+    evidence_id: str,
+    status: str,
+    summary: str,
+    source: str,
+    details: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "id": evidence_id,
+        "status": status,
+        "requiredForReleaseCandidate": True,
+        "summary": summary,
+        "source": source,
+        "details": details,
+    }
+
+
+def run_check(workspace_root: Path) -> dict[str, Any]:
+    workspace_root = workspace_root.resolve()
+    required_docs = required_file_status(workspace_root, REQUIRED_DOCS)
+    issue_templates = required_file_status(workspace_root, ISSUE_TEMPLATES)
+    portal_links = portal_link_status(workspace_root)
+    readme_portal_link = readme_links_portal(workspace_root)
+    known_limitations_present = required_docs["docs/app-platform-beta-known-limitations.md"]
+    tutorial_concepts_missing = missing_concepts(tutorial_doc_concept_text(workspace_root))
+    broken_links = broken_markdown_links(workspace_root)
+    redaction = redaction_findings(workspace_root)
+
+    missing_docs = sorted(path for path, present in required_docs.items() if not present)
+    missing_issue_templates = sorted(path for path, present in issue_templates.items() if not present)
+    missing_portal_links = sorted(path for path, present in portal_links.items() if not present)
+
+    docs_portal_passed = (
+        not missing_docs
+        and not missing_portal_links
+        and readme_portal_link
+        and known_limitations_present
+    )
+    beta_program_passed = (
+        required_docs["docs/app-platform-beta-program.md"] and not missing_issue_templates
+    )
+    beta_tutorials_passed = (
+        required_docs["docs/app-platform-beta-tutorials.md"] and not tutorial_concepts_missing
+    )
+    docs_redaction_passed = not broken_links and not redaction
+
+    evidence = [
+        evidence_item(
+            "app-platform.docs-portal",
+            "pass" if docs_portal_passed else "fail",
+            (
+                "App platform developer portal, required docs, known limitations, and README link are present."
+                if docs_portal_passed
+                else "App platform developer portal docs or required links are incomplete."
+            ),
+            "docs/app-platform-developer-portal.md",
+            {
+                "requiredDocsPresent": not missing_docs,
+                "missingDocs": missing_docs,
+                "portalLinksPresent": not missing_portal_links,
+                "missingPortalLinks": missing_portal_links,
+                "knownLimitationsPresent": known_limitations_present,
+                "readmeLinksPortal": readme_portal_link,
+            },
+        ),
+        evidence_item(
+            "app-platform.beta-program",
+            "pass" if beta_program_passed else "fail",
+            (
+                "Beta program doc and GitHub issue templates are present."
+                if beta_program_passed
+                else "Beta program doc or issue templates are missing."
+            ),
+            "docs/app-platform-beta-program.md",
+            {
+                "programDocPresent": required_docs["docs/app-platform-beta-program.md"],
+                "issueTemplatesPresent": not missing_issue_templates,
+                "missingIssueTemplates": missing_issue_templates,
+                "issueTemplates": list(ISSUE_TEMPLATES),
+            },
+        ),
+        evidence_item(
+            "app-platform.beta-tutorials",
+            "pass" if beta_tutorials_passed else "fail",
+            (
+                "Offline beta tutorials cover required commands and app-platform concepts."
+                if beta_tutorials_passed
+                else "Offline beta tutorials are missing required command or concept coverage."
+            ),
+            "docs/app-platform-beta-tutorials.md",
+            {
+                "tutorialsDocPresent": required_docs["docs/app-platform-beta-tutorials.md"],
+                "requiredConceptCount": len(REQUIRED_CONCEPTS),
+                "requiredConceptSource": "docs/app-platform-beta-tutorials.md",
+                "launcherAliasesNormalized": True,
+                "missingConcepts": tutorial_concepts_missing,
+            },
+        ),
+        evidence_item(
+            "app-platform.docs-redaction",
+            "pass" if docs_redaction_passed else "fail",
+            (
+                "Docs and issue templates passed local Markdown link and redaction checks."
+                if docs_redaction_passed
+                else "Docs or issue templates failed local Markdown link or redaction checks."
+            ),
+            "tools/release-certification/app_platform_docs_check.py",
+            {
+                "internalLinksOk": not broken_links,
+                "brokenLinks": broken_links,
+                "redactionOk": not redaction,
+                "redactionFindings": redaction,
+                "externalUrlsFetched": False,
+            },
+        ),
+    ]
+    status = "pass" if all(item["status"] == "pass" for item in evidence) else "fail"
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "tool": TOOL_NAME,
+        "status": status,
+        "evidence": evidence,
+    }
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_self_test(repo_root: Path) -> None:
+    summary = run_check(repo_root)
+    assert summary["status"] == "pass", summary
+    with tempfile.TemporaryDirectory(prefix="cryptad-docs-check-self-test-") as temp_name:
+        temp_root = Path(temp_name)
+        for path in sorted({*REQUIRED_DOCS, *REQUIRED_PORTAL_LINKS}):
+            source = repo_root / path
+            target = temp_root / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(read_text(source), encoding="utf-8")
+        for path in ISSUE_TEMPLATES:
+            source = repo_root / path
+            target = temp_root / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(read_text(source), encoding="utf-8")
+        (temp_root / "README.md").write_text(read_text(repo_root / "README.md"), encoding="utf-8")
+        missing_doc = temp_root / "docs/app-platform-beta-tutorials.md"
+        missing_doc.unlink()
+        failed = run_check(temp_root)
+        assert failed["status"] == "fail", failed
+        stale_doc = temp_root / "docs/app-platform-beta-tutorials.md"
+        stale_doc.write_text("# Stale beta tutorials\n\ncrypta-app dev\n", encoding="utf-8")
+        stale = run_check(temp_root)
+        stale_evidence = evidence_by_id(stale)
+        assert stale["status"] == "fail", stale
+        assert stale_evidence["app-platform.beta-tutorials"]["status"] == "fail", stale
+        assert "crypta-app init" in stale_evidence["app-platform.beta-tutorials"]["details"][
+            "missingConcepts"
+        ], stale
+        stale_doc.write_text(
+            read_text(repo_root / "docs/app-platform-beta-tutorials.md"), encoding="utf-8"
+        )
+        portal_doc = temp_root / "docs/app-platform-developer-portal.md"
+        portal_doc.write_text(
+            read_text(repo_root / "docs/app-platform-developer-portal.md").replace(
+                "(app-catalogs.md)", '(app-catalogs.md "catalog docs")'
+            ),
+            encoding="utf-8",
+        )
+        titled_portal = run_check(temp_root)
+        titled_portal_evidence = evidence_by_id(titled_portal)["app-platform.docs-portal"]
+        assert "docs/app-catalogs.md" not in titled_portal_evidence["details"][
+            "missingPortalLinks"
+        ], titled_portal
+        portal_doc.write_text(
+            read_text(repo_root / "docs/app-platform-developer-portal.md").replace(
+                "(app-catalogs.md)", "(app-catalogs.md.bak)"
+            ),
+            encoding="utf-8",
+        )
+        filename_mention_portal = run_check(temp_root)
+        portal_evidence = evidence_by_id(filename_mention_portal)["app-platform.docs-portal"]
+        assert portal_evidence["status"] == "fail", filename_mention_portal
+        assert "docs/app-catalogs.md" in portal_evidence["details"][
+            "missingPortalLinks"
+        ], filename_mention_portal
+        portal_doc.write_text(
+            read_text(repo_root / "docs/app-platform-developer-portal.md"), encoding="utf-8"
+        )
+        readme = temp_root / "README.md"
+        readme.write_text(
+            "This prose mentions docs/app-platform-developer-portal.md but does not link it.\n",
+            encoding="utf-8",
+        )
+        filename_mention_readme = run_check(temp_root)
+        readme_evidence = evidence_by_id(filename_mention_readme)["app-platform.docs-portal"]
+        assert readme_evidence["status"] == "fail", filename_mention_readme
+        assert readme_evidence["details"]["readmeLinksPortal"] is False, filename_mention_readme
+        readme.write_text(
+            "[App Platform Beta](/docs/app-platform-developer-portal.md)\n",
+            encoding="utf-8",
+        )
+        root_relative_readme = run_check(temp_root)
+        root_relative_evidence = evidence_by_id(root_relative_readme)
+        assert root_relative_evidence["app-platform.docs-portal"]["details"][
+            "readmeLinksPortal"
+        ] is True, root_relative_readme
+        assert not any(
+            broken["source"] == "README.md"
+            and broken["target"] == "/docs/app-platform-developer-portal.md"
+            for broken in root_relative_evidence["app-platform.docs-redaction"]["details"][
+                "brokenLinks"
+            ]
+        ), root_relative_readme
+        readme.write_text(read_text(repo_root / "README.md"), encoding="utf-8")
+        portal_linked_doc = temp_root / "docs/app-owned-ui.md"
+        portal_linked_doc.write_text(
+            read_text(repo_root / "docs/app-owned-ui.md")
+            + "\nAuthorization: Bearer concrete-token-value\n"
+            + "Insert URI: USK@abcdefghijklmno,qrstuvwxyz0123456789ABCDEFG/name/0\n"
+            + "Private key path: /root/.crypta-dev/keys/dev-local-bundle-private.der\n",
+            encoding="utf-8",
+        )
+        leaked_portal_doc = run_check(temp_root)
+        redaction_evidence = evidence_by_id(leaked_portal_doc)["app-platform.docs-redaction"]
+        assert redaction_evidence["status"] == "fail", leaked_portal_doc
+        assert {
+            "path": "docs/app-owned-ui.md",
+            "issue": "authorization-header",
+        } in redaction_evidence["details"]["redactionFindings"], leaked_portal_doc
+        assert {
+            "path": "docs/app-owned-ui.md",
+            "issue": "private-insert-uri",
+        } in redaction_evidence["details"]["redactionFindings"], leaked_portal_doc
+        assert {
+            "path": "docs/app-owned-ui.md",
+            "issue": "local-absolute-path",
+        } in redaction_evidence["details"]["redactionFindings"], leaked_portal_doc
+        portal_linked_doc.write_text(
+            read_text(repo_root / "docs/app-owned-ui.md")
+            + '\n[Broken portal-linked doc link](missing-beta-link.md "missing beta link")\n',
+            encoding="utf-8",
+        )
+        broken_portal_link = run_check(temp_root)
+        broken_link_evidence = evidence_by_id(broken_portal_link)["app-platform.docs-redaction"]
+        assert broken_link_evidence["status"] == "fail", broken_portal_link
+        assert {
+            "source": "docs/app-owned-ui.md",
+            "target": "missing-beta-link.md",
+            "reason": "missing",
+        } in broken_link_evidence["details"]["brokenLinks"], broken_portal_link
+        portal_linked_doc.write_text(
+            read_text(repo_root / "docs/app-owned-ui.md")
+            + "\n[Unsafe local link](/home/alice/private.md)\n",
+            encoding="utf-8",
+        )
+        unsafe_link = run_check(temp_root)
+        unsafe_link_evidence = evidence_by_id(unsafe_link)["app-platform.docs-redaction"]
+        assert {
+            "source": "docs/app-owned-ui.md",
+            "target": REDACTED_BROKEN_LINK_TARGET,
+            "reason": "missing",
+        } in unsafe_link_evidence["details"]["brokenLinks"], unsafe_link
+        assert "/home/alice/private.md" not in json.dumps(unsafe_link, sort_keys=True)
+        assert {
+            "path": "docs/app-owned-ui.md",
+            "issue": "local-absolute-path",
+        } in unsafe_link_evidence["details"]["redactionFindings"], unsafe_link
+        sensitive_uri_target = "USK@abcdefghijklmno,qrstuvwxyz0123456789ABCDEFG/private/doc.md"
+        sensitive_password_target = "formPassword=hunter2.md"
+        portal_linked_doc.write_text(
+            read_text(repo_root / "docs/app-owned-ui.md")
+            + f"\n[Sensitive URI link]({sensitive_uri_target})\n"
+            + f"[Sensitive password link]({sensitive_password_target})\n",
+            encoding="utf-8",
+        )
+        sensitive_links = run_check(temp_root)
+        sensitive_link_evidence = evidence_by_id(sensitive_links)["app-platform.docs-redaction"]
+        assert {
+            "source": "docs/app-owned-ui.md",
+            "target": REDACTED_BROKEN_LINK_TARGET,
+            "reason": "missing",
+        } in sensitive_link_evidence["details"]["brokenLinks"], sensitive_links
+        sensitive_links_encoded = json.dumps(sensitive_links, sort_keys=True)
+        assert sensitive_uri_target not in sensitive_links_encoded, sensitive_links
+        assert sensitive_password_target not in sensitive_links_encoded, sensitive_links
+        assert {
+            "path": "docs/app-owned-ui.md",
+            "issue": "private-insert-uri",
+        } in sensitive_link_evidence["details"]["redactionFindings"], sensitive_links
+        assert {
+            "path": "docs/app-owned-ui.md",
+            "issue": "form-password",
+        } in sensitive_link_evidence["details"]["redactionFindings"], sensitive_links
+    assert redaction_findings_for_text("Authorization: Bearer concrete-token-value") == [
+        "authorization-header"
+    ]
+    assert "authorization-header" in redaction_findings_for_text(
+        "Authorization: Basic dXNlcjpwYXNz"
+    )
+    assert "authorization-header" in redaction_findings_for_text(
+        '"Authorization": "Bearer real-token"'
+    )
+    assert "authorization-header" in redaction_findings_for_text(
+        "'Authorization': 'Basic dXNlcjpwYXNz'"
+    )
+    assert "authorization-header" in redaction_findings_for_text(
+        'Authorization: "Bearer real-token"'
+    )
+    assert "authorization-header" not in redaction_findings_for_text(
+        "Authorization: Bearer <token>"
+    )
+    assert "authorization-header" not in redaction_findings_for_text(
+        '"Authorization": "Bearer <token>"'
+    )
+    assert "partial-redaction" in redaction_findings_for_text(
+        "Authorization: Bearer <redacted> abc123"
+    )
+    assert "partial-redaction" in redaction_findings_for_text(
+        '"Authorization": "Bearer <redacted> abc123"'
+    )
+    assert "partial-redaction" in redaction_findings_for_text(
+        "Authorization: Basic <redacted> dXNlcjpwYXNz"
+    )
+    assert "partial-redaction" in redaction_findings_for_text(
+        "Cookie: <redacted>; sid=abcdef012345"
+    )
+    assert "partial-redaction" not in redaction_findings_for_text(
+        "Authorization: Bearer <redacted>"
+    )
+    assert "partial-redaction" not in redaction_findings_for_text("Cookie: <redacted>")
+    assert "private-key-block" in redaction_findings_for_text(
+        "-----BEGIN ENCRYPTED PRIVATE KEY-----"
+    )
+    assert "form-password" in redaction_findings_for_text("formPassword=hunter2")
+    assert "form-password" in redaction_findings_for_text("formPassword: hunter2")
+    assert "form-password" in redaction_findings_for_text('"formPassword": "hunter2"')
+    assert "form-password" in redaction_findings_for_text(
+        "CRYPTAD_CERT_FORM_PASSWORD=hunter2"
+    )
+    assert "form-password" in redaction_findings_for_text("--form-password hunter2")
+    assert "form-password" in redaction_findings_for_text("--form-password=hunter2")
+    assert "form-password" not in redaction_findings_for_text("formPassword=<redacted>")
+    assert "form-password" not in redaction_findings_for_text('"formPassword": "<redacted>"')
+    assert "form-password" not in redaction_findings_for_text(
+        "CRYPTAD_CERT_FORM_PASSWORD=<redacted> \\"
+    )
+    assert "form-password" not in redaction_findings_for_text("--form-password <redacted>")
+    assert "partial-redaction" in redaction_findings_for_text(
+        "CRYPTAD_CERT_FORM_PASSWORD=<redacted> hunter2"
+    )
+    assert "partial-redaction" in redaction_findings_for_text(
+        "--form-password <redacted> hunter2"
+    )
+    assert "token-assignment" in redaction_findings_for_text(
+        "CRYPTAD_APP_TOKEN=abcdef0123456789"
+    )
+    assert "token-assignment" in redaction_findings_for_text(
+        '"browserSessionToken": "abcdef0123456789"'
+    )
+    assert "token-assignment" in redaction_findings_for_text(
+        "appProcessToken: abcdef0123456789"
+    )
+    assert "token-assignment" not in redaction_findings_for_text("CRYPTAD_APP_TOKEN=...")
+    assert "token-assignment" not in redaction_findings_for_text(
+        '"browserSessionToken": "<opaque-browser-session-token>"'
+    )
+    assert "private-insert-uri" in redaction_findings_for_text(
+        "Insert URI: USK@abcdefghijklmno,qrstuvwxyz0123456789ABCDEFG/name/0"
+    )
+    assert "private-insert-uri" in redaction_findings_for_text(
+        "Insert URI: crypta:SSK@abcdefghijklmno,qrstuvwxyz0123456789ABCDEFG/name"
+    )
+    assert "private-insert-uri" not in redaction_findings_for_text(
+        "Placeholder: crypta:USK@<catalog-key>/cryptad-app-catalog.properties"
+    )
+    assert "private-insert-uri" not in redaction_findings_for_text(
+        "Placeholder: USK@.../profile.json"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "/root/.crypta-dev/keys/dev-local-bundle-private.der"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "C:/Users/Alice/.crypta-dev/keys/dev-local-bundle-private.der"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "file:///home/alice/.crypta-dev/keys/dev-local-bundle-private.der"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "file:///C:/Users/Alice/.crypta-dev/keys/dev-local-bundle-private.der"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "/etc/cryptad/form-password"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "/var/lib/cryptad/apphost"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "/opt/cryptad/config.yml"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "file://localhost/home/alice/key.pem"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "file:/home/alice/key.pem"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "file:/C:/Users/Alice/key.pem"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        r"\\server\share\crypta\keys\dev-private.der"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "file://server/share/crypta/key.pem"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "/tmp/crypta-release/keys/private.pem"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "file:///tmp/crypta-app-catalog/staged-bundle.zip"
+    )
+    assert "local-absolute-path" not in redaction_findings_for_text(
+        "/abs/path/outside/repo/dev-private.der"
+    )
+    assert "local-absolute-path" not in redaction_findings_for_text(
+        "file:///abs/path/outside/repo/dev-private.der"
+    )
+    assert "local-absolute-path" not in redaction_findings_for_text(
+        "file:/abs/path/outside/repo/dev-private.der"
+    )
+    assert "local-absolute-path" not in redaction_findings_for_text("/var/lib/cryptad")
+
+
+def evidence_by_id(summary: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {item["id"]: item for item in summary["evidence"]}
+
+
+def redaction_findings_for_text(text: str) -> list[str]:
+    issues = []
+    for issue, pattern in REDACTION_CHECKS:
+        if pattern.search(text):
+            issues.append(issue)
+    if has_disallowed_local_path(text):
+        issues.append("local-absolute-path")
+    return issues
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--workspace-root", type=Path, default=Path.cwd())
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--self-test", action="store_true")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    workspace_root = args.workspace_root.resolve()
+    if args.self_test:
+        run_self_test(workspace_root)
+        print("app-platform docs check self-test passed")
+        return 0
+    summary = run_check(workspace_root)
+    if args.output:
+        write_json(args.output, summary)
+    else:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release-certification/app_platform_docs_check.py
+++ b/tools/release-certification/app_platform_docs_check.py
@@ -97,7 +97,7 @@ REQUIRED_CONCEPTS = (
 REDACTION_ALLOWLIST_PATH_PREFIXES = (
     "/abs/path/",
     "/api/",
-    "/app/",
+    "/app/node/",
     "/apps/",
     "/downloads/",
     "/uploads/",
@@ -133,6 +133,7 @@ REDACTION_ALLOWLIST_EXACT_PATHS = (
     "/usr/share/wayland-sessions",
     "/usr/share/xsessions",
     "/var/lib/cryptad",
+    "/app/node",
 )
 
 PRIVATE_KEY_BLOCK_RE = re.compile(
@@ -839,6 +840,16 @@ def run_self_test(repo_root: Path) -> None:
     assert "local-absolute-path" in redaction_findings_for_text(
         "file:///tmp/crypta-app-catalog/staged-bundle.zip"
     )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "/app/secrets/private.pem"
+    )
+    assert "local-absolute-path" in redaction_findings_for_text(
+        "file:///app/secrets/private.pem"
+    )
+    assert "local-absolute-path" not in redaction_findings_for_text("/app/node")
+    assert "local-absolute-path" not in redaction_findings_for_text("/app/node/")
+    assert "local-absolute-path" not in redaction_findings_for_text("file:///app/node")
+    assert "local-absolute-path" not in redaction_findings_for_text("file:///app/node/")
     assert "local-absolute-path" not in redaction_findings_for_text(
         "/abs/path/outside/repo/dev-private.der"
     )

--- a/tools/release-certification/app_platform_docs_check.py
+++ b/tools/release-certification/app_platform_docs_check.py
@@ -226,7 +226,11 @@ FILE_URI_RE = re.compile(
     r"(?P<path>/[^\s`'\"<>)]*|[A-Za-z]:[\\/][^\s`'\"<>)]*)",
     re.IGNORECASE,
 )
-MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)]+)\)")
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]\r\n]+\]\(([^)]+)\)")
+MARKDOWN_REFERENCE_LINK_RE = re.compile(r"(?<!!)\[([^\]\r\n]+)\]\[([^\]\r\n]*)\]")
+MARKDOWN_REFERENCE_DEFINITION_RE = re.compile(
+    r"(?m)^[ \t]{0,3}\[([^\]\r\n]+)\]:[ \t]*(.+?)\s*$"
+)
 MARKDOWN_LINK_DESTINATION_RE = re.compile(
     r"^(?:<(?P<angle>[^<>\r\n]*)>|(?P<bare>\S+))"
     r"(?:\s+(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|\([^)\r\n]*\)))?\s*$"
@@ -301,6 +305,37 @@ def normalize_doc_link_target(raw_target: str) -> str:
     return path
 
 
+def normalize_reference_label(label: str) -> str:
+    return " ".join(label.strip().casefold().split())
+
+
+def markdown_reference_definitions(text: str) -> dict[str, str]:
+    definitions: dict[str, str] = {}
+    for match in MARKDOWN_REFERENCE_DEFINITION_RE.finditer(text):
+        label = normalize_reference_label(match.group(1))
+        if not label or label in definitions:
+            continue
+        target = normalize_doc_link_target(match.group(2))
+        if target:
+            definitions[label] = target
+    return definitions
+
+
+def markdown_doc_link_targets(text: str) -> list[str]:
+    targets: list[str] = []
+    for match in MARKDOWN_LINK_RE.finditer(text):
+        target = normalize_doc_link_target(match.group(1))
+        if target:
+            targets.append(target)
+    reference_definitions = markdown_reference_definitions(text)
+    for match in MARKDOWN_REFERENCE_LINK_RE.finditer(text):
+        label = match.group(2) or match.group(1)
+        target = reference_definitions.get(normalize_reference_label(label))
+        if target:
+            targets.append(target)
+    return targets
+
+
 def resolve_doc_link_target(workspace_root: Path, markdown_file: Path, target: str) -> Path:
     if target.startswith("/"):
         return (workspace_root / target.lstrip("/")).resolve()
@@ -313,10 +348,7 @@ def resolve_doc_link_target(workspace_root: Path, markdown_file: Path, target: s
 def markdown_link_targets(workspace_root: Path, markdown_file: Path) -> set[str]:
     targets: set[str] = set()
     text = read_text(markdown_file)
-    for match in MARKDOWN_LINK_RE.finditer(text):
-        target = normalize_doc_link_target(match.group(1))
-        if not target:
-            continue
+    for target in markdown_doc_link_targets(text):
         resolved = resolve_doc_link_target(workspace_root, markdown_file, target)
         try:
             relative = resolved.relative_to(workspace_root.resolve())
@@ -337,10 +369,7 @@ def broken_markdown_links(workspace_root: Path) -> list[dict[str, str]]:
     broken: list[dict[str, str]] = []
     for markdown_file in markdown_files_to_check(workspace_root):
         text = read_text(markdown_file)
-        for match in MARKDOWN_LINK_RE.finditer(text):
-            target = normalize_doc_link_target(match.group(1))
-            if not target:
-                continue
+        for target in markdown_doc_link_targets(text):
             resolved = resolve_doc_link_target(workspace_root, markdown_file, target)
             try:
                 resolved.relative_to(workspace_root.resolve())
@@ -638,6 +667,21 @@ def run_self_test(repo_root: Path) -> None:
         ], titled_portal
         portal_doc.write_text(
             read_text(repo_root / "docs/app-platform-developer-portal.md").replace(
+                "[app-catalogs.md](app-catalogs.md)",
+                "[app-catalogs.md][catalog-docs]",
+            )
+            + '\n[catalog-docs]: app-catalogs.md "catalog docs"\n',
+            encoding="utf-8",
+        )
+        reference_portal = run_check(temp_root)
+        reference_portal_evidence = evidence_by_id(reference_portal)[
+            "app-platform.docs-portal"
+        ]
+        assert "docs/app-catalogs.md" not in reference_portal_evidence["details"][
+            "missingPortalLinks"
+        ], reference_portal
+        portal_doc.write_text(
+            read_text(repo_root / "docs/app-platform-developer-portal.md").replace(
                 "(app-catalogs.md)", "(app-catalogs.md.bak)"
             ),
             encoding="utf-8",
@@ -676,6 +720,23 @@ def run_self_test(repo_root: Path) -> None:
                 "brokenLinks"
             ]
         ), root_relative_readme
+        readme.write_text(
+            '[App Platform Beta][portal-doc]\n\n'
+            '[portal-doc]: /docs/app-platform-developer-portal.md "portal docs"\n',
+            encoding="utf-8",
+        )
+        reference_readme = run_check(temp_root)
+        reference_readme_evidence = evidence_by_id(reference_readme)
+        assert reference_readme_evidence["app-platform.docs-portal"]["details"][
+            "readmeLinksPortal"
+        ] is True, reference_readme
+        assert not any(
+            broken["source"] == "README.md"
+            and broken["target"] == "/docs/app-platform-developer-portal.md"
+            for broken in reference_readme_evidence["app-platform.docs-redaction"]["details"][
+                "brokenLinks"
+            ]
+        ), reference_readme
         readme.write_text(read_text(repo_root / "README.md"), encoding="utf-8")
         portal_linked_doc = temp_root / "docs/app-owned-ui.md"
         portal_linked_doc.write_text(
@@ -713,6 +774,22 @@ def run_self_test(repo_root: Path) -> None:
             "target": "missing-beta-link.md",
             "reason": "missing",
         } in broken_link_evidence["details"]["brokenLinks"], broken_portal_link
+        portal_linked_doc.write_text(
+            read_text(repo_root / "docs/app-owned-ui.md")
+            + '\n[Broken portal-linked doc link][missing-beta]\n'
+            + '\n[missing-beta]: missing-beta-link.md "missing beta link"\n',
+            encoding="utf-8",
+        )
+        broken_reference_link = run_check(temp_root)
+        broken_reference_evidence = evidence_by_id(broken_reference_link)[
+            "app-platform.docs-redaction"
+        ]
+        assert broken_reference_evidence["status"] == "fail", broken_reference_link
+        assert {
+            "source": "docs/app-owned-ui.md",
+            "target": "missing-beta-link.md",
+            "reason": "missing",
+        } in broken_reference_evidence["details"]["brokenLinks"], broken_reference_link
         portal_linked_doc.write_text(
             read_text(repo_root / "docs/app-owned-ui.md")
             + "\n[Unsafe local link](/home/alice/private.md)\n",

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -22,6 +22,10 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
+# Local release-certification helpers must not create __pycache__ before git metadata is collected.
+sys.dont_write_bytecode = True
+import app_platform_docs_check
+
 
 TOOL_NAME = "release-certification"
 SCHEMA_VERSION = 1
@@ -37,6 +41,7 @@ ECOSYSTEM_MATRIX_SCHEMA_VERSION = 1
 CERT_STATUSES = ("pass", "warn", "fail", "skip", "missing")
 MODES = ("pr", "nightly", "release-candidate")
 PRIVATE_ARTIFACT_NAMES = ("private-insert-uris.json",)
+REDACTION_FINDING_EVIDENCE_IDS = frozenset({"app-platform.docs-redaction"})
 SENSITIVE_KEY_PATTERN = (
     r"token|password|passwd|secret|credential|authorization|cookie|set-cookie|"
     r"private[-_ ]?key|formPassword|browserSessionToken|CRYPTAD_APP_TOKEN|X-Crypta-App-Session|"
@@ -634,6 +639,25 @@ def unique_non_empty_strings(values: Any) -> list[str]:
     return result
 
 
+def has_unwaivable_redaction_findings(evidence_id: str, details: dict[str, Any]) -> bool:
+    redaction_findings = details.get("redactionFindings")
+    return (
+        evidence_id in REDACTION_FINDING_EVIDENCE_IDS
+        and isinstance(redaction_findings, list)
+        and bool(redaction_findings)
+    )
+
+
+def evidence_item_has_unwaivable_redaction_findings(item: EvidenceItem) -> bool:
+    return has_unwaivable_redaction_findings(item.id, item.details)
+
+
+def evidence_entry_has_unwaivable_redaction_findings(entry: dict[str, Any] | None) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    return has_unwaivable_redaction_findings(str(entry.get("id", "")), evidence_details(entry))
+
+
 def active_waivers_for_all(
     context: WaiverContext, target_ids: list[str], mode: str
 ) -> list[WaiverRecord]:
@@ -664,15 +688,34 @@ def with_waiver_record(item: EvidenceItem, waiver: WaiverRecord | None) -> Evide
     )
 
 
+def active_waiver_for_evidence_item(
+    context: WaiverContext, item: EvidenceItem, mode: str
+) -> WaiverRecord | None:
+    if evidence_item_has_unwaivable_redaction_findings(item):
+        return None
+    return active_waiver_for(context, item.id, [f"evidence.{item.id}"], mode)
+
+
 def apply_waiver_to_gate(gate: GateResult, context: WaiverContext, mode: str) -> GateResult:
     if gate.id == "ecosystem.waivers":
         return gate
     issue_ids = [str(value) for value in gate.details.get("issueIds", []) if value]
-    waiver = active_waiver_for(context, gate.id, issue_ids, mode)
+    unwaivable_failure_evidence_ids = set(
+        unique_non_empty_strings(gate.details.get("unwaivableFailureEvidenceIds", []))
+    )
+    waiver = (
+        None
+        if unwaivable_failure_evidence_ids
+        else active_waiver_for(context, gate.id, issue_ids, mode)
+    )
     waived_evidence_ids: list[str] = []
     if waiver is None and gate.status == "fail":
         failure_evidence_ids = unique_non_empty_strings(gate.details.get("failureEvidenceIds", []))
-        evidence_waivers = active_waivers_for_all(context, failure_evidence_ids, mode)
+        evidence_waivers = (
+            []
+            if unwaivable_failure_evidence_ids.intersection(failure_evidence_ids)
+            else active_waivers_for_all(context, failure_evidence_ids, mode)
+        )
         if evidence_waivers:
             waiver = evidence_waivers[-1]
             waived_evidence_ids = failure_evidence_ids
@@ -994,6 +1037,77 @@ def app_platform_evidence(
                     "missing" if evidence_id != "apphost.live" else "skip",
                     evidence_id != "apphost.live",
                     f"{evidence_id} was not reported by app-platform smoke",
+                    source,
+                    {},
+                )
+            )
+    return items
+
+
+def app_platform_docs_evidence(workspace_root: Path, out_dir: Path) -> list[EvidenceItem]:
+    source = display_path(
+        workspace_root / "tools/release-certification/app_platform_docs_check.py",
+        workspace_root,
+        out_dir,
+    )
+    try:
+        summary = app_platform_docs_check.run_check(workspace_root)
+    except Exception as exception:  # noqa: BLE001 - release evidence must degrade to redacted failure.
+        return [
+            EvidenceItem(
+                evidence_id,
+                "fail",
+                True,
+                "App-platform docs check failed to run",
+                source,
+                {"error": scrub_text(str(exception), workspace_root, out_dir)},
+            )
+            for evidence_id in app_platform_docs_check.EVIDENCE_IDS
+        ]
+    evidence = summary.get("evidence", [])
+    if not isinstance(evidence, list):
+        return [
+            EvidenceItem(
+                evidence_id,
+                "fail",
+                True,
+                "App-platform docs check produced no evidence list",
+                source,
+                {"summaryStatus": sanitize_value(summary.get("status"), workspace_root, out_dir)},
+            )
+            for evidence_id in app_platform_docs_check.EVIDENCE_IDS
+        ]
+    items: list[EvidenceItem] = []
+    seen: set[str] = set()
+    for value in evidence:
+        if not isinstance(value, dict):
+            continue
+        evidence_id = str(value.get("id", "app-platform.docs-unknown"))
+        seen.add(evidence_id)
+        items.append(
+            EvidenceItem(
+                id=evidence_id,
+                status=normalize_evidence_status(str(value.get("status", "missing"))),
+                required_for_release_candidate=bool(value.get("requiredForReleaseCandidate", True)),
+                summary=str(
+                    sanitize_value(value.get("summary", "No summary provided"), workspace_root, out_dir)
+                ),
+                source=str(sanitize_value(value.get("source", source), workspace_root, out_dir)),
+                details=dict(
+                    sanitize_value(value.get("details", {}), workspace_root, out_dir)
+                    if isinstance(value.get("details", {}), dict)
+                    else {}
+                ),
+            )
+        )
+    for evidence_id in app_platform_docs_check.EVIDENCE_IDS:
+        if evidence_id not in seen:
+            items.append(
+                EvidenceItem(
+                    evidence_id,
+                    "missing",
+                    True,
+                    f"{evidence_id} was not reported by app-platform docs check",
                     source,
                     {},
                 )
@@ -1361,6 +1475,24 @@ def ecosystem_matrix_row_specs() -> list[MatrixRowSpec]:
             docs=("docs/app-dev-cli.md", "docs/developer-beta-toolkit.md"),
         ),
         MatrixRowSpec(
+            id="app-platform-beta-docs-and-program",
+            category="app-platform",
+            title="App platform beta docs and program readiness",
+            required_evidence_ids=(
+                "app-platform.docs-portal",
+                "app-platform.beta-program",
+                "app-platform.beta-tutorials",
+                "app-platform.docs-redaction",
+            ),
+            docs=(
+                "docs/app-platform-developer-portal.md",
+                "docs/app-platform-beta-tutorials.md",
+                "docs/app-platform-beta-known-limitations.md",
+                "docs/app-platform-beta-program.md",
+                "docs/release-certification.md",
+            ),
+        ),
+        MatrixRowSpec(
             id="app-vault-and-generated-documents",
             category="app-platform",
             title="App vault, identity profile publishing, and generated documents",
@@ -1635,14 +1767,23 @@ def row_waivers(
     context: WaiverContext,
     mode: str,
     issue_ids: list[str],
+    unwaivable_evidence_ids: set[str],
 ) -> tuple[list[WaiverRecord], list[str]]:
     records: dict[str, WaiverRecord] = {}
     targets = [spec.id, *spec.evidence_ids(), *spec.all_gate_ids()]
+    if unwaivable_evidence_ids:
+        targets = [
+            target_id
+            for target_id in targets
+            if target_id != spec.id and target_id not in unwaivable_evidence_ids
+        ]
     for target_id in targets:
         waiver = active_waiver_for(context, target_id, issue_ids, mode)
         if waiver is not None:
             records[waiver.id] = waiver
     for evidence_id in spec.evidence_ids():
+        if evidence_id in unwaivable_evidence_ids:
+            continue
         waiver_id = evidence_details(evidence_entries.get(evidence_id)).get("waiverId")
         if waiver_id:
             waiver = active_waiver_for(context, str(waiver_id), issue_ids, mode)
@@ -1654,6 +1795,8 @@ def row_waivers(
         if isinstance(details, dict):
             waiver_id = details.get("waiverId")
             if waiver_id:
+                if str(waiver_id) in unwaivable_evidence_ids:
+                    continue
                 waiver = active_waiver_for(context, str(waiver_id), issue_ids, mode)
                 if waiver is not None:
                     records[waiver.id] = waiver
@@ -1667,7 +1810,10 @@ def row_release_blocker_waiver(
     mode: str,
     issue_ids: list[str],
     blocker_targets: list[str],
+    unwaivable_evidence_ids: set[str],
 ) -> WaiverRecord | None:
+    if unwaivable_evidence_ids.intersection(blocker_targets):
+        return None
     return active_waiver_for(
         context,
         spec.id,
@@ -1727,6 +1873,11 @@ def evaluate_matrix_row(
     optional_statuses = {
         evidence_id: evidence_status(evidence_entries.get(evidence_id))
         for evidence_id in spec.optional_evidence_ids
+    }
+    unwaivable_redaction_evidence_ids = {
+        evidence_id
+        for evidence_id in spec.evidence_ids()
+        if evidence_entry_has_unwaivable_redaction_findings(evidence_entries.get(evidence_id))
     }
     previous_statuses = {
         evidence_id: evidence_status(previous_evidence_entries.get(evidence_id))
@@ -1860,14 +2011,25 @@ def evaluate_matrix_row(
         summary = "Required evidence and referenced ecosystem gates passed."
 
     waiver_for_blocker = row_release_blocker_waiver(
-        spec, waiver_context, settings.mode, issue_ids, blocker_targets
+        spec,
+        waiver_context,
+        settings.mode,
+        issue_ids,
+        blocker_targets,
+        unwaivable_redaction_evidence_ids,
     )
     if release_blocker and waiver_for_blocker is not None:
         status = "warn"
         release_blocker = False
         summary = f"{summary} Waiver recorded: {waiver_for_blocker.reason}"
     waiver_records, waiver_ids = row_waivers(
-        spec, evidence_entries, gate_entries, waiver_context, settings.mode, issue_ids
+        spec,
+        evidence_entries,
+        gate_entries,
+        waiver_context,
+        settings.mode,
+        issue_ids,
+        unwaivable_redaction_evidence_ids,
     )
     if waiver_for_blocker is not None and waiver_for_blocker.id not in waiver_ids:
         waiver_records = sorted([*waiver_records, waiver_for_blocker], key=lambda record: record.id)
@@ -1904,6 +2066,8 @@ def evaluate_matrix_row(
         details["previousMatrixPresent"] = previous_matrix_present
     if spec.synthetic == "redaction":
         details["redaction"] = redaction
+    if unwaivable_redaction_evidence_ids:
+        details["unwaivableRedactionEvidenceIds"] = sorted(unwaivable_redaction_evidence_ids)
 
     return {
         "id": spec.id,
@@ -3537,6 +3701,10 @@ def render_report(summary: dict[str, Any]) -> str:
         "app-platform.first-party",
         "app-platform.devtools-cli",
         "app-platform.developer-beta-toolkit",
+        "app-platform.docs-portal",
+        "app-platform.beta-program",
+        "app-platform.beta-tutorials",
+        "app-platform.docs-redaction",
         "platform-api.contract",
         "app-vault.capabilities",
         "app-platform.identity-profile-publish",
@@ -3881,11 +4049,12 @@ def gather_evidence(settings: Settings, waiver_context: WaiverContext) -> list[E
             settings.mode,
         )
     )
+    evidence.extend(app_platform_docs_evidence(settings.workspace_root, settings.out_dir))
     return [
         sanitize_evidence_item(
             with_waiver_record(
                 item,
-                active_waiver_for(waiver_context, item.id, [f"evidence.{item.id}"], settings.mode),
+                active_waiver_for_evidence_item(waiver_context, item, settings.mode),
             ),
             settings.workspace_root,
             settings.out_dir,
@@ -4165,6 +4334,22 @@ def run_self_test(repo_root: Path) -> None:
                 target_doc.parent.mkdir(parents=True, exist_ok=True)
                 assert source_doc.is_file(), f"matrix doc path missing: {doc_path}"
                 shutil.copy2(source_doc, target_doc)
+        docs_check_paths = {
+            *app_platform_docs_check.REQUIRED_DOCS,
+            *app_platform_docs_check.REQUIRED_PORTAL_LINKS,
+            *app_platform_docs_check.ISSUE_TEMPLATES,
+            "README.md",
+        }
+        for source_doc in repo_root.glob("docs/**/*.md"):
+            target_doc = workspace / source_doc.relative_to(repo_root)
+            target_doc.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_doc, target_doc)
+        for doc_path in sorted(docs_check_paths):
+            source_doc = repo_root / doc_path
+            target_doc = workspace / doc_path
+            target_doc.parent.mkdir(parents=True, exist_ok=True)
+            assert source_doc.is_file(), f"docs-check path missing: {doc_path}"
+            shutil.copy2(source_doc, target_doc)
         shutil.copy2(fixture_dir / "self-test-interop-smoke.json", workspace / "build/interop-smoke/summary.json")
         shutil.copy2(
             fixture_dir / "self-test-interop-extended.json",
@@ -4215,6 +4400,7 @@ def run_self_test(repo_root: Path) -> None:
             "app-update",
             "first-party-beta-catalog",
             "developer-beta-toolkit",
+            "app-platform-beta-docs-and-program",
             "review-governance-transparency",
             "app-vault-and-generated-documents",
             "content-fetch-and-networked-content",
@@ -4247,6 +4433,10 @@ def run_self_test(repo_root: Path) -> None:
             "app-review.first-party-review-chain",
             "reference-app.trust-graph",
             "legacy-admin.removal-wave-2",
+            "app-platform.docs-portal",
+            "app-platform.beta-program",
+            "app-platform.beta-tutorials",
+            "app-platform.docs-redaction",
         ):
             assert evidence_id in covered_evidence_ids, evidence_id
         gate_ids = {gate["id"] for gate in summary["ecosystemGates"]}
@@ -4266,6 +4456,23 @@ def run_self_test(repo_root: Path) -> None:
         assert evidence_by_id["app-update.scheduler"]["requiredForReleaseCandidate"] is True
         assert evidence_by_id["app-update.rollback"]["status"] == "pass", evidence_by_id
         assert evidence_by_id["app-update.rollback"]["requiredForReleaseCandidate"] is True
+        for evidence_id in (
+            "app-platform.docs-portal",
+            "app-platform.beta-program",
+            "app-platform.beta-tutorials",
+            "app-platform.docs-redaction",
+        ):
+            assert evidence_by_id[evidence_id]["status"] == "pass", evidence_by_id
+            assert evidence_by_id[evidence_id]["requiredForReleaseCandidate"] is True
+        report_text = (out_dir / REPORT_FILE_NAME).read_text(encoding="utf-8")
+        for evidence_id in (
+            "app-platform.docs-portal",
+            "app-platform.beta-program",
+            "app-platform.beta-tutorials",
+            "app-platform.docs-redaction",
+        ):
+            assert f"### `{evidence_id}`" in report_text, evidence_id
+        assert "redactionFindings" in report_text, report_text
         assert evidence_by_id["app-vault.capabilities"]["status"] == "pass", evidence_by_id
         assert evidence_by_id["app-vault.capabilities"]["requiredForReleaseCandidate"] is True
         assert (
@@ -4462,6 +4669,88 @@ def run_self_test(repo_root: Path) -> None:
                 if isinstance(row, dict) and row.get("id") == row_id:
                     return row
             raise AssertionError(f"missing matrix row {row_id}")
+
+        portal_linked_doc = workspace / "docs/app-owned-ui.md"
+        original_portal_linked_doc = portal_linked_doc.read_text(encoding="utf-8")
+        try:
+            portal_linked_doc.write_text(
+                original_portal_linked_doc
+                + "\n[Broken docs-only link](missing-docs-only-link.md)\n",
+                encoding="utf-8",
+            )
+            waived_docs_link_summary, waived_docs_link_exit_code = run_with_previous(
+                "waived-docs-link-cert",
+                waivers={
+                    "app-platform.docs-redaction": (
+                        "Release manager accepted a temporary docs-only link gap."
+                    )
+                },
+            )
+            assert waived_docs_link_exit_code == 0, waived_docs_link_summary
+            assert waived_docs_link_summary["releaseCandidatePassed"] is True, waived_docs_link_summary
+            waived_docs_link_evidence = {
+                item["id"]: item for item in waived_docs_link_summary["evidence"]
+            }
+            docs_link_evidence = waived_docs_link_evidence["app-platform.docs-redaction"]
+            assert docs_link_evidence["status"] == "warn", docs_link_evidence
+            assert docs_link_evidence["details"]["waived"] is True, docs_link_evidence
+            assert docs_link_evidence["details"]["redactionFindings"] == [], docs_link_evidence
+            assert {
+                "source": "docs/app-owned-ui.md",
+                "target": "missing-docs-only-link.md",
+                "reason": "missing",
+            } in docs_link_evidence["details"]["brokenLinks"], docs_link_evidence
+
+            portal_linked_doc.write_text(
+                original_portal_linked_doc
+                + "\nAuthorization: Bearer concrete-token-value\n",
+                encoding="utf-8",
+            )
+            waived_docs_redaction_summary, waived_docs_redaction_exit_code = run_with_previous(
+                "waived-docs-redaction-cert",
+                waivers={
+                    "app-platform.docs-redaction": (
+                        "Release manager attempted to waive a docs redaction finding."
+                    )
+                },
+            )
+            assert waived_docs_redaction_exit_code == 1, waived_docs_redaction_summary
+            assert (
+                waived_docs_redaction_summary["releaseCandidatePassed"] is False
+            ), waived_docs_redaction_summary
+            waived_docs_redaction_evidence = {
+                item["id"]: item for item in waived_docs_redaction_summary["evidence"]
+            }
+            docs_redaction_evidence = waived_docs_redaction_evidence[
+                "app-platform.docs-redaction"
+            ]
+            assert docs_redaction_evidence["status"] == "fail", docs_redaction_evidence
+            assert "waived" not in docs_redaction_evidence["details"], docs_redaction_evidence
+            assert {
+                "path": "docs/app-owned-ui.md",
+                "issue": "authorization-header",
+            } in docs_redaction_evidence["details"]["redactionFindings"], docs_redaction_evidence
+            docs_redaction_row = matrix_row_by_id(
+                workspace / "build/waived-docs-redaction-cert",
+                "app-platform-beta-docs-and-program",
+            )
+            assert docs_redaction_row["status"] == "fail", docs_redaction_row
+            assert docs_redaction_row["releaseBlocker"] is True, docs_redaction_row
+            assert "app-platform.docs-redaction" not in docs_redaction_row.get(
+                "waiverIds", []
+            ), docs_redaction_row
+            assert "Waiver recorded" not in docs_redaction_row["summary"], docs_redaction_row
+            assert docs_redaction_row["details"]["unwaivableRedactionEvidenceIds"] == [
+                "app-platform.docs-redaction"
+            ], docs_redaction_row
+            failed_report = (
+                workspace / "build/waived-docs-redaction-cert" / REPORT_FILE_NAME
+            ).read_text(encoding="utf-8")
+            assert "### `app-platform.docs-redaction`" in failed_report, failed_report
+            assert "redactionFindings" in failed_report, failed_report
+            assert "docs/app-owned-ui.md" in failed_report, failed_report
+        finally:
+            portal_linked_doc.write_text(original_portal_linked_doc, encoding="utf-8")
 
         unmapped_required_path = write_app_summary_variant(
             "unmapped-required-evidence",

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -1760,6 +1760,21 @@ def aggregate_status_values(values: list[str], *, missing_if_empty: bool = False
     return "pass"
 
 
+def unwaivable_matrix_issue_ids(unwaivable_evidence_ids: set[str]) -> set[str]:
+    unwaivable_issue_ids = set(unwaivable_evidence_ids)
+    unwaivable_issue_ids.update(
+        f"evidence.{evidence_id}" for evidence_id in unwaivable_evidence_ids
+    )
+    return unwaivable_issue_ids
+
+
+def waivable_matrix_issue_ids(
+    issue_ids: list[str], unwaivable_evidence_ids: set[str]
+) -> list[str]:
+    unwaivable_issue_ids = unwaivable_matrix_issue_ids(unwaivable_evidence_ids)
+    return [issue_id for issue_id in issue_ids if issue_id not in unwaivable_issue_ids]
+
+
 def row_waivers(
     spec: MatrixRowSpec,
     evidence_entries: dict[str, dict[str, Any]],
@@ -1770,6 +1785,8 @@ def row_waivers(
     unwaivable_evidence_ids: set[str],
 ) -> tuple[list[WaiverRecord], list[str]]:
     records: dict[str, WaiverRecord] = {}
+    unwaivable_issue_ids = unwaivable_matrix_issue_ids(unwaivable_evidence_ids)
+    waivable_issue_ids = waivable_matrix_issue_ids(issue_ids, unwaivable_evidence_ids)
     targets = [spec.id, *spec.evidence_ids(), *spec.all_gate_ids()]
     if unwaivable_evidence_ids:
         targets = [
@@ -1778,7 +1795,7 @@ def row_waivers(
             if target_id != spec.id and target_id not in unwaivable_evidence_ids
         ]
     for target_id in targets:
-        waiver = active_waiver_for(context, target_id, issue_ids, mode)
+        waiver = active_waiver_for(context, target_id, waivable_issue_ids, mode)
         if waiver is not None:
             records[waiver.id] = waiver
     for evidence_id in spec.evidence_ids():
@@ -1786,7 +1803,7 @@ def row_waivers(
             continue
         waiver_id = evidence_details(evidence_entries.get(evidence_id)).get("waiverId")
         if waiver_id:
-            waiver = active_waiver_for(context, str(waiver_id), issue_ids, mode)
+            waiver = active_waiver_for(context, str(waiver_id), waivable_issue_ids, mode)
             if waiver is not None:
                 records[waiver.id] = waiver
     for gate_id in spec.all_gate_ids():
@@ -1795,9 +1812,9 @@ def row_waivers(
         if isinstance(details, dict):
             waiver_id = details.get("waiverId")
             if waiver_id:
-                if str(waiver_id) in unwaivable_evidence_ids:
+                if str(waiver_id) in unwaivable_issue_ids:
                     continue
-                waiver = active_waiver_for(context, str(waiver_id), issue_ids, mode)
+                waiver = active_waiver_for(context, str(waiver_id), waivable_issue_ids, mode)
                 if waiver is not None:
                     records[waiver.id] = waiver
     waiver_ids = sorted(records)
@@ -1814,10 +1831,11 @@ def row_release_blocker_waiver(
 ) -> WaiverRecord | None:
     if unwaivable_evidence_ids.intersection(blocker_targets):
         return None
+    waivable_issue_ids = waivable_matrix_issue_ids(issue_ids, unwaivable_evidence_ids)
     return active_waiver_for(
         context,
         spec.id,
-        sorted(dict.fromkeys(issue_ids + blocker_targets)),
+        sorted(dict.fromkeys(waivable_issue_ids + blocker_targets)),
         mode,
     )
 
@@ -4711,7 +4729,10 @@ def run_self_test(repo_root: Path) -> None:
                 waivers={
                     "app-platform.docs-redaction": (
                         "Release manager attempted to waive a docs redaction finding."
-                    )
+                    ),
+                    "evidence.app-platform.docs-redaction": (
+                        "Release manager attempted to waive a docs redaction issue id."
+                    ),
                 },
             )
             assert waived_docs_redaction_exit_code == 1, waived_docs_redaction_summary
@@ -4739,7 +4760,13 @@ def run_self_test(repo_root: Path) -> None:
             assert "app-platform.docs-redaction" not in docs_redaction_row.get(
                 "waiverIds", []
             ), docs_redaction_row
+            assert "evidence.app-platform.docs-redaction" not in docs_redaction_row.get(
+                "waiverIds", []
+            ), docs_redaction_row
             assert "Waiver recorded" not in docs_redaction_row["summary"], docs_redaction_row
+            assert "waived" not in docs_redaction_row["recommendation"].lower(), (
+                docs_redaction_row
+            )
             assert docs_redaction_row["details"]["unwaivableRedactionEvidenceIds"] == [
                 "app-platform.docs-redaction"
             ], docs_redaction_row


### PR DESCRIPTION
## Summary

- Add the app platform beta developer portal, offline beta tutorials, known limitations, beta program/runbook, and GitHub issue templates for feedback and app submissions.
- Wire deterministic app-platform docs evidence into release certification, including required-doc coverage, portal/readme links, local Markdown link checks, issue-template checks, and redaction checks.
- Add ecosystem matrix coverage for docs/beta readiness and refresh related app-platform/release docs plus agent skills for the new evidence flow.
- Harden the docs redaction gate against sensitive paths, private insert URIs, tokens, form passwords, private key assignments, unsafe broken-link targets, and non-waivable docs-redaction waiver paths.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 tools/release-certification/app_platform_docs_check.py --self-test`
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/release-certification/release_certification.py --self-test`
- `PYTHONDONTWRITEBYTECODE=1 python3 tools/release-certification/app_platform_smoke.py --self-test`
- `./gradlew spotlessApply`
- `git diff --check`
- `git diff --staged --check`

Base branch: `develop`