### PR TITLE
feat(platform): Add live USK catalog publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ debhelper-build-stamp
 *.log
 *.log.gz
 /logs/
+__pycache__/
+*.py[cod]
 *.substvars
 /debian/freenet/*
 .gradle

--- a/README.md
+++ b/README.md
@@ -445,9 +445,13 @@ The app ecosystem beta is documented through
 the current Platform API contract version, first-party app map, offline beta tutorials, known
 limitations, beta feedback and app submission workflow, and release-manager closeout path.
 
-The beta is offline-first for developer tests and dry-run publication planning. It does not create
-a public production app store, does not auto-install recommended catalog apps, does not require
-public Crypta network access for tests, and does not change FNP, FCP, Hyphanet/Freenet
+The beta is offline-first for developer tests and dry-run publication planning. Release operators
+can publish a signed first-party catalog with `crypta-app publish-usk --live` when a localhost node,
+form password, trusted public catalog key, and private insert URI are supplied through secure
+configuration. That live workflow publishes `cryptad-app-catalog.properties` and the sibling
+`cryptad-app-catalog.signature` at the same USK edition and writes sanitized evidence. It does not
+create a public production app store, does not auto-install recommended catalog apps, does not
+require public Crypta network access for tests, and does not change FNP, FCP, Hyphanet/Freenet
 compatibility behavior, or retained FProxy browse behavior.
 
 ## Developer App CLI

--- a/docs/app-catalogs.md
+++ b/docs/app-catalogs.md
@@ -27,9 +27,10 @@ review evidence from a reviewer key that the local node trusts for app review. L
 `review.status` and `review.note` catalog metadata remains publisher-advisory only.
 
 For third-party app authors, `crypta-app catalog entry` can generate the descriptor input for
-`catalog create`, and `crypta-app publish-usk --dry-run` can produce an offline publication
-checklist for a signed catalog. Those helpers do not change the runtime trust layers described
-here; they only reduce hand-authored descriptor and publication-plan mistakes. See
+`catalog create`, `crypta-app publish-usk --dry-run` can produce an offline publication checklist,
+and `crypta-app publish-usk --live` can publish a verified signed catalog through a configured
+localhost node. Those helpers do not change the runtime trust layers described here; they only
+reduce hand-authored descriptor, publication-plan, and live-publication mistakes. See
 [developer-beta-toolkit.md](developer-beta-toolkit.md).
 
 ## Catalog files
@@ -522,9 +523,10 @@ Supported catalog sources:
   `cryptad-app-catalog.properties` bytes, and the `signature` companion CHK contains the matching
   `cryptad-app-catalog.signature` bytes.
 
-`crypta:` is a catalog transport, not a trust boundary. The catalog signature must still verify
-against a configured trusted catalog key. Install and update flows still verify the catalog entry's
-artifact size and SHA-256, then verify the extracted signed bundle before AppHost receives it.
+`crypta:` is a catalog transport, not a trust boundary. Signed catalog verification must still
+verify the catalog signature against a configured trusted catalog key. Install and update flows
+still verify the catalog entry's artifact size and SHA-256, then verify the extracted signed
+bundle before AppHost receives it.
 
 Catalog artifact URIs support:
 
@@ -537,6 +539,12 @@ Crypta app ZIP artifacts must use bare CHK keys. `crypta:USK@...`, `crypta:SSK@.
 and `?signature=...` companion queries are rejected for catalog entry artifacts. Mutable USK/SSK
 keys remain supported for catalog sidecars, where they point to signed catalog bytes and sibling
 signature sidecars.
+
+For live USK catalog publication, publish `cryptad-app-catalog.properties` as the public
+`crypta:USK@.../cryptad-app-catalog.properties` source and publish
+`cryptad-app-catalog.signature` as the sibling at the same USK path and edition. When refresh
+resolves a newer USK edition, Cryptad fetches the matching sibling signature sidecar from that
+resolved edition and stores the replacement only after signed catalog verification succeeds.
 
 `crypta:CHK@...` is a transport location, not a trust boundary. The runtime fetches those bytes
 through `ContentFetchPort`, enforces the declared `bundle.size.bytes` and catalog artifact cap, and
@@ -567,7 +575,8 @@ Recommended catalog configuration:
 | `cryptad.firstPartyCatalog.enabled` | `CRYPTAD_FIRST_PARTY_CATALOG_ENABLED` | Set to `false` to hide the recommendation. |
 | `cryptad.firstPartyCatalog.id` | `CRYPTAD_FIRST_PARTY_CATALOG_ID` | Expected signed catalog id. Defaults to `crypta-first-party-beta`. |
 | `cryptad.firstPartyCatalog.source` | `CRYPTAD_FIRST_PARTY_CATALOG_SOURCE` | Source URI for `cryptad-app-catalog.properties`, usually `crypta:USK@.../cryptad-app-catalog.properties`. |
-| `cryptad.firstPartyCatalog.trustedCatalogKeyId` | `CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_KEY_ID` | Trusted catalog signing key id that must be present in the normal AppHost trusted-key registry. |
+| `cryptad.firstPartyCatalog.trustedCatalogKeyId` | `CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_CATALOG_KEY_ID` | Trusted catalog signing key id that must be present in the normal AppHost trusted-key registry. |
+| `cryptad.firstPartyCatalog.trustedKeyId` | `CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_KEY_ID` | Legacy trusted-key id alias, retained for older packaging. |
 | `cryptad.firstPartyCatalog.reviewerPolicyHint` | `CRYPTAD_FIRST_PARTY_CATALOG_REVIEWER_POLICY_HINT` | Optional display hint for the review policy used by the catalog. |
 
 The first-party beta catalog is expected to contain the current first-party apps:

--- a/docs/app-dev-cli.md
+++ b/docs/app-dev-cli.md
@@ -19,9 +19,10 @@ First-party repo apps can keep using their existing Gradle tasks. See
 [First-party Gradle workflow](#first-party-gradle-workflow).
 
 For the beta sidecar workflow, including `init --template queue-dashboard`, the mock development
-server, strict beta test wrapper, local key generation, and `publish-usk --dry-run`, see
-[developer-beta-toolkit.md](developer-beta-toolkit.md). For the full beta portal and submission
-path, see [app-platform-developer-portal.md](app-platform-developer-portal.md).
+server, strict beta test wrapper, local key generation, `publish-usk --dry-run`, and the explicit
+`publish-usk --live` release/operator path, see [developer-beta-toolkit.md](developer-beta-toolkit.md).
+For the full beta portal and submission path, see
+[app-platform-developer-portal.md](app-platform-developer-portal.md).
 
 ## Build and run the command
 
@@ -610,7 +611,7 @@ review keys outside the repository.
 3. Write catalog descriptors whose public artifact location is the returned CHK:
 
    ```properties
-   artifact.path=/abs/path/to/queue-manager.zip
+   artifact.path=<path-to-queue-manager.zip>
    bundle.uri=crypta:CHK@...
    summary=Manage local Crypta transfer queues.
    name=Queue Manager
@@ -623,12 +624,19 @@ review keys outside the repository.
    ```
 
 4. Create, sign, and verify the catalog with `crypta-app catalog create`, `crypta-app catalog
-   sign`, and `crypta-app catalog verify`. Publish both `cryptad-app-catalog.properties` and
-   `cryptad-app-catalog.signature` to the configured catalog USK.
+   sign`, and `crypta-app catalog verify`. Run `crypta-app publish-usk --dry-run` for the
+   deterministic plan, then use `crypta-app publish-usk --live` from the release/operator
+   environment to publish `cryptad-app-catalog.properties` and the sibling
+   `cryptad-app-catalog.signature` at the same USK edition. The private insert URI must be the
+   matching private USK directory insert URI for the configured public source parent. The CLI
+   retains the staged public sidecars until the live queue has consumed them and records only a
+   path-free warning in the summary; `--verify-live-fetch` verifies the currently fetchable public
+   bytes, but it does not authorize deleting disk-backed staging.
 
 5. Configure runtime onboarding with `CRYPTAD_FIRST_PARTY_CATALOG_SOURCE` and
-   `CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_KEY_ID`, plus the normal `CRYPTAD_APPHOST_*` trusted public
-   key settings. Operators add the catalog through Web Shell or
+   `CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_CATALOG_KEY_ID`, plus the normal `CRYPTAD_APPHOST_*`
+   trusted public key settings. The legacy `CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_KEY_ID` alias is
+   still accepted for older packaging. Operators add the catalog through Web Shell or
    `POST /api/v1/app-catalogs/recommended/crypta-first-party-beta/add`; apps are not installed
    until the operator confirms an install/update for each entry.
 

--- a/docs/app-platform-beta-known-limitations.md
+++ b/docs/app-platform-beta-known-limitations.md
@@ -7,8 +7,9 @@ This page records conservative limits and safety boundaries for the Crypta app e
 - This is an app ecosystem beta, not a public production app store.
 - First-party beta catalog support does not imply automatic app installation.
 - Recommended catalog metadata is an onboarding hint, not ranking, endorsement, or trust by itself.
-- Developer tooling supports offline and dry-run publication planning. Live insertion depends on
-  existing content and queue mechanisms plus the operator's deployment configuration.
+- Developer tooling supports offline and dry-run publication planning. Explicit live USK
+  publication depends on existing content and queue mechanisms plus the operator's localhost node
+  and secure private insert URI configuration.
 - `crypta-app dev`, `crypta-app test`, release self-tests, and docs certification do not depend on
   the public Crypta network.
 - The beta does not require Docker, Node.js, npm, external network access, signing secrets, or

--- a/docs/app-platform-beta-program.md
+++ b/docs/app-platform-beta-program.md
@@ -11,6 +11,7 @@ reproducible app flow:
 ```text
 scaffold app -> run mock dev server -> run offline tests -> sign bundle -> pack artifact
 -> create catalog entry -> create/sign/verify catalog -> produce dry-run USK publication plan
+-> optionally run explicit live USK publication from the release/operator environment
 -> review submission -> certify release readiness
 ```
 

--- a/docs/app-platform-beta-tutorials.md
+++ b/docs/app-platform-beta-tutorials.md
@@ -199,7 +199,26 @@ Write an offline Crypta USK publication plan:
 
 `crypta-app publish-usk --dry-run` writes a plan. It does not insert catalog bytes, signature
 bytes, or app ZIP artifacts into the public Crypta network. Live insertion remains a separate
-reviewed publishing workflow that uses the existing content and queue mechanisms.
+reviewed release/operator workflow that uses the existing content and queue mechanisms:
+
+```bash
+"$CRYPTA_APP" publish-usk --live \
+  --catalog-file dist/catalog/cryptad-app-catalog.properties \
+  --catalog-signature-file dist/catalog/cryptad-app-catalog.signature \
+  --catalog-source "crypta:USK@.../cryptad-app-catalog.properties" \
+  --private-insert-uri-env CRYPTAD_FIRST_PARTY_CATALOG_INSERT_URI \
+  --node-base-url http://127.0.0.1:8888/api/v1 \
+  --form-password-env CRYPTAD_CERT_FORM_PASSWORD \
+  --trusted-key-id dev-local-catalog \
+  --trusted-public-key-file "$HOME/.crypta-dev/keys/dev-local-catalog-public.der" \
+  --output dist/catalog/live-publication-summary.json
+```
+
+The live command verifies the signed catalog locally before insertion. It publishes
+`cryptad-app-catalog.signature` as the sibling sidecar at the same USK edition as
+`cryptad-app-catalog.properties`, and its output is sanitized for release evidence. Keep the
+private insert URI, form password, and private signing keys out of shell history, logs, and
+uploaded artifacts.
 
 ## Tutorial 4: reference app map
 

--- a/docs/app-platform-developer-portal.md
+++ b/docs/app-platform-developer-portal.md
@@ -103,6 +103,7 @@ Then follow this path:
 | Create a catalog entry descriptor | `crypta-app catalog entry` |
 | Create, sign, and verify a catalog | `crypta-app catalog create`, `crypta-app catalog sign`, `crypta-app catalog verify` |
 | Produce an offline USK publication plan | `crypta-app publish-usk --dry-run` |
+| Publish a signed catalog to a live USK | `crypta-app publish-usk --live` from the release/operator environment |
 | Submit app proposal or beta feedback | [app-platform-beta-program.md](app-platform-beta-program.md) |
 
 `crypta-app dev` is loopback-only by default and serves a mock Platform API. It does not install

--- a/docs/app-update-lifecycle.md
+++ b/docs/app-update-lifecycle.md
@@ -19,11 +19,16 @@ The v1 policy is:
 | Roll back | A successful update records the previous installed bundle as the durable rollback target. If replacement cannot complete, AppHost restores the previous bundle from a managed backup. | `app-update.rollback` |
 
 Silent automatic update is not the default. The background scheduler can refresh configured signed
-catalogs and discover candidates, and catalog refresh preserves the last verified catalog when a
-later refresh fails. Scheduler-triggered app checks delegate to `AppUpdateService.check(...)`.
-Applying an update still requires an operator or explicit API caller unless the operator selected a
-policy mode that allows automatic staging or apply. Manual remains the default policy for every
-app.
+catalogs, including a live USK catalog source such as
+`crypta:USK@.../cryptad-app-catalog.properties`, and discover candidates. Catalog refresh
+preserves the last verified catalog when a later refresh fails. Scheduler-triggered app checks
+delegate to `AppUpdateService.check(...)`. Applying an update requires an operator or explicit API
+caller unless the operator selected a policy mode that allows automatic staging or apply. Manual
+remains the default policy for every app.
+
+For release evidence, manual remains the default.
+Applying an update requires an operator or explicit API caller.
+This remains true when the scheduler refreshes a live USK catalog before candidate discovery.
 
 The update summary exposes scheduler state for clients. Scheduler summaries include enabled,
 status, last check, next check, last result, last failure, failure count, and sanitized error code

--- a/docs/cryptad-release-workflow-and-runbook.md
+++ b/docs/cryptad-release-workflow-and-runbook.md
@@ -79,7 +79,11 @@ Treat these as release blockers, in order:
 4. **First-party app signing and verification** - sign with the intended release or staging key inputs, then verify with the matching trusted public key inputs. Gate promotion on successful `./gradlew signFirstPartyApps` and `./gradlew verifyFirstPartyApps` runs. Keep private signing keys outside the repository.
 5. **App catalog smoke, when catalog sources ship** - verify each signed catalog source refreshes,
    validates artifact size/SHA-256, extracts safely, and can install or update through
-   `/api/v1/app-catalogs`. The catalog contract is documented in
+   `/api/v1/app-catalogs`. For first-party live USK catalog publication, verify the report includes
+   `catalog.live-usk-publication` and `catalog.live-usk-source-verification`; the public source is
+   `crypta:USK@.../cryptad-app-catalog.properties`, and
+   `cryptad-app-catalog.signature` is the sibling at the same USK edition. The catalog contract is
+   documented in
    [app-catalogs.md](app-catalogs.md).
 6. **Developer app CLI smoke, when `:platform-devtools` changes** - run
    `./gradlew :platform-devtools:test` and `./gradlew :platform-devtools:installDist`, then verify
@@ -131,9 +135,10 @@ Treat these as release blockers, in order:
    and token/path-free public status. Manual Linux smoke with host-installed `bwrap` is useful
    release-manager evidence when sandbox behavior changed.
 11. **App update lifecycle evidence** - verify the release certification report includes
-   `app-update.lifecycle`, `app-update.scheduler`, and `app-update.rollback`. The required offline
-   evidence must cover manual/stage/apply-when-stopped policy behavior, background catalog refresh
-   and app checks through the shared update service, path-free staged and scheduler summaries,
+   `app-update.lifecycle`, `app-update.scheduler`, `app-update.live-catalog-refresh`, and
+   `app-update.rollback`. The required offline evidence must cover manual/stage/apply-when-stopped
+   policy behavior, background catalog refresh and app checks through the shared update service,
+   live USK catalog refresh before candidate discovery, path-free staged and scheduler summaries,
    process health-gated apply, durable previous-bundle rollback, and the rule that rollback does
    not restore app data or cache. Optional live smoke may exercise install/update/rollback through
    localhost routes, but normal release-candidate evidence must not require a live node.

--- a/docs/developer-beta-toolkit.md
+++ b/docs/developer-beta-toolkit.md
@@ -329,11 +329,36 @@ as a plan and validation step: it should confirm which files would be published,
 would be used, which public source URI operators would add, and whether the catalog and signature
 sidecar files are present and parse.
 
-Live insertion is different. A live publish uses an insert-capable key, contacts a real daemon or
-publishing transport, consumes network resources, and may make the catalog source discoverable to
-anyone who knows the corresponding public URI. Do not run live insertion with private insert URIs
-or production keys in logs, shell history, CI summaries, review evidence, or release-certification
-artifacts.
+Live insertion is different. A live publish uses an insert-capable key, contacts a real localhost
+daemon, consumes network resources, and may make the catalog source discoverable to anyone who
+knows the corresponding public URI. The release/operator form is explicit:
+
+```bash
+crypta-app publish-usk --live \
+  --catalog-file dist/catalog/cryptad-app-catalog.properties \
+  --catalog-signature-file dist/catalog/cryptad-app-catalog.signature \
+  --catalog-source "crypta:USK@.../apps/dev-queue-dashboard/cryptad-app-catalog.properties" \
+  --private-insert-uri-env CRYPTAD_FIRST_PARTY_CATALOG_INSERT_URI \
+  --node-base-url http://127.0.0.1:8888/api/v1 \
+  --form-password-env CRYPTAD_CERT_FORM_PASSWORD \
+  --trusted-keys-file "$HOME/.crypta-dev/keys/trusted-app-keys.properties" \
+  --output dist/catalog/live-publication-summary.json
+```
+
+The private insert URI and form password must come from an environment variable or protected file,
+not from a positional argument. Live mode publishes `cryptad-app-catalog.properties` and the
+`cryptad-app-catalog.signature` sibling at the same USK path and edition, then writes a sanitized
+summary. The summary may include the public `crypta:USK@.../cryptad-app-catalog.properties`
+source, digest values, catalog id, signing key id, and queue status, but it must not include private
+insert URIs, private keys, form passwords, tokens, raw request bodies, or absolute staging paths.
+The private insert URI must be the matching private USK directory insert URI for the configured
+public source parent. For example,
+`crypta:USK@PUBLIC.../catalog/42/cryptad-app-catalog.properties` is inserted from the secure
+private USK root for the same `catalog/42` parent path, supplied only through the env/file option.
+Because the queue insert path reads staged disk files after the request is queued, the CLI retains
+the two public sidecar files until the live insert has finished consuming them. `--verify-live-fetch`
+proves the currently fetched public catalog and signature match the local signed files, but it is not
+treated as proof that the queued insert has consumed the staged directory.
 
 ## Runtime trust model
 

--- a/docs/first-party-beta-catalog.md
+++ b/docs/first-party-beta-catalog.md
@@ -13,8 +13,9 @@ SHA-256 checks, Platform API compatibility metadata, sandbox metadata, and permi
 separate layers.
 
 The third-party developer beta toolkit extends the standalone CLI with scaffold templates, a mock
-dev server, offline app tests, catalog entry generation, and a dry-run USK publication checklist.
-It does not replace this first-party beta catalog flow or its release gates. See
+dev server, offline app tests, catalog entry generation, a dry-run USK publication checklist, and
+an explicit live USK publication command for release operators. It does not replace this
+first-party beta catalog flow or its release gates. See
 [developer-beta-toolkit.md](developer-beta-toolkit.md) for the app-author workflow.
 
 `crypta:` transport is not a trust boundary. Crypta-hosted catalog and bundle artifacts still must
@@ -35,7 +36,8 @@ Set the recommended catalog source and trusted key hint in runtime or packaging 
 | `cryptad.firstPartyCatalog.enabled` | `CRYPTAD_FIRST_PARTY_CATALOG_ENABLED` | `true` |
 | `cryptad.firstPartyCatalog.id` | `CRYPTAD_FIRST_PARTY_CATALOG_ID` | `crypta-first-party-beta` |
 | `cryptad.firstPartyCatalog.source` | `CRYPTAD_FIRST_PARTY_CATALOG_SOURCE` | `crypta:USK@.../cryptad-app-catalog.properties` |
-| `cryptad.firstPartyCatalog.trustedCatalogKeyId` | `CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_KEY_ID` | `crypta-first-party-beta` |
+| `cryptad.firstPartyCatalog.trustedCatalogKeyId` | `CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_CATALOG_KEY_ID` | `crypta-first-party-beta` |
+| `cryptad.firstPartyCatalog.trustedKeyId` | `CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_KEY_ID` | Legacy trusted-key id alias, retained for older packaging. |
 | `cryptad.firstPartyCatalog.reviewerPolicyHint` | `CRYPTAD_FIRST_PARTY_CATALOG_REVIEWER_POLICY_HINT` | `crypta-app-review-v1` |
 
 The trusted key id hint must correspond to a public catalog/app signing key configured through the
@@ -182,27 +184,73 @@ platform-devtools/build/install/crypta-app/bin/crypta-app catalog verify \
   --trusted-public-key-file /abs/path/outside/repo/catalog-signing-public.pem
 ```
 
-Publish `cryptad-app-catalog.properties` and `cryptad-app-catalog.signature` to the public Crypta
-catalog location, usually a USK whose latest edition keeps the same sibling sidecar names. The
+Validate the release publication plan first:
+
+```bash
+platform-devtools/build/install/crypta-app/bin/crypta-app publish-usk --dry-run \
+  --catalog-file build/first-party-beta-catalog/cryptad-app-catalog.properties \
+  --catalog-signature-file build/first-party-beta-catalog/cryptad-app-catalog.signature \
+  --catalog-source "crypta:USK@.../cryptad-app-catalog.properties" \
+  --output build/first-party-beta-catalog/publication-plan.md
+```
+
+Publish `cryptad-app-catalog.properties` and `cryptad-app-catalog.signature` to the public live USK
+catalog location with explicit live mode:
+
+```bash
+platform-devtools/build/install/crypta-app/bin/crypta-app publish-usk --live \
+  --catalog-file build/first-party-beta-catalog/cryptad-app-catalog.properties \
+  --catalog-signature-file build/first-party-beta-catalog/cryptad-app-catalog.signature \
+  --catalog-source "crypta:USK@.../cryptad-app-catalog.properties" \
+  --private-insert-uri-env CRYPTAD_FIRST_PARTY_CATALOG_INSERT_URI \
+  --node-base-url http://127.0.0.1:8888/api/v1 \
+  --form-password-env CRYPTAD_CERT_FORM_PASSWORD \
+  --trusted-key-id crypta-first-party-beta \
+  --trusted-public-key-file "$CRYPTAD_CATALOG_SIGNING_PUBLIC_KEY_FILE" \
+  --output build/first-party-beta-catalog/live-publication-summary.json
+```
+
+The public catalog source is a USK whose latest edition keeps the same sibling sidecar names. The
 operator-facing source becomes:
 
 ```text
 crypta:USK@.../cryptad-app-catalog.properties
 ```
 
+The signature sidecar is `cryptad-app-catalog.signature` at the same USK path and edition. Signed
+catalog verification remains mandatory; live publication only changes the transport location for
+the signed sidecars. Bundle artifacts in catalog entries should remain immutable
+`crypta:CHK@...` ZIP URIs with declared size and SHA-256 values.
+
+The live queue endpoint registers a disk-backed directory insert. The private insert URI must be the
+matching private USK directory insert URI for the configured public source parent. For example,
+`crypta:USK@PUBLIC.../catalog/42/cryptad-app-catalog.properties` is inserted from the secure
+private USK root for the same `catalog/42` parent path, supplied only through the env/file option.
+`crypta-app publish-usk --live` leaves the staged public catalog and signature sidecars in place
+until the queued insert has finished consuming them; the sanitized summary records only a path-free
+retention warning. With `--verify-live-fetch`, the CLI fetches both sidecars from the public source
+and verifies that the currently fetched bytes match the signed local files, but it still retains the
+staged directory because an identical pre-existing public edition does not prove that the new queued
+insert has consumed its source files.
+
 Generated ZIPs, descriptors, signed catalog files, and release working files belong under `build/`
-or `dist/`. Do not check generated signed production catalogs or private keys into the repository.
+or `dist/`. Do not check generated signed production catalogs, private signing keys, reviewer
+private keys, private insert URIs, form passwords, tokens, raw request bodies, or raw catalog
+private insertion material into the repository or uploaded release artifacts.
 
 ## Certification evidence
 
-Release certification records `app-catalog.first-party-beta` plus app-review governance evidence
-such as `app-review.governance`, `app-review.reviewer-key-lifecycle`,
+Release certification records `catalog.live-usk-publication`,
+`catalog.live-usk-source-verification`, `app-update.live-catalog-refresh`,
+`app-catalog.first-party-beta`, plus app-review governance evidence such as
+`app-review.governance`, `app-review.reviewer-key-lifecycle`,
 `app-review.transparency-log`, `app-review.review-history-api`, and
 `app-review.first-party-review-chain`. The evidence is deterministic and offline: it checks for the
-recommended descriptor, API/Web Shell onboarding, Crypta CHK artifact transport tests,
-first-party metadata documentation, governed reviewer-key parsing, transparency-log verification,
-review-history routing, and whether the certification environment has source and key hints
-configured. Profile Publisher is also covered by
+recommended descriptor, live USK publication code path, sibling signature verification for resolved
+USK editions, scheduler catalog refresh before candidate discovery, API/Web Shell onboarding,
+Crypta CHK artifact transport tests, first-party metadata documentation, governed reviewer-key
+parsing, transparency-log verification, review-history routing, and whether the certification
+environment has source and key hints configured. Profile Publisher is also covered by
 `reference-app.profile-publisher`, `app-platform.identity-profile-publish`, and
 `app-platform.generated-document-insert`. Feed Reader is covered by `reference-app.feed-reader`
 and `app-platform.content-fetch`. Trust Graph Preview is covered by

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -102,13 +102,15 @@ Release-candidate mode requires these evidence ids:
 | `performance.smoke` | `build/perf-smoke/summary.json` | Performance smoke did not fail required metrics or deterministic regression thresholds. |
 | `app-platform.first-party` | App-platform smoke summary. | The first-party staged apps, including Queue Manager, Publisher, Site Publisher, Profile Publisher, Feed Reader, and Trust Graph Preview, have valid manifests, launchers, static UI assets, and SDK wiring. |
 | `app-platform.devtools-cli` | App-platform smoke summary. | `crypta-app init`, `validate`, and `pack` work for a generated sample app. |
-| `app-platform.developer-beta-toolkit` | App-platform smoke summary. | Developer beta toolkit command, template, mock-dev, offline-test, catalog entry, dry-run publication, docs, and self-test evidence is present. |
+| `app-platform.developer-beta-toolkit` | App-platform smoke summary. | Developer beta toolkit command, template, mock-dev, offline-test, catalog entry, dry-run publication, live publication CLI wiring, docs, and self-test evidence is present. |
 | `app-platform.docs-portal` | App-platform docs check. | The developer portal, required docs, known limitations page, portal links, and README portal link are present. |
 | `app-platform.beta-program` | App-platform docs check. | The beta program doc and app platform beta feedback/submission issue templates are present. |
 | `app-platform.beta-tutorials` | App-platform docs check. | Offline beta tutorials cover the required `crypta-app` commands, first-party app map, Platform API capabilities, review governance, update/rollback, and retained FProxy browse concepts. |
 | `app-platform.docs-redaction` | App-platform docs check. | Local Markdown links resolve without network access, and docs/templates pass obvious secret, token, private key, cookie, form-password, and local-path redaction checks. |
 | `app-platform.signed-bundles` | App-platform smoke summary. | First-party and sample bundle signing/verification evidence exists with configured non-production or release signing inputs. |
 | `catalog.smoke` | App-platform smoke summary. | Signed catalog create/sign/verify evidence exists and records digest, catalog id, and app id without private key material. |
+| `catalog.live-usk-publication` | App-platform smoke summary. | `crypta-app publish-usk --live` validates and verifies signed catalog sidecars, reads the private insert URI and form password only from secure sources, enqueues real localhost live insertion, and writes sanitized evidence. |
+| `catalog.live-usk-source-verification` | App-platform smoke summary. | `crypta:USK@.../cryptad-app-catalog.properties` refresh resolves matching editions, fetches `cryptad-app-catalog.signature` from the same USK edition, and stores replacements only after signed catalog verification. |
 | `app-catalog.first-party-beta` | App-platform smoke summary. | Recommended first-party beta catalog descriptor, Platform API/Web Shell onboarding, CHK artifact transport tests, first-party metadata docs, and configuration readiness reporting are present without a live public-network fetch. |
 | `app-review.governance` | App-platform smoke summary. | Reviewer-key lifecycle statuses, policy-version constraints, governance API routes, and Web Shell governance rendering are present and redacted. |
 | `app-review.reviewer-key-lifecycle` | App-platform smoke summary. | Trusted reviewer registry v2 parsing, active/retired/revoked semantics, duplicate-id fail-closed behavior, strict instants, and lifecycle verifier tests are present. |
@@ -123,6 +125,7 @@ Release-candidate mode requires these evidence ids:
 | `app-platform.trust-graph-preview` | App-platform smoke summary. | The v7 trust graph routes are present, documented, capability-gated by `trust.read` and `trust.write`, SDK trust helpers exist, and evidence is redacted. |
 | `app-platform.trust-statement-signing` | App-platform smoke summary. | The bounded AppVault route `POST /api/v1/app-vault/identities/{identityId}/trust-statement` is present, documented, requires `trust.write`, `vault.identities.read`, and `vault.identities.use`, and does not expose private material in evidence. |
 | `app-ui.design-system` | App-platform smoke summary. | Canonical app UI design-system assets exist and first-party staged bundles contain matching local copies. |
+| `app-update.live-catalog-refresh` | App-platform smoke summary. | App-update scheduler evidence shows configured signed catalog refresh, including live USK catalog refresh, before candidate discovery while keeping manual update policy as the default. |
 | `app-ui.lint` | App-platform smoke summary. | `crypta-app ui lint --strict --json` passed for first-party staged static UI bundles and produced sanitized path-free summaries. |
 | `app-ui.first-party-adoption` | App-platform smoke summary. | First-party source/staged UIs load design-system CSS in order, use stable `cr-*` classes, and show permission disclosure for declared permissions across the repo-owned static apps. |
 | `app-ui.smoke` | App-platform smoke summary. | First-party static UI and `crypta-platform.js` remain coherent and do not expose process-token names. |
@@ -163,15 +166,23 @@ diagnostics scope metadata stays bounded and redacted.
 `interop.extended` is optional in the machine gate but required by the release runbook when a
 release changes compatibility-sensitive behavior. `apphost.sandbox-provider` does not require
 host-installed bubblewrap in normal CI; it uses source checks and fake/offline provider tests.
-`app-update.lifecycle`, `app-update.scheduler`, and `app-update.rollback` do not require a live
-node; missing update evidence blocks release-candidate mode unless a release-manager waiver is
-recorded. `apphost.live` is optional stronger evidence because normal PR and scheduled CI must not
-require a live local node or operator form password.
+`app-update.lifecycle`, `app-update.scheduler`, `app-update.live-catalog-refresh`, and
+`app-update.rollback` do not require a live node; missing update evidence blocks
+release-candidate mode unless a release-manager waiver is recorded. `apphost.live` is optional
+stronger evidence because normal PR and scheduled CI must not require a live local node or operator
+form password.
 
 `app-catalog.first-party-beta` reports whether `CRYPTAD_FIRST_PARTY_CATALOG_SOURCE` and the trusted
 catalog key hints are configured in the certification environment, but it does not fetch a public
 Crypta catalog during normal tests. It uses source checks, documentation checks, and deterministic
 `platform-appcatalog` tests for `crypta:CHK@` artifact support.
+
+`catalog.live-usk-publication` and `catalog.live-usk-source-verification` are offline source
+evidence by default. They prove live publication support, redaction behavior, same USK sibling
+signature handling, and signed catalog verification for resolved USK editions. Optional live
+publication smoke may be run only against a localhost node with secrets supplied through environment
+variables or protected files; certification output must not include private insert URIs, form
+passwords, tokens, raw request bodies, private keys, or absolute staging paths.
 
 `app-platform.docs-portal`, `app-platform.beta-program`,
 `app-platform.beta-tutorials`, and `app-platform.docs-redaction` are deterministic local docs

--- a/platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateSchedulerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateSchedulerTest.java
@@ -52,6 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -124,6 +125,10 @@ class AppUpdateSchedulerTest {
     assertEquals(1, result.catalogsAttempted());
     assertEquals(1, result.appsChecked());
     verify(catalogManager).refresh(CATALOG_ID);
+    var inOrder = inOrder(catalogManager, updateService);
+    inOrder.verify(catalogManager).listCatalogs();
+    inOrder.verify(catalogManager).refresh(CATALOG_ID);
+    inOrder.verify(updateService).check(APP_ID, false);
     verify(updateService).check(APP_ID, false);
     Map<String, Object> summary = scheduler.summary(APP_ID);
     assertEquals(true, summary.get("enabled"));

--- a/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
+++ b/platform-appcatalog/src/test/java/network/crypta/platform/appcatalog/AppCatalogManagerTest.java
@@ -475,6 +475,76 @@ class AppCatalogManagerTest {
   }
 
   @Test
+  void fetch_whenCryptaResolvedCatalogHasSchemePrefix_expectSignatureFetchedFromResolvedEdition()
+      throws Exception {
+    byte[] catalogBytes = BASIC_CATALOG_PROPERTIES.getBytes(StandardCharsets.UTF_8);
+    byte[] signatureBytes = BASIC_CATALOG_SIGNATURE.getBytes(StandardCharsets.UTF_8);
+    String requestedCatalogKey = "USK@example/catalog/latest/cryptad-app-catalog.properties";
+    String resolvedCatalogKey = "crypta:USK@example/catalog/42/cryptad-app-catalog.properties";
+    String resolvedSignatureKey = "USK@example/catalog/42/cryptad-app-catalog.signature";
+    FakeContentFetchPort contentFetchPort =
+        new FakeContentFetchPort(
+            Map.of(requestedCatalogKey, catalogBytes, resolvedSignatureKey, signatureBytes),
+            Map.of(requestedCatalogKey, resolvedCatalogKey));
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(
+            new FixedResponseHttpClient(new IOException(UNEXPECTED_HTTP_FETCH)), contentFetchPort);
+    AppCatalogSource source = AppCatalogSource.parse("crypta:" + requestedCatalogKey);
+
+    FetchedCatalog fetched = fetcher.fetch(source);
+
+    assertEquals(
+        List.of(requestedCatalogKey, resolvedSignatureKey), contentFetchPort.requestedKeys());
+    org.junit.jupiter.api.Assertions.assertArrayEquals(catalogBytes, fetched.catalogBytes());
+    org.junit.jupiter.api.Assertions.assertArrayEquals(signatureBytes, fetched.signatureBytes());
+    assertEquals(Optional.of(resolvedCatalogKey), fetched.resolvedCatalogUri());
+  }
+
+  @Test
+  void fetch_whenCryptaResolvedCatalogChangesKeyKind_expectInvalidCatalogSource() {
+    byte[] catalogBytes = BASIC_CATALOG_PROPERTIES.getBytes(StandardCharsets.UTF_8);
+    String requestedCatalogKey = "USK@example/catalog/latest/cryptad-app-catalog.properties";
+    FakeContentFetchPort contentFetchPort =
+        new FakeContentFetchPort(
+            Map.of(requestedCatalogKey, catalogBytes),
+            Map.of(requestedCatalogKey, "SSK@example/catalog/42/cryptad-app-catalog.properties"));
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(
+            new FixedResponseHttpClient(new IOException(UNEXPECTED_HTTP_FETCH)), contentFetchPort);
+    AppCatalogSource source = AppCatalogSource.parse("crypta:" + requestedCatalogKey);
+
+    AppCatalogException exception =
+        assertThrows(AppCatalogException.class, () -> fetcher.fetch(source));
+
+    assertEquals(AppCatalogSidecars.INVALID_CATALOG_SOURCE, exception.errorCode());
+    assertEquals(List.of(requestedCatalogKey), contentFetchPort.requestedKeys());
+  }
+
+  @Test
+  void fetch_whenCryptaSourceUsesContentFetchPort_expectBoundedRequests() throws Exception {
+    byte[] catalogBytes = BASIC_CATALOG_PROPERTIES.getBytes(StandardCharsets.UTF_8);
+    byte[] signatureBytes = BASIC_CATALOG_SIGNATURE.getBytes(StandardCharsets.UTF_8);
+    FakeContentFetchPort contentFetchPort =
+        new FakeContentFetchPort(
+            Map.of(CRYPTA_CATALOG_KEY, catalogBytes, CRYPTA_SIGNATURE_KEY, signatureBytes));
+    AppCatalogFetcher fetcher =
+        new AppCatalogFetcher(
+            new FixedResponseHttpClient(new IOException(UNEXPECTED_HTTP_FETCH)), contentFetchPort);
+    AppCatalogSource source = AppCatalogSource.parse(CRYPTA_CATALOG_SOURCE);
+
+    fetcher.fetch(source);
+
+    List<BoundedContentFetchRequest> requests = contentFetchPort.requests();
+    assertEquals(2, requests.size());
+    assertEquals("catalog properties", requests.getFirst().purpose());
+    assertEquals(AppCatalogSidecars.MAX_CATALOG_BYTES, requests.get(0).maxBytes());
+    assertTrue(requests.get(0).timeout().compareTo(Duration.ZERO) > 0);
+    assertEquals("catalog signature", requests.get(1).purpose());
+    assertEquals(AppCatalogSidecars.MAX_SIGNATURE_BYTES, requests.get(1).maxBytes());
+    assertTrue(requests.get(1).timeout().compareTo(Duration.ZERO) > 0);
+  }
+
+  @Test
   void fetch_whenCryptaRuntimeIsUnavailable_expectCatalogFetchUnavailable() {
     AppCatalogFetcher fetcher =
         new AppCatalogFetcher(
@@ -1424,6 +1494,8 @@ class AppCatalogManagerTest {
     private final Map<String, byte[]> content = new java.util.LinkedHashMap<>();
     private final Map<String, String> resolvedUris = new java.util.LinkedHashMap<>();
     private final java.util.ArrayList<String> requestedKeys = new java.util.ArrayList<>();
+    private final java.util.ArrayList<BoundedContentFetchRequest> requests =
+        new java.util.ArrayList<>();
     private ContentFetchException failure;
 
     private FakeContentFetchPort(Map<String, byte[]> content) {
@@ -1437,6 +1509,7 @@ class AppCatalogManagerTest {
     @Override
     public BoundedContentFetchResult fetchContent(BoundedContentFetchRequest request)
         throws ContentFetchException {
+      requests.add(request);
       requestedKeys.add(request.uri());
       if (failure != null) {
         throw failure;
@@ -1470,10 +1543,15 @@ class AppCatalogManagerTest {
       this.resolvedUris.putAll(resolvedUris);
       failure = null;
       requestedKeys.clear();
+      requests.clear();
     }
 
     private List<String> requestedKeys() {
       return List.copyOf(requestedKeys);
+    }
+
+    private List<BoundedContentFetchRequest> requests() {
+      return List.copyOf(requests);
     }
   }
 

--- a/platform-devtools/build.gradle.kts
+++ b/platform-devtools/build.gradle.kts
@@ -9,6 +9,7 @@ version = rootProject.version
 val mainSourceSet = sourceSets.named("main")
 
 dependencies {
+  implementation(project(":foundation-crypto-keys"))
   implementation(project(":platform-design-system"))
   implementation(project(":platform-api")) { isTransitive = false }
   implementation(project(":platform-app-ui")) { isTransitive = false }

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/CryptaAppCli.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/CryptaAppCli.java
@@ -2,11 +2,13 @@ package network.crypta.platform.devtools;
 
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -20,6 +22,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 import network.crypta.platform.api.PlatformApiContract;
 import network.crypta.platform.api.PlatformApiContractJson;
 import network.crypta.platform.api.PlatformApiContractVerifier.CompatibilityFinding;
@@ -96,6 +99,9 @@ import picocli.CommandLine;
 public final class CryptaAppCli implements Runnable {
   private static final String WARNING_PREFIX = "Warning: ";
 
+  private static final AtomicReference<LiveUskPublisher> LIVE_USK_PUBLISHER_OVERRIDE =
+      new AtomicReference<>();
+
   private CommandSpec spec;
 
   /**
@@ -161,6 +167,11 @@ public final class CryptaAppCli implements Runnable {
           return CommandLine.ExitCode.SOFTWARE;
         });
     return commandLine.execute(arguments);
+  }
+
+  static AutoCloseable useLiveUskPublisherForTesting(LiveUskPublisher publisher) {
+    LiveUskPublisher previous = LIVE_USK_PUBLISHER_OVERRIDE.getAndSet(publisher);
+    return () -> LIVE_USK_PUBLISHER_OVERRIDE.set(previous);
   }
 
   /** Prints root command usage when no subcommand is selected. */
@@ -1491,7 +1502,7 @@ public final class CryptaAppCli implements Runnable {
   }
 
   /** Implements {@code crypta-app publish-usk}. */
-  @Command(name = "publish-usk", description = "Write an offline Crypta USK publication plan.")
+  @Command(name = "publish-usk", description = "Plan or publish a signed catalog to a Crypta USK.")
   static final class PublishUskCommand extends SpecAwareCommand implements Callable<Integer> {
     @Option(names = "--catalog-file", required = true, description = "Catalog properties file.")
     private Path catalogFile;
@@ -1508,24 +1519,76 @@ public final class CryptaAppCli implements Runnable {
         description = "Public crypta:USK catalog source URI.")
     private String catalogSource;
 
-    @Option(names = "--output", required = true, description = "Publication plan output.")
+    @Option(
+        names = "--output",
+        required = true,
+        description = "Publication plan or summary output.")
     private Path output;
 
     @Option(names = "--dry-run", description = "Generate a plan without live insertion.")
     private boolean dryRun;
 
+    @Option(names = "--live", description = "Publish through the configured localhost node.")
+    private boolean live;
+
+    @Option(
+        names = "--private-insert-uri-env",
+        description =
+            "Environment variable containing the matching private USK directory insert URI.")
+    private String privateInsertUriEnv;
+
+    @Option(
+        names = "--private-insert-uri-file",
+        description = "Protected file containing the matching private USK directory insert URI.")
+    private Path privateInsertUriFile;
+
+    @Option(names = "--node-base-url", description = "Local node URL, with or without /api/v1.")
+    private String nodeBaseUrl;
+
+    @Option(
+        names = "--form-password-env",
+        description = "Environment variable containing the form password.")
+    private String formPasswordEnv;
+
+    @Option(
+        names = "--form-password-file",
+        description = "Protected file containing the form password.")
+    private Path formPasswordFile;
+
+    @Option(names = "--trusted-keys-file", description = "Trusted keys properties file.")
+    private Path trustedKeysFile;
+
+    @Option(names = "--trusted-key-id", description = "Trusted key id for direct public key input.")
+    private String trustedKeyId;
+
+    @Option(names = "--trusted-public-key-base64", description = "Base64 or PEM public key.")
+    private String trustedPublicKeyBase64;
+
+    @Option(names = "--trusted-public-key-file", description = "Public key file.")
+    private Path trustedPublicKeyFile;
+
+    @Option(
+        names = "--verify-live-fetch",
+        description = "Require immediate live fetch verification.")
+    private boolean verifyLiveFetch;
+
     @Override
     public Integer call() throws Exception {
+      if (dryRun == live) {
+        throw new AppDistributionException(
+            "publish-usk requires exactly one of --dry-run or --live");
+      }
+      if (dryRun) {
+        return writeDryRunPlan();
+      }
+      return publishLive();
+    }
+
+    private Integer writeDryRunPlan() throws IOException {
       PublicationPlanWriter.Result result =
           PublicationPlanWriter.write(
               new PublicationPlanWriter.Request(
                   catalogFile, catalogSignatureFile, catalogSource, output));
-      if (!dryRun) {
-        throw new AppDistributionException(
-            "live_publish_not_supported: wrote offline plan "
-                + result.output().getFileName()
-                + "; perform Crypta inserts with a reviewed insertion workflow");
-      }
       super.commandLine()
           .getOut()
           .println(
@@ -1536,6 +1599,72 @@ public final class CryptaAppCli implements Runnable {
                   + " output="
                   + result.output().getFileName());
       return CommandLine.ExitCode.OK;
+    }
+
+    private Integer publishLive() throws IOException {
+      TrustedAppKeys trustedKeys =
+          KeyMaterialLoader.loadTrustedKeys(
+              trustedKeysFile, trustedKeyId, trustedPublicKeyBase64, trustedPublicKeyFile);
+      LiveUskPublicationResult result =
+          LiveUskPublicationService.publish(
+              new LiveUskPublicationService.Request(
+                  catalogFile,
+                  catalogSignatureFile,
+                  catalogSource,
+                  output,
+                  loadSecureText(privateInsertUriEnv, privateInsertUriFile, "private insert URI"),
+                  nodeBaseUrl,
+                  loadSecureText(formPasswordEnv, formPasswordFile, "form password"),
+                  verifyLiveFetch),
+              trustedKeys,
+              liveUskPublisher());
+      super.commandLine()
+          .getOut()
+          .println(
+              "Published Crypta USK catalog: "
+                  + result.catalogId()
+                  + " entries="
+                  + result.entryCount()
+                  + " output="
+                  + result.output().getFileName()
+                  + " catalogStatus="
+                  + result.catalogInsertStatus()
+                  + " signatureStatus="
+                  + result.signatureInsertStatus());
+      return CommandLine.ExitCode.OK;
+    }
+
+    private static String loadSecureText(String environmentName, Path file, String label)
+        throws IOException {
+      int sourceCount = (environmentName == null ? 0 : 1) + (file == null ? 0 : 1);
+      if (sourceCount != 1) {
+        throw new AppDistributionException(
+            label + " must be configured by exactly one env or file source");
+      }
+      String value;
+      if (environmentName != null) {
+        value = System.getenv(environmentName);
+        if (value == null || value.isBlank()) {
+          throw new AppDistributionException("missing required environment variable for " + label);
+        }
+      } else {
+        Path normalized = file.toAbsolutePath().normalize();
+        if (Files.isSymbolicLink(normalized)
+            || !Files.isRegularFile(normalized, LinkOption.NOFOLLOW_LINKS)) {
+          throw new AppDistributionException(label + " file must be a regular file");
+        }
+        value = Files.readString(normalized, StandardCharsets.UTF_8);
+      }
+      String trimmed = value.trim();
+      if (trimmed.isEmpty()) {
+        throw new AppDistributionException(label + " must not be blank");
+      }
+      return trimmed;
+    }
+
+    private static LiveUskPublisher liveUskPublisher() {
+      LiveUskPublisher publisher = LIVE_USK_PUBLISHER_OVERRIDE.get();
+      return publisher == null ? new PlatformApiLiveUskPublisher() : publisher;
     }
   }
 

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationResult.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationResult.java
@@ -1,0 +1,72 @@
+package network.crypta.platform.devtools;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Report-safe result for one live USK catalog publication attempt.
+ *
+ * <p>The live publication command needs a durable summary that release jobs, operators, and release
+ * certification can archive without carrying the secret-bearing request object. This record is that
+ * boundary. It keeps the public catalog source, sibling signature source, digests, signing-key id,
+ * catalog size, insertion outcomes, and verification outcomes, but it deliberately stores only file
+ * names for local artifacts. It does not retain private insert material, form passwords, node
+ * request bodies, node response bodies, or staging directories.
+ *
+ * <p>Instances are immutable snapshots. Optional components must be explicit non-null {@link
+ * Optional} instances, and the warning list is copied on construction so later caller mutation
+ * cannot change already-rendered release evidence. The values are still assumed to be sanitized
+ * before construction; writers should not recover additional data from a {@code
+ * LiveUskPublishRequest}.
+ *
+ * @param catalogId signed catalog id
+ * @param catalogFileName local catalog file basename
+ * @param catalogSignatureFileName local signature sidecar basename
+ * @param publicCatalogSource public {@code crypta:USK@.../cryptad-app-catalog.properties} source
+ * @param publicSignatureSource public sibling signature sidecar source
+ * @param resolvedCatalogSource resolved public catalog source, when available
+ * @param edition numeric USK edition when it can be derived from public or resolved source
+ * @param catalogSha256 SHA-256 digest of the catalog sidecar
+ * @param signatureSha256 SHA-256 digest of the signature sidecar
+ * @param catalogSigningKeyId key id from the catalog signature sidecar
+ * @param entryCount number of signed catalog entries
+ * @param catalogInsertStatus status for the catalog properties sidecar
+ * @param signatureInsertStatus status for the signature sidecar
+ * @param postPublishVerificationStatus status of optional live fetch verification
+ * @param schedulerRefreshVerificationStatus status of scheduler/catalog-refresh compatibility
+ * @param warnings sanitized warnings
+ * @param output normalized output path used by the CLI
+ */
+record LiveUskPublicationResult(
+    String catalogId,
+    String catalogFileName,
+    String catalogSignatureFileName,
+    String publicCatalogSource,
+    String publicSignatureSource,
+    Optional<String> resolvedCatalogSource,
+    Optional<String> edition,
+    String catalogSha256,
+    String signatureSha256,
+    String catalogSigningKeyId,
+    int entryCount,
+    String catalogInsertStatus,
+    String signatureInsertStatus,
+    String postPublishVerificationStatus,
+    String schedulerRefreshVerificationStatus,
+    List<String> warnings,
+    Path output) {
+  /**
+   * Normalizes report collections and verifies optional metadata containers.
+   *
+   * <p>Callers represent absent optional metadata with {@link Optional#empty()}, never with a null
+   * {@code Optional}. That keeps the record contract precise while still allowing warning lists to
+   * default to an empty immutable list when older test builders omit them.
+   */
+  LiveUskPublicationResult {
+    Objects.requireNonNull(resolvedCatalogSource, "resolvedCatalogSource");
+    Objects.requireNonNull(edition, "edition");
+    warnings = warnings == null ? List.of() : List.copyOf(warnings);
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationResultWriter.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationResultWriter.java
@@ -1,7 +1,6 @@
 package network.crypta.platform.devtools;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -25,6 +24,10 @@ import network.crypta.platform.appdist.AppDistributionException;
  * when needed and overwrites the target file without following the target as a symlink.
  */
 final class LiveUskPublicationResultWriter {
+  private static final String INCOMPLETE_PUBLICATION_STATUS = "incomplete";
+  private static final String INCOMPLETE_PUBLICATION_MESSAGE =
+      "live publication did not complete; ignore previous summaries for this output";
+
   /** Utility class; all rendering operations are static. */
   private LiveUskPublicationResultWriter() {}
 
@@ -54,11 +57,10 @@ final class LiveUskPublicationResultWriter {
    * Reserves the summary output path before a live publication side effect is attempted.
    *
    * <p>Live USK publication queues a durable insert before the final report is rendered. This
-   * preflight creates the parent directory and opens the summary target without following a symlink
-   * or truncating existing content, proving that the required evidence file is a regular writable
-   * path before the queue receives any secret-bearing insert request. The method intentionally
-   * emits sanitized errors only; callers should not report absolute output paths in failure
-   * messages.
+   * preflight creates the parent directory, rejects unsafe target shapes, and writes a small
+   * sanitized incomplete marker without following a symlink. Replacing any previous summary before
+   * the queue receives a secret-bearing insert request prevents release automation from reading
+   * stale success evidence if the current live attempt later fails.
    *
    * @param output normalized summary output path
    * @throws IOException if the output path cannot be reserved safely
@@ -73,19 +75,51 @@ final class LiveUskPublicationResultWriter {
         throw new AppDistributionException(
             "live publication output must be a regular writable file");
       }
-      try (OutputStream ignored =
-          Files.newOutputStream(
-              output,
-              StandardOpenOption.CREATE,
-              StandardOpenOption.WRITE,
-              LinkOption.NOFOLLOW_LINKS)) {
-        // Opening the stream is the reservation; no content is written before publication.
-      }
+      Files.writeString(
+          output,
+          incompleteMarker(output),
+          StandardCharsets.UTF_8,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.TRUNCATE_EXISTING,
+          StandardOpenOption.WRITE,
+          LinkOption.NOFOLLOW_LINKS);
     } catch (AppDistributionException exception) {
       throw exception;
     } catch (IOException exception) {
       throw new AppDistributionException("live publication output must be writable");
     }
+  }
+
+  /**
+   * Renders the report placeholder written before the live queue receives an insert request.
+   *
+   * <p>The marker is intentionally small and secret-free. It is valid JSON for JSON destinations
+   * and readable Markdown for operator summaries, but it cannot be mistaken for a successful live
+   * publication result because it records {@code publicationStatus=incomplete} and omits insert
+   * success fields.
+   *
+   * @param output normalized output path whose suffix selects the marker format
+   * @return sanitized incomplete summary marker
+   */
+  private static String incompleteMarker(Path output) {
+    if (output.toString().endsWith(".json")) {
+      return """
+      {
+        "schemaVersion": 1,
+        "mode": "live",
+        "publicationStatus": "%s",
+        "message": "%s"
+      }
+      """
+          .formatted(INCOMPLETE_PUBLICATION_STATUS, INCOMPLETE_PUBLICATION_MESSAGE);
+    }
+    return """
+    # Crypta Catalog Live USK Publication Summary
+
+    - Publication status: `%s`
+    - Message: `%s`
+    """
+        .formatted(INCOMPLETE_PUBLICATION_STATUS, INCOMPLETE_PUBLICATION_MESSAGE);
   }
 
   /**

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationResultWriter.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationResultWriter.java
@@ -1,12 +1,14 @@
 package network.crypta.platform.devtools;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
+import network.crypta.platform.appdist.AppDistributionException;
 
 /**
  * Writes sanitized live USK publication summaries.
@@ -46,6 +48,44 @@ final class LiveUskPublicationResultWriter {
         StandardOpenOption.TRUNCATE_EXISTING,
         StandardOpenOption.WRITE,
         LinkOption.NOFOLLOW_LINKS);
+  }
+
+  /**
+   * Reserves the summary output path before a live publication side effect is attempted.
+   *
+   * <p>Live USK publication queues a durable insert before the final report is rendered. This
+   * preflight creates the parent directory and opens the summary target without following a symlink
+   * or truncating existing content, proving that the required evidence file is a regular writable
+   * path before the queue receives any secret-bearing insert request. The method intentionally
+   * emits sanitized errors only; callers should not report absolute output paths in failure
+   * messages.
+   *
+   * @param output normalized summary output path
+   * @throws IOException if the output path cannot be reserved safely
+   */
+  static void preflightWritableOutput(Path output) throws IOException {
+    try {
+      Path parent = output.getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
+      if (Files.isSymbolicLink(output) || Files.isDirectory(output, LinkOption.NOFOLLOW_LINKS)) {
+        throw new AppDistributionException(
+            "live publication output must be a regular writable file");
+      }
+      try (OutputStream ignored =
+          Files.newOutputStream(
+              output,
+              StandardOpenOption.CREATE,
+              StandardOpenOption.WRITE,
+              LinkOption.NOFOLLOW_LINKS)) {
+        // Opening the stream is the reservation; no content is written before publication.
+      }
+    } catch (AppDistributionException exception) {
+      throw exception;
+    } catch (IOException exception) {
+      throw new AppDistributionException("live publication output must be writable");
+    }
   }
 
   /**

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationResultWriter.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationResultWriter.java
@@ -1,0 +1,271 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+
+/**
+ * Writes sanitized live USK publication summaries.
+ *
+ * <p>The writer renders the result model without consulting any secret-bearing request object. JSON
+ * output is intended for release jobs and certification evidence, while Markdown output is a
+ * compact operator summary. Both formats intentionally omit local absolute paths, private insert
+ * URIs, form passwords, raw node bodies, and key material beyond the public signing key id.
+ *
+ * <p>The output format is selected by the destination filename: paths ending in {@code .json}
+ * receive stable machine-readable evidence, and all other paths receive Markdown. Callers are
+ * expected to pass an already sanitized {@link LiveUskPublicationResult}; this class does not
+ * inspect live-node requests or local staging directories. It creates the output parent directory
+ * when needed and overwrites the target file without following the target as a symlink.
+ */
+final class LiveUskPublicationResultWriter {
+  /** Utility class; all rendering operations are static. */
+  private LiveUskPublicationResultWriter() {}
+
+  /**
+   * Writes one publication result.
+   *
+   * @param result report-safe live publication result
+   * @throws IOException if the output path cannot be created or written
+   */
+  static void write(LiveUskPublicationResult result) throws IOException {
+    Path parent = result.output().getParent();
+    if (parent != null) {
+      Files.createDirectories(parent);
+    }
+    String content = result.output().toString().endsWith(".json") ? json(result) : markdown(result);
+    Files.writeString(
+        result.output(),
+        content,
+        StandardCharsets.UTF_8,
+        StandardOpenOption.CREATE,
+        StandardOpenOption.TRUNCATE_EXISTING,
+        StandardOpenOption.WRITE,
+        LinkOption.NOFOLLOW_LINKS);
+  }
+
+  /**
+   * Renders a compact Markdown summary for an operator or release note attachment.
+   *
+   * <p>The Markdown form favors direct scanability over full machine schema stability. It includes
+   * the same report-safe fields as the JSON form, emits optional resolved-source and edition fields
+   * only when present, and places warnings in a separate section so release operators can see
+   * retained-staging or verification notes without parsing JSON.
+   *
+   * @param result sanitized publication result to render without reading secret-bearing inputs
+   * @return Markdown text suitable for a local operator summary file
+   */
+  private static String markdown(LiveUskPublicationResult result) {
+    StringBuilder builder = new StringBuilder();
+    builder
+        .append("# Crypta Catalog Live USK Publication Summary\n\n")
+        .append("- Catalog id: `")
+        .append(result.catalogId())
+        .append("`\n")
+        .append("- Entries: `")
+        .append(result.entryCount())
+        .append("`\n")
+        .append("- Catalog: `")
+        .append(result.catalogFileName())
+        .append("`\n")
+        .append("- Signature sidecar: `")
+        .append(result.catalogSignatureFileName())
+        .append("`\n")
+        .append("- Public catalog source: `")
+        .append(result.publicCatalogSource())
+        .append("`\n")
+        .append("- Public signature source: `")
+        .append(result.publicSignatureSource())
+        .append("`\n")
+        .append("- Catalog SHA-256: `")
+        .append(result.catalogSha256())
+        .append("`\n")
+        .append("- Signature SHA-256: `")
+        .append(result.signatureSha256())
+        .append("`\n")
+        .append("- Catalog signing key id: `")
+        .append(result.catalogSigningKeyId())
+        .append("`\n")
+        .append("- Catalog insert status: `")
+        .append(result.catalogInsertStatus())
+        .append("`\n")
+        .append("- Signature insert status: `")
+        .append(result.signatureInsertStatus())
+        .append("`\n")
+        .append("- Post-publish verification: `")
+        .append(result.postPublishVerificationStatus())
+        .append("`\n")
+        .append("- Scheduler refresh verification: `")
+        .append(result.schedulerRefreshVerificationStatus())
+        .append("`\n");
+    result
+        .resolvedCatalogSource()
+        .ifPresent(value -> appendMarkdownField(builder, "Resolved catalog source", value));
+    result.edition().ifPresent(value -> appendMarkdownField(builder, "Edition", value));
+    if (!result.warnings().isEmpty()) {
+      builder.append("\n## Warnings\n\n");
+      for (String warning : result.warnings()) {
+        builder.append("- ").append(warning).append('\n');
+      }
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Appends one optional Markdown scalar field when the caller has a value to report.
+   *
+   * <p>The helper keeps the optional fields visually consistent with the required fields. Values
+   * are wrapped as code spans because catalog sources and editions are literal operator-facing
+   * values, not prose.
+   *
+   * @param builder destination Markdown builder for the current summary
+   * @param name human-readable field label shown to operators
+   * @param value sanitized literal field value to render in a code span
+   */
+  private static void appendMarkdownField(StringBuilder builder, String name, String value) {
+    builder.append("- ").append(name).append(": `").append(value).append("`\n");
+  }
+
+  /**
+   * Renders deterministic JSON evidence for release automation.
+   *
+   * <p>The JSON form keeps a fixed field order so certification diffs stay readable. Optional
+   * source and edition fields are emitted as {@code null} when absent instead of being omitted, and
+   * warnings are always emitted as an array. Numeric fields that are part of the schema, such as
+   * the schema version and entry count, are written without quotes.
+   *
+   * @param result sanitized publication result to serialize as JSON
+   * @return JSON object text with a trailing newline
+   */
+  private static String json(LiveUskPublicationResult result) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("{\n");
+    stringField(builder, "schemaVersion", "1", false);
+    stringField(builder, "mode", "live", true);
+    stringField(builder, "catalogId", result.catalogId(), true);
+    stringField(builder, "catalogFile", result.catalogFileName(), true);
+    stringField(builder, "catalogSignatureFile", result.catalogSignatureFileName(), true);
+    stringField(builder, "publicCatalogSource", result.publicCatalogSource(), true);
+    stringField(builder, "publicSignatureSource", result.publicSignatureSource(), true);
+    optionalStringField(
+        builder, "resolvedCatalogSource", result.resolvedCatalogSource().orElse(null));
+    optionalStringField(builder, "edition", result.edition().orElse(null));
+    stringField(builder, "catalogSha256", result.catalogSha256(), true);
+    stringField(builder, "signatureSha256", result.signatureSha256(), true);
+    stringField(builder, "catalogSigningKeyId", result.catalogSigningKeyId(), true);
+    stringField(builder, "entryCount", Integer.toString(result.entryCount()), false);
+    stringField(builder, "catalogInsertStatus", result.catalogInsertStatus(), true);
+    stringField(builder, "signatureInsertStatus", result.signatureInsertStatus(), true);
+    stringField(
+        builder, "postPublishVerificationStatus", result.postPublishVerificationStatus(), true);
+    stringField(
+        builder,
+        "schedulerRefreshVerificationStatus",
+        result.schedulerRefreshVerificationStatus(),
+        true);
+    warnings(builder, result.warnings());
+    builder.append("}\n");
+    return builder.toString();
+  }
+
+  /**
+   * Appends one scalar JSON field and its trailing comma.
+   *
+   * <p>Most fields are strings and therefore escaped and quoted. A small number of numeric schema
+   * fields pass {@code false} for {@code quoteValue}; callers are responsible for supplying a value
+   * that is already valid JSON for those numeric positions.
+   *
+   * @param builder destination JSON builder currently inside the top-level object
+   * @param name field name to escape and write
+   * @param value scalar value to escape when quoted or write directly when numeric
+   * @param quoteValue whether the value should be emitted as a JSON string
+   */
+  private static void stringField(
+      StringBuilder builder, String name, String value, boolean quoteValue) {
+    builder.append("  \"").append(escape(name)).append("\": ");
+    if (quoteValue) {
+      builder.append('"').append(escape(value)).append('"');
+    } else {
+      builder.append(value);
+    }
+    builder.append(",\n");
+  }
+
+  /**
+   * Appends one optional JSON string field.
+   *
+   * <p>Optional fields are present in the schema even when no live node reported a resolved source
+   * or edition. This avoids consumers needing two separate object shapes for verified and
+   * not-yet-verified publications.
+   *
+   * @param builder destination JSON builder currently inside the top-level object
+   * @param name field name to escape and write
+   * @param value sanitized value, or {@code null} for a JSON {@code null}
+   */
+  private static void optionalStringField(StringBuilder builder, String name, String value) {
+    builder.append("  \"").append(escape(name)).append("\": ");
+    if (value == null) {
+      builder.append("null");
+    } else {
+      builder.append('"').append(escape(value)).append('"');
+    }
+    builder.append(",\n");
+  }
+
+  /**
+   * Appends the warning array at the end of the JSON object.
+   *
+   * <p>Warnings are already sanitized by the publication service. This renderer still escapes JSON
+   * control characters so a warning cannot break the evidence format or hide following fields.
+   *
+   * @param builder destination JSON builder currently inside the top-level object
+   * @param warnings ordered warning values to render as JSON strings
+   */
+  private static void warnings(StringBuilder builder, List<String> warnings) {
+    builder.append("  \"warnings\": [");
+    if (!warnings.isEmpty()) {
+      builder.append('\n');
+    }
+    for (int index = 0; index < warnings.size(); index++) {
+      builder.append("    \"").append(escape(warnings.get(index))).append('"');
+      if (index + 1 < warnings.size()) {
+        builder.append(',');
+      }
+      builder.append('\n');
+    }
+    if (!warnings.isEmpty()) {
+      builder.append("  ");
+    }
+    builder.append("]\n");
+  }
+
+  /**
+   * Escapes the JSON string characters emitted by this writer.
+   *
+   * <p>The writer only needs the common scalar escapes used by release evidence: backslash, double
+   * quote, newline, carriage return, and tab. Other characters are copied unchanged so public
+   * Crypta URIs and digest strings remain readable.
+   *
+   * @param value non-null scalar value to place inside a JSON string
+   * @return escaped text without surrounding quote characters
+   */
+  private static String escape(String value) {
+    StringBuilder escaped = new StringBuilder(value.length());
+    for (int index = 0; index < value.length(); index++) {
+      char character = value.charAt(index);
+      switch (character) {
+        case '\\' -> escaped.append("\\\\");
+        case '"' -> escaped.append("\\\"");
+        case '\n' -> escaped.append("\\n");
+        case '\r' -> escaped.append("\\r");
+        case '\t' -> escaped.append("\\t");
+        default -> escaped.append(character);
+      }
+    }
+    return escaped.toString();
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationService.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationService.java
@@ -1,0 +1,580 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import network.crypta.keys.FreenetURI;
+import network.crypta.platform.appcatalog.AppCatalogSignature;
+import network.crypta.platform.appcatalog.AppCatalogVerifier;
+import network.crypta.platform.appdist.AppDistributionException;
+import network.crypta.platform.appdist.TrustedAppKeys;
+
+/**
+ * Coordinates live USK catalog publication from validated local sidecars.
+ *
+ * <p>The service keeps the high-risk pieces ordered and testable: validate the same local inputs as
+ * dry-run planning, verify the signed catalog against explicit trusted public keys, validate live
+ * node and secure secret inputs without echoing them, confirm the private USK insert URI matches
+ * the configured public source, stage only the canonical catalog/signature filenames into a
+ * retained directory, invoke an injected live insertion adapter, then write a sanitized summary. It
+ * never stores private insert material or form passwords in the result model.
+ *
+ * <p>The class is deliberately stateless. Production code supplies the Platform API publisher,
+ * while tests can supply a fake publisher that observes the sanitized request boundary. Publication
+ * either fails before the live adapter is called, or returns a report-safe result after the adapter
+ * accepts the insertion request. Staged sidecars are retained because the live queue uses
+ * disk-backed source files that may be consumed after the HTTP call returns.
+ */
+final class LiveUskPublicationService {
+  /** Public Crypta URI scheme used by catalog sources. */
+  private static final String CRYPTA_SCHEME = "crypta:";
+
+  /** Public catalog source prefix required for first-party live USK publication. */
+  private static final String CRYPTA_USK_PREFIX = CRYPTA_SCHEME + "USK@";
+
+  /** Owner-only permissions for retained staging directories on POSIX filesystems. */
+  private static final Set<PosixFilePermission> OWNER_ONLY_DIRECTORY =
+      Set.of(
+          PosixFilePermission.OWNER_READ,
+          PosixFilePermission.OWNER_WRITE,
+          PosixFilePermission.OWNER_EXECUTE);
+
+  /** Status used when the caller did not request immediate public-source fetch verification. */
+  private static final String POST_PUBLISH_NOT_REQUESTED = "not_requested";
+
+  /**
+   * Path-free warning recorded whenever disk-backed sidecars remain available for the live queue.
+   */
+  private static final String STAGING_RETAINED_WARNING =
+      "staging_sidecars_retained_until_live_insert_completion";
+
+  /** Prevents construction of this stateless service. */
+  private LiveUskPublicationService() {}
+
+  /**
+   * Publishes one signed catalog through the supplied live insertion adapter.
+   *
+   * @param request live publication inputs and secure values
+   * @param trustedKeys trusted catalog signing keys used before insertion
+   * @param publisher configured live insertion adapter
+   * @return report-safe live publication result
+   * @throws IOException if local files or the live adapter fail
+   */
+  static LiveUskPublicationResult publish(
+      Request request, TrustedAppKeys trustedKeys, LiveUskPublisher publisher) throws IOException {
+    ValidatedPublicationInputs inputs =
+        PublicationInputValidator.validate(
+            request.catalogFile(),
+            request.catalogSignatureFile(),
+            request.catalogSource(),
+            request.output());
+    AppCatalogVerifier.verify(inputs.catalogBytes(), inputs.signatureBytes(), trustedKeys);
+    URI nodeBaseUrl = normalizeNodeBaseUrl(request.nodeBaseUrl());
+    String privateInsertUri = requirePrivateInsertUri(request.privateInsertUri());
+    requireInsertUriMatchesPublicSource(privateInsertUri, inputs.catalogSource());
+    String formPassword = requireFormPassword(request.formPassword());
+    String publicSignatureSource = publicSignatureSource(inputs.catalogSource());
+    List<String> cleanupWarnings = new ArrayList<>();
+    Path stagingDirectory = stageSidecars(inputs);
+    LiveUskPublishRequest publishRequest =
+        LiveUskPublishRequest.builder()
+            .nodeBaseUrl(nodeBaseUrl)
+            .formPassword(formPassword)
+            .privateInsertUri(privateInsertUri)
+            .stagingDirectory(stagingDirectory)
+            .identifier(publicationIdentifier(inputs))
+            .publicCatalogSource(inputs.catalogSource())
+            .publicSignatureSource(publicSignatureSource)
+            .catalogBytes(inputs.catalogBytes())
+            .signatureBytes(inputs.signatureBytes())
+            .verifyLiveFetch(request.verifyLiveFetch())
+            .build();
+    LiveUskPublishResponse response = publisher.publish(publishRequest);
+    cleanupWarnings.add(STAGING_RETAINED_WARNING);
+    List<String> warnings = new ArrayList<>(response.warnings());
+    warnings.addAll(cleanupWarnings);
+    if (!request.verifyLiveFetch()
+        && POST_PUBLISH_NOT_REQUESTED.equals(response.postPublishVerificationStatus())) {
+      warnings.add("post_publish_fetch_verification_not_requested");
+    }
+    LiveUskPublicationResult result =
+        new LiveUskPublicationResult(
+            inputs.catalog().catalogId(),
+            AppTestRedactor.fileName(inputs.catalogFile()),
+            AppTestRedactor.fileName(inputs.catalogSignatureFile()),
+            inputs.catalogSource(),
+            publicSignatureSource,
+            response.resolvedCatalogSource(),
+            edition(response.resolvedCatalogSource().orElse(inputs.catalogSource())),
+            inputs.catalogSha256(),
+            inputs.signatureSha256(),
+            inputs.signature().keyId(),
+            inputs.catalog().entries().size(),
+            response.catalogInsertStatus(),
+            response.signatureInsertStatus(),
+            response.postPublishVerificationStatus(),
+            response.schedulerRefreshVerificationStatus(),
+            sanitizeWarnings(warnings),
+            inputs.output());
+    LiveUskPublicationResultWriter.write(result);
+    return result;
+  }
+
+  /**
+   * Normalizes and validates the localhost Platform API base URL.
+   *
+   * <p>Live publication is allowed only through local HTTP(S) endpoints. The method rejects user
+   * info, query strings, fragments, and non-loopback hosts before any secret-bearing form is built.
+   * It does not resolve DNS names other than the literal {@code localhost}; accepting DNS aliases
+   * would make the private insert URI and form password dependent on external name resolution.
+   *
+   * @param rawNodeBaseUrl operator-supplied node or Platform API base URL
+   * @return normalized URI safe to use as the base for local Platform API routes
+   * @throws AppDistributionException if the URL is malformed or not a localhost HTTP(S) URL
+   */
+  private static URI normalizeNodeBaseUrl(String rawNodeBaseUrl) throws AppDistributionException {
+    String value = rawNodeBaseUrl == null ? "" : rawNodeBaseUrl.trim();
+    if (value.isEmpty()) {
+      throw new AppDistributionException("live publish requires --node-base-url");
+    }
+    URI uri;
+    try {
+      uri = new URI(value);
+    } catch (URISyntaxException exception) {
+      throw new AppDistributionException("live publish node base URL is malformed", exception);
+    }
+    String scheme = uri.getScheme();
+    String host = uri.getHost();
+    if (scheme == null
+        || host == null
+        || uri.getRawQuery() != null
+        || uri.getRawFragment() != null
+        || uri.getRawUserInfo() != null
+        || (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))) {
+      throw new AppDistributionException(
+          "live publish node base URL must be a localhost HTTP(S) URL without query text");
+    }
+    if (!isLoopbackHost(host)) {
+      throw new AppDistributionException("live publish node base URL must use a localhost host");
+    }
+    return uri.normalize();
+  }
+
+  /**
+   * Checks whether a host string is an accepted loopback literal.
+   *
+   * <p>The accepted set is intentionally narrow: {@code localhost}, IPv4 {@code 127.0.0.0/8}
+   * literals, and the common IPv6 loopback forms. Hostnames that merely start with loopback text
+   * are rejected by {@link #isIpv4LoopbackLiteral(String)} because they are DNS names, not IP
+   * literals.
+   *
+   * @param host raw host component returned by {@link URI#getHost()}
+   * @return {@code true} when the host is accepted for secret-bearing local publication
+   */
+  private static boolean isLoopbackHost(String host) {
+    String normalized = stripIpv6Brackets(host.toLowerCase(java.util.Locale.ROOT));
+    return "localhost".equals(normalized)
+        || isIpv4LoopbackLiteral(normalized)
+        || "::1".equals(normalized)
+        || "0:0:0:0:0:0:0:1".equals(normalized);
+  }
+
+  /**
+   * Removes square brackets from an IPv6 host literal when present.
+   *
+   * <p>{@link URI#getHost()} normally returns IPv6 hosts without brackets, but this helper keeps
+   * the loopback check robust if a future caller passes a bracketed literal directly.
+   *
+   * @param host lower-cased host string to inspect
+   * @return host without enclosing IPv6 brackets, or the original string
+   */
+  private static String stripIpv6Brackets(String host) {
+    if (host.length() >= 2 && host.charAt(0) == '[' && host.charAt(host.length() - 1) == ']') {
+      return host.substring(1, host.length() - 1);
+    }
+    return host;
+  }
+
+  /**
+   * Validates a dotted IPv4 loopback literal without accepting DNS names.
+   *
+   * <p>The method requires exactly four numeric labels, the first label {@code 127}, and every
+   * label in the byte range. That accepts the full IPv4 loopback block while rejecting strings such
+   * as {@code 127.0.0.1.example} and malformed decimal forms.
+   *
+   * @param host lower-cased host string without IPv6 brackets
+   * @return {@code true} when {@code host} is a valid dotted IPv4 loopback literal
+   */
+  private static boolean isIpv4LoopbackLiteral(String host) {
+    String[] parts = host.split("\\.", -1);
+    if (parts.length != 4 || !"127".equals(parts[0])) {
+      return false;
+    }
+    for (String part : parts) {
+      if (part.isEmpty() || !part.chars().allMatch(Character::isDigit)) {
+        return false;
+      }
+      try {
+        if (Integer.parseInt(part) > 255) {
+          return false;
+        }
+      } catch (NumberFormatException _) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Validates the private insert URI string loaded from a secure source.
+   *
+   * <p>The live directory insert requires a private USK insert URI for the catalog parent path. The
+   * value must be single-line text and must not include the public {@code crypta:} scheme. The
+   * source correlation check later derives the corresponding public request URI and compares it
+   * with the operator-supplied public catalog source.
+   *
+   * @param rawPrivateInsertUri text loaded from the configured environment variable or protected
+   *     file
+   * @return trimmed private USK insert URI text
+   * @throws AppDistributionException if the value is missing, multi-line, public, or not USK-shaped
+   */
+  private static String requirePrivateInsertUri(String rawPrivateInsertUri)
+      throws AppDistributionException {
+    String value = requireSingleLine(rawPrivateInsertUri, "private insert URI");
+    if (value.startsWith(CRYPTA_SCHEME)) {
+      throw new AppDistributionException(
+          "private insert URI must not use the public crypta scheme");
+    }
+    String lower = value.toLowerCase(java.util.Locale.ROOT);
+    if (!lower.startsWith("usk@")) {
+      throw new AppDistributionException("private insert URI must be a USK insert URI");
+    }
+    return value;
+  }
+
+  /**
+   * Ensures the private insert URI corresponds to the advertised public catalog source.
+   *
+   * <p>Without this check, an operator typo could enqueue bytes to one USK while writing release
+   * evidence for another public source. The method derives the public request URI from the private
+   * insert URI, appends the catalog filename for the directory insert, and compares it with the
+   * configured {@code crypta:USK@.../cryptad-app-catalog.properties} source.
+   *
+   * @param privateInsertUri validated private USK insert URI text
+   * @param publicCatalogSource validated public catalog source from the CLI request
+   * @throws AppDistributionException if parsing fails or the public/private sources do not match
+   */
+  private static void requireInsertUriMatchesPublicSource(
+      String privateInsertUri, String publicCatalogSource) throws AppDistributionException {
+    FreenetURI privateUri = parseBareUri(privateInsertUri, "private insert URI");
+    FreenetURI actualPublicSource =
+        parseBareUri(stripCryptaScheme(publicCatalogSource), "public catalog source");
+    FreenetURI expectedPublicSource = expectedPublicCatalogSource(privateUri);
+    if (!expectedPublicSource.equals(actualPublicSource)) {
+      throw new AppDistributionException("private insert URI does not match public catalog source");
+    }
+  }
+
+  /**
+   * Derives the expected public catalog source from a private USK directory insert URI.
+   *
+   * <p>The Platform API queue insert publishes a directory whose manifest children are the catalog
+   * properties and signature sidecar. The private URI therefore points at the directory root, and
+   * this method adds the canonical catalog filename after deriving the public request URI.
+   *
+   * @param privateUri parsed private USK insert URI for the catalog directory root
+   * @return parsed public catalog source expected for the catalog properties child
+   * @throws AppDistributionException if the private URI cannot be converted to a request URI
+   */
+  private static FreenetURI expectedPublicCatalogSource(FreenetURI privateUri)
+      throws AppDistributionException {
+    try {
+      FreenetURI publicBase = privateUri.deriveRequestURIFromInsertURI();
+      return parseBareUri(
+          publicBase.toString(false, false) + "/" + AppCatalogSignature.CATALOG_FILE_NAME,
+          "derived public catalog source");
+    } catch (MalformedURLException exception) {
+      throw new AppDistributionException(
+          "private insert URI must be an insert URI matching the public catalog source", exception);
+    }
+  }
+
+  /**
+   * Parses a bare Crypta key URI and requires USK semantics.
+   *
+   * <p>The internal key parser expects values without the public {@code crypta:} scheme. The {@code
+   * label} is used only in sanitized validation errors and must not contain the URI value.
+   *
+   * @param value bare key URI text such as {@code USK@.../catalog/42}
+   * @param label sanitized name of the field being parsed
+   * @return parsed USK key URI
+   * @throws AppDistributionException if the key cannot be parsed or is not a USK
+   */
+  private static FreenetURI parseBareUri(String value, String label)
+      throws AppDistributionException {
+    try {
+      FreenetURI uri = new FreenetURI(value);
+      if (!uri.isUSK()) {
+        throw new AppDistributionException(label + " must be a USK URI");
+      }
+      return uri;
+    } catch (MalformedURLException exception) {
+      throw new AppDistributionException(label + " is not a valid USK URI", exception);
+    }
+  }
+
+  /**
+   * Removes the public {@code crypta:} scheme from a catalog source before key parsing.
+   *
+   * <p>Validation has already required the public source shape. This helper keeps the parser call
+   * explicit and avoids accepting other schemes in the private URI path.
+   *
+   * @param publicCatalogSource catalog source value from validated publication inputs
+   * @return source text without the leading {@code crypta:} scheme when present
+   */
+  private static String stripCryptaScheme(String publicCatalogSource) {
+    return publicCatalogSource.startsWith(CRYPTA_SCHEME)
+        ? publicCatalogSource.substring(CRYPTA_SCHEME.length())
+        : publicCatalogSource;
+  }
+
+  /**
+   * Validates the form password loaded from a secure source.
+   *
+   * <p>The password is needed only to authenticate the localhost mutation route. The returned value
+   * is passed directly to the live insertion adapter and is never copied into the result model.
+   *
+   * @param rawFormPassword text loaded from the configured environment variable or protected file
+   * @return trimmed single-line form password
+   * @throws AppDistributionException if the value is missing or multi-line
+   */
+  private static String requireFormPassword(String rawFormPassword)
+      throws AppDistributionException {
+    return requireSingleLine(rawFormPassword, "form password");
+  }
+
+  /**
+   * Requires one non-empty line of secret-bearing configuration.
+   *
+   * <p>The helper rejects embedded line breaks and NUL characters so accidental file concatenation
+   * or malformed environment values cannot leak into HTTP form construction. Error messages mention
+   * only the field label, not the supplied value.
+   *
+   * @param value raw field text, possibly null or padded with whitespace
+   * @param label sanitized field name used in validation messages
+   * @return trimmed single-line value
+   * @throws AppDistributionException if the value is empty or contains forbidden characters
+   */
+  private static String requireSingleLine(String value, String label)
+      throws AppDistributionException {
+    String checked = value == null ? "" : value.trim();
+    if (checked.isEmpty()) {
+      throw new AppDistributionException("live publish requires " + label);
+    }
+    if (checked.indexOf('\n') >= 0
+        || checked.indexOf('\r') >= 0
+        || checked.indexOf('\u0000') >= 0) {
+      throw new AppDistributionException(label + " must be a single-line value");
+    }
+    return checked;
+  }
+
+  /**
+   * Computes the public sibling signature source for a public catalog source.
+   *
+   * <p>The publication input validator has already required a catalog source ending in the
+   * canonical catalog filename. Replacing the final path segment keeps the signature sidecar at the
+   * same USK path and edition.
+   *
+   * @param publicCatalogSource validated public catalog source for the properties file
+   * @return public source for {@code cryptad-app-catalog.signature}
+   */
+  private static String publicSignatureSource(String publicCatalogSource) {
+    int slash = publicCatalogSource.lastIndexOf('/');
+    return publicCatalogSource.substring(0, slash + 1) + AppCatalogSignature.SIGNATURE_FILE_NAME;
+  }
+
+  /**
+   * Builds a deterministic queue identifier for the publication attempt.
+   *
+   * <p>The identifier combines the catalog id with a short catalog digest prefix. It is stable
+   * enough for operators to correlate queue entries without including local paths, private insert
+   * material, or full catalog contents in the identifier.
+   *
+   * @param inputs validated local publication snapshot
+   * @return deterministic queue identifier safe for node request metadata
+   */
+  private static String publicationIdentifier(ValidatedPublicationInputs inputs) {
+    return "cryptad-catalog-"
+        + inputs.catalog().catalogId()
+        + "-"
+        + inputs.catalogSha256().substring(0, 12);
+  }
+
+  /**
+   * Stages canonical catalog and signature sidecars for the disk-backed directory insert.
+   *
+   * <p>The staging directory is created beside the requested summary output when possible, so
+   * release jobs can keep live-publication evidence and retained sidecars in the same controlled
+   * area. Only the canonical public sidecar filenames are written. The directory is intentionally
+   * not removed here because the live queue may read these files after the HTTP call returns.
+   *
+   * @param inputs validated publication inputs containing exact catalog and signature bytes
+   * @return retained staging directory containing the two public sidecar files
+   * @throws IOException if the directory or sidecar files cannot be created
+   */
+  private static Path stageSidecars(ValidatedPublicationInputs inputs) throws IOException {
+    Path stagingDirectory = createPrivateStagingDirectory(stagingParent(inputs.output()));
+    Files.write(
+        stagingDirectory.resolve(AppCatalogSignature.CATALOG_FILE_NAME),
+        inputs.catalogBytes(),
+        StandardOpenOption.CREATE_NEW,
+        StandardOpenOption.WRITE);
+    Files.write(
+        stagingDirectory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME),
+        inputs.signatureBytes(),
+        StandardOpenOption.CREATE_NEW,
+        StandardOpenOption.WRITE);
+    return stagingDirectory;
+  }
+
+  /**
+   * Chooses the parent that should hold retained live-publication sidecars.
+   *
+   * <p>When the output path has no parent, the current working directory is used instead of the JVM
+   * default temp directory so staging stays with operator-controlled release output.
+   *
+   * @param output requested summary output path
+   * @return existing directory that can contain the retained staging directory
+   * @throws IOException if the requested output parent cannot be created
+   */
+  private static Path stagingParent(Path output) throws IOException {
+    Path outputParent = output.getParent();
+    if (outputParent == null) {
+      return Path.of("").toAbsolutePath().normalize();
+    }
+    return Files.createDirectories(outputParent);
+  }
+
+  /**
+   * Creates an owner-only retained staging directory below the selected parent.
+   *
+   * <p>The directory name is generated atomically. POSIX hosts receive owner-only permissions at
+   * creation time; other filesystems are restricted immediately through the portable {@link
+   * java.io.File} permission API before any sidecar bytes are written.
+   *
+   * @param stagingParent parent directory for retained live-publication sidecars
+   * @return owner-only staging directory
+   * @throws IOException if the directory cannot be created or restricted
+   */
+  // The directory is created under an operator-selected parent and locked down before any catalog
+  // sidecar bytes are staged for the disk-backed live insert queue.
+  @SuppressWarnings("java:S5443")
+  private static Path createPrivateStagingDirectory(Path stagingParent) throws IOException {
+    try {
+      return Files.createTempDirectory(
+          stagingParent,
+          "cryptad-live-usk-catalog-",
+          PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY));
+    } catch (UnsupportedOperationException _) {
+      Path stagingDirectory = Files.createTempDirectory(stagingParent, "cryptad-live-usk-catalog-");
+      try {
+        restrictPortableOwnerOnlyDirectory(stagingDirectory);
+        return stagingDirectory;
+      } catch (IOException | RuntimeException exception) {
+        Files.deleteIfExists(stagingDirectory);
+        throw exception;
+      }
+    }
+  }
+
+  /**
+   * Applies owner-only access to a retained staging directory on non-POSIX filesystems.
+   *
+   * @param stagingDirectory staging directory that must be accessible only by the current owner
+   * @throws IOException if any portable permission operation is rejected by the runtime
+   */
+  private static void restrictPortableOwnerOnlyDirectory(Path stagingDirectory) throws IOException {
+    java.io.File file = stagingDirectory.toFile();
+    if (!file.setReadable(false, false)
+        || !file.setWritable(false, false)
+        || !file.setExecutable(false, false)
+        || !file.setReadable(true, true)
+        || !file.setWritable(true, true)
+        || !file.setExecutable(true, true)) {
+      throw new IOException("failed to restrict live publication staging directory");
+    }
+  }
+
+  /**
+   * Extracts a numeric USK edition from a public catalog source.
+   *
+   * <p>The parser is intentionally lightweight because the catalog source was already validated
+   * elsewhere. It looks at the path segment immediately before the catalog filename and returns it
+   * only when that segment is an integer, including negative moving-edition notation.
+   *
+   * @param publicSource public catalog source or resolved catalog source
+   * @return numeric edition segment when one is present
+   */
+  private static Optional<String> edition(String publicSource) {
+    if (!publicSource.startsWith(CRYPTA_USK_PREFIX)) {
+      return Optional.empty();
+    }
+    int fileSlash = publicSource.lastIndexOf('/');
+    if (fileSlash <= CRYPTA_USK_PREFIX.length()) {
+      return Optional.empty();
+    }
+    int editionSlash = publicSource.lastIndexOf('/', fileSlash - 1);
+    if (editionSlash < CRYPTA_USK_PREFIX.length()) {
+      return Optional.empty();
+    }
+    String candidate = publicSource.substring(editionSlash + 1, fileSlash);
+    return candidate.matches("-?\\d+") ? Optional.of(candidate) : Optional.empty();
+  }
+
+  /**
+   * Redacts and deduplicates warnings before they reach release evidence.
+   *
+   * <p>Publisher implementations should already return safe warnings, but the service applies the
+   * shared app-test redactor as a final guard and preserves first occurrence order through the
+   * stream distinct operation.
+   *
+   * @param warnings warning strings from the publisher and local publication checks
+   * @return sanitized warning strings with duplicates removed
+   */
+  private static List<String> sanitizeWarnings(List<String> warnings) {
+    return warnings.stream().map(AppTestRedactor::redact).distinct().toList();
+  }
+
+  /**
+   * Live publication request with secrets already loaded from secure sources.
+   *
+   * @param catalogFile local catalog properties file
+   * @param catalogSignatureFile local catalog signature sidecar
+   * @param catalogSource public catalog source
+   * @param output sanitized summary output path
+   * @param privateInsertUri private insert URI loaded from env or protected file
+   * @param nodeBaseUrl localhost node or Platform API base URL
+   * @param formPassword form password loaded from env or protected file
+   * @param verifyLiveFetch require immediate live fetch verification after queue insertion
+   */
+  record Request(
+      Path catalogFile,
+      Path catalogSignatureFile,
+      String catalogSource,
+      Path output,
+      String privateInsertUri,
+      String nodeBaseUrl,
+      String formPassword,
+      boolean verifyLiveFetch) {}
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationService.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationService.java
@@ -10,6 +10,7 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -100,7 +101,13 @@ final class LiveUskPublicationService {
             .signatureBytes(inputs.signatureBytes())
             .verifyLiveFetch(request.verifyLiveFetch())
             .build();
-    LiveUskPublishResponse response = publisher.publish(publishRequest);
+    LiveUskPublishResponse response;
+    try {
+      response = publisher.publish(publishRequest);
+    } catch (IOException exception) {
+      cleanupStagingAfterFailedPublish(stagingDirectory, exception);
+      throw exception;
+    }
     cleanupWarnings.add(STAGING_RETAINED_WARNING);
     List<String> warnings = new ArrayList<>(response.warnings());
     warnings.addAll(cleanupWarnings);
@@ -447,6 +454,42 @@ final class LiveUskPublicationService {
         StandardOpenOption.CREATE_NEW,
         StandardOpenOption.WRITE);
     return stagingDirectory;
+  }
+
+  /**
+   * Removes staged sidecars when publication fails before the queue accepts them.
+   *
+   * <p>Failures after queue acceptance keep staging in place because the daemon may still consume
+   * the disk-backed directory. Cleanup errors are reported with sanitized text and without exposing
+   * local staging paths.
+   *
+   * @param stagingDirectory staged directory created for the live insert
+   * @param failure sanitized publication failure raised by the live publisher
+   * @throws IOException if cleanup itself cannot complete
+   */
+  private static void cleanupStagingAfterFailedPublish(Path stagingDirectory, IOException failure)
+      throws IOException {
+    if (failure instanceof LiveUskPublishException) {
+      return;
+    }
+    try {
+      deleteRecursively(stagingDirectory);
+    } catch (IOException _) {
+      throw new AppDistributionException(
+          "live_publish_failed: could not clean staged sidecars after publication failure",
+          failure);
+    }
+  }
+
+  private static void deleteRecursively(Path root) throws IOException {
+    if (!Files.exists(root)) {
+      return;
+    }
+    try (var stream = Files.walk(root)) {
+      for (Path path : stream.sorted(Comparator.reverseOrder()).toList()) {
+        Files.deleteIfExists(path);
+      }
+    }
   }
 
   /**

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationService.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublicationService.java
@@ -84,6 +84,7 @@ final class LiveUskPublicationService {
     requireInsertUriMatchesPublicSource(privateInsertUri, inputs.catalogSource());
     String formPassword = requireFormPassword(request.formPassword());
     String publicSignatureSource = publicSignatureSource(inputs.catalogSource());
+    LiveUskPublicationResultWriter.preflightWritableOutput(inputs.output());
     List<String> cleanupWarnings = new ArrayList<>();
     Path stagingDirectory = stageSidecars(inputs);
     LiveUskPublishRequest publishRequest =

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublishException.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublishException.java
@@ -1,0 +1,36 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+import network.crypta.platform.appdist.AppDistributionException;
+
+/**
+ * Reports a live USK publication failure with staging-retention guidance.
+ *
+ * <p>The production live publisher queues a persistent, disk-backed directory insert and may then
+ * do optional public-source verification. Once the queue accepts the insert, staged sidecar files
+ * must remain available even if later verification fails, because the daemon may still be reading
+ * the source directory. Failures before queue acceptance can safely remove staging.
+ *
+ * <p>This exception keeps that distinction inside the devtools implementation boundary without
+ * adding private insert URIs, form passwords, request bodies, or local staging paths to error text.
+ */
+final class LiveUskPublishException extends AppDistributionException {
+  private LiveUskPublishException(String message, IOException cause) {
+    super(message, cause);
+  }
+
+  /**
+   * Wraps a failure that happened after the live queue accepted the directory insert.
+   *
+   * @param cause sanitized failure raised after queue acceptance
+   * @return publication exception that tells the service to retain staged sidecars
+   */
+  static LiveUskPublishException afterQueueAccepted(IOException cause) {
+    return new LiveUskPublishException(sanitizedMessage(cause), cause);
+  }
+
+  private static String sanitizedMessage(IOException cause) {
+    String message = cause.getMessage();
+    return message == null || message.isBlank() ? "live_publish_failed" : message;
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublishRequest.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublishRequest.java
@@ -1,0 +1,192 @@
+package network.crypta.platform.devtools;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/**
+ * Secret-bearing request passed only to the live USK insertion adapter.
+ *
+ * <p>This value contains the private insert URI, form password, and retained staging directory
+ * needed for the localhost daemon call. It deliberately overrides {@link #toString()} so accidental
+ * diagnostics cannot expose those values. Publication summaries must be built from {@code
+ * LiveUskPublishResponse} and {@code LiveUskPublicationResult}, not from this request.
+ *
+ * <p>The request also carries exact catalog and signature bytes for optional post-publish
+ * verification. Those arrays are defensively copied on construction and access so a publisher
+ * cannot accidentally mutate the service's validation snapshot. The class is package-local because
+ * it is an implementation boundary between the CLI service and the insertion backend, not a stable
+ * public API.
+ */
+final class LiveUskPublishRequest {
+  private final URI nodeBaseUrl;
+  private final String formPassword;
+  private final String privateInsertUri;
+  private final Path stagingDirectory;
+  private final String identifier;
+  private final String publicCatalogSource;
+  private final String publicSignatureSource;
+  private final byte[] catalogBytes;
+  private final byte[] signatureBytes;
+  private final boolean verifyLiveFetch;
+
+  private LiveUskPublishRequest(Builder builder) {
+    this.nodeBaseUrl = Objects.requireNonNull(builder.nodeBaseUrl, "nodeBaseUrl");
+    this.formPassword = Objects.requireNonNull(builder.formPassword, "formPassword");
+    this.privateInsertUri = Objects.requireNonNull(builder.privateInsertUri, "privateInsertUri");
+    this.stagingDirectory = Objects.requireNonNull(builder.stagingDirectory, "stagingDirectory");
+    this.identifier = Objects.requireNonNull(builder.identifier, "identifier");
+    this.publicCatalogSource =
+        Objects.requireNonNull(builder.publicCatalogSource, "publicCatalogSource");
+    this.publicSignatureSource =
+        Objects.requireNonNull(builder.publicSignatureSource, "publicSignatureSource");
+    this.catalogBytes = Objects.requireNonNull(builder.catalogBytes, "catalogBytes").clone();
+    this.signatureBytes = Objects.requireNonNull(builder.signatureBytes, "signatureBytes").clone();
+    this.verifyLiveFetch = builder.verifyLiveFetch;
+  }
+
+  static Builder builder() {
+    return new Builder();
+  }
+
+  URI nodeBaseUrl() {
+    return nodeBaseUrl;
+  }
+
+  String formPassword() {
+    return formPassword;
+  }
+
+  String privateInsertUri() {
+    return privateInsertUri;
+  }
+
+  Path stagingDirectory() {
+    return stagingDirectory;
+  }
+
+  String identifier() {
+    return identifier;
+  }
+
+  String publicCatalogSource() {
+    return publicCatalogSource;
+  }
+
+  String publicSignatureSource() {
+    return publicSignatureSource;
+  }
+
+  /**
+   * Returns a copy of the verified catalog bytes.
+   *
+   * <p>The returned array can be used for live fetch comparison or tests without exposing the
+   * request's internal storage to mutation.
+   *
+   * @return defensive copy of the catalog properties bytes
+   */
+  byte[] catalogBytes() {
+    return catalogBytes.clone();
+  }
+
+  /**
+   * Returns a copy of the verified signature sidecar bytes.
+   *
+   * <p>The returned array is the exact sidecar content validated before queueing the live insert,
+   * copied so callers cannot alter the request after construction.
+   *
+   * @return defensive copy of the catalog signature bytes
+   */
+  byte[] signatureBytes() {
+    return signatureBytes.clone();
+  }
+
+  boolean verifyLiveFetch() {
+    return verifyLiveFetch;
+  }
+
+  @Override
+  public String toString() {
+    return "LiveUskPublishRequest[redacted]";
+  }
+
+  /**
+   * Builder for the secret-bearing live publish adapter request.
+   *
+   * <p>The builder keeps construction readable at call sites while the resulting request remains an
+   * immutable, redacted value. Byte arrays are copied when accepted and again when the request is
+   * built so a caller cannot mutate the exact sidecar bytes used for live fetch verification.
+   */
+  static final class Builder {
+    private URI nodeBaseUrl;
+    private String formPassword;
+    private String privateInsertUri;
+    private Path stagingDirectory;
+    private String identifier;
+    private String publicCatalogSource;
+    private String publicSignatureSource;
+    private byte[] catalogBytes;
+    private byte[] signatureBytes;
+    private boolean verifyLiveFetch;
+
+    Builder nodeBaseUrl(URI nodeBaseUrl) {
+      this.nodeBaseUrl = Objects.requireNonNull(nodeBaseUrl, "nodeBaseUrl");
+      return this;
+    }
+
+    Builder formPassword(String formPassword) {
+      this.formPassword = Objects.requireNonNull(formPassword, "formPassword");
+      return this;
+    }
+
+    Builder privateInsertUri(String privateInsertUri) {
+      this.privateInsertUri = Objects.requireNonNull(privateInsertUri, "privateInsertUri");
+      return this;
+    }
+
+    Builder stagingDirectory(Path stagingDirectory) {
+      this.stagingDirectory = Objects.requireNonNull(stagingDirectory, "stagingDirectory");
+      return this;
+    }
+
+    Builder identifier(String identifier) {
+      this.identifier = Objects.requireNonNull(identifier, "identifier");
+      return this;
+    }
+
+    Builder publicCatalogSource(String publicCatalogSource) {
+      this.publicCatalogSource = Objects.requireNonNull(publicCatalogSource, "publicCatalogSource");
+      return this;
+    }
+
+    Builder publicSignatureSource(String publicSignatureSource) {
+      this.publicSignatureSource =
+          Objects.requireNonNull(publicSignatureSource, "publicSignatureSource");
+      return this;
+    }
+
+    Builder catalogBytes(byte[] catalogBytes) {
+      this.catalogBytes = Objects.requireNonNull(catalogBytes, "catalogBytes").clone();
+      return this;
+    }
+
+    Builder signatureBytes(byte[] signatureBytes) {
+      this.signatureBytes = Objects.requireNonNull(signatureBytes, "signatureBytes").clone();
+      return this;
+    }
+
+    Builder verifyLiveFetch(boolean verifyLiveFetch) {
+      this.verifyLiveFetch = verifyLiveFetch;
+      return this;
+    }
+
+    LiveUskPublishRequest build() {
+      return new LiveUskPublishRequest(this);
+    }
+
+    @Override
+    public String toString() {
+      return "LiveUskPublishRequest.Builder[redacted]";
+    }
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublishResponse.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublishResponse.java
@@ -1,0 +1,40 @@
+package network.crypta.platform.devtools;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Sanitized response from a live USK insertion adapter.
+ *
+ * <p>The response contains only status labels, public or already-sanitized fetch metadata, and
+ * bounded warnings. It must never include private insert URIs, form passwords, local staging paths,
+ * raw request bodies, raw node response bodies, or key material.
+ *
+ * @param catalogInsertStatus status for the catalog properties sidecar
+ * @param signatureInsertStatus status for the signature sidecar
+ * @param resolvedCatalogSource resolved public catalog source, when verified or reported
+ * @param postPublishVerificationStatus status of optional live fetch verification
+ * @param schedulerRefreshVerificationStatus status of scheduler/catalog-refresh compatibility
+ * @param warnings sanitized warnings to include in the final summary
+ */
+record LiveUskPublishResponse(
+    String catalogInsertStatus,
+    String signatureInsertStatus,
+    Optional<String> resolvedCatalogSource,
+    String postPublishVerificationStatus,
+    String schedulerRefreshVerificationStatus,
+    List<String> warnings) {
+  /**
+   * Validates optional metadata and normalizes nullable warning lists at the publisher boundary.
+   *
+   * <p>Publisher implementations are intentionally small adapters around external node behavior, so
+   * this constructor keeps the stricter rule that optional metadata is represented by a non-null
+   * {@link Optional}. The copied warning list prevents later mutation from changing the publication
+   * evidence after the service has built its final summary.
+   */
+  LiveUskPublishResponse {
+    Objects.requireNonNull(resolvedCatalogSource, "resolvedCatalogSource");
+    warnings = warnings == null ? List.of() : List.copyOf(warnings);
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublisher.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/LiveUskPublisher.java
@@ -1,0 +1,28 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+
+/**
+ * Inserts validated catalog sidecars through a configured live-node workflow.
+ *
+ * <p>The interface keeps the live insertion boundary injectable. Production uses the localhost
+ * Platform API queue route, while tests can provide an in-memory implementation that records the
+ * sanitized request shape without contacting a daemon. The request necessarily carries sensitive
+ * one-call insertion material and a local staging directory; the response is the point where that
+ * material must be reduced to sanitized status labels, public fetch metadata, and bounded warnings.
+ * Implementations must not log, stringify, or return private insert URIs, form passwords, local
+ * staging paths, request bodies, or node response bodies.
+ */
+@FunctionalInterface
+interface LiveUskPublisher {
+  /**
+   * Publishes catalog and signature sidecars.
+   *
+   * @param request live insertion request carrying credentials and staged sidecars for this call
+   *     only
+   * @return sanitized publication status reported by the insertion workflow
+   * @throws IOException when the configured live-node endpoint cannot be reached or the adapter
+   *     cannot complete its configured I/O
+   */
+  LiveUskPublishResponse publish(LiveUskPublishRequest request) throws IOException;
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisher.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisher.java
@@ -1,0 +1,577 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import network.crypta.platform.appcatalog.AppCatalogSignature;
+import network.crypta.platform.appdist.AppDistributionException;
+
+/**
+ * Publishes catalog sidecars through the localhost Platform API queue insertion route.
+ *
+ * <p>The current runtime exposes live inserts through the queue API rather than a catalog-specific
+ * publication SPI. This adapter stages the catalog and signature as a two-file directory and asks
+ * the daemon to enqueue one persistent directory insert at the private USK insert URI. The public
+ * catalog source then addresses {@code cryptad-app-catalog.properties} as a manifest child, and the
+ * signature sidecar addresses the sibling {@code cryptad-app-catalog.signature}. Optional live
+ * fetch verification uses the same Platform API content-fetch route and compares exact bytes
+ * without recording response bodies.
+ */
+final class PlatformApiLiveUskPublisher implements LiveUskPublisher {
+  /** Per-request network bound so a live publication command cannot wait indefinitely. */
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+  /** Media type used by the existing Platform API form endpoints. */
+  private static final String FORM_CONTENT_TYPE =
+      "application/x-www-form-urlencoded; charset=UTF-8";
+
+  /**
+   * Queue outcome that means the daemon accepted the persistent insert request.
+   *
+   * <p>This is not treated as proof that publication has propagated or that disk-backed staging
+   * files have been consumed; the caller retains staging for operator cleanup.
+   */
+  private static final String OUTCOME_STARTED = "STARTED";
+
+  /** Sanitized status recorded when the queue accepts a catalog or signature insert request. */
+  private static final String STATUS_QUEUED = "queued";
+
+  /** Summary value used when the operator did not request live fetch verification. */
+  private static final String POST_PUBLISH_NOT_REQUESTED = "not_requested";
+
+  /** Summary value used only after fetched catalog and signature bytes match local sidecars. */
+  private static final String POST_PUBLISH_VERIFIED = "verified";
+
+  /** Scheduler compatibility is reported by the service layer, not this low-level publisher. */
+  private static final String SCHEDULER_REFRESH_NOT_RUN = "not_run";
+
+  /** Verification fetch cap for catalog properties; production catalogs should be much smaller. */
+  private static final long MAX_CATALOG_BYTES = 1024L * 1024L;
+
+  /** Verification fetch cap for detached signature sidecars. */
+  private static final long MAX_SIGNATURE_BYTES = 64L * 1024L;
+
+  /** Internal sentinel used when a fetch response does not report a resolved public source. */
+  private static final String ABSENT_RESOLVED_SOURCE = "";
+
+  /** HTTP transport used for localhost Platform API requests. */
+  private final HttpClient httpClient;
+
+  /**
+   * Creates a publisher with a bounded no-redirect HTTP client.
+   *
+   * <p>The CLI has already validated that the base URL points at localhost. The client still avoids
+   * redirects so a misconfigured node endpoint cannot silently forward private insert material or a
+   * form password to another URL.
+   */
+  PlatformApiLiveUskPublisher() {
+    this(
+        HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NEVER)
+            .build());
+  }
+
+  /**
+   * Creates a publisher with an explicit client for tests.
+   *
+   * @param httpClient HTTP client used for Platform API requests
+   */
+  PlatformApiLiveUskPublisher(HttpClient httpClient) {
+    this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+  }
+
+  @Override
+  public LiveUskPublishResponse publish(LiveUskPublishRequest request) throws IOException {
+    enqueueDirectoryInsert(request);
+    Optional<String> resolvedCatalogSource = Optional.empty();
+    String postPublishStatus = POST_PUBLISH_NOT_REQUESTED;
+    if (request.verifyLiveFetch()) {
+      resolvedCatalogSource = verifyFetchedSidecars(request);
+      postPublishStatus = POST_PUBLISH_VERIFIED;
+    }
+    return new LiveUskPublishResponse(
+        STATUS_QUEUED,
+        STATUS_QUEUED,
+        resolvedCatalogSource,
+        postPublishStatus,
+        SCHEDULER_REFRESH_NOT_RUN,
+        List.of());
+  }
+
+  /**
+   * Enqueues the staged catalog directory as one persistent USK insert.
+   *
+   * <p>The queue API receives the private insert URI, form password, and local staging path. Those
+   * values are intentionally kept inside the request body and are never copied into exception
+   * messages or publication summaries.
+   *
+   * @param request live publication request with validated public/private source correlation
+   * @throws IOException when the daemon cannot be contacted
+   */
+  private void enqueueDirectoryInsert(LiveUskPublishRequest request) throws IOException {
+    String body =
+        form(
+            "formPassword",
+            request.formPassword(),
+            "sourcePath",
+            request.stagingDirectory().toString(),
+            "insertUri",
+            request.privateInsertUri(),
+            "identifier",
+            request.identifier(),
+            "compatibilityMode",
+            "COMPAT_CURRENT");
+    HttpResponse<String> response =
+        sendPost(apiEndpoint(request.nodeBaseUrl(), "queue/inserts/directory"), body);
+    if (response.statusCode() != 200 && response.statusCode() != 201) {
+      throw new AppDistributionException(
+          "live_publish_failed: node returned HTTP "
+              + response.statusCode()
+              + " while enqueueing catalog USK insert");
+    }
+    String outcome =
+        jsonString(response.body(), "outcome")
+            .orElseThrow(
+                () ->
+                    new AppDistributionException(
+                        "live_publish_failed: node did not report a queue insert outcome"));
+    if (!OUTCOME_STARTED.equals(outcome)) {
+      throw new AppDistributionException(
+          "live_publish_failed: node did not start catalog USK insert");
+    }
+  }
+
+  /**
+   * Fetches the public catalog and matching sibling signature, then compares both to local bytes.
+   *
+   * <p>If the catalog fetch resolves a moving USK to a concrete edition, the signature fetch is
+   * derived from that resolved catalog source so both sidecars are verified at the same edition.
+   * The method returns only the sanitized resolved catalog source that the final report may expose.
+   *
+   * @param request live publication request containing local sidecar bytes and public sources
+   * @return resolved public catalog source, when reported by the node
+   * @throws IOException when either verification fetch cannot complete
+   */
+  private Optional<String> verifyFetchedSidecars(LiveUskPublishRequest request) throws IOException {
+    FetchResult catalog =
+        fetchContent(
+            request.nodeBaseUrl(),
+            request.formPassword(),
+            request.publicCatalogSource(),
+            MAX_CATALOG_BYTES);
+    String signatureFetchSource =
+        catalog
+            .resolvedSource()
+            .map(PlatformApiLiveUskPublisher::signatureSiblingSource)
+            .orElse(request.publicSignatureSource());
+    FetchResult signature =
+        fetchContent(
+            request.nodeBaseUrl(),
+            request.formPassword(),
+            signatureFetchSource,
+            MAX_SIGNATURE_BYTES);
+    if (!Arrays.equals(request.catalogBytes(), catalog.bytes())) {
+      throw new AppDistributionException(
+          "live_publish_verification_failed: fetched catalog bytes do not match local catalog");
+    }
+    if (!Arrays.equals(request.signatureBytes(), signature.bytes())) {
+      throw new AppDistributionException(
+          "live_publish_verification_failed: fetched signature bytes do not match local signature");
+    }
+    return catalog.resolvedSource();
+  }
+
+  /**
+   * Replaces the catalog file name in a public source with the signature sidecar name.
+   *
+   * @param catalogSource public catalog source, preferably resolved to a concrete edition
+   * @return sibling source for {@code cryptad-app-catalog.signature}
+   */
+  private static String signatureSiblingSource(String catalogSource) {
+    int slash = catalogSource.lastIndexOf('/');
+    if (slash < 0) {
+      return catalogSource;
+    }
+    return catalogSource.substring(0, slash + 1) + AppCatalogSignature.SIGNATURE_FILE_NAME;
+  }
+
+  /**
+   * Fetches one public sidecar through the Platform API content route.
+   *
+   * <p>The node response is decoded from base64 and reduced to bytes plus an optional sanitized
+   * resolved URI. HTTP status codes and parse failures are reported without echoing response
+   * bodies.
+   *
+   * @param nodeBaseUrl localhost Platform API base URL
+   * @param formPassword form password for the local node
+   * @param publicSource public Crypta source to fetch
+   * @param maxBytes maximum response size accepted by the node route
+   * @return fetched bytes and optional resolved public source
+   * @throws IOException when the fetch request cannot be sent
+   */
+  private FetchResult fetchContent(
+      URI nodeBaseUrl, String formPassword, String publicSource, long maxBytes) throws IOException {
+    String body =
+        form(
+            "formPassword",
+            formPassword,
+            "uri",
+            publicSource,
+            "format",
+            "base64",
+            "maxBytes",
+            Long.toString(maxBytes),
+            "purpose",
+            "live-usk-catalog-publication");
+    HttpResponse<String> response = sendPost(apiEndpoint(nodeBaseUrl, "content/fetch"), body);
+    if (response.statusCode() != 200) {
+      throw new AppDistributionException(
+          "live_publish_verification_failed: node returned HTTP "
+              + response.statusCode()
+              + " while fetching published sidecars");
+    }
+    String contentBase64 =
+        jsonString(response.body(), "contentBase64")
+            .orElseThrow(
+                () ->
+                    new AppDistributionException(
+                        "live_publish_verification_failed: content fetch response was incomplete"));
+    byte[] bytes;
+    try {
+      bytes = Base64.getDecoder().decode(contentBase64);
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException(
+          "live_publish_verification_failed: content fetch bytes were malformed", exception);
+    }
+    Optional<String> resolvedSource =
+        jsonString(response.body(), "resolvedUri").flatMap(this::resolvedSource);
+    return new FetchResult(bytes, resolvedSource.orElse(ABSENT_RESOLVED_SOURCE));
+  }
+
+  /**
+   * Sends one bounded JSON-accepting POST request to the local node.
+   *
+   * @param endpoint full Platform API endpoint
+   * @param body already encoded form body
+   * @return HTTP response body for internal parsing only
+   * @throws IOException when transport fails or the request is interrupted
+   */
+  private HttpResponse<String> sendPost(URI endpoint, String body) throws IOException {
+    HttpRequest request =
+        HttpRequest.newBuilder(endpoint)
+            .timeout(REQUEST_TIMEOUT)
+            .header("Content-Type", FORM_CONTENT_TYPE)
+            .header("Accept", "application/json")
+            .POST(HttpRequest.BodyPublishers.ofString(body, StandardCharsets.UTF_8))
+            .build();
+    try {
+      return httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IOException("interrupted while contacting live node", exception);
+    } catch (IllegalArgumentException exception) {
+      throw new AppDistributionException("live publish node endpoint is malformed", exception);
+    }
+  }
+
+  /**
+   * Builds a Platform API v1 endpoint from an operator-supplied base URL.
+   *
+   * @param nodeBaseUrl validated local node base URL, with or without {@code /api/v1}
+   * @param relativePath endpoint path below {@code /api/v1}
+   * @return normalized endpoint URI
+   */
+  private static URI apiEndpoint(URI nodeBaseUrl, String relativePath) {
+    String base = nodeBaseUrl.toString();
+    while (base.endsWith("/")) {
+      base = base.substring(0, base.length() - 1);
+    }
+    if (!base.endsWith("/api/v1")) {
+      base = base + "/api/v1";
+    }
+    return URI.create(base + "/" + relativePath);
+  }
+
+  /**
+   * Builds a UTF-8 {@code application/x-www-form-urlencoded} body.
+   *
+   * @param fields alternating field names and values
+   * @return encoded form body
+   * @throws IllegalArgumentException if the argument list is not name/value paired
+   */
+  private static String form(String... fields) {
+    if (fields.length % 2 != 0) {
+      throw new IllegalArgumentException("form fields must be name/value pairs");
+    }
+    StringBuilder builder = new StringBuilder();
+    for (int index = 0; index < fields.length; index += 2) {
+      if (index > 0) {
+        builder.append('&');
+      }
+      builder.append(encode(fields[index])).append('=').append(encode(fields[index + 1]));
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Percent-encodes a single form field value.
+   *
+   * @param value raw field name or value
+   * @return form-encoded representation
+   */
+  private static String encode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Extracts one JSON string field from a small Platform API response.
+   *
+   * <p>This intentionally narrow scanner avoids adding a dependency to the devtools CLI path while
+   * still honoring JSON string escaping for the fields this adapter consumes. It only accepts a
+   * quoted string value after the named field and returns no raw response text to callers.
+   *
+   * @param body JSON response body kept in memory only for this parse
+   * @param fieldName scalar field to extract
+   * @return decoded field value when present
+   */
+  private static Optional<String> jsonString(String body, String fieldName) {
+    String fieldToken = "\"" + fieldName + "\"";
+    int searchFrom = 0;
+    while (searchFrom < body.length()) {
+      int fieldStart = body.indexOf(fieldToken, searchFrom);
+      if (fieldStart < 0) {
+        return Optional.empty();
+      }
+      int valueStart = stringValueStart(body, fieldStart + fieldToken.length());
+      if (valueStart >= 0) {
+        return readJsonString(body, valueStart);
+      }
+      searchFrom = fieldStart + 1;
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Finds the opening content position of a JSON string field value.
+   *
+   * @param body JSON response body
+   * @param afterFieldName index immediately after the quoted field name
+   * @return first character inside the string value, or {@code -1} when the match is not a string
+   */
+  private static int stringValueStart(String body, int afterFieldName) {
+    int colon = skipWhitespace(body, afterFieldName);
+    if (colon >= body.length() || body.charAt(colon) != ':') {
+      return -1;
+    }
+    int quote = skipWhitespace(body, colon + 1);
+    if (quote >= body.length() || body.charAt(quote) != '"') {
+      return -1;
+    }
+    return quote + 1;
+  }
+
+  /**
+   * Advances over JSON whitespace.
+   *
+   * @param value string to scan
+   * @param start first index to inspect
+   * @return index of the next non-whitespace character, possibly {@code value.length()}
+   */
+  private static int skipWhitespace(String value, int start) {
+    int index = start;
+    while (index < value.length() && Character.isWhitespace(value.charAt(index))) {
+      index++;
+    }
+    return index;
+  }
+
+  /**
+   * Reads a JSON string from its first content character.
+   *
+   * @param body JSON response body
+   * @param contentStart first character after the opening quote
+   * @return decoded JSON string value, or empty when the string is incomplete
+   */
+  private static Optional<String> readJsonString(String body, int contentStart) {
+    StringBuilder builder = new StringBuilder();
+    int index = contentStart;
+    while (index < body.length()) {
+      char character = body.charAt(index);
+      if (character == '"') {
+        return Optional.of(builder.toString());
+      }
+      if (character == '\\') {
+        int escapedIndex = index + 1;
+        if (escapedIndex >= body.length()) {
+          return Optional.empty();
+        }
+        index = appendJsonEscape(builder, body, escapedIndex);
+      } else {
+        builder.append(character);
+        index++;
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Appends one JSON escape sequence and returns the next scan index.
+   *
+   * @param builder decoded JSON string accumulator
+   * @param body JSON response body
+   * @param escapedIndex index of the character immediately after the backslash
+   * @return next index to inspect in {@code body}
+   */
+  private static int appendJsonEscape(StringBuilder builder, String body, int escapedIndex) {
+    char escaped = body.charAt(escapedIndex);
+    switch (escaped) {
+      case 'b' -> builder.append('\b');
+      case 'f' -> builder.append('\f');
+      case 'n' -> builder.append('\n');
+      case 'r' -> builder.append('\r');
+      case 't' -> builder.append('\t');
+      case 'u' -> {
+        return appendUnicodeEscape(builder, body, escapedIndex);
+      }
+      default -> builder.append(escaped);
+    }
+    return escapedIndex + 1;
+  }
+
+  /**
+   * Appends a JSON Unicode escape when valid, otherwise preserves the escaped marker.
+   *
+   * @param builder decoded JSON string accumulator
+   * @param body JSON response body
+   * @param escapedIndex index of the {@code u} escape marker
+   * @return next index to inspect in {@code body}
+   */
+  private static int appendUnicodeEscape(StringBuilder builder, String body, int escapedIndex) {
+    Optional<Character> unicode = unicodeEscape(body, escapedIndex + 1);
+    if (unicode.isPresent()) {
+      builder.append(unicode.orElseThrow());
+      return escapedIndex + 5;
+    }
+    builder.append('u');
+    return escapedIndex + 1;
+  }
+
+  /**
+   * Decodes one four-hex-digit JSON Unicode escape.
+   *
+   * @param body JSON response body
+   * @param hexStart first hex digit after the JSON Unicode escape prefix
+   * @return decoded character when all four hex digits are present and valid
+   */
+  private static Optional<Character> unicodeEscape(String body, int hexStart) {
+    if (hexStart + 4 > body.length()) {
+      return Optional.empty();
+    }
+    int value = 0;
+    for (int offset = 0; offset < 4; offset++) {
+      int digit = Character.digit(body.charAt(hexStart + offset), 16);
+      if (digit < 0) {
+        return Optional.empty();
+      }
+      value = (value << 4) + digit;
+    }
+    return Optional.of((char) value);
+  }
+
+  /**
+   * Sanitizes and normalizes a node-reported resolved source.
+   *
+   * <p>The release summary may include public fetch URIs, so this helper rejects control
+   * characters, query strings, and fragments before accepting either a {@code crypta:} URI or a
+   * bare Crypta key with a public scheme added.
+   *
+   * @param rawResolvedUri value reported by the node's fetch response
+   * @return sanitized public source safe for publication evidence
+   */
+  private Optional<String> resolvedSource(String rawResolvedUri) {
+    if (rawResolvedUri == null || rawResolvedUri.isBlank()) {
+      return Optional.empty();
+    }
+    String value = rawResolvedUri.trim();
+    if (value.indexOf('\n') >= 0
+        || value.indexOf('\r') >= 0
+        || value.indexOf('\u0000') >= 0
+        || value.indexOf('?') >= 0
+        || value.indexOf('#') >= 0) {
+      return Optional.empty();
+    }
+    String lower = value.toLowerCase(java.util.Locale.ROOT);
+    if (lower.startsWith("crypta:")) {
+      return Optional.of(value);
+    }
+    if (lower.startsWith("usk@")
+        || lower.startsWith("ssk@")
+        || lower.startsWith("chk@")
+        || lower.startsWith("ksk@")) {
+      return Optional.of("crypta:" + value);
+    }
+    return Optional.empty();
+  }
+
+  /** Fetch response reduced to immutable bytes and optional public resolved-source metadata. */
+  private static final class FetchResult {
+    private final byte[] bytes;
+    private final String resolvedSource;
+
+    private FetchResult(byte[] bytes, String resolvedSource) {
+      this.bytes = Objects.requireNonNull(bytes, "bytes").clone();
+      this.resolvedSource = Objects.requireNonNull(resolvedSource, "resolvedSource");
+    }
+
+    /**
+     * Returns a defensive copy of the fetched sidecar bytes.
+     *
+     * @return fetched bytes
+     */
+    byte[] bytes() {
+      return bytes.clone();
+    }
+
+    Optional<String> resolvedSource() {
+      return resolvedSource.isEmpty() ? Optional.empty() : Optional.of(resolvedSource);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof FetchResult that)) {
+        return false;
+      }
+      return Arrays.equals(bytes, that.bytes) && resolvedSource.equals(that.resolvedSource);
+    }
+
+    @Override
+    public int hashCode() {
+      return 31 * Arrays.hashCode(bytes) + resolvedSource.hashCode();
+    }
+
+    @Override
+    public String toString() {
+      return "FetchResult[bytesLength="
+          + bytes.length
+          + ", bytesHashCode="
+          + Arrays.hashCode(bytes)
+          + ", resolvedSource="
+          + resolvedSource()
+          + "]";
+    }
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisher.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisher.java
@@ -95,20 +95,29 @@ final class PlatformApiLiveUskPublisher implements LiveUskPublisher {
 
   @Override
   public LiveUskPublishResponse publish(LiveUskPublishRequest request) throws IOException {
-    enqueueDirectoryInsert(request);
-    Optional<String> resolvedCatalogSource = Optional.empty();
-    String postPublishStatus = POST_PUBLISH_NOT_REQUESTED;
-    if (request.verifyLiveFetch()) {
-      resolvedCatalogSource = verifyFetchedSidecars(request);
-      postPublishStatus = POST_PUBLISH_VERIFIED;
+    boolean queueAccepted = false;
+    try {
+      enqueueDirectoryInsert(request);
+      queueAccepted = true;
+      Optional<String> resolvedCatalogSource = Optional.empty();
+      String postPublishStatus = POST_PUBLISH_NOT_REQUESTED;
+      if (request.verifyLiveFetch()) {
+        resolvedCatalogSource = verifyFetchedSidecars(request);
+        postPublishStatus = POST_PUBLISH_VERIFIED;
+      }
+      return new LiveUskPublishResponse(
+          STATUS_QUEUED,
+          STATUS_QUEUED,
+          resolvedCatalogSource,
+          postPublishStatus,
+          SCHEDULER_REFRESH_NOT_RUN,
+          List.of());
+    } catch (IOException exception) {
+      if (queueAccepted) {
+        throw LiveUskPublishException.afterQueueAccepted(exception);
+      }
+      throw exception;
     }
-    return new LiveUskPublishResponse(
-        STATUS_QUEUED,
-        STATUS_QUEUED,
-        resolvedCatalogSource,
-        postPublishStatus,
-        SCHEDULER_REFRESH_NOT_RUN,
-        List.of());
   }
 
   /**

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisher.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisher.java
@@ -1,6 +1,7 @@
 package network.crypta.platform.devtools;
 
 import java.io.IOException;
+import java.net.ProxySelector;
 import java.net.URI;
 import java.net.URLEncoder;
 import java.net.http.HttpClient;
@@ -68,16 +69,17 @@ final class PlatformApiLiveUskPublisher implements LiveUskPublisher {
   private final HttpClient httpClient;
 
   /**
-   * Creates a publisher with a bounded no-redirect HTTP client.
+   * Creates a publisher with a bounded no-proxy, no-redirect HTTP client.
    *
    * <p>The CLI has already validated that the base URL points at localhost. The client still avoids
-   * redirects so a misconfigured node endpoint cannot silently forward private insert material or a
-   * form password to another URL.
+   * inherited JVM proxy selectors and redirects so a misconfigured runtime cannot silently forward
+   * private insert material or a form password outside the validated loopback endpoint.
    */
   PlatformApiLiveUskPublisher() {
     this(
         HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(10))
+            .proxy(ProxySelector.of(null))
             .followRedirects(HttpClient.Redirect.NEVER)
             .build());
   }

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/PublicationInputValidator.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/PublicationInputValidator.java
@@ -58,17 +58,18 @@ final class PublicationInputValidator {
     byte[] signatureBytes = Files.readAllBytes(normalizedSignatureFile);
     AppCatalog catalog = AppCatalogParser.parse(catalogBytes);
     AppCatalogSignature signature = AppCatalogVerifier.readSignature(signatureBytes);
-    return new ValidatedPublicationInputs(
-        normalizedCatalogFile,
-        normalizedSignatureFile,
-        catalogSource.trim(),
-        normalizedOutput,
-        catalogBytes,
-        signatureBytes,
-        catalog,
-        signature,
-        sha256Hex(catalogBytes),
-        sha256Hex(signatureBytes));
+    return ValidatedPublicationInputs.builder()
+        .catalogFile(normalizedCatalogFile)
+        .catalogSignatureFile(normalizedSignatureFile)
+        .catalogSource(catalogSource.trim())
+        .output(normalizedOutput)
+        .catalogBytes(catalogBytes)
+        .signatureBytes(signatureBytes)
+        .catalog(catalog)
+        .signature(signature)
+        .catalogSha256(sha256Hex(catalogBytes))
+        .signatureSha256(sha256Hex(signatureBytes))
+        .build();
   }
 
   /**

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/PublicationInputValidator.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/PublicationInputValidator.java
@@ -1,0 +1,140 @@
+package network.crypta.platform.devtools;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import network.crypta.platform.appcatalog.AppCatalog;
+import network.crypta.platform.appcatalog.AppCatalogParser;
+import network.crypta.platform.appcatalog.AppCatalogSignature;
+import network.crypta.platform.appcatalog.AppCatalogVerifier;
+import network.crypta.platform.appdist.AppDistributionException;
+
+/**
+ * Validates the shared local inputs for offline and live catalog publication.
+ *
+ * <p>The publication commands deliberately treat local validation as a single reusable step:
+ * normalize paths, reject symlinked or missing sidecars, require the canonical catalog and
+ * signature filenames ({@code cryptad-app-catalog.properties} and {@code
+ * cryptad-app-catalog.signature}), parse the catalog, structurally read the signature sidecar,
+ * validate the public {@code crypta:USK@.../cryptad-app-catalog.properties} source, and compute
+ * stable digests before any plan or live insertion summary is written. The returned snapshot
+ * contains exact sidecar bytes for later signature verification, but never exposes local absolute
+ * paths through report-rendering helpers.
+ */
+final class PublicationInputValidator {
+  /** Utility class; validation is performed through static methods. */
+  private PublicationInputValidator() {}
+
+  /**
+   * Validates one catalog publication request.
+   *
+   * @param catalogFile local catalog properties file
+   * @param catalogSignatureFile local catalog signature sidecar
+   * @param catalogSource public catalog source URI expected after publication
+   * @param output report output path
+   * @return normalized and parsed publication inputs
+   * @throws IOException if catalog or signature bytes cannot be read
+   */
+  static ValidatedPublicationInputs validate(
+      Path catalogFile, Path catalogSignatureFile, String catalogSource, Path output)
+      throws IOException {
+    Path normalizedCatalogFile = catalogFile.toAbsolutePath().normalize();
+    Path normalizedSignatureFile = catalogSignatureFile.toAbsolutePath().normalize();
+    Path normalizedOutput = output.toAbsolutePath().normalize();
+    requireUskSource(catalogSource);
+    requireReadable(normalizedCatalogFile, "catalog file");
+    requireReadable(normalizedSignatureFile, "catalog signature file");
+    requireCanonicalFileName(
+        normalizedCatalogFile, AppCatalogSignature.CATALOG_FILE_NAME, "catalog file");
+    requireCanonicalFileName(
+        normalizedSignatureFile,
+        AppCatalogSignature.SIGNATURE_FILE_NAME,
+        "catalog signature sidecar");
+    byte[] catalogBytes = Files.readAllBytes(normalizedCatalogFile);
+    byte[] signatureBytes = Files.readAllBytes(normalizedSignatureFile);
+    AppCatalog catalog = AppCatalogParser.parse(catalogBytes);
+    AppCatalogSignature signature = AppCatalogVerifier.readSignature(signatureBytes);
+    return new ValidatedPublicationInputs(
+        normalizedCatalogFile,
+        normalizedSignatureFile,
+        catalogSource.trim(),
+        normalizedOutput,
+        catalogBytes,
+        signatureBytes,
+        catalog,
+        signature,
+        sha256Hex(catalogBytes),
+        sha256Hex(signatureBytes));
+  }
+
+  /**
+   * Requires a concrete local file without following symlink indirection.
+   *
+   * <p>Publication evidence must describe the sidecar filenames only, but the live publisher still
+   * reads bytes from local disk. Rejecting symlinks keeps the command tied to the operator-selected
+   * sidecars and avoids surprising path traversal through a staging location.
+   *
+   * @param file normalized path to validate
+   * @param label human-readable sidecar label for sanitized error messages
+   * @throws AppDistributionException if the path is not a regular file
+   */
+  private static void requireReadable(Path file, String label) throws AppDistributionException {
+    if (Files.isSymbolicLink(file) || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
+      throw new AppDistributionException(label + " must be a regular file");
+    }
+  }
+
+  /**
+   * Enforces the catalog sidecar filenames expected by public USK consumers.
+   *
+   * @param file normalized path whose basename is checked
+   * @param expected required basename
+   * @param label human-readable sidecar label for sanitized error messages
+   * @throws AppDistributionException if the basename would publish at a non-standard sibling path
+   */
+  private static void requireCanonicalFileName(Path file, String expected, String label)
+      throws AppDistributionException {
+    if (!expected.equals(file.getFileName().toString())) {
+      throw new AppDistributionException(label + " must be " + expected);
+    }
+  }
+
+  /**
+   * Validates the public catalog source shape used by first-party live publication.
+   *
+   * <p>The signed catalog trust path expects a public {@code crypta:USK@...} source ending in the
+   * catalog properties filename. Query strings and fragments are rejected so a companion signature
+   * sidecar can be derived as a plain sibling file at the same USK path and edition.
+   *
+   * @param source operator-supplied public catalog source
+   * @throws AppDistributionException if the source is not the canonical live USK catalog source
+   */
+  private static void requireUskSource(String source) throws AppDistributionException {
+    String value = source == null ? "" : source.trim();
+    if (!value.startsWith("crypta:USK@")
+        || value.contains("?")
+        || value.contains("#")
+        || !value.endsWith("/" + AppCatalogSignature.CATALOG_FILE_NAME)) {
+      throw new AppDistributionException(
+          "publish-usk requires --catalog-source crypta:USK@.../cryptad-app-catalog.properties");
+    }
+  }
+
+  /**
+   * Computes the stable digest recorded in dry-run plans and live publication summaries.
+   *
+   * @param bytes sidecar bytes to digest
+   * @return lowercase SHA-256 hex digest
+   */
+  private static String sha256Hex(byte[] bytes) {
+    try {
+      return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 digest is unavailable", exception);
+    }
+  }
+}

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/PublicationInputValidator.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/PublicationInputValidator.java
@@ -54,6 +54,8 @@ final class PublicationInputValidator {
         normalizedSignatureFile,
         AppCatalogSignature.SIGNATURE_FILE_NAME,
         "catalog signature sidecar");
+    requireOutputDoesNotAliasSidecar(
+        normalizedOutput, normalizedCatalogFile, normalizedSignatureFile);
     byte[] catalogBytes = Files.readAllBytes(normalizedCatalogFile);
     byte[] signatureBytes = Files.readAllBytes(normalizedSignatureFile);
     AppCatalog catalog = AppCatalogParser.parse(catalogBytes);
@@ -101,6 +103,43 @@ final class PublicationInputValidator {
       throws AppDistributionException {
     if (!expected.equals(file.getFileName().toString())) {
       throw new AppDistributionException(label + " must be " + expected);
+    }
+  }
+
+  /**
+   * Rejects publication reports that would overwrite signed catalog sidecars.
+   *
+   * <p>Dry-run plans and live summaries are written after validation with truncate semantics. The
+   * output path therefore must not be the catalog properties file, the detached signature sidecar,
+   * or an existing filesystem alias such as a hard link or symlink to either sidecar. The error
+   * message deliberately omits local paths because publication failures may be copied into release
+   * evidence or operator logs.
+   *
+   * @param output normalized report output path
+   * @param catalogFile normalized signed catalog path
+   * @param signatureFile normalized detached signature sidecar path
+   * @throws AppDistributionException if output aliases either signed sidecar
+   */
+  private static void requireOutputDoesNotAliasSidecar(
+      Path output, Path catalogFile, Path signatureFile) throws AppDistributionException {
+    if (aliasesSidecar(output, catalogFile) || aliasesSidecar(output, signatureFile)) {
+      throw new AppDistributionException(
+          "publication output must be separate from catalog file and signature sidecar");
+    }
+  }
+
+  private static boolean aliasesSidecar(Path output, Path sidecar) throws AppDistributionException {
+    if (output.equals(sidecar)) {
+      return true;
+    }
+    if (!Files.exists(output, LinkOption.NOFOLLOW_LINKS)) {
+      return false;
+    }
+    try {
+      return Files.isSameFile(output, sidecar);
+    } catch (IOException _) {
+      throw new AppDistributionException(
+          "publication output could not be checked for sidecar aliasing");
     }
   }
 

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/PublicationPlanWriter.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/PublicationPlanWriter.java
@@ -9,10 +9,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.List;
 import network.crypta.platform.appcatalog.AppCatalog;
 import network.crypta.platform.appcatalog.AppCatalogEntry;
-import network.crypta.platform.appcatalog.AppCatalogParser;
 import network.crypta.platform.appcatalog.AppCatalogSignature;
-import network.crypta.platform.appcatalog.AppCatalogVerifier;
-import network.crypta.platform.appdist.AppDistributionException;
 
 /**
  * Writes offline Crypta USK publication plans for signed app catalogs.
@@ -40,23 +37,14 @@ final class PublicationPlanWriter {
    * @throws IOException if catalog artifacts cannot be read or the plan cannot be written
    */
   static Result write(Request request) throws IOException {
-    Request checked = request.normalize();
-    requireUskSource(checked.catalogSource());
-    requireReadable(checked.catalogFile(), "catalog file");
-    requireReadable(checked.catalogSignatureFile(), "catalog signature file");
-    byte[] catalogBytes = Files.readAllBytes(checked.catalogFile());
-    byte[] signatureBytes = Files.readAllBytes(checked.catalogSignatureFile());
-    AppCatalog catalog = AppCatalogParser.parse(catalogBytes);
-    AppCatalogVerifier.readSignature(signatureBytes);
-    if (!AppCatalogSignature.SIGNATURE_FILE_NAME.equals(
-        checked.catalogSignatureFile().getFileName().toString())) {
-      throw new AppDistributionException(
-          "catalog signature sidecar must be cryptad-app-catalog.signature");
-    }
+    ValidatedPublicationInputs checked =
+        PublicationInputValidator.validate(
+            request.catalogFile(),
+            request.catalogSignatureFile(),
+            request.catalogSource(),
+            request.output());
     String content =
-        checked.output().toString().endsWith(".json")
-            ? json(checked, catalog)
-            : markdown(checked, catalog);
+        checked.output().toString().endsWith(".json") ? json(checked) : markdown(checked);
     Path parent = checked.output().getParent();
     if (parent != null) {
       Files.createDirectories(parent);
@@ -69,48 +57,18 @@ final class PublicationPlanWriter {
         StandardOpenOption.TRUNCATE_EXISTING,
         StandardOpenOption.WRITE,
         LinkOption.NOFOLLOW_LINKS);
-    return new Result(catalog.catalogId(), catalog.entries().size(), checked.output());
-  }
-
-  /**
-   * Ensures a plan input is a real local file and not a symlink.
-   *
-   * @param file normalized input path to check
-   * @param label human-readable label used in CLI diagnostics
-   * @throws AppDistributionException if the input is missing, a symlink, or not a regular file
-   */
-  private static void requireReadable(Path file, String label) throws AppDistributionException {
-    if (Files.isSymbolicLink(file) || !Files.isRegularFile(file, LinkOption.NOFOLLOW_LINKS)) {
-      throw new AppDistributionException(label + " must be a regular file");
-    }
-  }
-
-  /**
-   * Validates the public catalog source URI required by {@code publish-usk}.
-   *
-   * @param source catalog source URI supplied by the developer
-   * @throws AppDistributionException if the source is not the expected Crypta USK catalog path
-   */
-  private static void requireUskSource(String source) throws AppDistributionException {
-    String value = source == null ? "" : source.trim();
-    if (!value.startsWith("crypta:USK@")
-        || value.contains("?")
-        || value.contains("#")
-        || !value.endsWith("/" + AppCatalogSignature.CATALOG_FILE_NAME)) {
-      throw new AppDistributionException(
-          "publish-usk requires --catalog-source crypta:USK@.../"
-              + AppCatalogSignature.CATALOG_FILE_NAME);
-    }
+    return new Result(
+        checked.catalog().catalogId(), checked.catalog().entries().size(), checked.output());
   }
 
   /**
    * Renders the human-readable publication checklist.
    *
    * @param request normalized plan request with local file names and catalog source
-   * @param catalog parsed signed catalog metadata
    * @return Markdown plan text with redacted Crypta URI material
    */
-  private static String markdown(Request request, AppCatalog catalog) {
+  private static String markdown(ValidatedPublicationInputs request) {
+    AppCatalog catalog = request.catalog();
     StringBuilder builder = new StringBuilder();
     builder
         .append("# Crypta Catalog USK Publication Plan\n\n")
@@ -164,10 +122,10 @@ final class PublicationPlanWriter {
    * Renders the machine-readable publication checklist.
    *
    * @param request normalized plan request with local file names and catalog source
-   * @param catalog parsed signed catalog metadata
    * @return deterministic JSON plan text with redacted Crypta URI material
    */
-  private static String json(Request request, AppCatalog catalog) {
+  private static String json(ValidatedPublicationInputs request) {
+    AppCatalog catalog = request.catalog();
     StringBuilder builder = new StringBuilder();
     builder.append("{\n");
     field(builder, "schemaVersion", "1", false);
@@ -260,6 +218,7 @@ final class PublicationPlanWriter {
      *
      * @return equivalent request with absolute normalized paths
      */
+    @SuppressWarnings("unused")
     Request normalize() {
       return new Request(
           catalogFile.toAbsolutePath().normalize(),

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/ValidatedPublicationInputs.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/ValidatedPublicationInputs.java
@@ -1,51 +1,92 @@
 package network.crypta.platform.devtools;
 
 import java.nio.file.Path;
+import java.util.Objects;
 import network.crypta.platform.appcatalog.AppCatalog;
 import network.crypta.platform.appcatalog.AppCatalogSignature;
 
 /**
  * Immutable snapshot of validated catalog publication inputs.
  *
- * <p>The record is intentionally package-scoped because it is a coordination type between the
- * developer CLI's dry-run writer and live publication service. It keeps the exact bytes needed for
- * signature verification and live staging, plus only derived report-safe metadata such as digests
- * and file basenames. Callers should use {@link AppTestRedactor#fileName(Path)} when rendering any
- * of the local paths held here.
+ * <p>This package-scoped value coordinates the developer CLI's dry-run writer and live publication
+ * service. It keeps the exact bytes needed for signature verification and live staging, plus only
+ * derived report-safe metadata such as digests and file basenames. Callers should use {@link
+ * AppTestRedactor#fileName(Path)} when rendering any of the local paths held here.
  *
- * @param catalogFile normalized local catalog file path
- * @param catalogSignatureFile normalized local signature sidecar path
- * @param catalogSource public {@code crypta:USK@.../cryptad-app-catalog.properties} source
- * @param output normalized report output path
- * @param catalogBytes exact catalog properties bytes
- * @param signatureBytes exact signature sidecar bytes
- * @param catalog parsed catalog metadata
- * @param signature parsed signature metadata
- * @param catalogSha256 SHA-256 digest of {@code catalogBytes}
- * @param signatureSha256 SHA-256 digest of {@code signatureBytes}
+ * <p>The class is intentionally not a record. Two fields are mutable byte arrays, and an ordinary
+ * class avoids record-generated equality, hashing, and string rendering that would treat arrays by
+ * identity or expose implementation details. Construction goes through a builder so the many
+ * validation fields remain named at the call site without introducing a wide public constructor.
  */
-@SuppressWarnings("ArrayRecordComponent")
-record ValidatedPublicationInputs(
-    Path catalogFile,
-    Path catalogSignatureFile,
-    String catalogSource,
-    Path output,
-    byte[] catalogBytes,
-    byte[] signatureBytes,
-    AppCatalog catalog,
-    AppCatalogSignature signature,
-    String catalogSha256,
-    String signatureSha256) {
+final class ValidatedPublicationInputs {
+  private final Path catalogFile;
+  private final Path catalogSignatureFile;
+  private final String catalogSource;
+  private final Path output;
+  private final byte[] catalogBytes;
+  private final byte[] signatureBytes;
+  private final AppCatalog catalog;
+  private final AppCatalogSignature signature;
+  private final String catalogSha256;
+  private final String signatureSha256;
+
+  private ValidatedPublicationInputs(Builder builder) {
+    catalogFile = Objects.requireNonNull(builder.catalogFile, "catalogFile");
+    catalogSignatureFile =
+        Objects.requireNonNull(builder.catalogSignatureFile, "catalogSignatureFile");
+    catalogSource = Objects.requireNonNull(builder.catalogSource, "catalogSource");
+    output = Objects.requireNonNull(builder.output, "output");
+    catalogBytes = Objects.requireNonNull(builder.catalogBytes, "catalogBytes").clone();
+    signatureBytes = Objects.requireNonNull(builder.signatureBytes, "signatureBytes").clone();
+    catalog = Objects.requireNonNull(builder.catalog, "catalog");
+    signature = Objects.requireNonNull(builder.signature, "signature");
+    catalogSha256 = Objects.requireNonNull(builder.catalogSha256, "catalogSha256");
+    signatureSha256 = Objects.requireNonNull(builder.signatureSha256, "signatureSha256");
+  }
+
   /**
-   * Defensively copies mutable sidecar byte arrays at the validation boundary.
+   * Starts construction of a validated publication input snapshot.
    *
-   * <p>The validator passes this record to both dry-run and live publication paths. Copying here
-   * keeps later caller mutations from changing the bytes that are verified, staged, and digested
-   * for evidence.
+   * @return empty builder whose fields are populated by the validator
    */
-  ValidatedPublicationInputs {
-    catalogBytes = catalogBytes.clone();
-    signatureBytes = signatureBytes.clone();
+  static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns the normalized local catalog properties path.
+   *
+   * @return catalog properties file path selected by the operator
+   */
+  Path catalogFile() {
+    return catalogFile;
+  }
+
+  /**
+   * Returns the normalized local detached signature sidecar path.
+   *
+   * @return signature sidecar file path selected by the operator
+   */
+  Path catalogSignatureFile() {
+    return catalogSignatureFile;
+  }
+
+  /**
+   * Returns the public catalog source expected after dry-run planning or live publication.
+   *
+   * @return public {@code crypta:USK@.../cryptad-app-catalog.properties} source
+   */
+  String catalogSource() {
+    return catalogSource;
+  }
+
+  /**
+   * Returns the normalized publication report output path.
+   *
+   * @return dry-run plan or live summary output path
+   */
+  Path output() {
+    return output;
   }
 
   /**
@@ -53,8 +94,7 @@ record ValidatedPublicationInputs(
    *
    * @return defensive copy of the validated catalog bytes
    */
-  @Override
-  public byte[] catalogBytes() {
+  byte[] catalogBytes() {
     return catalogBytes.clone();
   }
 
@@ -63,8 +103,114 @@ record ValidatedPublicationInputs(
    *
    * @return defensive copy of the validated signature bytes
    */
-  @Override
-  public byte[] signatureBytes() {
+  byte[] signatureBytes() {
     return signatureBytes.clone();
+  }
+
+  /**
+   * Returns parsed catalog metadata.
+   *
+   * @return parsed signed-catalog properties model
+   */
+  AppCatalog catalog() {
+    return catalog;
+  }
+
+  /**
+   * Returns parsed detached signature metadata.
+   *
+   * @return parsed catalog signature sidecar
+   */
+  AppCatalogSignature signature() {
+    return signature;
+  }
+
+  /**
+   * Returns the stable SHA-256 digest of the validated catalog bytes.
+   *
+   * @return lowercase hexadecimal catalog digest
+   */
+  String catalogSha256() {
+    return catalogSha256;
+  }
+
+  /**
+   * Returns the stable SHA-256 digest of the validated signature bytes.
+   *
+   * @return lowercase hexadecimal signature digest
+   */
+  String signatureSha256() {
+    return signatureSha256;
+  }
+
+  /** Builder used by {@link PublicationInputValidator} after all local inputs pass validation. */
+  static final class Builder {
+    private Path catalogFile;
+    private Path catalogSignatureFile;
+    private String catalogSource;
+    private Path output;
+    private byte[] catalogBytes;
+    private byte[] signatureBytes;
+    private AppCatalog catalog;
+    private AppCatalogSignature signature;
+    private String catalogSha256;
+    private String signatureSha256;
+
+    private Builder() {}
+
+    Builder catalogFile(Path catalogFile) {
+      this.catalogFile = Objects.requireNonNull(catalogFile, "catalogFile");
+      return this;
+    }
+
+    Builder catalogSignatureFile(Path catalogSignatureFile) {
+      this.catalogSignatureFile =
+          Objects.requireNonNull(catalogSignatureFile, "catalogSignatureFile");
+      return this;
+    }
+
+    Builder catalogSource(String catalogSource) {
+      this.catalogSource = Objects.requireNonNull(catalogSource, "catalogSource");
+      return this;
+    }
+
+    Builder output(Path output) {
+      this.output = Objects.requireNonNull(output, "output");
+      return this;
+    }
+
+    Builder catalogBytes(byte[] catalogBytes) {
+      this.catalogBytes = Objects.requireNonNull(catalogBytes, "catalogBytes").clone();
+      return this;
+    }
+
+    Builder signatureBytes(byte[] signatureBytes) {
+      this.signatureBytes = Objects.requireNonNull(signatureBytes, "signatureBytes").clone();
+      return this;
+    }
+
+    Builder catalog(AppCatalog catalog) {
+      this.catalog = Objects.requireNonNull(catalog, "catalog");
+      return this;
+    }
+
+    Builder signature(AppCatalogSignature signature) {
+      this.signature = Objects.requireNonNull(signature, "signature");
+      return this;
+    }
+
+    Builder catalogSha256(String catalogSha256) {
+      this.catalogSha256 = Objects.requireNonNull(catalogSha256, "catalogSha256");
+      return this;
+    }
+
+    Builder signatureSha256(String signatureSha256) {
+      this.signatureSha256 = Objects.requireNonNull(signatureSha256, "signatureSha256");
+      return this;
+    }
+
+    ValidatedPublicationInputs build() {
+      return new ValidatedPublicationInputs(this);
+    }
   }
 }

--- a/platform-devtools/src/main/java/network/crypta/platform/devtools/ValidatedPublicationInputs.java
+++ b/platform-devtools/src/main/java/network/crypta/platform/devtools/ValidatedPublicationInputs.java
@@ -1,0 +1,70 @@
+package network.crypta.platform.devtools;
+
+import java.nio.file.Path;
+import network.crypta.platform.appcatalog.AppCatalog;
+import network.crypta.platform.appcatalog.AppCatalogSignature;
+
+/**
+ * Immutable snapshot of validated catalog publication inputs.
+ *
+ * <p>The record is intentionally package-scoped because it is a coordination type between the
+ * developer CLI's dry-run writer and live publication service. It keeps the exact bytes needed for
+ * signature verification and live staging, plus only derived report-safe metadata such as digests
+ * and file basenames. Callers should use {@link AppTestRedactor#fileName(Path)} when rendering any
+ * of the local paths held here.
+ *
+ * @param catalogFile normalized local catalog file path
+ * @param catalogSignatureFile normalized local signature sidecar path
+ * @param catalogSource public {@code crypta:USK@.../cryptad-app-catalog.properties} source
+ * @param output normalized report output path
+ * @param catalogBytes exact catalog properties bytes
+ * @param signatureBytes exact signature sidecar bytes
+ * @param catalog parsed catalog metadata
+ * @param signature parsed signature metadata
+ * @param catalogSha256 SHA-256 digest of {@code catalogBytes}
+ * @param signatureSha256 SHA-256 digest of {@code signatureBytes}
+ */
+@SuppressWarnings("ArrayRecordComponent")
+record ValidatedPublicationInputs(
+    Path catalogFile,
+    Path catalogSignatureFile,
+    String catalogSource,
+    Path output,
+    byte[] catalogBytes,
+    byte[] signatureBytes,
+    AppCatalog catalog,
+    AppCatalogSignature signature,
+    String catalogSha256,
+    String signatureSha256) {
+  /**
+   * Defensively copies mutable sidecar byte arrays at the validation boundary.
+   *
+   * <p>The validator passes this record to both dry-run and live publication paths. Copying here
+   * keeps later caller mutations from changing the bytes that are verified, staged, and digested
+   * for evidence.
+   */
+  ValidatedPublicationInputs {
+    catalogBytes = catalogBytes.clone();
+    signatureBytes = signatureBytes.clone();
+  }
+
+  /**
+   * Returns the exact catalog properties bytes captured during validation.
+   *
+   * @return defensive copy of the validated catalog bytes
+   */
+  @Override
+  public byte[] catalogBytes() {
+    return catalogBytes.clone();
+  }
+
+  /**
+   * Returns the exact detached signature sidecar bytes captured during validation.
+   *
+   * @return defensive copy of the validated signature bytes
+   */
+  @Override
+  public byte[] signatureBytes() {
+    return signatureBytes.clone();
+  }
+}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/DeveloperBetaToolkitCliTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/DeveloperBetaToolkitCliTest.java
@@ -12,6 +12,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermission;
 import java.time.Duration;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -29,6 +32,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class DeveloperBetaToolkitCliTest {
   private static final Pattern BOOTSTRAP_SESSION_PATTERN =
       Pattern.compile("\"browserSessionToken\"\\s*:\\s*\"([^\"]+)\"");
+  private static final String LIVE_PUBLIC_USK_PREFIX =
+      "USK@sdFxM0Z4zx4-gXhGwzXAVYvOUi6NRfdGbyJa797bNAg,"
+          + "ZP4aASnyZax8nYOvCOlUebegsmbGQIXfVzw7iyOsXEc,AQACAAE";
+  private static final String LIVE_PRIVATE_INSERT_URI =
+      "USK@ZTeIa1g4T3OYCdUFfHrFSlRnt5coeFFDCIZxWSb7abs,"
+          + "ZP4aASnyZax8nYOvCOlUebegsmbGQIXfVzw7iyOsXEc,AQECAAE/catalog/42";
+  private static final String LIVE_PUBLIC_CATALOG_SOURCE =
+      "crypta:" + LIVE_PUBLIC_USK_PREFIX + "/catalog/42/cryptad-app-catalog.properties";
+  private static final String LIVE_PUBLIC_SIGNATURE_SOURCE =
+      "crypta:" + LIVE_PUBLIC_USK_PREFIX + "/catalog/42/cryptad-app-catalog.signature";
 
   @TempDir private Path tempDir;
 
@@ -403,6 +416,9 @@ class DeveloperBetaToolkitCliTest {
     Path entry = tempDir.resolve("catalog-entry.properties");
     Path catalog = tempDir.resolve("cryptad-app-catalog.properties");
     Path plan = tempDir.resolve("publish-plan.md");
+    Path liveSummary = tempDir.resolve("live-summary.json");
+    Path privateInsertUriFile = keysDir.resolve("catalog-insert-uri.txt");
+    Path formPasswordFile = keysDir.resolve("form-password.txt");
 
     runCli(
         "keys",
@@ -497,7 +513,7 @@ class DeveloperBetaToolkitCliTest {
             "--output",
             plan.toString(),
             "--dry-run");
-    CliResult livePublish =
+    CliResult missingModePublish =
         runCli(
             "publish-usk",
             "--catalog-file",
@@ -508,16 +524,99 @@ class DeveloperBetaToolkitCliTest {
             "crypta:USK@private-insert-material/cryptad-app-catalog.properties",
             "--output",
             tempDir.resolve("live-plan.md").toString());
+    CliResult missingLiveConfig =
+        runCli(
+            "publish-usk",
+            "--catalog-file",
+            catalog.toString(),
+            "--catalog-signature-file",
+            signature.toString(),
+            "--catalog-source",
+            LIVE_PUBLIC_CATALOG_SOURCE,
+            "--output",
+            tempDir.resolve("missing-live-summary.json").toString(),
+            "--trusted-keys-file",
+            trustedKeys.toString(),
+            "--node-base-url",
+            "http://127.0.0.1:8888/api/v1",
+            "--live");
+    Files.writeString(privateInsertUriFile, LIVE_PRIVATE_INSERT_URI + "\n", StandardCharsets.UTF_8);
+    Files.writeString(formPasswordFile, "form-secret\n", StandardCharsets.UTF_8);
+    LiveUskPublishRequest[] liveRequest = new LiveUskPublishRequest[1];
+    CliResult livePublish;
+    try (var _ =
+        CryptaAppCli.useLiveUskPublisherForTesting(
+            request -> {
+              liveRequest[0] = request;
+              assertLivePublisherReceivedExpectedRequest(request);
+              return new LiveUskPublishResponse(
+                  "queued",
+                  "queued",
+                  Optional.of(LIVE_PUBLIC_CATALOG_SOURCE),
+                  "not_requested",
+                  "not_run",
+                  List.of());
+            })) {
+      livePublish =
+          runCli(
+              "publish-usk",
+              "--catalog-file",
+              catalog.toString(),
+              "--catalog-signature-file",
+              signature.toString(),
+              "--catalog-source",
+              LIVE_PUBLIC_CATALOG_SOURCE,
+              "--output",
+              liveSummary.toString(),
+              "--trusted-keys-file",
+              trustedKeys.toString(),
+              "--private-insert-uri-file",
+              privateInsertUriFile.toString(),
+              "--form-password-file",
+              formPasswordFile.toString(),
+              "--node-base-url",
+              "http://127.0.0.1:8888/api/v1",
+              "--live");
+    }
 
     String descriptor = Files.readString(entry, StandardCharsets.UTF_8);
     String planText = Files.readString(plan, StandardCharsets.UTF_8);
+    String liveSummaryText = Files.readString(liveSummary, StandardCharsets.UTF_8);
+    assertCatalogEntryDescriptor(entryResult, descriptor);
+    assertCatalogCommandsSucceeded(create, sign, verify);
+    assertDryRunPublication(publish, planText);
+    assertPublishModeValidationFailures(missingModePublish, missingLiveConfig);
+    assertLivePublicationSummary(
+        livePublish, liveSummaryText, privateInsertUriFile, formPasswordFile);
+    assertTrue(Files.exists(liveRequest[0].stagingDirectory()));
+    deleteRecursively(liveRequest[0].stagingDirectory());
+  }
+
+  private static void assertLivePublisherReceivedExpectedRequest(LiveUskPublishRequest request) {
+    assertEquals(LIVE_PRIVATE_INSERT_URI, request.privateInsertUri());
+    assertEquals("form-secret", request.formPassword());
+    assertFalse(request.verifyLiveFetch());
+    assertTrue(
+        Files.isRegularFile(request.stagingDirectory().resolve("cryptad-app-catalog.properties")));
+    assertTrue(
+        Files.isRegularFile(request.stagingDirectory().resolve("cryptad-app-catalog.signature")));
+  }
+
+  private static void assertCatalogEntryDescriptor(CliResult entryResult, String descriptor) {
     assertEquals(CommandLine.ExitCode.OK, entryResult.exitCode());
     assertTrue(descriptor.contains("bundle.uri=crypta:CHK@catalog-app-bundle\n"));
     assertTrue(
         descriptor.contains("permissions.rationale.queue.read=Reads mock transfer queue state.\n"));
+  }
+
+  private static void assertCatalogCommandsSucceeded(
+      CliResult create, CliResult sign, CliResult verify) {
     assertEquals(CommandLine.ExitCode.OK, create.exitCode());
     assertEquals(CommandLine.ExitCode.OK, sign.exitCode());
     assertEquals(CommandLine.ExitCode.OK, verify.exitCode());
+  }
+
+  private void assertDryRunPublication(CliResult publish, String planText) {
     assertEquals(CommandLine.ExitCode.OK, publish.exitCode());
     assertTrue(publish.out().contains("Wrote Crypta USK publication plan: dev entries=1"));
     assertTrue(planText.contains("Crypta Catalog USK Publication Plan"));
@@ -525,8 +624,37 @@ class DeveloperBetaToolkitCliTest {
     assertTrue(planText.contains("crypta:CHK@[REDACTED]"));
     assertFalse(planText.contains("private-insert-material"));
     assertFalse(planText.contains(tempDir.toString()));
-    assertEquals(CommandLine.ExitCode.SOFTWARE, livePublish.exitCode());
-    assertTrue(livePublish.err().contains("live_publish_not_supported"));
+  }
+
+  private static void assertPublishModeValidationFailures(
+      CliResult missingModePublish, CliResult missingLiveConfig) {
+    assertEquals(CommandLine.ExitCode.SOFTWARE, missingModePublish.exitCode());
+    assertTrue(missingModePublish.err().contains("requires exactly one of --dry-run or --live"));
+    assertEquals(CommandLine.ExitCode.SOFTWARE, missingLiveConfig.exitCode());
+    assertTrue(
+        missingLiveConfig
+            .err()
+            .contains("private insert URI must be configured by exactly one env or file source"));
+  }
+
+  private void assertLivePublicationSummary(
+      CliResult livePublish,
+      String liveSummaryText,
+      Path privateInsertUriFile,
+      Path formPasswordFile) {
+    assertEquals(CommandLine.ExitCode.OK, livePublish.exitCode(), livePublish.err());
+    assertTrue(livePublish.out().contains("Published Crypta USK catalog: dev entries=1"));
+    assertTrue(liveSummaryText.contains("\"mode\": \"live\""));
+    assertTrue(liveSummaryText.contains("\"catalogInsertStatus\": \"queued\""));
+    assertTrue(liveSummaryText.contains("\"catalogSigningKeyId\": \"dev-local\""));
+    assertTrue(liveSummaryText.contains("staging_sidecars_retained_until_live_insert_completion"));
+    assertTrue(liveSummaryText.contains(LIVE_PUBLIC_SIGNATURE_SOURCE));
+    assertFalse(liveSummaryText.contains(LIVE_PRIVATE_INSERT_URI));
+    assertFalse(liveSummaryText.contains("ZTeIa1g4T3OYCdUFfHrFSlRnt5coeFFDCIZxWSb7abs"));
+    assertFalse(liveSummaryText.contains("form-secret"));
+    assertFalse(liveSummaryText.contains(privateInsertUriFile.toString()));
+    assertFalse(liveSummaryText.contains(formPasswordFile.toString()));
+    assertFalse(liveSummaryText.contains(tempDir.toString()));
   }
 
   @Test
@@ -929,6 +1057,17 @@ class DeveloperBetaToolkitCliTest {
     int exitCode =
         CryptaAppCli.execute(new PrintWriter(out, true), new PrintWriter(err, true), arguments);
     return new CliResult(exitCode, out.toString(), err.toString());
+  }
+
+  private static void deleteRecursively(Path root) throws IOException {
+    if (!Files.exists(root)) {
+      return;
+    }
+    try (var stream = Files.walk(root)) {
+      for (Path path : stream.sorted(Comparator.reverseOrder()).toList()) {
+        Files.deleteIfExists(path);
+      }
+    }
   }
 
   private record CliResult(int exitCode, String out, String err) {}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationResultWriterTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationResultWriterTest.java
@@ -55,6 +55,36 @@ class LiveUskPublicationResultWriterTest {
     assertFalse(markdown.contains(tempDir.toString()));
   }
 
+  @Test
+  void preflightWritableOutput_whenJsonOutputExists_expectIncompleteMarker() throws Exception {
+    Path output = tempDir.resolve("live-summary.json");
+    Files.writeString(
+        output, "{\"publicationStatus\":\"complete\",\"catalogInsertStatus\":\"queued\"}");
+
+    LiveUskPublicationResultWriter.preflightWritableOutput(output);
+
+    String json = Files.readString(output, StandardCharsets.UTF_8);
+    assertTrue(json.contains("\"publicationStatus\": \"incomplete\""));
+    assertTrue(json.contains("ignore previous summaries"));
+    assertFalse(json.contains("\"catalogInsertStatus\":\"queued\""));
+    assertFalse(json.contains("\"publicationStatus\":\"complete\""));
+    assertFalse(json.contains(tempDir.toString()));
+  }
+
+  @Test
+  void preflightWritableOutput_whenMarkdownOutputExists_expectIncompleteMarker() throws Exception {
+    Path output = tempDir.resolve("live-summary.md");
+    Files.writeString(output, "- Catalog insert status: `queued`\n");
+
+    LiveUskPublicationResultWriter.preflightWritableOutput(output);
+
+    String markdown = Files.readString(output, StandardCharsets.UTF_8);
+    assertTrue(markdown.contains("- Publication status: `incomplete`"));
+    assertTrue(markdown.contains("ignore previous summaries"));
+    assertFalse(markdown.contains("Catalog insert status"));
+    assertFalse(markdown.contains(tempDir.toString()));
+  }
+
   private static LiveUskPublicationResult resultWithoutResolvedMetadata(
       Path output, List<String> warnings) {
     return result(output, false, "", "", warnings);

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationResultWriterTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationResultWriterTest.java
@@ -1,0 +1,93 @@
+package network.crypta.platform.devtools;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import network.crypta.platform.appcatalog.AppCatalogSignature;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class LiveUskPublicationResultWriterTest {
+  private static final String RESOLVED_CATALOG_SOURCE =
+      "crypta:USK@PUBLIC/catalog/43/" + AppCatalogSignature.CATALOG_FILE_NAME;
+  private static final String RESOLVED_EDITION = "43";
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void write_whenJsonOutputRequested_expectNullOptionalsAndEscapedWarnings() throws Exception {
+    Path output = tempDir.resolve("live-summary.json");
+    LiveUskPublicationResult result =
+        resultWithoutResolvedMetadata(output, List.of("quoted \"warning\"\nnext"));
+
+    LiveUskPublicationResultWriter.write(result);
+
+    String json = Files.readString(output, StandardCharsets.UTF_8);
+    assertTrue(json.contains("\"mode\": \"live\""));
+    assertTrue(json.contains("\"resolvedCatalogSource\": null"));
+    assertTrue(json.contains("\"edition\": null"));
+    assertTrue(json.contains("\"entryCount\": 2"));
+    assertTrue(json.contains("quoted \\\"warning\\\"\\nnext"));
+    assertFalse(json.contains(tempDir.toString()));
+  }
+
+  @Test
+  void write_whenMarkdownOutputRequested_expectOptionalFieldsAndWarnings() throws Exception {
+    Path output = tempDir.resolve("live-summary.md");
+    LiveUskPublicationResult result =
+        resultWithResolvedMetadata(
+            output, List.of("staging_sidecars_retained_until_live_insert_completion"));
+
+    LiveUskPublicationResultWriter.write(result);
+
+    String markdown = Files.readString(output, StandardCharsets.UTF_8);
+    assertTrue(markdown.contains("# Crypta Catalog Live USK Publication Summary"));
+    assertTrue(markdown.contains("- Resolved catalog source: `crypta:USK@PUBLIC/catalog/43/"));
+    assertTrue(markdown.contains("- Edition: `43`"));
+    assertTrue(markdown.contains("## Warnings"));
+    assertTrue(markdown.contains("staging_sidecars_retained_until_live_insert_completion"));
+    assertFalse(markdown.contains(tempDir.toString()));
+  }
+
+  private static LiveUskPublicationResult resultWithoutResolvedMetadata(
+      Path output, List<String> warnings) {
+    return result(output, false, "", "", warnings);
+  }
+
+  private static LiveUskPublicationResult resultWithResolvedMetadata(
+      Path output, List<String> warnings) {
+    return result(output, true, RESOLVED_CATALOG_SOURCE, RESOLVED_EDITION, warnings);
+  }
+
+  private static LiveUskPublicationResult result(
+      Path output,
+      boolean includeResolvedMetadata,
+      String resolvedCatalogSource,
+      String edition,
+      List<String> warnings) {
+    return new LiveUskPublicationResult(
+        "dev",
+        AppCatalogSignature.CATALOG_FILE_NAME,
+        AppCatalogSignature.SIGNATURE_FILE_NAME,
+        "crypta:USK@PUBLIC/catalog/42/" + AppCatalogSignature.CATALOG_FILE_NAME,
+        "crypta:USK@PUBLIC/catalog/42/" + AppCatalogSignature.SIGNATURE_FILE_NAME,
+        includeResolvedMetadata ? Optional.of(resolvedCatalogSource) : Optional.empty(),
+        includeResolvedMetadata ? Optional.of(edition) : Optional.empty(),
+        "0".repeat(64),
+        "1".repeat(64),
+        "dev-local",
+        2,
+        "queued",
+        "queued",
+        "verified",
+        "not_run",
+        warnings,
+        output);
+  }
+}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationServiceTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationServiceTest.java
@@ -1,5 +1,6 @@
 package network.crypta.platform.devtools;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -256,6 +257,61 @@ class LiveUskPublicationServiceTest {
   }
 
   @Test
+  void publish_whenPublisherFailsBeforeQueueAccepted_expectStagingCleanedWithoutSummary()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path catalogFile = writeSignedCatalog(keyPair);
+    Path output = tempDir.resolve("live-summary.json");
+    FailingPublisher publisher =
+        new FailingPublisher(new AppDistributionException("live_publish_failed: node unreachable"));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                LiveUskPublicationService.publish(
+                    request(catalogFile, output, false), trustedKeys(keyPair), publisher));
+
+    assertTrue(exception.getMessage().contains("node unreachable"));
+    assertTrue(publisher.invoked);
+    assertFalse(Files.exists(publisher.stagingDirectory));
+    assertFalse(hasLiveStagingDirectory(tempDir));
+    assertEquals(0L, Files.size(output));
+  }
+
+  @Test
+  void publish_whenPublisherFailsAfterQueueAccepted_expectStagingRetained() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path catalogFile = writeSignedCatalog(keyPair);
+    Path output = tempDir.resolve("live-summary.json");
+    FailingPublisher publisher =
+        new FailingPublisher(
+            LiveUskPublishException.afterQueueAccepted(
+                new AppDistributionException(
+                    "live_publish_verification_failed: fetched catalog bytes do not match local"
+                        + " catalog")));
+
+    try {
+      assertThrows(
+          LiveUskPublishException.class,
+          () ->
+              LiveUskPublicationService.publish(
+                  request(catalogFile, output, true), trustedKeys(keyPair), publisher));
+
+      assertTrue(publisher.invoked);
+      assertTrue(Files.exists(publisher.stagingDirectory));
+      assertTrue(
+          Files.isRegularFile(
+              publisher.stagingDirectory.resolve(AppCatalogSignature.CATALOG_FILE_NAME)));
+      assertEquals(0L, Files.size(output));
+    } finally {
+      if (publisher.stagingDirectory != null) {
+        deleteRecursively(publisher.stagingDirectory);
+      }
+    }
+  }
+
+  @Test
   void publish_whenTrustedKeyIsMissing_expectFailureBeforeLiveInsert() throws Exception {
     KeyPair keyPair = keyPair();
     Path catalogFile = writeSignedCatalog(keyPair);
@@ -380,6 +436,27 @@ class LiveUskPublicationServiceTest {
       assertTrue(
           Files.isRegularFile(stagingDirectory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME)));
       return response;
+    }
+  }
+
+  private static final class FailingPublisher implements LiveUskPublisher {
+    private final IOException failure;
+    private boolean invoked;
+    private Path stagingDirectory;
+
+    private FailingPublisher(IOException failure) {
+      this.failure = failure;
+    }
+
+    @Override
+    public LiveUskPublishResponse publish(LiveUskPublishRequest request) throws IOException {
+      invoked = true;
+      stagingDirectory = request.stagingDirectory();
+      assertTrue(
+          Files.isRegularFile(stagingDirectory.resolve(AppCatalogSignature.CATALOG_FILE_NAME)));
+      assertTrue(
+          Files.isRegularFile(stagingDirectory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME)));
+      throw failure;
     }
   }
 }

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationServiceTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationServiceTest.java
@@ -1,0 +1,352 @@
+package network.crypta.platform.devtools;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import network.crypta.platform.appcatalog.AppCatalogException;
+import network.crypta.platform.appcatalog.AppCatalogSignature;
+import network.crypta.platform.appcatalog.AppCatalogSigner;
+import network.crypta.platform.appdist.AppDistributionException;
+import network.crypta.platform.appdist.TrustedAppKey;
+import network.crypta.platform.appdist.TrustedAppKeys;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class LiveUskPublicationServiceTest {
+  private static final String SHA256 = "0".repeat(64);
+  private static final String PUBLIC_USK_PREFIX =
+      "USK@sdFxM0Z4zx4-gXhGwzXAVYvOUi6NRfdGbyJa797bNAg,"
+          + "ZP4aASnyZax8nYOvCOlUebegsmbGQIXfVzw7iyOsXEc,AQACAAE";
+  private static final String PRIVATE_USK_PREFIX =
+      "USK@ZTeIa1g4T3OYCdUFfHrFSlRnt5coeFFDCIZxWSb7abs,"
+          + "ZP4aASnyZax8nYOvCOlUebegsmbGQIXfVzw7iyOsXEc,AQECAAE";
+  private static final String PUBLIC_SOURCE =
+      "crypta:" + PUBLIC_USK_PREFIX + "/catalog/42/" + AppCatalogSignature.CATALOG_FILE_NAME;
+  private static final String PRIVATE_INSERT_URI = PRIVATE_USK_PREFIX + "/catalog/42";
+  private static final String FORM_PASSWORD = "form-password-secret";
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void publish_whenFakePublisherSucceeds_expectSanitizedSummaryAndRetainedStaging()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path catalogFile = writeSignedCatalog(keyPair);
+    Path output = tempDir.resolve("live-summary.json");
+    RecordingPublisher publisher =
+        new RecordingPublisher(
+            new LiveUskPublishResponse(
+                "queued",
+                "queued",
+                Optional.of(PUBLIC_SOURCE),
+                "verified",
+                "not_run",
+                List.of("safe_warning")));
+
+    try {
+      LiveUskPublicationResult result =
+          LiveUskPublicationService.publish(
+              request(catalogFile, output, true), trustedKeys(keyPair), publisher);
+
+      String summary = Files.readString(output, StandardCharsets.UTF_8);
+      assertEquals("dev", result.catalogId());
+      assertEquals(1, result.entryCount());
+      assertEquals("dev-local", result.catalogSigningKeyId());
+      assertEquals("42", result.edition().orElseThrow());
+      assertTrue(summary.contains("\"mode\": \"live\""));
+      assertTrue(summary.contains("\"catalogInsertStatus\": \"queued\""));
+      assertTrue(summary.contains("\"signatureInsertStatus\": \"queued\""));
+      assertTrue(summary.contains("\"postPublishVerificationStatus\": \"verified\""));
+      assertTrue(summary.contains("\"catalogSha256\""));
+      assertTrue(summary.contains("\"signatureSha256\""));
+      assertTrue(summary.contains(PUBLIC_SOURCE));
+      assertTrue(summary.contains(publicSignatureSource()));
+      assertTrue(summary.contains("staging_sidecars_retained_until_live_insert_completion"));
+      assertFalse(summary.contains(PRIVATE_INSERT_URI));
+      assertFalse(summary.contains("ZTeIa1g4T3OYCdUFfHrFSlRnt5coeFFDCIZxWSb7abs"));
+      assertFalse(summary.contains(FORM_PASSWORD));
+      assertFalse(summary.contains(tempDir.toString()));
+      assertFalse(summary.contains(publisher.stagingDirectory.toString()));
+      assertTrue(Files.exists(publisher.stagingDirectory));
+      assertOwnerOnlyStagingDirectory(publisher.stagingDirectory);
+      assertArrayEquals(Files.readAllBytes(catalogFile), publisher.catalogBytes);
+      assertArrayEquals(
+          Files.readAllBytes(catalogFile.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME)),
+          publisher.signatureBytes);
+    } finally {
+      if (publisher.stagingDirectory != null) {
+        deleteRecursively(publisher.stagingDirectory);
+      }
+    }
+  }
+
+  @Test
+  void publish_whenInsertIsOnlyQueued_expectStagingRetainedWithoutPathInSummary() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path catalogFile = writeSignedCatalog(keyPair);
+    Path output = tempDir.resolve("live-summary.json");
+    RecordingPublisher publisher =
+        new RecordingPublisher(
+            new LiveUskPublishResponse(
+                "queued", "queued", Optional.empty(), "not_requested", "not_run", List.of()));
+
+    try {
+      LiveUskPublicationResult result =
+          LiveUskPublicationService.publish(
+              request(catalogFile, output, false), trustedKeys(keyPair), publisher);
+
+      String summary = Files.readString(output, StandardCharsets.UTF_8);
+      assertEquals("not_requested", result.postPublishVerificationStatus());
+      assertTrue(
+          Files.isRegularFile(
+              publisher.stagingDirectory.resolve(AppCatalogSignature.CATALOG_FILE_NAME)));
+      assertTrue(
+          Files.isRegularFile(
+              publisher.stagingDirectory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME)));
+      assertOwnerOnlyStagingDirectory(publisher.stagingDirectory);
+      assertTrue(summary.contains("staging_sidecars_retained_until_live_insert_completion"));
+      assertFalse(summary.contains(publisher.stagingDirectory.toString()));
+      assertFalse(summary.contains(tempDir.toString()));
+    } finally {
+      if (publisher.stagingDirectory != null) {
+        deleteRecursively(publisher.stagingDirectory);
+      }
+    }
+  }
+
+  @Test
+  void publish_whenPrivateInsertUriUsesPublicScheme_expectFailureWithoutPublisherOrSummary()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path catalogFile = writeSignedCatalog(keyPair);
+    Path output = tempDir.resolve("live-summary.json");
+    RecordingPublisher publisher =
+        new RecordingPublisher(
+            new LiveUskPublishResponse(
+                "queued", "queued", Optional.empty(), "not_requested", "not_run", List.of()));
+
+    assertThrows(
+        AppDistributionException.class,
+        () ->
+            LiveUskPublicationService.publish(
+                new LiveUskPublicationService.Request(
+                    catalogFile,
+                    catalogFile.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME),
+                    PUBLIC_SOURCE,
+                    output,
+                    "crypta:USK@PUBLIC/catalog/42",
+                    "http://127.0.0.1:8888/api/v1",
+                    FORM_PASSWORD,
+                    false),
+                trustedKeys(keyPair),
+                publisher));
+
+    assertFalse(publisher.invoked);
+    assertFalse(Files.exists(output));
+  }
+
+  @Test
+  void publish_whenPrivateInsertUriDoesNotMatchPublicSource_expectFailureWithoutPublisherOrSummary()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path catalogFile = writeSignedCatalog(keyPair);
+    Path output = tempDir.resolve("live-summary.json");
+    RecordingPublisher publisher =
+        new RecordingPublisher(
+            new LiveUskPublishResponse(
+                "queued", "queued", Optional.empty(), "not_requested", "not_run", List.of()));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                LiveUskPublicationService.publish(
+                    new LiveUskPublicationService.Request(
+                        catalogFile,
+                        catalogFile.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME),
+                        PUBLIC_SOURCE,
+                        output,
+                        PRIVATE_USK_PREFIX + "/wrong-catalog/42",
+                        "http://127.0.0.1:8888/api/v1",
+                        FORM_PASSWORD,
+                        false),
+                    trustedKeys(keyPair),
+                    publisher));
+
+    assertTrue(exception.getMessage().contains("does not match public catalog source"));
+    assertFalse(exception.getMessage().contains(PRIVATE_USK_PREFIX));
+    assertFalse(exception.getMessage().contains(FORM_PASSWORD));
+    assertFalse(publisher.invoked);
+    assertFalse(Files.exists(output));
+  }
+
+  @Test
+  void publish_whenNodeHostOnlyStartsWithLoopbackPrefix_expectFailureWithoutPublisherOrSummary()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path catalogFile = writeSignedCatalog(keyPair);
+    Path output = tempDir.resolve("live-summary.json");
+    RecordingPublisher publisher =
+        new RecordingPublisher(
+            new LiveUskPublishResponse(
+                "queued", "queued", Optional.empty(), "not_requested", "not_run", List.of()));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                LiveUskPublicationService.publish(
+                    new LiveUskPublicationService.Request(
+                        catalogFile,
+                        catalogFile.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME),
+                        PUBLIC_SOURCE,
+                        output,
+                        PRIVATE_INSERT_URI,
+                        "http://127.0.0.1.attacker.example:8888/api/v1",
+                        FORM_PASSWORD,
+                        false),
+                    trustedKeys(keyPair),
+                    publisher));
+
+    assertTrue(exception.getMessage().contains("localhost host"));
+    assertFalse(exception.getMessage().contains(PRIVATE_INSERT_URI));
+    assertFalse(exception.getMessage().contains(FORM_PASSWORD));
+    assertFalse(publisher.invoked);
+    assertFalse(Files.exists(output));
+  }
+
+  @Test
+  void publish_whenTrustedKeyIsMissing_expectFailureBeforeLiveInsert() throws Exception {
+    KeyPair keyPair = keyPair();
+    Path catalogFile = writeSignedCatalog(keyPair);
+    Path output = tempDir.resolve("live-summary.json");
+    RecordingPublisher publisher =
+        new RecordingPublisher(
+            new LiveUskPublishResponse(
+                "queued", "queued", Optional.empty(), "not_requested", "not_run", List.of()));
+    LiveUskPublicationService.Request request = request(catalogFile, output, false);
+    TrustedAppKeys trustedKeys = TrustedAppKeys.empty();
+
+    assertThrows(
+        AppCatalogException.class,
+        () -> LiveUskPublicationService.publish(request, trustedKeys, publisher));
+
+    assertFalse(publisher.invoked);
+    assertFalse(Files.exists(output));
+  }
+
+  private LiveUskPublicationService.Request request(
+      Path catalogFile, Path output, boolean verifyLiveFetch) {
+    return new LiveUskPublicationService.Request(
+        catalogFile,
+        catalogFile.resolveSibling(AppCatalogSignature.SIGNATURE_FILE_NAME),
+        PUBLIC_SOURCE,
+        output,
+        PRIVATE_INSERT_URI,
+        "http://127.0.0.1:8888/api/v1",
+        FORM_PASSWORD,
+        verifyLiveFetch);
+  }
+
+  private static String publicSignatureSource() {
+    return "crypta:" + PUBLIC_USK_PREFIX + "/catalog/42/" + AppCatalogSignature.SIGNATURE_FILE_NAME;
+  }
+
+  private Path writeSignedCatalog(KeyPair keyPair) throws Exception {
+    Path catalogFile = tempDir.resolve(AppCatalogSignature.CATALOG_FILE_NAME);
+    Files.writeString(
+        catalogFile,
+        """
+        catalog.version=1
+        catalog.id=dev
+        catalog.name=Development Apps
+        catalog.generatedAt=2026-05-14T00:00:00Z
+        catalog.entries=queue-app
+        app.queue-app.id=queue-app
+        app.queue-app.name=Queue App
+        app.queue-app.version=0.1.0
+        app.queue-app.summary=Queue dashboard.
+        app.queue-app.bundle.uri=crypta:CHK@public-bundle-key
+        app.queue-app.bundle.sha256=%s
+        app.queue-app.bundle.size.bytes=0
+        app.queue-app.bundle.type=zip
+        app.queue-app.permissions=queue.read
+        """
+            .formatted(SHA256),
+        StandardCharsets.UTF_8);
+    AppCatalogSigner.sign(catalogFile, "dev-local", keyPair.getPrivate());
+    return catalogFile;
+  }
+
+  private static KeyPair keyPair() throws Exception {
+    return KeyPairGenerator.getInstance("Ed25519").generateKeyPair();
+  }
+
+  private static TrustedAppKeys trustedKeys(KeyPair keyPair) throws AppDistributionException {
+    return TrustedAppKeys.of(TrustedAppKey.ed25519("dev-local", keyPair.getPublic().getEncoded()));
+  }
+
+  private static void deleteRecursively(Path root) throws Exception {
+    if (!Files.exists(root)) {
+      return;
+    }
+    try (var stream = Files.walk(root)) {
+      for (Path path : stream.sorted(Comparator.reverseOrder()).toList()) {
+        Files.deleteIfExists(path);
+      }
+    }
+  }
+
+  private static void assertOwnerOnlyStagingDirectory(Path stagingDirectory) throws Exception {
+    if (!Files.getFileStore(stagingDirectory).supportsFileAttributeView("posix")) {
+      return;
+    }
+    assertEquals(
+        Set.of(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE),
+        Files.getPosixFilePermissions(stagingDirectory));
+  }
+
+  private static final class RecordingPublisher implements LiveUskPublisher {
+    private final LiveUskPublishResponse response;
+    private boolean invoked;
+    private Path stagingDirectory;
+    private byte[] catalogBytes;
+    private byte[] signatureBytes;
+
+    private RecordingPublisher(LiveUskPublishResponse response) {
+      this.response = response;
+    }
+
+    @Override
+    public LiveUskPublishResponse publish(LiveUskPublishRequest request) {
+      invoked = true;
+      stagingDirectory = request.stagingDirectory();
+      catalogBytes = request.catalogBytes();
+      signatureBytes = request.signatureBytes();
+      assertEquals(PRIVATE_INSERT_URI, request.privateInsertUri());
+      assertEquals(FORM_PASSWORD, request.formPassword());
+      assertTrue(
+          Files.isRegularFile(stagingDirectory.resolve(AppCatalogSignature.CATALOG_FILE_NAME)));
+      assertTrue(
+          Files.isRegularFile(stagingDirectory.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME)));
+      return response;
+    }
+  }
+}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationServiceTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationServiceTest.java
@@ -230,6 +230,32 @@ class LiveUskPublicationServiceTest {
   }
 
   @Test
+  void publish_whenSummaryOutputIsDirectory_expectFailureBeforeLiveInsertOrStaging()
+      throws Exception {
+    KeyPair keyPair = keyPair();
+    Path catalogFile = writeSignedCatalog(keyPair);
+    Path output = tempDir.resolve("live-summary.json");
+    Files.createDirectory(output);
+    RecordingPublisher publisher =
+        new RecordingPublisher(
+            new LiveUskPublishResponse(
+                "queued", "queued", Optional.empty(), "not_requested", "not_run", List.of()));
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                LiveUskPublicationService.publish(
+                    request(catalogFile, output, false), trustedKeys(keyPair), publisher));
+
+    assertTrue(exception.getMessage().contains("regular writable file"));
+    assertFalse(exception.getMessage().contains(PRIVATE_INSERT_URI));
+    assertFalse(exception.getMessage().contains(FORM_PASSWORD));
+    assertFalse(publisher.invoked);
+    assertFalse(hasLiveStagingDirectory(tempDir));
+  }
+
+  @Test
   void publish_whenTrustedKeyIsMissing_expectFailureBeforeLiveInsert() throws Exception {
     KeyPair keyPair = keyPair();
     Path catalogFile = writeSignedCatalog(keyPair);
@@ -308,6 +334,13 @@ class LiveUskPublicationServiceTest {
       for (Path path : stream.sorted(Comparator.reverseOrder()).toList()) {
         Files.deleteIfExists(path);
       }
+    }
+  }
+
+  private static boolean hasLiveStagingDirectory(Path parent) throws Exception {
+    try (var stream = Files.list(parent)) {
+      return stream.anyMatch(
+          path -> path.getFileName().toString().startsWith("cryptad-live-usk-catalog-"));
     }
   }
 

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationServiceTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/LiveUskPublicationServiceTest.java
@@ -257,11 +257,15 @@ class LiveUskPublicationServiceTest {
   }
 
   @Test
-  void publish_whenPublisherFailsBeforeQueueAccepted_expectStagingCleanedWithoutSummary()
+  void publish_whenPublisherFailsBeforeQueueAccepted_expectStagingCleanedAndSummaryInvalidated()
       throws Exception {
     KeyPair keyPair = keyPair();
     Path catalogFile = writeSignedCatalog(keyPair);
     Path output = tempDir.resolve("live-summary.json");
+    Files.writeString(
+        output,
+        "{\"publicationStatus\":\"complete\",\"catalogInsertStatus\":\"queued\"}",
+        StandardCharsets.UTF_8);
     FailingPublisher publisher =
         new FailingPublisher(new AppDistributionException("live_publish_failed: node unreachable"));
 
@@ -276,7 +280,7 @@ class LiveUskPublicationServiceTest {
     assertTrue(publisher.invoked);
     assertFalse(Files.exists(publisher.stagingDirectory));
     assertFalse(hasLiveStagingDirectory(tempDir));
-    assertEquals(0L, Files.size(output));
+    assertIncompleteSummaryMarker(output);
   }
 
   @Test
@@ -303,7 +307,7 @@ class LiveUskPublicationServiceTest {
       assertTrue(
           Files.isRegularFile(
               publisher.stagingDirectory.resolve(AppCatalogSignature.CATALOG_FILE_NAME)));
-      assertEquals(0L, Files.size(output));
+      assertIncompleteSummaryMarker(output);
     } finally {
       if (publisher.stagingDirectory != null) {
         deleteRecursively(publisher.stagingDirectory);
@@ -346,6 +350,14 @@ class LiveUskPublicationServiceTest {
 
   private static String publicSignatureSource() {
     return "crypta:" + PUBLIC_USK_PREFIX + "/catalog/42/" + AppCatalogSignature.SIGNATURE_FILE_NAME;
+  }
+
+  private static void assertIncompleteSummaryMarker(Path output) throws Exception {
+    String summary = Files.readString(output, StandardCharsets.UTF_8);
+    assertTrue(summary.contains("\"publicationStatus\": \"incomplete\""));
+    assertTrue(summary.contains("ignore previous summaries"));
+    assertFalse(summary.contains("\"catalogInsertStatus\":\"queued\""));
+    assertFalse(summary.contains("\"publicationStatus\":\"complete\""));
   }
 
   private Path writeSignedCatalog(KeyPair keyPair) throws Exception {

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisherTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisherTest.java
@@ -1,0 +1,230 @@
+package network.crypta.platform.devtools;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import network.crypta.platform.appdist.AppDistributionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class PlatformApiLiveUskPublisherTest {
+  private static final byte[] CATALOG_BYTES = "catalog bytes".getBytes(StandardCharsets.UTF_8);
+  private static final byte[] SIGNATURE_BYTES = "signature bytes".getBytes(StandardCharsets.UTF_8);
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void publish_whenCatalogFetchResolvesEdition_expectSignatureFetchedFromResolvedSibling()
+      throws Exception {
+    ArrayList<String> fetchedUris = new ArrayList<>();
+    AtomicInteger fetchCount = new AtomicInteger();
+    HttpServer server =
+        HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    server.createContext(
+        "/api/v1/queue/inserts/directory",
+        exchange -> sendJson(exchange, 201, "{\"outcome\":\"STARTED\"}"));
+    server.createContext(
+        "/api/v1/content/fetch",
+        exchange ->
+            handleFetch(
+                exchange,
+                fetchedUris,
+                fetchCount,
+                "USK@PUBLIC/catalog/42/cryptad-app-catalog.properties"));
+    server.start();
+    try {
+      PlatformApiLiveUskPublisher publisher = new PlatformApiLiveUskPublisher();
+      URI nodeBaseUrl = URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/api/v1");
+      LiveUskPublishRequest request = requestWithLiveFetchVerification(nodeBaseUrl);
+
+      LiveUskPublishResponse response = publisher.publish(request);
+
+      assertEquals("queued", response.catalogInsertStatus());
+      assertEquals("queued", response.signatureInsertStatus());
+      assertEquals("verified", response.postPublishVerificationStatus());
+      assertEquals(
+          Optional.of("crypta:USK@PUBLIC/catalog/42/cryptad-app-catalog.properties"),
+          response.resolvedCatalogSource());
+      assertEquals(
+          List.of(
+              "crypta:USK@PUBLIC/catalog/-1/cryptad-app-catalog.properties",
+              "crypta:USK@PUBLIC/catalog/42/cryptad-app-catalog.signature"),
+          fetchedUris);
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void publish_whenResolvedUriIsUnsafe_expectSignatureFetchedFromOriginalSibling()
+      throws Exception {
+    ArrayList<String> fetchedUris = new ArrayList<>();
+    AtomicInteger fetchCount = new AtomicInteger();
+    HttpServer server =
+        HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    server.createContext(
+        "/api/v1/queue/inserts/directory",
+        exchange -> sendJson(exchange, 201, "{\"outcome\":\"STARTED\"}"));
+    server.createContext(
+        "/api/v1/content/fetch",
+        exchange ->
+            handleFetch(
+                exchange,
+                fetchedUris,
+                fetchCount,
+                "USK@PUBLIC/catalog/42/cryptad-app-catalog.properties?edition=42"));
+    server.start();
+    try {
+      PlatformApiLiveUskPublisher publisher = new PlatformApiLiveUskPublisher();
+      URI nodeBaseUrl = URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/api/v1");
+
+      LiveUskPublishResponse response =
+          publisher.publish(requestWithLiveFetchVerification(nodeBaseUrl));
+
+      assertEquals(Optional.empty(), response.resolvedCatalogSource());
+      assertEquals(
+          List.of(
+              "crypta:USK@PUBLIC/catalog/-1/cryptad-app-catalog.properties",
+              "crypta:USK@PUBLIC/catalog/-1/cryptad-app-catalog.signature"),
+          fetchedUris);
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
+  void publish_whenQueueOutcomeIsNotStarted_expectSanitizedFailure() throws Exception {
+    LinkedHashMap<String, String> queueForm = new LinkedHashMap<>();
+    HttpServer server =
+        HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    server.createContext(
+        "/api/v1/queue/inserts/directory",
+        exchange -> {
+          queueForm.putAll(readForm(exchange));
+          sendJson(exchange, 200, "{\"outcome\":\"FAILED\",\"message\":\"ignored secret body\"}");
+        });
+    server.start();
+    try {
+      PlatformApiLiveUskPublisher publisher = new PlatformApiLiveUskPublisher();
+      URI nodeBaseUrl = URI.create("http://127.0.0.1:" + server.getAddress().getPort());
+      LiveUskPublishRequest request =
+          LiveUskPublishRequest.builder()
+              .nodeBaseUrl(nodeBaseUrl)
+              .formPassword("redacted-form-password")
+              .privateInsertUri("redacted-insert-uri")
+              .stagingDirectory(tempDir)
+              .identifier("cryptad-catalog-dev")
+              .publicCatalogSource("crypta:USK@PUBLIC/catalog/-1/cryptad-app-catalog.properties")
+              .publicSignatureSource("crypta:USK@PUBLIC/catalog/-1/cryptad-app-catalog.signature")
+              .catalogBytes(CATALOG_BYTES)
+              .signatureBytes(SIGNATURE_BYTES)
+              .verifyLiveFetch(false)
+              .build();
+
+      AppDistributionException exception =
+          assertThrows(AppDistributionException.class, () -> publisher.publish(request));
+
+      assertEquals(
+          "live_publish_failed: node did not start catalog USK insert", exception.getMessage());
+      assertEquals("redacted-form-password", queueForm.get("formPassword"));
+      assertEquals("redacted-insert-uri", queueForm.get("insertUri"));
+      assertEquals(tempDir.toString(), queueForm.get("sourcePath"));
+      assertFalse(exception.getMessage().contains("redacted-form-password"));
+      assertFalse(exception.getMessage().contains("redacted-insert-uri"));
+      assertFalse(exception.getMessage().contains(tempDir.toString()));
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  private static void handleFetch(
+      HttpExchange exchange, List<String> fetchedUris, AtomicInteger fetchCount, String resolvedUri)
+      throws IOException {
+    Map<String, String> form = readForm(exchange);
+    fetchedUris.add(form.get("uri"));
+    if (fetchCount.getAndIncrement() == 0) {
+      sendJson(
+          exchange,
+          200,
+          "{\"contentBase64\":\"%s\",\"resolvedUri\":\"%s\"}"
+              .formatted(Base64.getEncoder().encodeToString(CATALOG_BYTES), resolvedUri));
+      return;
+    }
+    sendJson(
+        exchange,
+        200,
+        "{\"contentBase64\":\"%s\"}"
+            .formatted(Base64.getEncoder().encodeToString(SIGNATURE_BYTES)));
+  }
+
+  private static LiveUskPublishRequest requestWithLiveFetchVerification(URI nodeBaseUrl) {
+    return LiveUskPublishRequest.builder()
+        .nodeBaseUrl(nodeBaseUrl)
+        .formPassword("form-password")
+        .privateInsertUri("redacted-insert-uri")
+        .stagingDirectory(Path.of("redacted-staging"))
+        .identifier("cryptad-catalog-dev")
+        .publicCatalogSource("crypta:USK@PUBLIC/catalog/-1/cryptad-app-catalog.properties")
+        .publicSignatureSource("crypta:USK@PUBLIC/catalog/-1/cryptad-app-catalog.signature")
+        .catalogBytes(CATALOG_BYTES)
+        .signatureBytes(SIGNATURE_BYTES)
+        .verifyLiveFetch(true)
+        .build();
+  }
+
+  private static Map<String, String> readForm(HttpExchange exchange) throws IOException {
+    String body = new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    LinkedHashMap<String, String> form = new LinkedHashMap<>();
+    int start = 0;
+    while (start <= body.length()) {
+      int ampersand = body.indexOf('&', start);
+      int end = ampersand < 0 ? body.length() : ampersand;
+      if (end > start) {
+        addFormPair(form, body.substring(start, end));
+      }
+      if (ampersand < 0) {
+        break;
+      }
+      start = ampersand + 1;
+    }
+    return form;
+  }
+
+  private static void addFormPair(Map<String, String> form, String pair) {
+    int equals = pair.indexOf('=');
+    String name = equals < 0 ? pair : pair.substring(0, equals);
+    String value = equals < 0 ? "" : pair.substring(equals + 1);
+    form.put(
+        URLDecoder.decode(name, StandardCharsets.UTF_8),
+        URLDecoder.decode(value, StandardCharsets.UTF_8));
+  }
+
+  private static void sendJson(HttpExchange exchange, int statusCode, String body)
+      throws IOException {
+    byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+    exchange.getResponseHeaders().set("Content-Type", "application/json; charset=UTF-8");
+    exchange.sendResponseHeaders(statusCode, bytes.length);
+    try (OutputStream outputStream = exchange.getResponseBody()) {
+      outputStream.write(bytes);
+    }
+  }
+}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisherTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisherTest.java
@@ -6,6 +6,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.SocketAddress;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -31,6 +34,45 @@ class PlatformApiLiveUskPublisherTest {
   private static final byte[] SIGNATURE_BYTES = "signature bytes".getBytes(StandardCharsets.UTF_8);
 
   @TempDir private Path tempDir;
+
+  @Test
+  void publish_whenDefaultProxySelectorConfigured_expectLoopbackRequestBypassesProxy()
+      throws Exception {
+    AtomicInteger proxySelections = new AtomicInteger();
+    ProxySelector previousProxySelector = ProxySelector.getDefault();
+    HttpServer server =
+        HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    server.createContext(
+        "/api/v1/queue/inserts/directory",
+        exchange -> sendJson(exchange, 201, "{\"outcome\":\"STARTED\"}"));
+    server.start();
+    ProxySelector.setDefault(
+        new ProxySelector() {
+          @Override
+          public List<Proxy> select(URI uri) {
+            proxySelections.incrementAndGet();
+            return List.of(Proxy.NO_PROXY);
+          }
+
+          @Override
+          public void connectFailed(URI uri, SocketAddress sa, IOException ioe) {}
+        });
+    try {
+      PlatformApiLiveUskPublisher publisher = new PlatformApiLiveUskPublisher();
+      URI nodeBaseUrl = URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/api/v1");
+
+      LiveUskPublishResponse response =
+          publisher.publish(requestWithoutLiveFetchVerification(nodeBaseUrl));
+
+      assertEquals("queued", response.catalogInsertStatus());
+      assertEquals("queued", response.signatureInsertStatus());
+      assertEquals("not_requested", response.postPublishVerificationStatus());
+      assertEquals(0, proxySelections.get());
+    } finally {
+      ProxySelector.setDefault(previousProxySelector);
+      server.stop(0);
+    }
+  }
 
   @Test
   void publish_whenCatalogFetchResolvesEdition_expectSignatureFetchedFromResolvedSibling()
@@ -177,6 +219,14 @@ class PlatformApiLiveUskPublisherTest {
   }
 
   private static LiveUskPublishRequest requestWithLiveFetchVerification(URI nodeBaseUrl) {
+    return baseRequest(nodeBaseUrl).verifyLiveFetch(true).build();
+  }
+
+  private static LiveUskPublishRequest requestWithoutLiveFetchVerification(URI nodeBaseUrl) {
+    return baseRequest(nodeBaseUrl).verifyLiveFetch(false).build();
+  }
+
+  private static LiveUskPublishRequest.Builder baseRequest(URI nodeBaseUrl) {
     return LiveUskPublishRequest.builder()
         .nodeBaseUrl(nodeBaseUrl)
         .formPassword("form-password")
@@ -186,9 +236,7 @@ class PlatformApiLiveUskPublisherTest {
         .publicCatalogSource("crypta:USK@PUBLIC/catalog/-1/cryptad-app-catalog.properties")
         .publicSignatureSource("crypta:USK@PUBLIC/catalog/-1/cryptad-app-catalog.signature")
         .catalogBytes(CATALOG_BYTES)
-        .signatureBytes(SIGNATURE_BYTES)
-        .verifyLiveFetch(true)
-        .build();
+        .signatureBytes(SIGNATURE_BYTES);
   }
 
   private static Map<String, String> readForm(HttpExchange exchange) throws IOException {

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisherTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/PlatformApiLiveUskPublisherTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
 class PlatformApiLiveUskPublisherTest {
@@ -154,6 +155,33 @@ class PlatformApiLiveUskPublisherTest {
   }
 
   @Test
+  void publish_whenLiveFetchVerificationFailsAfterQueueStart_expectStagingRetentionException()
+      throws Exception {
+    AtomicInteger fetchCount = new AtomicInteger();
+    HttpServer server =
+        HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+    server.createContext(
+        "/api/v1/queue/inserts/directory",
+        exchange -> sendJson(exchange, 201, "{\"outcome\":\"STARTED\"}"));
+    server.createContext(
+        "/api/v1/content/fetch", exchange -> handleMismatchedCatalogFetch(exchange, fetchCount));
+    server.start();
+    try {
+      PlatformApiLiveUskPublisher publisher = new PlatformApiLiveUskPublisher();
+      URI nodeBaseUrl = URI.create("http://127.0.0.1:" + server.getAddress().getPort() + "/api/v1");
+
+      LiveUskPublishException exception =
+          assertThrows(
+              LiveUskPublishException.class,
+              () -> publisher.publish(requestWithLiveFetchVerification(nodeBaseUrl)));
+
+      assertTrue(exception.getMessage().contains("fetched catalog bytes do not match"));
+    } finally {
+      server.stop(0);
+    }
+  }
+
+  @Test
   void publish_whenQueueOutcomeIsNotStarted_expectSanitizedFailure() throws Exception {
     LinkedHashMap<String, String> queueForm = new LinkedHashMap<>();
     HttpServer server =
@@ -209,6 +237,25 @@ class PlatformApiLiveUskPublisherTest {
           200,
           "{\"contentBase64\":\"%s\",\"resolvedUri\":\"%s\"}"
               .formatted(Base64.getEncoder().encodeToString(CATALOG_BYTES), resolvedUri));
+      return;
+    }
+    sendJson(
+        exchange,
+        200,
+        "{\"contentBase64\":\"%s\"}"
+            .formatted(Base64.getEncoder().encodeToString(SIGNATURE_BYTES)));
+  }
+
+  private static void handleMismatchedCatalogFetch(HttpExchange exchange, AtomicInteger fetchCount)
+      throws IOException {
+    if (fetchCount.getAndIncrement() == 0) {
+      sendJson(
+          exchange,
+          200,
+          "{\"contentBase64\":\"%s\"}"
+              .formatted(
+                  Base64.getEncoder()
+                      .encodeToString("wrong catalog".getBytes(StandardCharsets.UTF_8))));
       return;
     }
     sendJson(

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/PublicationInputValidatorTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/PublicationInputValidatorTest.java
@@ -10,6 +10,7 @@ import network.crypta.platform.appdist.AppDistributionException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -39,6 +40,7 @@ class PublicationInputValidatorTest {
     assertEquals(output.toAbsolutePath().normalize(), inputs.output());
     assertEquals(sha256(Files.readAllBytes(catalogFile)), inputs.catalogSha256());
     assertEquals(sha256(Files.readAllBytes(signatureFile)), inputs.signatureSha256());
+    assertRetainsValidatedBytes(inputs, catalogFile, signatureFile);
   }
 
   @Test
@@ -132,6 +134,18 @@ class PublicationInputValidatorTest {
         """,
         StandardCharsets.UTF_8);
     return signatureFile;
+  }
+
+  private static void assertRetainsValidatedBytes(
+      ValidatedPublicationInputs inputs, Path catalogFile, Path signatureFile) throws Exception {
+    byte[] catalogBytes = inputs.catalogBytes();
+    byte[] signatureBytes = inputs.signatureBytes();
+
+    catalogBytes[0] = (byte) (catalogBytes[0] + 1);
+    signatureBytes[0] = (byte) (signatureBytes[0] + 1);
+
+    assertArrayEquals(Files.readAllBytes(catalogFile), inputs.catalogBytes());
+    assertArrayEquals(Files.readAllBytes(signatureFile), inputs.signatureBytes());
   }
 
   private static String sha256(byte[] bytes) throws Exception {

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/PublicationInputValidatorTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/PublicationInputValidatorTest.java
@@ -1,0 +1,140 @@
+package network.crypta.platform.devtools;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import network.crypta.platform.appcatalog.AppCatalogSignature;
+import network.crypta.platform.appdist.AppDistributionException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SuppressWarnings("java:S100")
+class PublicationInputValidatorTest {
+  private static final String SHA256 = "0".repeat(64);
+  private static final String PUBLIC_SOURCE =
+      "  crypta:USK@PUBLIC/catalog/42/" + AppCatalogSignature.CATALOG_FILE_NAME + "  ";
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void validate_whenInputsAreCanonical_expectParsedInputsAndDigests() throws Exception {
+    Path catalogFile = writeCatalog(AppCatalogSignature.CATALOG_FILE_NAME);
+    Path signatureFile = writeSignature();
+    Path output = tempDir.resolve("reports").resolve("summary.json");
+
+    ValidatedPublicationInputs inputs =
+        PublicationInputValidator.validate(catalogFile, signatureFile, PUBLIC_SOURCE, output);
+
+    assertEquals("dev", inputs.catalog().catalogId());
+    assertEquals(1, inputs.catalog().entries().size());
+    assertEquals("dev-local", inputs.signature().keyId());
+    assertEquals(PUBLIC_SOURCE.trim(), inputs.catalogSource());
+    assertEquals(catalogFile.toAbsolutePath().normalize(), inputs.catalogFile());
+    assertEquals(signatureFile.toAbsolutePath().normalize(), inputs.catalogSignatureFile());
+    assertEquals(output.toAbsolutePath().normalize(), inputs.output());
+    assertEquals(sha256(Files.readAllBytes(catalogFile)), inputs.catalogSha256());
+    assertEquals(sha256(Files.readAllBytes(signatureFile)), inputs.signatureSha256());
+  }
+
+  @Test
+  void validate_whenCatalogSourceHasQuery_expectFailure() throws Exception {
+    Path catalogFile = writeCatalog(AppCatalogSignature.CATALOG_FILE_NAME);
+    Path signatureFile = writeSignature();
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                PublicationInputValidator.validate(
+                    catalogFile,
+                    signatureFile,
+                    "crypta:USK@PUBLIC/catalog/42/"
+                        + AppCatalogSignature.CATALOG_FILE_NAME
+                        + "?edition=42",
+                    tempDir.resolve("summary.json")));
+
+    assertEquals(
+        "publish-usk requires --catalog-source crypta:USK@.../cryptad-app-catalog.properties",
+        exception.getMessage());
+  }
+
+  @Test
+  void validate_whenCatalogFileNameIsNotCanonical_expectFailure() throws Exception {
+    Path catalogFile = writeCatalog("catalog.properties");
+    Path signatureFile = writeSignature();
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                PublicationInputValidator.validate(
+                    catalogFile, signatureFile, PUBLIC_SOURCE, tempDir.resolve("summary.json")));
+
+    assertEquals(
+        "catalog file must be " + AppCatalogSignature.CATALOG_FILE_NAME, exception.getMessage());
+  }
+
+  @Test
+  void validate_whenSignatureSidecarIsMissing_expectFailure() throws Exception {
+    Path catalogFile = writeCatalog(AppCatalogSignature.CATALOG_FILE_NAME);
+    Path missingSignature = tempDir.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                PublicationInputValidator.validate(
+                    catalogFile, missingSignature, PUBLIC_SOURCE, tempDir.resolve("summary.json")));
+
+    assertEquals("catalog signature file must be a regular file", exception.getMessage());
+  }
+
+  private Path writeCatalog(String fileName) throws Exception {
+    Path catalogFile = tempDir.resolve(fileName);
+    Files.writeString(
+        catalogFile,
+        """
+        catalog.version=1
+        catalog.id=dev
+        catalog.name=Development Apps
+        catalog.generatedAt=2026-05-14T00:00:00Z
+        catalog.entries=queue-app
+        app.queue-app.id=queue-app
+        app.queue-app.name=Queue App
+        app.queue-app.version=0.1.0
+        app.queue-app.summary=Queue dashboard.
+        app.queue-app.bundle.uri=crypta:CHK@public-bundle-key
+        app.queue-app.bundle.sha256=%s
+        app.queue-app.bundle.size.bytes=0
+        app.queue-app.bundle.type=zip
+        app.queue-app.permissions=queue.read
+        """
+            .formatted(SHA256),
+        StandardCharsets.UTF_8);
+    return catalogFile;
+  }
+
+  private Path writeSignature() throws Exception {
+    Path signatureFile = tempDir.resolve(AppCatalogSignature.SIGNATURE_FILE_NAME);
+    Files.writeString(
+        signatureFile,
+        """
+        catalog.signature.version=1
+        catalog.signature.algorithm=Ed25519
+        catalog.signature.key.id=dev-local
+        catalog.signature.payload=cryptad-app-catalog.properties
+        catalog.signature.value.base64=AQID
+        """,
+        StandardCharsets.UTF_8);
+    return signatureFile;
+  }
+
+  private static String sha256(byte[] bytes) throws Exception {
+    return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256").digest(bytes));
+  }
+}

--- a/platform-devtools/src/test/java/network/crypta/platform/devtools/PublicationInputValidatorTest.java
+++ b/platform-devtools/src/test/java/network/crypta/platform/devtools/PublicationInputValidatorTest.java
@@ -1,5 +1,6 @@
 package network.crypta.platform.devtools;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.io.TempDir;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 @SuppressWarnings("java:S100")
 class PublicationInputValidatorTest {
@@ -96,6 +98,57 @@ class PublicationInputValidatorTest {
     assertEquals("catalog signature file must be a regular file", exception.getMessage());
   }
 
+  @Test
+  void validate_whenOutputIsCatalogFile_expectFailureWithoutChangingCatalog() throws Exception {
+    Path catalogFile = writeCatalog(AppCatalogSignature.CATALOG_FILE_NAME);
+    Path signatureFile = writeSignature();
+    String catalogBefore = Files.readString(catalogFile, StandardCharsets.UTF_8);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                PublicationInputValidator.validate(
+                    catalogFile, signatureFile, PUBLIC_SOURCE, catalogFile));
+
+    assertOutputAliasFailure(exception);
+    assertEquals(catalogBefore, Files.readString(catalogFile, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void validate_whenOutputIsSignatureSidecar_expectFailureWithoutChangingSignature()
+      throws Exception {
+    Path catalogFile = writeCatalog(AppCatalogSignature.CATALOG_FILE_NAME);
+    Path signatureFile = writeSignature();
+    String signatureBefore = Files.readString(signatureFile, StandardCharsets.UTF_8);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                PublicationInputValidator.validate(
+                    catalogFile, signatureFile, PUBLIC_SOURCE, signatureFile));
+
+    assertOutputAliasFailure(exception);
+    assertEquals(signatureBefore, Files.readString(signatureFile, StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void validate_whenOutputHardLinksCatalogFile_expectFailure() throws Exception {
+    Path catalogFile = writeCatalog(AppCatalogSignature.CATALOG_FILE_NAME);
+    Path signatureFile = writeSignature();
+    Path outputAlias = createHardLinkOrSkip(catalogFile);
+
+    AppDistributionException exception =
+        assertThrows(
+            AppDistributionException.class,
+            () ->
+                PublicationInputValidator.validate(
+                    catalogFile, signatureFile, PUBLIC_SOURCE, outputAlias));
+
+    assertOutputAliasFailure(exception);
+  }
+
   private Path writeCatalog(String fileName) throws Exception {
     Path catalogFile = tempDir.resolve(fileName);
     Files.writeString(
@@ -134,6 +187,22 @@ class PublicationInputValidatorTest {
         """,
         StandardCharsets.UTF_8);
     return signatureFile;
+  }
+
+  private Path createHardLinkOrSkip(Path target) throws Exception {
+    Path alias = tempDir.resolve("catalog-plan.json");
+    try {
+      Files.createLink(alias, target);
+    } catch (UnsupportedOperationException | IOException | SecurityException _) {
+      assumeTrue(false, "hard links are not supported by this filesystem");
+    }
+    return alias;
+  }
+
+  private static void assertOutputAliasFailure(AppDistributionException exception) {
+    assertEquals(
+        "publication output must be separate from catalog file and signature sidecar",
+        exception.getMessage());
   }
 
   private static void assertRetainsValidatedBytes(

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -4980,7 +4980,7 @@ def collect_app_update_live_catalog_refresh_evidence(settings: Settings) -> Evid
             )
             and "refresh(catalogId)" in catalog_handler_text
         ),
-        "pathAndSecretFreeSchedulerEvidence": (
+        "schedulerSummaryPrivacyGuard": (
             "summary_whenSchedulerStatePresent_expectPathFreeSchedulerSummary"
             in scheduler_test_text
             and "secret-token" in scheduler_test_text
@@ -6082,6 +6082,15 @@ def run_self_test(repo_root: Path) -> None:
         assert scheduler_checks["schedulerPathAndPrivateDataFree"] is True, scheduler_checks
         assert scheduler_checks["schedulerLifecycleDocumented"] is True, scheduler_checks
         assert evidence_by_id["app-update.live-catalog-refresh"]["status"] == "pass"
+        live_catalog_refresh_checks = evidence_by_id["app-update.live-catalog-refresh"]["details"][
+            "checks"
+        ]
+        assert (
+            live_catalog_refresh_checks["schedulerSummaryPrivacyGuard"] is True
+        ), live_catalog_refresh_checks
+        assert all(
+            isinstance(value, bool) for value in live_catalog_refresh_checks.values()
+        ), live_catalog_refresh_checks
         assert evidence_by_id["app-update.rollback"]["status"] == "pass"
         assert evidence_by_id["app-update.rollback"]["requiredForReleaseCandidate"] is True
         rollback_checks = evidence_by_id["app-update.rollback"]["details"]["checks"]

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -1188,7 +1188,13 @@ def collect_developer_beta_toolkit_evidence(settings: Settings) -> EvidenceItem:
         "mockSessionRequired": "invalid_app_browser_session" in text["mockApi"] and "X-Crypta-App-Session" in text["mockApi"],
         "offlineTestSmoke": "dev.bootstrap-smoke" in text["testSuite"] and "AppTestReport" in text["testSuite"],
         "catalogDescriptorGenerator": "artifact.path" in text["catalogEntry"] and "permissions.rationale." in text["catalogEntry"],
-        "publishPlanDryRunOnly": "live_publish_not_supported" in text["cli"] and "Crypta Catalog USK Publication Plan" in text["publishPlan"],
+        "publishUskDryRunAndLive": (
+            "--dry-run" in text["cli"]
+            and "--live" in text["cli"]
+            and "PublicationPlanWriter" in text["cli"]
+            and "LiveUskPublicationService" in text["cli"]
+            and "Crypta Catalog USK Publication Plan" in text["publishPlan"]
+        ),
         "keyGeneration": "Ed25519" in text["keyGenerator"] and "trusted.keys.version=1" in text["keyGenerator"],
         "selfTestsCoverFlow": (
             "test_whenFreshStaticTemplateCheckedStrict_expectPassingHumanAndJsonReport" in text["toolkitTests"]
@@ -1569,6 +1575,253 @@ def collect_catalog_evidence(settings: Settings, sample_paths: dict[str, Path]) 
     if sign_result.exit_code != 0 or verify_result.exit_code != 0:
         return EvidenceItem("catalog.smoke", "fail", True, "Signed catalog smoke failed.", source, details)
     return EvidenceItem("catalog.smoke", "pass", True, "Catalog create, sign, and verify smoke passed.", source, details)
+
+
+def collect_live_usk_catalog_publication_evidence(
+    settings: Settings, sample_paths: dict[str, Path]
+) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    devtools_dir = workspace / "platform-devtools/src/main/java/network/crypta/platform/devtools"
+    test_dir = workspace / "platform-devtools/src/test/java/network/crypta/platform/devtools"
+    cli_text = read_source(devtools_dir / "CryptaAppCli.java")
+    service_text = read_source(devtools_dir / "LiveUskPublicationService.java")
+    publisher_text = read_source(devtools_dir / "PlatformApiLiveUskPublisher.java")
+    result_text = read_source(devtools_dir / "LiveUskPublicationResult.java")
+    writer_text = read_source(devtools_dir / "LiveUskPublicationResultWriter.java")
+    validator_text = read_source(devtools_dir / "PublicationInputValidator.java")
+    tests_text = "\n".join(
+        read_source(path)
+        for path in (
+            test_dir / "DeveloperBetaToolkitCliTest.java",
+            test_dir / "LiveUskPublicationServiceTest.java",
+            test_dir / "PublicationPlanWriterTest.java",
+        )
+    )
+    docs_text = "\n".join(
+        read_source(workspace / path)
+        for path in (
+            "docs/developer-beta-toolkit.md",
+            "docs/app-platform-beta-tutorials.md",
+            "docs/first-party-beta-catalog.md",
+            "docs/app-catalogs.md",
+            "docs/release-certification.md",
+            "docs/cryptad-release-workflow-and-runbook.md",
+        )
+    )
+    checks = {
+        "explicitLiveMode": (
+            '"--live"' in cli_text
+            and '"--dry-run"' in cli_text
+            and "requires exactly one of --dry-run or --live" in cli_text
+        ),
+        "secureLiveInputs": (
+            "--private-insert-uri-env" in cli_text
+            and "--private-insert-uri-file" in cli_text
+            and "--form-password-env" in cli_text
+            and "--form-password-file" in cli_text
+            and "loadSecureText" in cli_text
+        ),
+        "localVerificationBeforeInsert": (
+            "PublicationInputValidator.validate" in service_text
+            and "AppCatalogVerifier.verify" in service_text
+            and "requirePrivateInsertUri" in service_text
+        ),
+        "realQueueInsertionPath": (
+            "queue/inserts/directory" in publisher_text
+            and "sourcePath" in publisher_text
+            and "insertUri" in publisher_text
+            and "COMPAT_CURRENT" in publisher_text
+            and "followRedirects(HttpClient.Redirect.NEVER)" in publisher_text
+        ),
+        "optionalLiveFetchVerification": (
+            "content/fetch" in publisher_text
+            and "contentBase64" in publisher_text
+            and "live_publish_verification_failed" in publisher_text
+        ),
+        "sanitizedResultModel": (
+            "catalogSha256" in result_text
+            and "signatureSha256" in result_text
+            and "catalogSigningKeyId" in result_text
+            and "catalogInsertStatus" in result_text
+            and "schedulerRefreshVerificationStatus" in result_text
+            and "privateInsertUri" not in writer_text
+            and "formPassword" not in writer_text
+            and "stagingDirectory" not in writer_text
+        ),
+        "sharedInputValidation": (
+            "crypta:USK@.../" in validator_text
+            and "cryptad-app-catalog.properties" in validator_text
+            and "cryptad-app-catalog.signature" in validator_text
+        ),
+        "testsCoverLiveAndRedaction": (
+            "publish_whenFakePublisherSucceeds_expectSanitizedSummaryAndRetainedStaging"
+            in tests_text
+            and "publish_whenInsertIsOnlyQueued_expectStagingRetainedWithoutPathInSummary"
+            in tests_text
+            and "publish_whenPrivateInsertUriDoesNotMatchPublicSource_expectFailureWithoutPublisherOrSummary"
+            in tests_text
+            and "private insert URI must be configured by exactly one env or file source"
+            in tests_text
+            and "staging_sidecars_retained_until_live_insert_completion" in tests_text
+            and "assertFalse(liveSummaryText.contains(LIVE_PRIVATE_INSERT_URI))" in tests_text
+        ),
+        "docsCoverLivePublication": (
+            "crypta-app publish-usk --live" in docs_text
+            and "private insert URI" in docs_text
+            and "cryptad-app-catalog.signature" in docs_text
+            and "same USK" in docs_text
+            and "dry-run" in docs_text.lower()
+        ),
+    }
+    errors = [key for key, passed in checks.items() if not passed]
+    details = {
+        "liveNodeRequired": False,
+        "actualLiveInsertionOptional": True,
+        "publicSourceShape": "crypta:USK@.../cryptad-app-catalog.properties",
+        "signatureSidecar": "cryptad-app-catalog.signature",
+        "checks": checks,
+        "sources": {
+            "cli": display_path(devtools_dir / "CryptaAppCli.java", workspace),
+            "service": display_path(devtools_dir / "LiveUskPublicationService.java", workspace),
+            "publisher": display_path(devtools_dir / "PlatformApiLiveUskPublisher.java", workspace),
+            "result": display_path(devtools_dir / "LiveUskPublicationResult.java", workspace),
+            "writer": display_path(devtools_dir / "LiveUskPublicationResultWriter.java", workspace),
+            "validator": display_path(devtools_dir / "PublicationInputValidator.java", workspace),
+            "tests": display_path(test_dir / "LiveUskPublicationServiceTest.java", workspace),
+        },
+    }
+    if errors:
+        return EvidenceItem(
+            "catalog.live-usk-publication",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "Live USK catalog publication evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "catalog.live-usk-publication",
+        "pass",
+        True,
+        "Live USK catalog publication source and redaction evidence passed.",
+        source,
+        details,
+    )
+
+
+def collect_live_usk_source_verification_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    appcatalog_dir = workspace / "platform-appcatalog/src/main/java/network/crypta/platform/appcatalog"
+    appcatalog_tests = workspace / "platform-appcatalog/src/test/java/network/crypta/platform/appcatalog"
+    api_tests = workspace / "platform-api/src/test/java/network/crypta/platform/api/appcatalogs"
+    source_text = read_source(appcatalog_dir / "AppCatalogSource.java")
+    uri_text = read_source(appcatalog_dir / "CryptaCatalogUri.java")
+    fetcher_text = read_source(appcatalog_dir / "AppCatalogFetcher.java")
+    manager_text = read_source(appcatalog_dir / "AppCatalogManager.java")
+    recommended_text = read_source(appcatalog_dir / "RecommendedAppCatalogs.java")
+    appcatalog_test_text = read_source(appcatalog_tests / "AppCatalogManagerTest.java")
+    api_test_text = read_source(api_tests / "AppCatalogsApiHandlerTest.java")
+    docs_text = "\n".join(
+        read_source(workspace / path)
+        for path in (
+            "docs/app-catalogs.md",
+            "docs/first-party-beta-catalog.md",
+            "docs/app-update-lifecycle.md",
+        )
+    )
+    checks = {
+        "cryptaUskSourceAccepted": (
+            "CryptaCatalogUri.parse" in source_text
+            and "crypta:USK@" in uri_text
+            and "SIGNATURE_QUERY_PREFIX" in uri_text
+        ),
+        "resolvedEditionSignatureSidecar": (
+            "signatureFetchKeyForResolvedCatalog" in uri_text
+            and "normalizeResolvedCatalogFetchKey" in uri_text
+            and "requireCompatibleResolvedKeyKind" in uri_text
+            and "siblingSignatureKey(resolvedKey)" in uri_text
+        ),
+        "boundedContentFetch": (
+            "ContentFetchPort" in fetcher_text
+            and "signatureFetchKeyForResolvedCatalog(catalogBytes.resolvedUri())" in fetcher_text
+            and "MAX_CATALOG_BYTES" in fetcher_text
+            and "MAX_SIGNATURE_BYTES" in fetcher_text
+        ),
+        "verifyBeforeStorage": (
+            "AppCatalogVerifier.verify" in manager_text
+            and "sourceStore.write(catalog, source, fetched" in manager_text
+            and "CATALOG_ID_MISMATCH" in manager_text
+        ),
+        "refreshPreservesPreviousOnFailure": (
+            "recordRefreshFailure" in manager_text
+            and "previous stored sidecars remain in place" in manager_text
+        ),
+        "firstPartySourceConfigDriven": (
+            "CRYPTAD_FIRST_PARTY_CATALOG_SOURCE" in recommended_text
+            and "CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_CATALOG_KEY_ID" in recommended_text
+        ),
+        "testsCoverResolvedEdition": (
+            "fetch_whenCryptaCatalogResolvesToUskEdition_expectSignatureFetchedFromResolvedEdition"
+            in appcatalog_test_text
+            and "fetch_whenCryptaResolvedCatalogHasSchemePrefix_expectSignatureFetchedFromResolvedEdition"
+            in appcatalog_test_text
+            and "fetch_whenCryptaResolvedCatalogChangesKeyKind_expectInvalidCatalogSource"
+            in appcatalog_test_text
+            and "fetch_whenCryptaSourceUsesContentFetchPort_expectBoundedRequests"
+            in appcatalog_test_text
+        ),
+        "testsCoverRefreshPreservation": (
+            "refresh_whenCryptaFetchFails_expectPreviousVerifiedCatalogPreservedAndMetadataUpdated"
+            in appcatalog_test_text
+            and "refresh_whenCryptaVerificationFailsAfterResolvedFetch_expectMetadataUsesResolvedUri"
+            in appcatalog_test_text
+        ),
+        "recommendedSummariesRedactSources": (
+            "listRecommendedCatalogs_whenConfiguredAndTrusted_expectCanAddAndRedactedSource"
+            in api_test_text
+            and "listRecommendedCatalogs_whenHttpsSourceHasQuery_expectQueryRedacted"
+            in api_test_text
+            and "listRecommendedCatalogs_whenFileSourceConfigured_expectPathRedacted"
+            in api_test_text
+        ),
+        "docsCoverUskVerification": (
+            "crypta:USK@" in docs_text
+            and "same USK" in docs_text
+            and "signed catalog verification" in docs_text.lower()
+            and "cryptad-app-catalog.signature" in docs_text
+        ),
+    }
+    errors = [key for key, passed in checks.items() if not passed]
+    details = {
+        "liveNodeRequired": False,
+        "checks": checks,
+        "sources": {
+            "sourceModel": display_path(appcatalog_dir / "AppCatalogSource.java", workspace),
+            "cryptaUri": display_path(appcatalog_dir / "CryptaCatalogUri.java", workspace),
+            "fetcher": display_path(appcatalog_dir / "AppCatalogFetcher.java", workspace),
+            "manager": display_path(appcatalog_dir / "AppCatalogManager.java", workspace),
+            "tests": display_path(appcatalog_tests / "AppCatalogManagerTest.java", workspace),
+        },
+    }
+    if errors:
+        return EvidenceItem(
+            "catalog.live-usk-source-verification",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "Live USK source verification evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "catalog.live-usk-source-verification",
+        "pass",
+        True,
+        "Live USK source verification evidence passed deterministic checks.",
+        source,
+        details,
+    )
 
 
 def collect_first_party_beta_catalog_evidence(settings: Settings) -> EvidenceItem:
@@ -4664,6 +4917,117 @@ def collect_app_update_scheduler_evidence(settings: Settings) -> EvidenceItem:
     )
 
 
+def collect_app_update_live_catalog_refresh_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    scheduler_source = (
+        workspace / "platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateScheduler.java"
+    )
+    update_service_source = (
+        workspace / "platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateService.java"
+    )
+    scheduler_test_source = (
+        workspace / "platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateSchedulerTest.java"
+    )
+    catalog_routes_source = (
+        workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppRoutes.java"
+    )
+    catalog_handler_source = (
+        workspace
+        / "platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java"
+    )
+    lifecycle_doc = workspace / "docs/app-update-lifecycle.md"
+    catalog_doc = workspace / "docs/app-catalogs.md"
+    scheduler_text = read_source(scheduler_source)
+    update_service_text = read_source(update_service_source)
+    scheduler_test_text = read_source(scheduler_test_source)
+    catalog_routes_text = read_source(catalog_routes_source)
+    catalog_handler_text = read_source(catalog_handler_source)
+    docs_text = read_source(lifecycle_doc) + "\n" + read_source(catalog_doc)
+    checks = {
+        "refreshBeforeCandidateDiscovery": (
+            "catalogManager.listCatalogs()" in scheduler_text
+            and "catalogManager.refresh(catalog.catalogId())" in scheduler_text
+            and "updateService.check(state.appId(), false)" in scheduler_text
+            and "inOrder(catalogManager, updateService)" in scheduler_test_text
+        ),
+        "refreshFailureContained": (
+            "MESSAGE_CATALOG_REFRESH_FAILED" in scheduler_text
+            and "tick_whenCatalogRefreshFails_expectFailureContainedAndAppsStillChecked"
+            in scheduler_test_text
+        ),
+        "schedulerDoesNotApplyDirectly": (
+            "updateService.stage(" not in scheduler_text
+            and "updateService.apply(" not in scheduler_text
+            and "appHost.updateFromDirectory(" not in scheduler_text
+            and "catalogManager.prepareInstallPlan(" not in scheduler_text
+        ),
+        "manualPolicyStillDefault": (
+            "manual remains the default" in scheduler_text.lower()
+            and "tick_whenManualPolicy_expectCheckOnlyAndNoStageOrApply" in scheduler_test_text
+            and "verify(catalogManager, never()).prepareInstallPlan" in scheduler_test_text
+        ),
+        "policyDrivenUpdatesStayInService": (
+            "check(state.appId(), false)" in scheduler_text
+            and "check(" in update_service_text
+            and "stage(" in update_service_text
+            and "apply(" in update_service_text
+        ),
+        "manualRefreshRouteExists": (
+            '"refresh".equals(action)' in catalog_routes_text
+            and '"/app-catalogs/{catalogId}/refresh"' in read_source(
+                workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiContract.java"
+            )
+            and "refresh(catalogId)" in catalog_handler_text
+        ),
+        "pathAndSecretFreeSchedulerEvidence": (
+            "summary_whenSchedulerStatePresent_expectPathFreeSchedulerSummary"
+            in scheduler_test_text
+            and "secret-token" in scheduler_test_text
+            and "contains(tempDir.toString())" in scheduler_test_text
+        ),
+        "docsCoverLiveCatalogRefresh": (
+            "live USK catalog" in docs_text
+            and "catalog refresh" in docs_text.lower()
+            and "last verified" in docs_text.lower()
+            and "manual remains the default" in docs_text.lower()
+        ),
+    }
+    errors = [key for key, passed in checks.items() if not passed]
+    details = {
+        "liveNodeRequired": False,
+        "policy": "manual default; scheduler refreshes catalogs before candidate discovery",
+        "silentAutoUpdateDefault": False,
+        "checks": checks,
+        "sources": {
+            "scheduler": display_path(scheduler_source, workspace),
+            "updateService": display_path(update_service_source, workspace),
+            "schedulerTest": display_path(scheduler_test_source, workspace),
+            "catalogRoutes": display_path(catalog_routes_source, workspace),
+            "catalogHandler": display_path(catalog_handler_source, workspace),
+            "lifecycleDoc": display_path(lifecycle_doc, workspace),
+            "catalogDoc": display_path(catalog_doc, workspace),
+        },
+    }
+    if errors:
+        return EvidenceItem(
+            "app-update.live-catalog-refresh",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "Live catalog refresh scheduler evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "app-update.live-catalog-refresh",
+        "pass",
+        True,
+        "Live catalog refresh scheduler evidence passed deterministic checks.",
+        source,
+        details,
+    )
+
+
 def collect_app_update_rollback_evidence(settings: Settings) -> EvidenceItem:
     source = summary_source(settings)
     apphost_source = (
@@ -5003,7 +5367,9 @@ def run(settings: Settings) -> tuple[dict[str, Any], int]:
         collect_trust_statement_signing_evidence(settings),
         collect_signed_bundle_evidence(settings, sample_paths),
         collect_catalog_evidence(settings, sample_paths),
+        collect_live_usk_catalog_publication_evidence(settings, sample_paths),
         collect_first_party_beta_catalog_evidence(settings),
+        collect_live_usk_source_verification_evidence(settings),
         collect_app_review_receipt_evidence(settings),
         collect_app_review_policy_evidence(settings),
         collect_app_review_governance_evidence(settings),
@@ -5026,6 +5392,7 @@ def run(settings: Settings) -> tuple[dict[str, Any], int]:
         collect_sandbox_provider_evidence(settings),
         collect_app_update_lifecycle_evidence(settings),
         collect_app_update_scheduler_evidence(settings),
+        collect_app_update_live_catalog_refresh_evidence(settings),
         collect_app_update_rollback_evidence(settings),
         collect_live_evidence(settings, sample_paths),
     ]
@@ -5540,10 +5907,12 @@ def run_self_test(repo_root: Path) -> None:
         assert contract_details["snapshotCommand"]["exitCode"] == 0, contract_item
         assert contract_details["verifier"]["cert-smoke"]["exitCode"] == 0, contract_item
         assert evidence_by_id["catalog.smoke"]["status"] in {"warn", "pass"}
+        assert evidence_by_id["catalog.live-usk-publication"]["status"] == "pass"
         first_party_beta_item = evidence_by_id["app-catalog.first-party-beta"]
         assert first_party_beta_item["status"] == "pass", first_party_beta_item
         assert first_party_beta_item["details"]["catalogId"] == "crypta-first-party-beta"
         assert first_party_beta_item["details"]["requiredFirstPartyApps"] == list(APP_IDS)
+        assert evidence_by_id["catalog.live-usk-source-verification"]["status"] == "pass"
         assert evidence_by_id["app-ui.design-system"]["status"] == "pass"
         assert evidence_by_id["app-ui.lint"]["status"] == "pass"
         assert evidence_by_id["app-ui.first-party-adoption"]["status"] == "pass"
@@ -5712,6 +6081,7 @@ def run_self_test(repo_root: Path) -> None:
         assert scheduler_checks["schedulerPerAppSerialized"] is True, scheduler_checks
         assert scheduler_checks["schedulerPathAndPrivateDataFree"] is True, scheduler_checks
         assert scheduler_checks["schedulerLifecycleDocumented"] is True, scheduler_checks
+        assert evidence_by_id["app-update.live-catalog-refresh"]["status"] == "pass"
         assert evidence_by_id["app-update.rollback"]["status"] == "pass"
         assert evidence_by_id["app-update.rollback"]["requiredForReleaseCandidate"] is True
         rollback_checks = evidence_by_id["app-update.rollback"]["details"]["checks"]
@@ -6165,7 +6535,24 @@ def make_self_test_workspace(workspace: Path) -> None:
     )
     (appcatalog_dir / "RecommendedAppCatalogs.java").write_text(
         "final class RecommendedAppCatalogs { static final String FIRST_PARTY_BETA_CATALOG_ID = "
-        "\"crypta-first-party-beta\"; String env = \"CRYPTAD_FIRST_PARTY_CATALOG_SOURCE\"; }\n",
+        "\"crypta-first-party-beta\"; String env = \"CRYPTAD_FIRST_PARTY_CATALOG_SOURCE "
+        "CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_CATALOG_KEY_ID\"; }\n",
+        encoding="utf-8",
+    )
+    (appcatalog_dir / "AppCatalogSource.java").write_text(
+        "final class AppCatalogSource { Object source = CryptaCatalogUri.parse(\"crypta:USK@example/cryptad-app-catalog.properties\"); }\n",
+        encoding="utf-8",
+    )
+    (appcatalog_dir / "CryptaCatalogUri.java").write_text(
+        "final class CryptaCatalogUri { String s = \"crypta:USK@ SIGNATURE_QUERY_PREFIX "
+        "signatureFetchKeyForResolvedCatalog normalizeResolvedCatalogFetchKey "
+        "requireCompatibleResolvedKeyKind siblingSignatureKey(resolvedKey)\"; }\n",
+        encoding="utf-8",
+    )
+    (appcatalog_dir / "AppCatalogFetcher.java").write_text(
+        "final class AppCatalogFetcher { String s = \"ContentFetchPort "
+        "signatureFetchKeyForResolvedCatalog(catalogBytes.resolvedUri()) MAX_CATALOG_BYTES "
+        "MAX_SIGNATURE_BYTES\"; }\n",
         encoding="utf-8",
     )
     (appcatalog_dir / "AppCatalogArtifactDownloader.java").write_text(
@@ -6174,7 +6561,9 @@ def make_self_test_workspace(workspace: Path) -> None:
         encoding="utf-8",
     )
     (appcatalog_dir / "AppCatalogManager.java").write_text(
-        "final class AppCatalogManager { Object downloader = new AppCatalogArtifactDownloader(contentFetchPort); }\n",
+        "final class AppCatalogManager { Object downloader = new AppCatalogArtifactDownloader(contentFetchPort); "
+        "String s = \"AppCatalogVerifier.verify sourceStore.write(catalog, source, fetched "
+        "CATALOG_ID_MISMATCH recordRefreshFailure previous stored sidecars remain in place\"; }\n",
         encoding="utf-8",
     )
     appcatalog_tests = workspace / "platform-appcatalog/src/test/java/network/crypta/platform/appcatalog"
@@ -6182,7 +6571,13 @@ def make_self_test_workspace(workspace: Path) -> None:
     (appcatalog_tests / "AppCatalogManagerTest.java").write_text(
         "void entry_whenArtifactUriIsCryptaChk_expectAccepted() {}\n"
         "void prepareInstallPlan_whenCryptaArtifactUsesContentFetchPort_expectVerifiedPlan() {}\n"
-        "void download_whenCryptaRuntimeIsUnavailable_expectArtifactFetchUnavailable() {}\n",
+        "void download_whenCryptaRuntimeIsUnavailable_expectArtifactFetchUnavailable() {}\n"
+        "void fetch_whenCryptaCatalogResolvesToUskEdition_expectSignatureFetchedFromResolvedEdition() {}\n"
+        "void fetch_whenCryptaResolvedCatalogHasSchemePrefix_expectSignatureFetchedFromResolvedEdition() {}\n"
+        "void fetch_whenCryptaResolvedCatalogChangesKeyKind_expectInvalidCatalogSource() {}\n"
+        "void fetch_whenCryptaSourceUsesContentFetchPort_expectBoundedRequests() {}\n"
+        "void refresh_whenCryptaFetchFails_expectPreviousVerifiedCatalogPreservedAndMetadataUpdated() {}\n"
+        "void refresh_whenCryptaVerificationFailsAfterResolvedFetch_expectMetadataUsesResolvedUri() {}\n",
         encoding="utf-8",
     )
     for test_name in ("AppCatalogParserTest.java", "AppCatalogEntryDescriptorTest.java", "RecommendedAppCatalogsTest.java"):
@@ -6197,13 +6592,14 @@ def make_self_test_workspace(workspace: Path) -> None:
     )
     (api_dir / "PlatformApiAppRoutes.java").write_text(
         "final class PlatformApiAppRoutes { void routeRecommendedAppCatalogs() {} "
-        "void routeRecommendedAppCatalogAddOrApp() {} }\n",
+        "void routeRecommendedAppCatalogAddOrApp() {} boolean refresh = \"refresh\".equals(action); }\n",
         encoding="utf-8",
     )
     (api_dir / "PlatformApiContract.java").write_text(
         "final class PlatformApiContract { static final int CURRENT_CONTRACT_VERSION = 7; "
         "String list = \"/app-catalogs/recommended\"; "
         "String add = \"/app-catalogs/recommended/{catalogId}/add\"; "
+        "String refresh = \"/app-catalogs/{catalogId}/refresh\"; "
         "String listAction = \"catalogs.recommended.list\"; "
         "String addAction = \"catalogs.recommended.add\"; "
         "String profileDocument = \"/app-vault/identities/{identityId}/profile-document\"; "
@@ -6306,6 +6702,14 @@ def make_self_test_workspace(workspace: Path) -> None:
         "String route = \"trust-graph/score\"; String capability = \"trust.read\"; }\n",
         encoding="utf-8",
     )
+    appcatalog_api_tests = workspace / "platform-api/src/test/java/network/crypta/platform/api/appcatalogs"
+    appcatalog_api_tests.mkdir(parents=True, exist_ok=True)
+    (appcatalog_api_tests / "AppCatalogsApiHandlerTest.java").write_text(
+        "void listRecommendedCatalogs_whenConfiguredAndTrusted_expectCanAddAndRedactedSource() {}\n"
+        "void listRecommendedCatalogs_whenHttpsSourceHasQuery_expectQueryRedacted() {}\n"
+        "void listRecommendedCatalogs_whenFileSourceConfigured_expectPathRedacted() {}\n",
+        encoding="utf-8",
+    )
     shell = workspace / "platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js"
     shell.parent.mkdir(parents=True, exist_ok=True)
     shell.write_text(
@@ -6327,7 +6731,13 @@ def make_self_test_workspace(workspace: Path) -> None:
         "It has no old WebOfTrust plugin compatibility. No FNP/FCP/wire protocol changes are involved. "
         "api.minimumVersion, changelog.summary, and review receipts. "
         "Maintain artifacts as crypta:CHK@artifact and set CRYPTAD_FIRST_PARTY_CATALOG_SOURCE "
-        "with CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_KEY_ID. "
+        "with CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_KEY_ID and "
+        "CRYPTAD_FIRST_PARTY_CATALOG_TRUSTED_CATALOG_KEY_ID. "
+        "Run crypta-app publish-usk --dry-run for the offline plan, then crypta-app publish-usk --live "
+        "with a private insert URI loaded from env or protected file. The live USK catalog source is "
+        "crypta:USK@.../cryptad-app-catalog.properties and cryptad-app-catalog.signature is the "
+        "sibling sidecar at the same USK edition. Signed catalog verification remains mandatory. "
+        "Catalog refresh records last verified state, and manual remains the default update policy. "
         "POST /api/v1/app-vault/identities creates browser-safe app-owned identities with "
         "vault.identities.create. POST /api/v1/app-vault/identities/{identityId}/profile-document "
         "uses vault.identities.read and vault.identities.use for profile document signing. "
@@ -6429,7 +6839,11 @@ def make_self_test_workspace(workspace: Path) -> None:
         '@Command(name = "test") class AppTestCommand {}\n'
         '@Command(name = "generate") class KeysGenerateCommand {}\n'
         '@Command(name = "entry") class CatalogEntryCommand {}\n'
-        '@Command(name = "publish-usk") class PublishUskCommand { String e = "live_publish_not_supported"; }\n',
+        '@Command(name = "publish-usk") class PublishUskCommand { String dry = "--dry-run"; '
+        'String live = "--live"; String insertEnv = "--private-insert-uri-env"; '
+        'String insertFile = "--private-insert-uri-file"; String passwordEnv = "--form-password-env"; '
+        'String passwordFile = "--form-password-file"; String s = "PublicationPlanWriter '
+        'LiveUskPublicationService loadSecureText requires exactly one of --dry-run or --live"; }\n',
         encoding="utf-8",
     )
     (devtools_dir / "AppTemplateKind.java").write_text(
@@ -6456,6 +6870,33 @@ def make_self_test_workspace(workspace: Path) -> None:
         "class PublicationPlanWriter { String s = \"Crypta Catalog USK Publication Plan\"; }\n",
         encoding="utf-8",
     )
+    (devtools_dir / "PublicationInputValidator.java").write_text(
+        "class PublicationInputValidator { String s = \"crypta:USK@.../ "
+        "cryptad-app-catalog.properties cryptad-app-catalog.signature\"; }\n",
+        encoding="utf-8",
+    )
+    (devtools_dir / "LiveUskPublicationService.java").write_text(
+        "class LiveUskPublicationService { Object v = PublicationInputValidator.validate(); "
+        "String s = \"AppCatalogVerifier.verify requirePrivateInsertUri\"; }\n",
+        encoding="utf-8",
+    )
+    (devtools_dir / "PlatformApiLiveUskPublisher.java").write_text(
+        "class PlatformApiLiveUskPublisher { String s = \"queue/inserts/directory sourcePath "
+        "insertUri COMPAT_CURRENT content/fetch contentBase64 live_publish_verification_failed "
+        "followRedirects(HttpClient.Redirect.NEVER)\"; }\n",
+        encoding="utf-8",
+    )
+    (devtools_dir / "LiveUskPublicationResult.java").write_text(
+        "record LiveUskPublicationResult(String catalogSha256, String signatureSha256, "
+        "String catalogSigningKeyId, String catalogInsertStatus, "
+        "String schedulerRefreshVerificationStatus) {}\n",
+        encoding="utf-8",
+    )
+    (devtools_dir / "LiveUskPublicationResultWriter.java").write_text(
+        "class LiveUskPublicationResultWriter { String s = \"catalogSha256 signatureSha256 "
+        "catalogSigningKeyId catalogInsertStatus schedulerRefreshVerificationStatus\"; }\n",
+        encoding="utf-8",
+    )
     devserver_dir = devtools_dir / "devserver"
     devserver_dir.mkdir(parents=True, exist_ok=True)
     (devserver_dir / "CryptaAppDevServer.java").write_text(
@@ -6476,7 +6917,21 @@ def make_self_test_workspace(workspace: Path) -> None:
     (toolkit_test_dir / "DeveloperBetaToolkitCliTest.java").write_text(
         "void test_whenFreshStaticTemplateCheckedStrict_expectPassingHumanAndJsonReport() {}\n"
         "void catalogEntryAndPublishUsk_whenSignedArtifactsPrepared_expectOfflinePlan() {}\n"
-        "void devServer_whenStaticAppServed_expectBootstrapStaticAndSessionProtectedApi() {}\n",
+        "void devServer_whenStaticAppServed_expectBootstrapStaticAndSessionProtectedApi() {}\n"
+        "void publish_whenFakePublisherSucceeds_expectSanitizedSummaryAndRetainedStaging() {}\n"
+        "void publish_whenInsertIsOnlyQueued_expectStagingRetainedWithoutPathInSummary() {}\n"
+        "void publish_whenPrivateInsertUriDoesNotMatchPublicSource_expectFailureWithoutPublisherOrSummary() {}\n"
+        "String e = \"private insert URI must be configured by exactly one env or file source\";\n"
+        "String w = \"staging_sidecars_retained_until_live_insert_completion\";\n"
+        "void redaction() { assertFalse(liveSummaryText.contains(LIVE_PRIVATE_INSERT_URI)); }\n",
+        encoding="utf-8",
+    )
+    (toolkit_test_dir / "LiveUskPublicationServiceTest.java").write_text(
+        "void publish_whenFakePublisherSucceeds_expectSanitizedSummaryAndRetainedStaging() {}\n",
+        encoding="utf-8",
+    )
+    (toolkit_test_dir / "PublicationPlanWriterTest.java").write_text(
+        "void write_whenDryRun_expectPlan() {}\n",
         encoding="utf-8",
     )
     (docs / DEVELOPER_BETA_TOOLKIT_DOC.name).write_text(
@@ -6485,7 +6940,11 @@ def make_self_test_workspace(workspace: Path) -> None:
         "crypta-app test --bundle-dir . --strict\n"
         "crypta-app keys generate\n"
         "crypta-app catalog entry\n"
-        "crypta-app publish-usk --dry-run\n",
+        "crypta-app publish-usk --dry-run\n"
+        "crypta-app publish-usk --live --private-insert-uri-env CRYPTAD_FIRST_PARTY_CATALOG_INSERT_URI "
+        "--form-password-env CRYPTAD_CERT_FORM_PASSWORD\n"
+        "The private insert URI is secret, cryptad-app-catalog.signature is published at the same USK, "
+        "and dry-run remains available.\n",
         encoding="utf-8",
     )
     (workspace / APP_UI_DESIGN_SYSTEM_DOC).write_text(
@@ -6672,6 +7131,10 @@ record AppUpdateCandidate() {
 class AppUpdateService {
   AppUpdateService.SchedulerSummaryProvider schedulerSummaryProvider;
 
+  public synchronized Map<String, Object> check(String appId, boolean includeStaged) {
+    return summary(appId, installed);
+  }
+
   public synchronized Map<String, Object> stage(String appId) {
     AppUpdateCandidate candidate = candidateOrDetect(appId, installed);
     AppCatalogInstallPlan plan = catalogManager.prepareInstallPlan(candidate.catalogId(), appId);
@@ -6755,6 +7218,7 @@ public final class AppUpdateScheduler {
   private static final String MESSAGE_CATALOG_REFRESH_FAILED =
       "Scheduler catalog refresh failed; cached verified catalogs remain in use.";
   private static final String MESSAGE_APP_CHECK_FAILED = "Scheduler update check failed.";
+  // Manual remains the default; the scheduler discovers candidates and refreshes live USK catalog sources.
   AppUpdateSchedulerTickResult tick(Instant now) {
     if (!running.compareAndSet(false, true)) {
       return AppUpdateSchedulerTickResult.alreadyRunning(now);
@@ -6808,6 +7272,9 @@ class AppUpdateSchedulerConfigTest {
     (appupdates_test_dir / "AppUpdateSchedulerTest.java").write_text(
         """
 class AppUpdateSchedulerTest {
+  void tick_whenCatalogAndAppAreDue_expectRefreshOnceThenDelegatesCheck() {
+    Object order = inOrder(catalogManager, updateService);
+  }
   void tick_whenManualPolicy_expectCheckOnlyAndNoStageOrApply() {
     verify(catalogManager, never()).prepareInstallPlan(eq(CATALOG_ID), eq(APP_ID));
     verify(appHost, never()).updateFromDirectory(eq(APP_ID), eq(tempDir));
@@ -6893,6 +7360,7 @@ class AppCatalogsApiHandler {
   String recommendedCatalogError = "recommended_catalog_trusted_key_missing";
   void listRecommendedCatalogs() {}
   void addRecommended() {}
+  void refresh(String catalogId) { refresh(catalogId); }
   void summarize() {
     json.put("versionDifferent", versionDifferent(entry.version(), installedVersion, installed != null));
     json.put("updateAvailable", updateAvailable(entry.version(), installedVersion, installed != null).orElse(null));
@@ -6916,7 +7384,8 @@ AppHost v1 uses an `apply_when_stopped` policy.
 Silent automatic update is not the default.
 Applying an update requires an operator or explicit API caller.
 The policy modes are manual, stage, and apply_when_stopped.
-The background scheduler uses AppUpdateService.check and manual remains the default.
+The background scheduler uses AppUpdateService.check after live USK catalog refresh and manual remains the default.
+Catalog refresh records the last verified signed catalog state before candidate discovery.
 Release evidence is app-update.scheduler.
 Rollback covers only the immutable installed bundle.
 Rollback does not roll back app data directories or app cache directories.

--- a/tools/release-certification/fixtures/self-test-app-platform-smoke.json
+++ b/tools/release-certification/fixtures/self-test-app-platform-smoke.json
@@ -898,8 +898,12 @@
         "checks": {
           "docsCoverLiveCatalogRefresh": true,
           "manualPolicyStillDefault": true,
+          "manualRefreshRouteExists": true,
+          "policyDrivenUpdatesStayInService": true,
           "refreshBeforeCandidateDiscovery": true,
-          "schedulerDoesNotApplyDirectly": true
+          "refreshFailureContained": true,
+          "schedulerDoesNotApplyDirectly": true,
+          "schedulerSummaryPrivacyGuard": true
         },
         "liveNodeRequired": false,
         "policy": "manual default; scheduler refreshes catalogs before candidate discovery"

--- a/tools/release-certification/fixtures/self-test-app-platform-smoke.json
+++ b/tools/release-certification/fixtures/self-test-app-platform-smoke.json
@@ -261,6 +261,38 @@
     },
     {
       "details": {
+        "checks": {
+          "explicitLiveMode": true,
+          "localVerificationBeforeInsert": true,
+          "realQueueInsertionPath": true,
+          "sanitizedResultModel": true,
+          "secureLiveInputs": true
+        },
+        "publicSourceShape": "crypta:USK@.../cryptad-app-catalog.properties",
+        "signatureSidecar": "cryptad-app-catalog.signature"
+      },
+      "id": "catalog.live-usk-publication",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Live USK catalog publication source and redaction evidence passed."
+    },
+    {
+      "details": {
+        "checks": {
+          "resolvedEditionSignatureSidecar": true,
+          "verifyBeforeStorage": true
+        },
+        "liveNodeRequired": false
+      },
+      "id": "catalog.live-usk-source-verification",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Live USK source verification evidence passed deterministic checks."
+    },
+    {
+      "details": {
         "catalogId": "crypta-first-party-beta",
         "configuration": {
           "sourceConfigured": false,
@@ -860,6 +892,23 @@
       "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
       "status": "pass",
       "summary": "App-update background scheduler passed deterministic offline evidence checks."
+    },
+    {
+      "details": {
+        "checks": {
+          "docsCoverLiveCatalogRefresh": true,
+          "manualPolicyStillDefault": true,
+          "refreshBeforeCandidateDiscovery": true,
+          "schedulerDoesNotApplyDirectly": true
+        },
+        "liveNodeRequired": false,
+        "policy": "manual default; scheduler refreshes catalogs before candidate discovery"
+      },
+      "id": "app-update.live-catalog-refresh",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Live catalog refresh scheduler evidence passed deterministic checks."
     },
     {
       "details": {

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -937,6 +937,8 @@ def app_platform_evidence(
         "app-platform.trust-statement-signing",
         "app-platform.signed-bundles",
         "catalog.smoke",
+        "catalog.live-usk-publication",
+        "catalog.live-usk-source-verification",
         "app-catalog.first-party-beta",
         "app-review.trusted-receipts",
         "app-review.policy",
@@ -960,6 +962,7 @@ def app_platform_evidence(
         "apphost.sandbox-provider",
         "app-update.lifecycle",
         "app-update.scheduler",
+        "app-update.live-catalog-refresh",
         "app-update.rollback",
         "apphost.live",
     ]
@@ -1543,6 +1546,7 @@ def ecosystem_matrix_row_specs() -> list[MatrixRowSpec]:
             required_evidence_ids=(
                 "app-update.lifecycle",
                 "app-update.scheduler",
+                "app-update.live-catalog-refresh",
                 "app-update.rollback",
             ),
             gate_ids=("ecosystem.app-update-rollback",),
@@ -1554,6 +1558,8 @@ def ecosystem_matrix_row_specs() -> list[MatrixRowSpec]:
             title="First-party beta catalog and signed bundles",
             required_evidence_ids=(
                 "catalog.smoke",
+                "catalog.live-usk-publication",
+                "catalog.live-usk-source-verification",
                 "app-catalog.first-party-beta",
                 "app-platform.signed-bundles",
             ),
@@ -3036,7 +3042,12 @@ def evaluate_app_update_rollback_gate(
     failures: list[str] = []
     warnings: list[str] = []
     details: dict[str, Any] = {}
-    for evidence_id in ("app-update.lifecycle", "app-update.scheduler", "app-update.rollback"):
+    for evidence_id in (
+        "app-update.lifecycle",
+        "app-update.scheduler",
+        "app-update.live-catalog-refresh",
+        "app-update.rollback",
+    ):
         status = evidence_status(current.get(evidence_id))
         previous_status = evidence_status(previous.get(evidence_id))
         details[evidence_id] = {"currentStatus": status, "previousStatus": previous_status}
@@ -3732,6 +3743,8 @@ def render_report(summary: dict[str, Any]) -> str:
         "app-platform.trust-statement-signing",
         "app-platform.signed-bundles",
         "catalog.smoke",
+        "catalog.live-usk-publication",
+        "catalog.live-usk-source-verification",
         "app-catalog.first-party-beta",
         "app-review.trusted-receipts",
         "app-review.policy",
@@ -3752,6 +3765,7 @@ def render_report(summary: dict[str, Any]) -> str:
         "apphost.sandbox-provider",
         "app-update.lifecycle",
         "app-update.scheduler",
+        "app-update.live-catalog-refresh",
         "app-update.rollback",
         "apphost.live",
     ):


### PR DESCRIPTION
## Summary
- Add explicit `crypta-app publish-usk --live` support for signed first-party catalog publication to a live Crypta USK while preserving deterministic `--dry-run` publication plans.
- Publish the catalog properties and sibling `cryptad-app-catalog.signature` through the localhost Platform API queue path with secure env/file secret inputs, public/private USK source correlation, no-proxy HTTP client behavior, retained staging sidecars, output preflight, and sanitized JSON/Markdown summaries.
- Extend app-catalog/app-update scheduler coverage, release-certification evidence, docs, and redaction checks for PR-238 live catalog publication and refresh discovery.

## Test Plan
- `./gradlew spotlessApply`
- `./gradlew :platform-devtools:test --tests '*PlatformApiLiveUskPublisherTest' --tests '*LiveUskPublicationServiceTest'`
- `./gradlew :platform-devtools:test`
- `python3 tools/release-certification/app_platform_smoke.py --self-test`
- `python3 tools/release-certification/release_certification.py --self-test`

## Additional Verification
- `python3 tools/release-certification/app_platform_smoke.py --mode release-candidate --out-dir build/app-platform-smoke-review-fix` was run to inspect the generated live catalog refresh evidence. The live refresh evidence passed and preserved boolean check values; the overall local release-candidate smoke failed because signing/reviewer inputs were not configured (`app-platform.signed-bundles`, `catalog.smoke`, and `app-review.first-party-catalog`).

## Notes
- Live-node insertion smoke was not run; no localhost Crypta node credentials or publication insert URI were configured for this environment.
- Generated evidence was reviewed to keep private insert URIs, form passwords, tokens, raw bodies, and absolute staging paths out of release artifacts.