### PR TITLE
feat(app-platform): Add legacy plugin migration

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRemovalPolicy.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRemovalPolicy.java
@@ -31,6 +31,10 @@ final class LegacyAdminRemovalPolicy {
   /** Stable first-party app id for the Publisher static UI replacement. */
   private static final String PUBLISHER_APP_ID = "publisher";
 
+  /** Exact static query used by Web Shell when it deliberately opens legacy security fallback. */
+  private static final String SECURITY_LEVELS_LEGACY_FALLBACK_QUERY =
+      "legacyFallback=security-levels";
+
   /** Prevents construction because the policy is stateless and entirely function-based. */
   private LegacyAdminRemovalPolicy() {}
 
@@ -71,6 +75,9 @@ final class LegacyAdminRemovalPolicy {
       return Optional.empty();
     }
     LegacyAdminSurface legacyAdminSurface = surface.orElseThrow();
+    if (isExplicitSecurityLevelsLegacyFallback(method, uri, legacyAdminSurface)) {
+      return Optional.empty();
+    }
     if (!replacementAvailable(legacyAdminSurface, ctx)) {
       return Optional.empty();
     }
@@ -138,6 +145,13 @@ final class LegacyAdminRemovalPolicy {
     return !"GET".equals(method) && !"HEAD".equals(method);
   }
 
+  private static boolean isExplicitSecurityLevelsLegacyFallback(
+      String method, URI uri, LegacyAdminSurface surface) {
+    return "security-levels".equals(surface.id())
+        && !isMutatingRequestMethod(method)
+        && SECURITY_LEVELS_LEGACY_FALLBACK_QUERY.equals(uri.getRawQuery());
+  }
+
   /**
    * Checks whether the mapped replacement can be used for this request.
    *
@@ -164,6 +178,7 @@ final class LegacyAdminRemovalPolicy {
           "connectivity",
           "alerts",
           "config",
+          "security-levels",
           "core-update",
           "statistics" ->
           webShellReplacementAvailable(ctx);

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java
@@ -54,8 +54,10 @@ public final class LegacyAdminRetirementRegistry {
   private static final int NO_REMOVAL_WAVE = 0;
   private static final int REMOVAL_WAVE_1 = 1;
   private static final int REMOVAL_WAVE_2 = 2;
+  private static final int REMOVAL_WAVE_3 = 3;
   private static final String REMOVED_BY_DEFAULT_SINCE_WAVE_1 = "phase-6-pr-8";
   private static final String REMOVED_BY_DEFAULT_SINCE_WAVE_2 = "phase-7-pr-230";
+  private static final String REMOVED_BY_DEFAULT_SINCE_WAVE_3 = "phase-8-pr-244";
   private static final String FALLBACK_POLICY_NONE = "none";
   private static final String FALLBACK_POLICY_RENDER_LEGACY = "render-legacy";
   private static final String FALLBACK_POLICY_MUTATING_LEGACY = "mutating-legacy-fallback";
@@ -168,13 +170,7 @@ public final class LegacyAdminRetirementRegistry {
                   + " persistence actions.",
               scopedCoveredRemoval(
                   LegacyAdminRemovalScope.PREFIX_FAMILY, List.of(), REMOVAL_WAVE_2)),
-          replaced(
-              "security-levels",
-              "Security levels",
-              SecurityLevelsToadlet.PATH,
-              SHELL_SECURITY_URL,
-              "Web Shell security",
-              "Web Shell owns the primary security-level view and common mutations."),
+          securityLevelsWave3Redirect(),
           wave2Redirect(
               "core-update",
               "Core update actions",
@@ -195,13 +191,7 @@ public final class LegacyAdminRetirementRegistry {
                   LegacyAdminRemovalScope.EXPLICIT_CHILDREN,
                   List.of(StatisticsToadlet.TOADLET_URL + "requesters.html"),
                   REMOVAL_WAVE_2)),
-          replaced(
-              "diagnostic",
-              "Diagnostic report",
-              DiagnosticToadlet.TOADLET_URL,
-              SHELL_DIAGNOSTICS_URL,
-              "Web Shell diagnostics",
-              "The plain-text export remains useful as fallback and debug output."),
+          diagnosticFallbackReplacement(),
           pendingWizard(
               "first-time-wizard",
               "First-time wizard",
@@ -468,21 +458,15 @@ public final class LegacyAdminRetirementRegistry {
         MutatingRequestReplacement.PARTIAL_LEGACY_FALLBACK);
   }
 
-  private static LegacyAdminSurface replaced(
-      String id,
-      String title,
-      String legacyPath,
-      String replacementUrl,
-      String replacementLabel,
-      String notes) {
+  private static LegacyAdminSurface diagnosticFallbackReplacement() {
     return new LegacyAdminSurface(
-        id,
-        title,
-        legacyPath,
+        "diagnostic",
+        "Diagnostic report",
+        DiagnosticToadlet.TOADLET_URL,
         LegacyAdminRetirementState.PRIMARY_REPLACED,
-        replacementUrl,
-        replacementLabel,
-        notes,
+        SHELL_DIAGNOSTICS_URL,
+        "Web Shell diagnostics",
+        "The plain-text export remains useful as fallback and debug output.",
         LegacyAdminRemovalMode.RENDER_LEGACY,
         NO_REMOVAL_WAVE,
         null,
@@ -554,6 +538,30 @@ public final class LegacyAdminRetirementRegistry {
         LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT,
         REMOVAL_WAVE_2,
         REMOVED_BY_DEFAULT_SINCE_WAVE_2,
+        mutatingReplacement.fallbackPolicy,
+        removalExecution.scope(),
+        removalExecution.scopeExpandedInWave(),
+        removalExecution.explicitChildPaths(),
+        mutatingReplacement.blockLegacyRequests,
+        true,
+        false);
+  }
+
+  private static LegacyAdminSurface securityLevelsWave3Redirect() {
+    RemovalExecution removalExecution = canonicalMutationFallback();
+    MutatingRequestReplacement mutatingReplacement = removalExecution.mutatingRequestReplacement();
+    return new LegacyAdminSurface(
+        "security-levels",
+        "Security levels",
+        SecurityLevelsToadlet.PATH,
+        LegacyAdminRetirementState.PRIMARY_REPLACED,
+        SHELL_SECURITY_URL,
+        "Web Shell security",
+        "Web Shell owns the primary security-level view and common mutations; master-password"
+            + " and high-physical-security flows remain legacy fallback.",
+        LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT,
+        REMOVAL_WAVE_3,
+        REMOVED_BY_DEFAULT_SINCE_WAVE_3,
         mutatingReplacement.fallbackPolicy,
         removalExecution.scope(),
         removalExecution.scopeExpandedInWave(),

--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java
@@ -100,7 +100,23 @@ public final class WebShellToadlet extends Toadlet {
    */
   static WebShellBootstrap createNodeManagementBootstrap(
       List<WebShellBootstrap.LegacyLink> legacyLinks) {
-    return WebShellBootstrap.nodeManagement(legacyLinks);
+    return createNodeManagementBootstrap(legacySecurityLevelsPath(), legacyLinks);
+  }
+
+  /**
+   * Creates the node-management bootstrap model with an explicit security-levels fallback path.
+   *
+   * @param legacySecurityLevelsPath configured legacy security route for explicit fallback flows
+   * @param legacyLinks ordered legacy deep links to surface in the shell footer area
+   * @return immutable bootstrap model for the first-party node-management shell
+   */
+  static WebShellBootstrap createNodeManagementBootstrap(
+      String legacySecurityLevelsPath, List<WebShellBootstrap.LegacyLink> legacyLinks) {
+    return WebShellBootstrap.nodeManagement(legacySecurityLevelsPath, legacyLinks);
+  }
+
+  private static String legacySecurityLevelsPath() {
+    return LegacyAdminRetirementRegistry.require("security-levels").legacyPath();
   }
 
   /**

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRemovalPolicyTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRemovalPolicyTest.java
@@ -53,9 +53,7 @@ class LegacyAdminRemovalPolicyTest {
   }
 
   @Test
-  void decide_whenRetainedLaterWavePrimaryReplacedRequested_expectNoDecision() {
-    assertFalse(
-        LegacyAdminRemovalPolicy.decide("GET", URI.create(SecurityLevelsToadlet.PATH)).isPresent());
+  void decide_whenDiagnosticPrimaryReplacedRequested_expectNoDecision() {
     assertFalse(
         LegacyAdminRemovalPolicy.decide("GET", URI.create(DiagnosticToadlet.TOADLET_URL))
             .isPresent());
@@ -82,6 +80,85 @@ class LegacyAdminRemovalPolicyTest {
   @Test
   void decide_whenWaveTwoAlertsPostRequested_expectLegacyFallbackForBulkActions() {
     assertFalse(LegacyAdminRemovalPolicy.decide("POST", URI.create("/alerts/")).isPresent());
+  }
+
+  @Test
+  void decide_whenWaveThreeSecurityLevelsGetRequested_expectWebShellRedirect() {
+    LegacyAdminRemovalDecision decision =
+        LegacyAdminRemovalPolicy.decide("GET", URI.create(SecurityLevelsToadlet.PATH))
+            .orElseThrow();
+
+    assertEquals("security-levels", decision.surface().id());
+    assertEquals(303, decision.statusCode());
+    assertTrue(decision.redirect());
+    assertEquals("/app/node/#security", decision.replacementUrl());
+    assertEquals(LegacyAdminUsageEvent.REPLACEMENT_RESPONSE, decision.usageEvent());
+  }
+
+  @Test
+  void decide_whenWaveThreeSecurityLevelsExplicitLegacyFallbackRequested_expectLegacyPage() {
+    assertFalse(
+        LegacyAdminRemovalPolicy.decide(
+                "GET", URI.create(SecurityLevelsToadlet.PATH + "?legacyFallback=security-levels"))
+            .isPresent());
+  }
+
+  @Test
+  void decide_whenWaveThreeSecurityLevelsExplicitLegacyFallbackHeadRequested_expectLegacyPage() {
+    assertFalse(
+        LegacyAdminRemovalPolicy.decide(
+                "HEAD", URI.create(SecurityLevelsToadlet.PATH + "?legacyFallback=security-levels"))
+            .isPresent());
+  }
+
+  @Test
+  void decide_whenWaveThreeSecurityLevelsLegacyFallbackHasExtraQuery_expectWebShellRedirect() {
+    LegacyAdminRemovalDecision decision =
+        LegacyAdminRemovalPolicy.decide(
+                "GET",
+                URI.create(
+                    SecurityLevelsToadlet.PATH + "?legacyFallback=security-levels&token=secret"))
+            .orElseThrow();
+
+    assertEquals("security-levels", decision.surface().id());
+    assertEquals(303, decision.statusCode());
+    assertEquals("/app/node/#security", decision.replacementUrl());
+  }
+
+  @Test
+  void decide_whenWaveThreeSecurityLevelsUnknownQueryRequested_expectWebShellRedirect() {
+    LegacyAdminRemovalDecision decision =
+        LegacyAdminRemovalPolicy.decide(
+                "GET", URI.create(SecurityLevelsToadlet.PATH + "?legacyFallback=unexpected"))
+            .orElseThrow();
+
+    assertEquals("security-levels", decision.surface().id());
+    assertEquals(303, decision.statusCode());
+    assertEquals("/app/node/#security", decision.replacementUrl());
+  }
+
+  @Test
+  void decide_whenWaveThreeSecurityLevelsSlashlessHeadRequested_expectWebShellRedirect() {
+    LegacyAdminRemovalDecision decision =
+        LegacyAdminRemovalPolicy.decide("HEAD", URI.create("/seclevels")).orElseThrow();
+
+    assertEquals("security-levels", decision.surface().id());
+    assertEquals(303, decision.statusCode());
+    assertTrue(decision.redirect());
+    assertEquals("/app/node/#security", decision.replacementUrl());
+  }
+
+  @Test
+  void decide_whenWaveThreeSecurityLevelsPostRequested_expectLegacyFallbackForPartialCoverage() {
+    assertFalse(
+        LegacyAdminRemovalPolicy.decide("POST", URI.create(SecurityLevelsToadlet.PATH))
+            .isPresent());
+  }
+
+  @Test
+  void decide_whenWaveThreeSecurityLevelsChildRequested_expectNoPrefixFamilyRemoval() {
+    assertFalse(
+        LegacyAdminRemovalPolicy.decide("GET", URI.create("/seclevels/network")).isPresent());
   }
 
   @Test
@@ -157,6 +234,7 @@ class LegacyAdminRemovalPolicyTest {
     assertFalse(LegacyAdminRemovalPolicy.isRemovedMutatingPath(URI.create("/alerts/")));
     assertFalse(LegacyAdminRemovalPolicy.isRemovedMutatingPath(URI.create("/core-update/")));
     assertFalse(LegacyAdminRemovalPolicy.isRemovedMutatingPath(URI.create("/stats/")));
+    assertFalse(LegacyAdminRemovalPolicy.isRemovedMutatingPath(URI.create("/seclevels/")));
   }
 
   @Test
@@ -207,6 +285,9 @@ class LegacyAdminRemovalPolicyTest {
     assertFalse(
         LegacyAdminRemovalPolicy.decide(
                 "GET", URI.create(LegacyHttpPaths.CONFIG_PATH + "node"), ctx)
+            .isPresent());
+    assertFalse(
+        LegacyAdminRemovalPolicy.decide("GET", URI.create(SecurityLevelsToadlet.PATH), ctx)
             .isPresent());
   }
 

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementNoticeTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementNoticeTest.java
@@ -10,15 +10,15 @@ class LegacyAdminRetirementNoticeTest {
   @Test
   void render_whenSurfacePrimaryReplaced_expectFallbackNoticeWithReplacementLink() {
     String html =
-        LegacyAdminRetirementNotice.render(LegacyAdminRetirementRegistry.require("security-levels"))
+        LegacyAdminRetirementNotice.render(LegacyAdminRetirementRegistry.require("diagnostic"))
             .orElseThrow()
             .generate();
 
     assertTrue(html.contains("Legacy fallback page"));
     assertTrue(html.contains("This legacy page remains available as a fallback and debug view."));
     assertTrue(html.contains("The primary flow is now in"));
-    assertTrue(html.contains("href=\"/app/node/#security\""));
-    assertTrue(html.contains("Web Shell security"));
+    assertTrue(html.contains("href=\"/app/node/#diagnostics\""));
+    assertTrue(html.contains("Web Shell diagnostics"));
   }
 
   @Test

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementRegistryTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/LegacyAdminRetirementRegistryTest.java
@@ -73,6 +73,20 @@ class LegacyAdminRetirementRegistryTest {
   }
 
   @Test
+  void removalWaveSurfaces_whenWaveThreeRequested_expectSecurityLevelsOnly() {
+    List<String> waveThreeIds =
+        LegacyAdminRetirementRegistry.removalWaveSurfaces(3).stream()
+            .map(LegacyAdminSurface::id)
+            .toList();
+
+    assertEquals(List.of("security-levels"), waveThreeIds);
+    assertFalse(waveThreeIds.contains("queue-downloads"));
+    assertFalse(waveThreeIds.contains("alerts"));
+    assertFalse(waveThreeIds.contains("diagnostic"));
+    assertFalse(waveThreeIds.contains("content-filter"));
+  }
+
+  @Test
   void scopeExpandedInWaveSurfaces_whenWaveTwoRequested_expectExpandedScopeSurfaces() {
     List<String> expandedIds =
         LegacyAdminRetirementRegistry.scopeExpandedInWaveSurfaces(2).stream()
@@ -98,6 +112,23 @@ class LegacyAdminRetirementRegistryTest {
   }
 
   @Test
+  void require_whenSecurityLevelsRequested_expectWaveThreeSafeReadRedirectWithMutationFallback() {
+    LegacyAdminSurface surface = LegacyAdminRetirementRegistry.require("security-levels");
+
+    assertEquals(LegacyAdminRetirementState.PRIMARY_REPLACED, surface.state());
+    assertEquals(LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT, surface.removalMode());
+    assertEquals(3, surface.removalWave());
+    assertEquals("phase-8-pr-244", surface.removedByDefaultSince());
+    assertEquals("mutating-legacy-fallback", surface.fallbackPolicy());
+    assertEquals(LegacyAdminRemovalScope.CANONICAL_AND_SLASHLESS_ALIAS, surface.removalScope());
+    assertEquals(0, surface.scopeExpandedInWave());
+    assertEquals(List.of(), surface.explicitRemovalChildPaths());
+    assertFalse(surface.blockMutatingRequests());
+    assertEquals(SecurityLevelsToadlet.PATH, surface.legacyPath());
+    assertEquals(WebShellPaths.SHELL_ROOT + "#security", surface.replacementUrl());
+  }
+
+  @Test
   void require_whenDiagnosticRequested_expectPlainTextExportRetainedAsLegacyFallback() {
     LegacyAdminSurface surface = LegacyAdminRetirementRegistry.require("diagnostic");
 
@@ -105,6 +136,32 @@ class LegacyAdminRetirementRegistryTest {
     assertEquals(LegacyAdminRemovalMode.RENDER_LEGACY, surface.removalMode());
     assertEquals(0, surface.removalWave());
     assertEquals(WebShellPaths.SHELL_ROOT + "#diagnostics", surface.replacementUrl());
+  }
+
+  @Test
+  void require_whenRetainedOrPendingSurfacesRequested_expectNotRemovedByDefault() {
+    for (String id :
+        List.of(
+            "content-filter",
+            "chat",
+            "translation",
+            "help",
+            "first-time-wizard",
+            "first-time-wizard-js")) {
+      LegacyAdminSurface surface = LegacyAdminRetirementRegistry.require(id);
+
+      assertEquals(0, surface.removalWave(), id);
+      assertTrue(
+          surface.state() == LegacyAdminRetirementState.RETAINED
+              || surface.state() == LegacyAdminRetirementState.PENDING,
+          id);
+    }
+  }
+
+  @Test
+  void findByLegacyPath_whenFProxyBrowseRouteRequested_expectNoRetirementSurface() {
+    assertFalse(LegacyAdminRetirementRegistry.findByLegacyPath("/").isPresent());
+    assertFalse(LegacyAdminRetirementRegistry.findByLegacyPath("/CHK@abc").isPresent());
   }
 
   @Test

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/WebShellToadletBootstrapTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/WebShellToadletBootstrapTest.java
@@ -51,6 +51,15 @@ class WebShellToadletBootstrapTest {
   }
 
   @Test
+  void createNodeManagementBootstrap_whenSlashlessSecurityPathProvided_preservesConfiguredPath() {
+    WebShellBootstrap bootstrap =
+        WebShellToadlet.createNodeManagementBootstrap(
+            "/security-custom", WebShellToadlet.defaultLegacyLinks());
+
+    assertEquals("/security-custom", bootstrap.legacySecurityLevelsPath());
+  }
+
+  @Test
   void defaultLegacyLinks_whenBuilt_expectOnlyPendingOrRetainedFallbackPages() {
     List<WebShellBootstrap.LegacyLink> links = WebShellToadlet.defaultLegacyLinks();
 

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/WebShellToadletBootstrapTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/WebShellToadletBootstrapTest.java
@@ -14,6 +14,7 @@ class WebShellToadletBootstrapTest {
   void createNodeManagementBootstrap_whenCustomLegacyPathsProvided_usesConfiguredPaths() {
     WebShellBootstrap bootstrap =
         WebShellToadlet.createNodeManagementBootstrap(
+            "/security-custom/",
             List.of(
                 new WebShellBootstrap.LegacyLink("/friends-custom/", "Friends"),
                 new WebShellBootstrap.LegacyLink("/strangers-custom/", "Strangers"),
@@ -25,6 +26,7 @@ class WebShellToadletBootstrapTest {
                 new WebShellBootstrap.LegacyLink("/config-custom/", "Config")));
 
     assertEquals(WebShellPaths.SHELL_ROOT, bootstrap.shellRoot());
+    assertEquals("/security-custom/", bootstrap.legacySecurityLevelsPath());
     assertEquals(
         List.of(
             "/friends-custom/",
@@ -36,6 +38,16 @@ class WebShellToadletBootstrapTest {
             "/alerts-custom/",
             "/config-custom/"),
         bootstrap.legacyLinks().stream().map(WebShellBootstrap.LegacyLink::path).toList());
+  }
+
+  @Test
+  void createNodeManagementBootstrap_whenDefaultBuilt_expectSecurityFallbackPathFromRegistry() {
+    WebShellBootstrap bootstrap =
+        WebShellToadlet.createNodeManagementBootstrap(WebShellToadlet.defaultLegacyLinks());
+
+    assertEquals(
+        LegacyAdminRetirementRegistry.require("security-levels").legacyPath(),
+        bootstrap.legacySecurityLevelsPath());
   }
 
   @Test

--- a/docs/app-platform-beta-known-limitations.md
+++ b/docs/app-platform-beta-known-limitations.md
@@ -49,6 +49,9 @@ This page records conservative limits and safety boundaries for the Crypta app e
 - Trust Graph Preview has durable local backend storage for anchors and imported public
   statements, but it remains a local preview. It is not full Web of Trust, old plugin
   compatibility, global moderation, routing policy, peer selection, or a background crawler.
+- The [legacy plugin migration guide](legacy-plugin-migration-guide.md) documents app-platform
+  migration patterns, but it does not restore old plugin ABI compatibility or old FCP plugin
+  command compatibility.
 - Social Inbox Preview is a social/mail-like migration spike outside daemon core and legacy plugin
   APIs. Its `crypta.social.message.v1` route is bounded social-message signing only; it is not a
   generic browser signing API, full WoT, Freetalk, Sone, Freemail, encrypted mail transport,
@@ -121,7 +124,8 @@ app ids, capability names, evidence ids, and redacted summaries instead of raw p
 ## Non-goals
 
 The beta does not introduce a live public app store, live public-network test dependency, global
-transparency log, full Web of Trust, generic crawling, arbitrary HTTP/HTTPS fetching, a generic
-filesystem or database API for apps, Freetalk/Sone/Freemail compatibility, encrypted mail
-delivery, daemon-core social or mail protocols, new sandbox provider, new update scheduler policy,
-legacy route removal wave 3, or any FNP/FCP/wire protocol change.
+transparency log, full Web of Trust, old plugin ABI compatibility, old FCP plugin command
+compatibility, generic crawling, arbitrary HTTP/HTTPS fetching, a generic filesystem or database
+API for apps, Freetalk/Sone/Freemail compatibility, encrypted mail delivery, daemon-core social or
+mail protocols, new sandbox provider, new update scheduler policy, or any FNP/FCP/wire protocol
+change.

--- a/docs/app-platform-beta-program.md
+++ b/docs/app-platform-beta-program.md
@@ -154,12 +154,15 @@ Use this runbook to decide whether the ecosystem beta is ready for a release can
 
 6. Confirm the app-review governance evidence passes: review receipts, reviewer key lifecycle,
    local transparency log, review-history API, and first-party review chain.
-7. Confirm legacy retirement evidence passes and FProxy browse remains retained.
-8. Confirm docs evidence passes: portal, beta tutorials, beta program, known limitations, issue
+7. Confirm the legacy plugin migration guide evidence passes:
+   `legacy-plugin.migration-guide` and `legacy-plugin.social-inbox-spike`.
+8. Confirm legacy retirement evidence passes, including `legacy-admin.removal-wave-3`, and FProxy
+   browse remains retained.
+9. Confirm docs evidence passes: portal, beta tutorials, beta program, known limitations, issue
    templates, internal links, and redaction checks.
-9. Confirm the ecosystem certification matrix includes `app-platform-beta-docs-and-program` and no
+10. Confirm the ecosystem certification matrix includes `app-platform-beta-docs-and-program` and no
    active blocker remains unless a release manager recorded an explicit waiver.
-10. Publish release notes with the known beta limitations and any accepted waivers or residual
+11. Publish release notes with the known beta limitations and any accepted waivers or residual
     risks.
 
 Release-candidate mode should require docs and beta evidence unless a release-manager waiver
@@ -171,7 +174,7 @@ The Phase 7 closeout story is:
 
 ```text
 first-party catalog + developer toolkit + reference apps + trust graph preview
-+ review governance + legacy wave 2 + ecosystem certification matrix
++ review governance + legacy plugin migration guide + legacy wave 3 + ecosystem certification matrix
 -> documented and certified as Ecosystem Beta readiness
 ```
 

--- a/docs/app-platform-developer-portal.md
+++ b/docs/app-platform-developer-portal.md
@@ -37,6 +37,7 @@ Use this portal first, then follow the detailed source-of-truth pages for the ar
 | Social Inbox Preview | [social-inbox-reference-app.md](social-inbox-reference-app.md) |
 | Feed Reader reference app | [feed-reader-reference-app.md](feed-reader-reference-app.md) |
 | Trust Graph Preview | [trust-graph-preview.md](trust-graph-preview.md) |
+| Legacy plugin migration guide | [legacy-plugin-migration-guide.md](legacy-plugin-migration-guide.md) |
 | Legacy HTTP boundary | [legacy-http-boundary.md](legacy-http-boundary.md) |
 | Legacy retirement plan | [legacy-retirement-plan.md](legacy-retirement-plan.md) |
 | Release certification | [release-certification.md](release-certification.md) |
@@ -125,7 +126,8 @@ Phase 7 closeout treats these workstreams as one ecosystem beta readiness story:
 | Reference apps | [social-inbox-reference-app.md](social-inbox-reference-app.md), [feed-reader-reference-app.md](feed-reader-reference-app.md), [trust-graph-preview.md](trust-graph-preview.md), `reference-app.*` evidence |
 | Review governance | [app-review-governance.md](app-review-governance.md), `review receipt`, `reviewer key lifecycle`, `transparency log` evidence |
 | Updates and rollback | [app-update-lifecycle.md](app-update-lifecycle.md), `background update scheduler`, `rollback` evidence |
-| Legacy admin status | [legacy-retirement-plan.md](legacy-retirement-plan.md), `legacy-admin.removal-wave-1`, `legacy-admin.removal-wave-2`; FProxy browse remains retained |
+| Legacy plugin migration | [legacy-plugin-migration-guide.md](legacy-plugin-migration-guide.md), `legacy-plugin.migration-guide`, `legacy-plugin.social-inbox-spike` |
+| Legacy admin status | [legacy-retirement-plan.md](legacy-retirement-plan.md), `legacy-admin.removal-wave-1`, `legacy-admin.removal-wave-2`, `legacy-admin.removal-wave-3`; FProxy browse remains retained |
 | Ecosystem matrix | [release-certification.md](release-certification.md), `ecosystem certification matrix` |
 | Docs and beta program | This portal, [app-platform-beta-tutorials.md](app-platform-beta-tutorials.md), [app-platform-beta-known-limitations.md](app-platform-beta-known-limitations.md), [app-platform-beta-program.md](app-platform-beta-program.md) |
 

--- a/docs/legacy-plugin-migration-guide.md
+++ b/docs/legacy-plugin-migration-guide.md
@@ -1,0 +1,180 @@
+# Legacy plugin migration guide
+
+This guide explains how legacy plugin-style functionality should move to the Crypta app platform.
+
+## Status and non-goals
+
+The old plugin runtime removed status is intentional: the Cryptad node no longer implements the
+old in-process plugin runtime, `network.crypta.pluginmanager`, plugin toadlets, or old plugin FCP
+commands.
+
+This PR does not restore old plugin ABI compatibility, old FCP plugin command compatibility, or
+compatibility shims for WebOfTrust, Freetalk, Sone, or Freemail plugin APIs. Migration work should
+use out-of-process apps, Platform API routes, signed bundles, signed catalogs, app review
+governance, and operator-approved local app-service grants instead of daemon-core plugins.
+
+The migration path also does not change FNP, FCP, Hyphanet/Freenet wire behavior, FProxy browse,
+content rendering, or retained legacy admin fallback routes.
+
+## Migration architecture overview
+
+Legacy plugin responsibilities map to existing app-platform mechanisms:
+
+| Legacy plugin concern | New app-platform mechanism |
+| --- | --- |
+| Plugin UI | App-owned isolated UI, local design system, and browser SDK |
+| Plugin configuration/state | App manifest plus app data durable store |
+| Plugin identity/secrets | App vault grants and bounded AppVault signing routes |
+| Content polling | Content subscriptions |
+| Content publishing | App-generated documents plus queue APIs |
+| Trust scoring | Trust Graph Preview plus an app-service grant to `trust.score` |
+| Social/message board patterns | Social Inbox Preview migration spike |
+| Distribution | Signed bundles, signed catalogs, and trusted review receipts |
+| Compatibility/review | Platform API contract verifier and app review governance |
+
+The app platform keeps authority explicit. Apps declare capabilities and rationales in their
+manifest, use SDK helpers for Platform API calls, and rely on operator-approved grants when one app
+needs a local service from another app.
+
+## Category-specific migration patterns
+
+### WebOfTrust-like trust layer
+
+Map WebOfTrust-like or WoT-like trust behavior to Trust Graph Preview. The current preview gives
+apps a local trust graph backend, durable trust graph storage, AppVault-backed trust-statement
+signing, content subscriptions for public trust-statement exchange, and a mediated `trust.score`
+service that consumers can call only after an operator-approved app-service grant.
+
+A migrated trust app should:
+
+- Keep identity/private material in AppVault.
+- Store UI-local draft and filter state in app data.
+- Use content subscriptions for public trust-statement follow behavior.
+- Publish generated trust documents through app-generated document insert routes.
+- Advertise local scoring through app-service metadata instead of direct localhost access.
+- Obtain review receipts before catalog distribution.
+
+This is not full WoT, not global moderation, not routing policy, not old WebOfTrust plugin
+compatibility, and not an old plugin ABI compatibility layer.
+
+### Freetalk/Sone-like social feed or forum layer
+
+Map Freetalk/Sone-like social feed, forum, profile, or message-board behavior to Social Inbox
+Preview, Profile Publisher, Feed Reader, content subscriptions, app-data state, and Trust Graph
+score annotations.
+
+Social or forum apps should:
+
+- Use Profile Publisher or AppVault profile-document signing for public author metadata.
+- Use Social Inbox-style bounded `crypta.social.message.v1` documents for message-like content.
+- Follow public source feeds with durable content subscriptions.
+- Persist source summaries, read state, drafts, and imported-message summaries in app data.
+- Publish generated outbox or feed documents with app-generated document insert routes.
+- Use Trust Graph Preview score annotations through `trust.score` app-service grants when trust
+  context is useful.
+
+This is not old Freetalk/Sone plugin compatibility, not a daemon-core social store, not global
+moderation, and not a new social network protocol in daemon core.
+
+### Freemail-like mail/message layer
+
+Treat Social Inbox Preview as a bounded mail/social migration spike, not as Freemail
+compatibility. It proves that message-like workflows can compose AppVault identity use, generated
+documents, content subscriptions, app data, and Trust Graph annotations outside daemon core.
+
+Freemail-like designs should start as app-level designs with their own explicit threat model,
+manifest capabilities, catalog review, and user-facing limitations. Future encrypted mail would be
+a separate app design that uses app-platform primitives where appropriate. It is not encrypted
+email delivery in this PR, not Freemail protocol compatibility, and not a resurrection of core or
+plugin mail APIs.
+
+### Content publishing plugins
+
+Map content publishing plugins to Site Publisher, Profile Publisher, generated app documents, and
+queue APIs. Apps should stage generated bytes through the app-generated document insert route when
+the app creates the document, and should use queue read/write capabilities only for the minimum
+publisher workflow they need.
+
+Publishing apps should avoid local source-path authority unless a replacement explicitly covers
+that legacy workflow. Release evidence should record document type, content type, queue status,
+hashes, counts, and booleans instead of raw document bodies or private insert URIs.
+
+### Queue or insert-helper plugins
+
+Map queue or insert-helper plugins to Queue Manager, Publisher, Site Publisher, Profile Publisher,
+or Platform API queue/content routes. Queue integrations should use the SDK queue helpers and
+`content.insert.app-document` for app-generated documents. They should not parse legacy queue HTML,
+scrape FProxy pages, or call removed plugin FCP commands.
+
+## Developer migration recipe
+
+Use this checklist before proposing an app migration:
+
+- Inventory the legacy plugin's permissions, persisted state, network effects, daemon callbacks,
+  UI surfaces, and side effects.
+- Choose an app-owned UI flow and SDK helpers instead of a plugin toadlet.
+- Map identities, secrets, and signing operations to app vault grants and bounded AppVault routes.
+- Map local configuration and mutable state to app data namespaces and records.
+- Map polling or follow behavior to content subscriptions.
+- Map trust dependencies to app-service grants, usually `trust-graph` / `trust.score` for local
+  score annotations.
+- Add manifest permissions and a rationale for every requested capability.
+- Run app UI lint and Platform API compatibility verification.
+- Package and sign the app bundle.
+- Publish a signed catalog entry when the app is ready for distribution.
+- Obtain an independent review receipt or document why review governance is pending.
+- Add release-certification evidence that proves the migration path without raw payloads or
+  secrets.
+
+## Executable migration spike
+
+`apps/social-inbox` is the current executable social/mail-like migration spike. See
+[social-inbox-reference-app.md](social-inbox-reference-app.md) for the app contract, manifest
+permissions, durable state, and evidence ids.
+
+The spike demonstrates:
+
+- App vault identity listing, creation, and bounded profile/social-message signing.
+- App data records for UI state, sources, outbox summaries, imported-message summaries, read state,
+  and explicit drafts.
+- Content subscriptions for bounded USK social source follow behavior.
+- App-generated outbox documents inserted through queue/content Platform API routes.
+- Trust Graph Preview score annotations through the `trust.score` app-service grant path.
+- Signed bundle, signed catalog, review receipt, and catalog/review governance flow.
+
+The spike deliberately stays outside daemon core and old plugin APIs. It is not full WoT, not
+Freetalk/Sone/Freemail compatibility, not encrypted mail transport, and not a daemon-core message
+store.
+
+## Security and privacy boundaries
+
+Migration designs must keep these boundaries:
+
+- No ambient localhost trust. Apps use Platform API routes and mediated app-service grants.
+- No private insert URI leakage in docs, app data, logs, diagnostics, release evidence, or bug
+  reports.
+- No raw message bodies, fetched bodies, trust bodies, request bodies, or signatures in release
+  evidence.
+- No form passwords, app tokens, browser-session tokens, private keys, cookies, credentials, or
+  recovery material in reports or examples.
+- App-to-app calls require operator-approved grants and current provider descriptors.
+- Browser-visible app UI remains origin-isolated where the platform provides that mode; server-side
+  Platform API capability checks remain authoritative.
+- Signed bundles and signed catalogs verify distribution artifacts; review receipts provide
+  independent governance evidence and do not replace catalog or bundle signatures.
+
+Do not encourage apps to call arbitrary localhost services, proxy generic RPC, reuse another app's
+app data, or bypass AppVault for private material.
+
+## Known limitations
+
+- No plugin ABI compatibility.
+- No old FCP plugin command compatibility.
+- No full WoT.
+- No WebOfTrust, Freetalk, Sone, or Freemail compatibility.
+- No encrypted mail transport.
+- No daemon-core social or mail store.
+- No network protocol change.
+- No generic browser signing API.
+- Legacy retained routes remain retained until their replacements are complete and separately
+  certified.

--- a/docs/legacy-retirement-plan.md
+++ b/docs/legacy-retirement-plan.md
@@ -12,7 +12,8 @@ replaced legacy admin page routes no longer render the old page by default. They
 replacement redirect for safe reads or a gone-with-replacement response for mutating requests.
 Phase 7 PR-230, tracked as `legacy-admin.removal-wave-2`, expands that execution policy to the
 next bounded set of admin/control-plane pages only when the replacement is reachable for the
-current request.
+current request. Phase 8 PR-244, tracked as `legacy-admin.removal-wave-3`, applies the same
+policy to the safe-read security-levels route only.
 
 FProxy browse remains retained. FProxy browse and content-rendering surfaces are explicitly
 retained. The browse split under
@@ -95,12 +96,48 @@ replacement pages, diagnostics, or release-certification evidence.
 The raw diagnostic export remains retained. `/diagnostic/` still renders the legacy plain-text
 diagnostic report because release, interop, and support workflows use that export and this PR does
 not add an equivalent explicit Platform API or Web Shell export. Security-level recovery and
-confirmation flows also remain later-wave work; `/seclevels/` continues to render legacy fallback.
+confirmation flows remain legacy fallback and are not covered by wave 2.
 
 Wave 2 does not remove FProxy browse, key/content rendering, content filter, startup wizard,
 node-to-node messages, translation, help, chat/forum discovery, Platform API routes, Web Shell
 routes, app-owned UI routes, directory chooser/helper flows, or local file-browser helpers outside
 the explicit queue helper paths above.
+
+## Removal wave 3
+
+Wave 3 is tracked in release certification as `legacy-admin.removal-wave-3`. It applies
+removal-by-default only to the security-levels canonical route and its slashless alias when Web
+Shell security is reachable for the current request. Web Shell security requires full operator
+access and Web Shell as the advertised primary UI. If that replacement is unavailable, direct
+legacy fallback remains available and diagnostics count a fallback render.
+
+Wave 3 intentionally does not use prefix-family matching for security routes. It does not remove
+`/seclevels/` child or recovery flows unless a later audit proves complete replacement coverage.
+Query strings, form fields, option values, master passwords, password-file paths, recovery inputs,
+tokens, node references, and Freenet/Crypta URIs are never included in replacement pages,
+diagnostics, or release-certification evidence.
+
+Web Shell security keeps a bootstrap-resolved explicit fallback link for physical `HIGH`,
+master-password, and recovery workflows that still need the legacy GET page to render their forms.
+The fallback URL uses the configured `security-levels` legacy route from the retirement registry,
+then appends the fixed `legacyFallback=security-levels` marker. Only that marker bypasses the
+safe-read redirect; arbitrary query strings still receive the normal replacement redirect and are
+not reflected into responses or evidence.
+
+| Legacy route scope | Surface id | Safe read behavior | Mutating behavior | Replacement |
+| --- | --- | --- | --- | --- |
+| Configured security-levels canonical path and slashless alias | `security-levels` | `303 See Other` when Web Shell security is available; otherwise legacy fallback; Web Shell can open the exact bootstrap-resolved fallback marker for HIGH/master-password forms | Legacy fallback remains for master-password, database/password-file, high physical security, and recovery flows unless Web Shell/API coverage explicitly covers the action | `/app/node/#security` |
+
+Wave 3 explicitly retains or leaves pending:
+
+- FProxy browse and key/content rendering.
+- Content filter.
+- Raw diagnostic export.
+- Startup wizard and emergency fallback.
+- Node-to-node messages.
+- Retained chat/forum discovery.
+- Translation and help.
+- Local directory/file helper infrastructure outside already-reviewed explicit queue helper paths.
 
 ## Current map
 
@@ -146,21 +183,24 @@ but it is a content reference app rather than a legacy admin replacement target.
 
 Primary-replaced legacy admin pages that are not removed by default still render a non-blocking
 notice that links to the Web Shell or first-party app replacement. Wave-1 and wave-2 removed
-routes do not render that notice by default when their replacements are reachable because the
-central request gate returns the replacement response before the legacy toadlet is invoked.
+routes, plus the wave-3 `security-levels` safe-read route, do not render that notice by default
+when their replacements are reachable because the central request gate returns the replacement
+response before the legacy toadlet is invoked.
 
 `PRIMARY_REPLACED` pages are omitted from the Web Shell legacy-link panel and from legacy
 page-chrome entry points when a Web Shell or first-party app path is now primary. Wave-1 canonical
 URLs now return replacement responses instead of rendering the old page. Wave-2 URLs for alerts,
 config, core-update status, statistics, and selected queue helpers do the same under their explicit
-route scopes. Later-wave primary-replaced URLs still render the legacy page and replacement notice
-until a future removal wave changes their execution mode.
+route scopes. Wave-3 safe reads for `/seclevels/` redirect to Web Shell security under the
+canonical route scope while mutating requests remain legacy fallback. Later-wave primary-replaced
+URLs still render the legacy page and replacement notice until a future removal wave changes their
+execution mode.
 
 The legacy top-level Queue and Friends category roots no longer fall back to `/downloads/` or
 `/friends/` as normal navigation. Queue is shown only when Queue Manager is installed, static, and
 usable for the current full-access browser session. Friends is shown only while Web Shell is the
-advertised primary UI. Status and Config retain their later-wave fallbacks in this batch because
-`/alerts/`, `/seclevels/`, and related flows are not part of wave 1.
+advertised primary UI. Status and Config retain their documented fallbacks for any route or action
+not covered by the current removal scope.
 
 Retained browse/FProxy surfaces and `PENDING` admin routes are unchanged by this batch. They remain
 available as legacy entry points until a later PR proves a complete replacement and documents the

--- a/docs/legacy-retirement-plan.md
+++ b/docs/legacy-retirement-plan.md
@@ -117,12 +117,13 @@ Query strings, form fields, option values, master passwords, password-file paths
 tokens, node references, and Freenet/Crypta URIs are never included in replacement pages,
 diagnostics, or release-certification evidence.
 
-Web Shell security keeps a bootstrap-resolved explicit fallback link for physical `HIGH`,
-master-password, and recovery workflows that still need the legacy GET page to render their forms.
-The fallback URL uses the configured `security-levels` legacy route from the retirement registry,
-then appends the fixed `legacyFallback=security-levels` marker. Only that marker bypasses the
-safe-read redirect; arbitrary query strings still receive the normal replacement redirect and are
-not reflected into responses or evidence.
+Web Shell security keeps a bootstrap-resolved explicit fallback link in the Security panel and in
+legacy-required error states for physical `HIGH`, master-password, and recovery workflows that
+still need the legacy GET page to render their forms. The fallback URL uses the configured
+`security-levels` legacy route from the retirement registry, then appends the fixed
+`legacyFallback=security-levels` marker. Only that marker bypasses the safe-read redirect;
+arbitrary query strings still receive the normal replacement redirect and are not reflected into
+responses or evidence.
 
 | Legacy route scope | Surface id | Safe read behavior | Mutating behavior | Replacement |
 | --- | --- | --- | --- | --- |

--- a/docs/plugin-system.md
+++ b/docs/plugin-system.md
@@ -8,5 +8,7 @@ What this means:
 - The `network.crypta.pluginmanager` package and plugin toadlets/FCP plugin commands are no longer implemented.
 - Legacy FCP plugin command names are rejected with a deterministic unsupported-message response.
 - Core update behavior remains package-based (`CoreUpdater`).
+- Legacy plugin-style functionality should migrate to the app platform using
+  [legacy-plugin-migration-guide.md](legacy-plugin-migration-guide.md).
 
 This document is intentionally short to avoid preserving outdated plugin-architecture guidance.

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -150,6 +150,8 @@ Release-candidate mode requires these evidence ids:
 | `reference-app.social-inbox-app-data` | App-platform smoke summary. | Social Inbox uses app data for sources, outbox summaries, imported-message summaries, read state, and explicit drafts while excluding private insert URIs, browser-session tokens, private identity material, raw fetched documents, and raw signatures. |
 | `reference-app.social-inbox-trust-annotations` | App-platform smoke summary. | Social Inbox queries Trust Graph Preview's `trust.score` service through an active app-service grant with `subjectKind=identity` and `context=message-author`, renders scores as annotations, and keeps unscored or ungranted messages visible. |
 | `migration.social-mail-preview` | App-platform smoke summary. | The migration spike evidence proves the social/mail-like layer composes AppVault, content insert/fetch/subscriptions, durable app data, and the mediated Trust Graph score service outside daemon core and legacy plugin APIs. |
+| `legacy-plugin.migration-guide` | App-platform smoke summary. | The legacy plugin migration guide exists, is linked from plugin-system and app-platform docs, documents old plugin runtime removal, and maps legacy plugin categories to app-platform mechanisms without restoring old plugin ABI or FCP command compatibility. |
+| `legacy-plugin.social-inbox-spike` | App-platform smoke summary. | Social Inbox is certified as the executable social/mail-like migration spike with AppVault, app data, content subscriptions, app-generated documents, and mediated Trust Graph score service grants. |
 | `reference-app.feed-reader` | App-platform smoke summary. | Feed Reader exists as the first content-subscription reference app, declares `content.fetch`, `content.subscribe`, and generated-document publication permissions, uses SDK feed helpers, and keeps evidence free of raw feed bodies and private fetch inputs. |
 | `reference-app.feed-reader-subscriptions` | App-platform smoke summary. | Feed Reader requires at least API v9, is tested through v12, uses `CryptaPlatform.content.subscriptions.*` for durable USK follow behavior, shows scheduler metadata, and does not rely on a tab-local timer as the durable follow path. |
 | `reference-app.feed-reader-app-data` | App-platform smoke summary. | Feed Reader requires at least contract v9, is tested through v12, declares `app.data.*`, uses SDK JSON record helpers for bounded feed sources, selected source, read/render metadata, and safe publisher draft state, and keeps evidence free of raw feed bodies and app-data values. |
@@ -159,6 +161,7 @@ Release-candidate mode requires these evidence ids:
 | `legacy.retirement` | App-platform smoke summary. | The legacy-admin retirement registry is visible, counts are stable, replaced surfaces are absent from primary shell fallback links, and retained/pending legacy routes remain documented. |
 | `legacy-admin.removal-wave-1` | App-platform smoke summary. | The first removal wave records the removed-by-default route ids, replacement URLs, safe-read redirect behavior, mutating-request block behavior, retained browse status, diagnostics counters, and redaction checks without requiring a live node. |
 | `legacy-admin.removal-wave-2` | App-platform smoke summary. | The second removal wave records the next removed-by-default route ids, queue/config/statistics route-scope expansion metadata, replacement URLs, partial mutation fallback policy, retained diagnostic export status, diagnostics counters, and redaction checks without requiring a live node. |
+| `legacy-admin.removal-wave-3` | App-platform smoke summary. | The third removal wave records `security-levels` safe-read redirects to Web Shell security, mutating legacy fallback for incomplete security flows, stable wave 1/2 route sets, retained browse/filter/diagnostic/wizard surfaces, and redaction checks without requiring a live node. |
 | `apphost.sandbox-provider` | App-platform smoke summary. | AppHost sandbox provider source and deterministic offline tests prove bubblewrap selection, enforced status reporting, fail-closed required sandbox behavior, and token/path-free public status. |
 | `app-update.lifecycle` | App-platform smoke summary. | Offline source and test evidence proves manual/stage/apply-when-stopped update policy, candidate detection semantics, compatibility/review/permission gates, and process health-gated apply behavior. |
 | `app-update.scheduler` | App-platform smoke summary. | Offline source and test evidence proves background catalog refresh, installed-app update checks through `AppUpdateService.check(...)`, durable path-free scheduler summaries, failure backoff, and the manual default policy. |
@@ -185,6 +188,16 @@ and core-update installer and package-store actions that remain fallback. It als
 FProxy browse remains retained, content filter remains retained, pending wizard and node-to-node
 message routes remain out of scope, the raw diagnostic export remains retained, and the new
 diagnostics scope metadata stays bounded and redacted.
+
+`legacy-admin.removal-wave-3` is deterministic offline evidence for `/seclevels/` only. It proves
+that safe reads redirect to `/app/node/#security` when Web Shell security is reachable, that POST
+and other mutating requests remain legacy fallback for master-password, password-file, high
+physical security, and recovery flows, and that the route scope is limited to the canonical path
+and slashless alias. It also proves that FProxy browse and content rendering remain retained, the
+content filter remains retained, raw diagnostic export remains retained, startup wizard and
+emergency fallback remain pending, node-to-node messages remain pending, and evidence excludes
+query strings, form passwords, tokens, private insert URIs, raw bodies, raw signatures, and local
+paths.
 
 `interop.extended` is optional in the machine gate but required by the release runbook when a
 release changes compatibility-sensitive behavior. `apphost.sandbox-provider` does not require
@@ -294,6 +307,8 @@ Social Inbox Preview supplies the social/mail migration reference path. Release 
 `reference-app.social-inbox-service-grant`, `app-services.registry`, `app-services.grants`,
 `app-services.trust-score-provider`, `app-services.web-shell`, `app-services.redaction`, and
 `migration.social-mail-preview` before a release claims social/mail migration preview support.
+`legacy-plugin.migration-guide` and `legacy-plugin.social-inbox-spike` certify the broader legacy
+plugin-to-app migration guidance and the executable Social Inbox spike.
 Social Inbox evidence must not include raw social message bodies, raw fetched social documents,
 raw request bodies, raw signature values, private insert URIs, private identity material, app
 process tokens, browser-session tokens, form passwords, private keys, absolute staging paths, or
@@ -438,8 +453,8 @@ evidence disappears, Trust Graph Preview evidence disappears, generated document
 disappears, content-fetch evidence disappears, trust-statement signing evidence disappears, or a
 reference app no longer proves its required helper usage. Legacy
 retirement gates block missing removal-wave evidence, including
-`legacy-admin.removal-wave-2`, or failed retained browse safety evidence and warn on removed-route
-count changes without update-note metadata.
+`legacy-admin.removal-wave-2` and `legacy-admin.removal-wave-3`, or failed retained browse safety
+evidence and warn on removed-route count changes without update-note metadata.
 
 ## Waivers
 

--- a/docs/social-inbox-reference-app.md
+++ b/docs/social-inbox-reference-app.md
@@ -20,6 +20,9 @@ implementation, old plugin ABI compatibility, WebOfTrust plugin compatibility la
 Freetalk/Sone/Freemail compatibility layer, encrypted mail transport, moderation system,
 daemon-core message store, daemon-core message protocol, or network protocol changes.
 
+For broader legacy plugin categories and migration recipes, see
+[legacy-plugin-migration-guide.md](legacy-plugin-migration-guide.md).
+
 ## App metadata
 
 ```text

--- a/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrap.java
+++ b/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrap.java
@@ -117,8 +117,8 @@ public record WebShellBootstrap(
    * @param value root path to validate
    * @param label logical field name used in validation messages
    * @throws NullPointerException if {@code value} is {@code null}
-   * @throws IllegalArgumentException if the path is blank or is not wrapped in leading and trailing
-   *     slashes
+   * @throws IllegalArgumentException if the path is blank, does not start with {@code /}, or does
+   *     not end with {@code /}
    */
   private static void requireRootPath(String value, String label) {
     requireText(value, label);
@@ -139,6 +139,40 @@ public record WebShellBootstrap(
   }
 
   /**
+   * Requires one same-origin absolute path for a legacy route that may be registered slashless.
+   *
+   * <p>Most Web Shell fields are route roots and therefore require a trailing slash. The legacy
+   * security route is different: it mirrors the configured legacy toadlet path exactly, including
+   * installations that set {@code network.crypta.seclevels.path} to a slashless route. The value is
+   * still constrained to a local path with no query or fragment so browser bootstrap data cannot
+   * become an open redirect or leak request metadata.
+   *
+   * @param value path value to validate
+   * @throws NullPointerException if {@code value} is {@code null}
+   * @throws IllegalArgumentException if the path is blank, is not a single-leading-slash local
+   *     path, or contains query/fragment data
+   */
+  private static void requireLegacySecurityLevelsPath(String value) {
+    requireText(value, "legacySecurityLevelsPath");
+    if (value.charAt(0) != '/' || value.startsWith("//")) {
+      throw new IllegalArgumentException(
+          "legacySecurityLevelsPath must start with a single leading '/'");
+    }
+    try {
+      URI uri = URI.create("http://localhost" + value);
+      if (!value.equals(uri.getRawPath())
+          || uri.getRawQuery() != null
+          || uri.getRawFragment() != null) {
+        throw new IllegalArgumentException(
+            "legacySecurityLevelsPath must be a valid absolute local path");
+      }
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "legacySecurityLevelsPath must be a valid absolute local path", e);
+    }
+  }
+
+  /**
    * Creates an immutable shell bootstrap payload.
    *
    * <p>The constructor keeps the data deliberately narrow: route roots, a short descriptive title,
@@ -146,8 +180,8 @@ public record WebShellBootstrap(
    * first shell while keeping the adapter bridge free to remain a thin transport layer.
    *
    * @throws NullPointerException if any required field is {@code null}
-   * @throws IllegalArgumentException if any root path is blank, does not start with {@code /}, or
-   *     does not end with {@code /}
+   * @throws IllegalArgumentException if any route path is blank, is not local, or contains query or
+   *     fragment data
    */
   public WebShellBootstrap {
     requireText(shellTitle, "shellTitle");
@@ -159,7 +193,7 @@ public record WebShellBootstrap(
       requireText(formPassword, "formPassword");
     }
     requireRootPath(legacyRoot, "legacyRoot");
-    requireRootPath(legacySecurityLevelsPath, "legacySecurityLevelsPath");
+    requireLegacySecurityLevelsPath(legacySecurityLevelsPath);
     legacyLinks = List.copyOf(Objects.requireNonNull(legacyLinks, "legacyLinks"));
     if (legacyLinks.isEmpty()) {
       throw new IllegalArgumentException("legacyLinks must not be empty");

--- a/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrap.java
+++ b/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrap.java
@@ -22,6 +22,7 @@ import network.crypta.platform.webshell.routes.WebShellPaths;
  * @param formPassword legacy mutation token used by the current Platform API bridge, or {@code
  *     null} when the shell should stay read-only
  * @param legacyRoot legacy HTTP root used for deep links back to existing pages
+ * @param legacySecurityLevelsPath legacy security page path used for explicit fallback flows
  * @param legacyLinks user-visible deep links back to the legacy admin pages
  */
 public record WebShellBootstrap(
@@ -32,6 +33,7 @@ public record WebShellBootstrap(
     String platformApiRoot,
     String formPassword,
     String legacyRoot,
+    String legacySecurityLevelsPath,
     List<LegacyLink> legacyLinks) {
   /** Default shell title used by the node-management UI. */
   public static final String DEFAULT_SHELL_TITLE = "Cryptad Web Shell";
@@ -47,12 +49,20 @@ public record WebShellBootstrap(
   public static final String DEFAULT_LEGACY_ROOT = "/";
 
   /**
-   * Creates the current shell bootstrap payload with the default node-management layout.
+   * Creates the current shell bootstrap payload with an adapter-resolved legacy security path.
    *
+   * <p>The platform shell does not own the legacy security-levels route. The serving adapter must
+   * pass the route it registered for the legacy security toadlet, including deployments that
+   * customize that path through local configuration. Keeping the value as an explicit parameter
+   * prevents the browser bootstrap from drifting away from the route map that actually handles the
+   * fallback forms.
+   *
+   * @param legacySecurityLevelsPath configured path for the legacy security-levels page
    * @param legacyLinks user-visible deep links back to the legacy admin pages
    * @return bootstrap payload suitable for the first-party shell
    */
-  public static WebShellBootstrap nodeManagement(List<LegacyLink> legacyLinks) {
+  public static WebShellBootstrap nodeManagement(
+      String legacySecurityLevelsPath, List<LegacyLink> legacyLinks) {
     return new WebShellBootstrap(
         DEFAULT_SHELL_TITLE,
         DEFAULT_SHELL_DESCRIPTION,
@@ -61,6 +71,7 @@ public record WebShellBootstrap(
         DEFAULT_PLATFORM_API_ROOT,
         null,
         DEFAULT_LEGACY_ROOT,
+        legacySecurityLevelsPath,
         legacyLinks);
   }
 
@@ -81,6 +92,7 @@ public record WebShellBootstrap(
         platformApiRoot,
         normalizedFormPassword,
         legacyRoot,
+        legacySecurityLevelsPath,
         legacyLinks);
   }
 
@@ -147,6 +159,7 @@ public record WebShellBootstrap(
       requireText(formPassword, "formPassword");
     }
     requireRootPath(legacyRoot, "legacyRoot");
+    requireRootPath(legacySecurityLevelsPath, "legacySecurityLevelsPath");
     legacyLinks = List.copyOf(Objects.requireNonNull(legacyLinks, "legacyLinks"));
     if (legacyLinks.isEmpty()) {
       throw new IllegalArgumentException("legacyLinks must not be empty");

--- a/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrapJson.java
+++ b/platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrapJson.java
@@ -20,7 +20,7 @@ public final class WebShellBootstrapJson {
    * @return JSON representation suitable for browser bootstrap
    */
   public static String serialize(WebShellBootstrap bootstrap) {
-    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(8);
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(9);
     json.put("shellTitle", bootstrap.shellTitle());
     json.put("shellDescription", bootstrap.shellDescription());
     json.put("shellRoot", bootstrap.shellRoot());
@@ -28,6 +28,7 @@ public final class WebShellBootstrapJson {
     json.put("platformApiRoot", bootstrap.platformApiRoot());
     json.put("formPassword", bootstrap.formPassword());
     json.put("legacyRoot", bootstrap.legacyRoot());
+    json.put("legacySecurityLevelsPath", bootstrap.legacySecurityLevelsPath());
     json.put(
         "legacyLinks",
         bootstrap.legacyLinks().stream().map(WebShellBootstrapJson::serializeLink).toList());

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -338,7 +338,8 @@ a {
   height: 100%;
 }
 
-.publisher-result-actions {
+.publisher-result-actions,
+.security-fallback-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -247,14 +247,27 @@
     setSectionStatus(sections.securityStatus, message, tone);
   }
 
+  function securityLegacyFallbackLink(label) {
+    const fallbackLink = document.createElement("a");
+    fallbackLink.href = legacySecurityLevelsFallbackPath;
+    fallbackLink.textContent = label;
+    return fallbackLink;
+  }
+
   function setSecurityLegacyFallbackStatus(message) {
     clear(sections.securityStatus);
     const paragraph = text("p", "status-message is-error", `${message} `);
-    const fallbackLink = document.createElement("a");
-    fallbackLink.href = legacySecurityLevelsFallbackPath;
-    fallbackLink.textContent = "Open the legacy security page.";
-    paragraph.append(fallbackLink);
+    paragraph.append(securityLegacyFallbackLink("Open the legacy security page."));
     sections.securityStatus.append(paragraph);
+  }
+
+  function renderSecurityLegacyFallbackAction() {
+    const actions = document.createElement("div");
+    actions.className = "security-fallback-actions";
+    const fallbackLink = securityLegacyFallbackLink("Open legacy password and recovery forms");
+    fallbackLink.className = "button button-secondary";
+    actions.append(fallbackLink);
+    return actions;
   }
 
   function securityErrorRequiresLegacyFallback(error) {
@@ -700,6 +713,7 @@
         ["Password file path", data.masterPasswordFilePath || "Unavailable"],
       ]),
     );
+    sections.security.append(renderSecurityLegacyFallbackAction());
     if (securityControls.networkLevel) {
       securityControls.networkLevel.value = data.networkThreatLevel || "NORMAL";
     }

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -8,8 +8,14 @@
 
   const apiRoot = normalizeLocalRootPath(bootstrap.platformApiRoot, "/api/v1/");
   const shellRoot = normalizeLocalRootPath(bootstrap.shellRoot, "/app/node/");
+  const legacySecurityLevelsPath = normalizeLocalRootPath(
+    bootstrap.legacySecurityLevelsPath,
+    "/seclevels/",
+  );
   const apiRootUrl = new URL(apiRoot, window.location.origin);
   const shellRootUrl = new URL(shellRoot, window.location.origin);
+  const legacySecurityLevelsFallbackPath =
+    legacySecurityLevelsPath + "?legacyFallback=security-levels";
   let formPassword = typeof bootstrap.formPassword === "string" ? bootstrap.formPassword : "";
   const legacyLinks = Array.isArray(bootstrap.legacyLinks) ? bootstrap.legacyLinks : [];
   const shellState = {
@@ -239,6 +245,28 @@
 
   function setSecurityStatus(message, tone) {
     setSectionStatus(sections.securityStatus, message, tone);
+  }
+
+  function setSecurityLegacyFallbackStatus(message) {
+    clear(sections.securityStatus);
+    const paragraph = text("p", "status-message is-error", `${message} `);
+    const fallbackLink = document.createElement("a");
+    fallbackLink.href = legacySecurityLevelsFallbackPath;
+    fallbackLink.textContent = "Open the legacy security page.";
+    paragraph.append(fallbackLink);
+    sections.securityStatus.append(paragraph);
+  }
+
+  function securityErrorRequiresLegacyFallback(error) {
+    if (
+      error instanceof Error &&
+      (error.apiErrorCode === "physical_threat_level_password_required" ||
+        error.apiErrorCode === "physical_threat_level_master_password_cleanup_failed")
+    ) {
+      return true;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return message.includes("Use the legacy security page");
   }
 
   function setUpdatesStatus(message, tone) {
@@ -4113,6 +4141,14 @@
     return `${response.status} ${response.statusText}`;
   }
 
+  function createApiError(data, response) {
+    const error = new Error(extractApiError(data, response));
+    if (data && data.error && typeof data.error.code === "string") {
+      error.apiErrorCode = data.error.code;
+    }
+    return error;
+  }
+
   function renderError(node, label, error) {
     clear(node);
     const message =
@@ -4124,7 +4160,7 @@
     const response = await fetch(url, { headers: { Accept: "application/json" } });
     const data = await response.json().catch(() => ({}));
     if (!response.ok) {
-      throw new Error(extractApiError(data, response));
+      throw createApiError(data, response);
     }
     return data;
   }
@@ -4138,7 +4174,7 @@
     if (optionalStatuses.includes(response.status)) {
       return null;
     }
-    throw new Error(extractApiError(data, response));
+    throw createApiError(data, response);
   }
 
   async function loadBestEffortOptionalJson(url) {
@@ -4183,7 +4219,7 @@
     });
     const data = await response.json().catch(() => ({}));
     if (!response.ok) {
-      throw new Error(extractApiError(data, response));
+      throw createApiError(data, response);
     }
     return data;
   }
@@ -4946,9 +4982,8 @@
         (currentSnapshot.physicalThreatLevel === "HIGH" &&
           (requestedPhysical === "LOW" || requestedPhysical === "NORMAL")))
     ) {
-      setSecurityStatus(
+      setSecurityLegacyFallbackStatus(
         "Changing to or from physical HIGH still requires the legacy security page because it updates master-password state.",
-        "is-error",
       );
       return;
     }
@@ -5004,7 +5039,12 @@
       updateWizardToolbar();
       await Promise.all([loadSecuritySection(), loadWizardSection()]);
     } catch (error) {
-      setSecurityStatus(error instanceof Error ? error.message : String(error), "is-error");
+      const message = error instanceof Error ? error.message : String(error);
+      if (securityErrorRequiresLegacyFallback(error)) {
+        setSecurityLegacyFallbackStatus(message);
+        return;
+      }
+      setSecurityStatus(message, "is-error");
     }
   }
 

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -8,7 +8,7 @@
 
   const apiRoot = normalizeLocalRootPath(bootstrap.platformApiRoot, "/api/v1/");
   const shellRoot = normalizeLocalRootPath(bootstrap.shellRoot, "/app/node/");
-  const legacySecurityLevelsPath = normalizeLocalRootPath(
+  const legacySecurityLevelsPath = normalizeLocalPath(
     bootstrap.legacySecurityLevelsPath,
     "/seclevels/",
   );
@@ -189,6 +189,21 @@
         return fallback;
       }
       return url.pathname.endsWith("/") ? url.pathname : `${url.pathname}/`;
+    } catch (error) {
+      return fallback;
+    }
+  }
+
+  function normalizeLocalPath(value, fallback) {
+    if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) {
+      return fallback;
+    }
+    try {
+      const url = new URL(value, window.location.origin);
+      if (url.origin !== window.location.origin || url.search !== "" || url.hash !== "") {
+        return fallback;
+      }
+      return url.pathname;
     } catch (error) {
       return fallback;
     }

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellBootstrapTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellBootstrapTest.java
@@ -45,6 +45,15 @@ class WebShellBootstrapTest {
   }
 
   @Test
+  void nodeManagement_whenSlashlessSecurityPathProvided_expectConfiguredPathPreserved() {
+    WebShellBootstrap bootstrap =
+        WebShellBootstrap.nodeManagement(
+            "/security-custom", List.of(new WebShellBootstrap.LegacyLink("/friends/", "Friends")));
+
+    assertEquals("/security-custom", bootstrap.legacySecurityLevelsPath());
+  }
+
+  @Test
   void toJson_whenValuesContainJsonSensitiveCharacters_expectEscapedPayload() {
     WebShellBootstrap bootstrap =
         new WebShellBootstrap(

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellBootstrapTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellBootstrapTest.java
@@ -13,13 +13,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
 class WebShellBootstrapTest {
+  private static final String CONFIGURED_SECURITY_LEVELS_PATH = "/security-custom/";
+
   @Test
-  void nodeManagement_whenLegacyLinksProvided_expectStableDefaultRoutesAndProvidedLinks() {
+  void nodeManagement_whenLegacyLinksAndSecurityPathProvided_expectStableRoutesAndProvidedLinks() {
     List<WebShellBootstrap.LegacyLink> legacyLinks =
         List.of(
             new WebShellBootstrap.LegacyLink("/friends-custom/", "Friends"),
             new WebShellBootstrap.LegacyLink("/downloads-custom/", "Downloads"));
-    WebShellBootstrap bootstrap = WebShellBootstrap.nodeManagement(legacyLinks);
+    WebShellBootstrap bootstrap =
+        WebShellBootstrap.nodeManagement(CONFIGURED_SECURITY_LEVELS_PATH, legacyLinks);
 
     assertEquals(WebShellBootstrap.DEFAULT_SHELL_TITLE, bootstrap.shellTitle());
     assertEquals(WebShellPaths.SHELL_ROOT, bootstrap.shellRoot());
@@ -27,7 +30,18 @@ class WebShellBootstrapTest {
     assertEquals(WebShellBootstrap.DEFAULT_PLATFORM_API_ROOT, bootstrap.platformApiRoot());
     assertNull(bootstrap.formPassword());
     assertEquals(WebShellBootstrap.DEFAULT_LEGACY_ROOT, bootstrap.legacyRoot());
+    assertEquals(CONFIGURED_SECURITY_LEVELS_PATH, bootstrap.legacySecurityLevelsPath());
     assertEquals(legacyLinks, bootstrap.legacyLinks());
+  }
+
+  @Test
+  void nodeManagement_whenSecurityPathProvided_expectConfiguredLegacyFallbackPath() {
+    WebShellBootstrap bootstrap =
+        WebShellBootstrap.nodeManagement(
+            CONFIGURED_SECURITY_LEVELS_PATH,
+            List.of(new WebShellBootstrap.LegacyLink("/friends/", "Friends")));
+
+    assertEquals(CONFIGURED_SECURITY_LEVELS_PATH, bootstrap.legacySecurityLevelsPath());
   }
 
   @Test
@@ -41,6 +55,7 @@ class WebShellBootstrapTest {
             "/api/v1/",
             "secret<token>",
             "/",
+            "/security-custom/",
             List.of(new WebShellBootstrap.LegacyLink("/friends/", "Friends & Allies")));
 
     assertEquals(
@@ -51,6 +66,7 @@ class WebShellBootstrapTest {
             + "\"platformApiRoot\":\"/api/v1/\","
             + "\"formPassword\":\"secret\\u003ctoken\\u003e\","
             + "\"legacyRoot\":\"/\","
+            + "\"legacySecurityLevelsPath\":\"/security-custom/\","
             + "\"legacyLinks\":[{\"path\":\"/friends/\",\"label\":\"Friends \\u0026 Allies\"}]}",
         WebShellBootstrapJson.serialize(bootstrap));
   }
@@ -59,6 +75,7 @@ class WebShellBootstrapTest {
   void withFormPassword_whenBlank_expectMutationTokenCleared() {
     WebShellBootstrap bootstrap =
         WebShellBootstrap.nodeManagement(
+                CONFIGURED_SECURITY_LEVELS_PATH,
                 List.of(new WebShellBootstrap.LegacyLink("/friends/", "Friends")))
             .withFormPassword("");
 
@@ -76,11 +93,17 @@ class WebShellBootstrapTest {
 
   @Test
   void legacyLink_whenPathIsSchemeRelativeOrContainsQuery_expectRejected() {
+    List<WebShellBootstrap.LegacyLink> validLegacyLinks =
+        List.of(new WebShellBootstrap.LegacyLink("/friends/", "Friends"));
+
     assertThrows(
         IllegalArgumentException.class,
         () -> new WebShellBootstrap.LegacyLink("//evil.example/", "External"));
     assertThrows(
         IllegalArgumentException.class,
         () -> new WebShellBootstrap.LegacyLink("/friends/?tab=all", "Friends"));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> WebShellBootstrap.nodeManagement("/seclevels/?tab=legacy", validLegacyLinks));
   }
 }

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellPageRendererTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellPageRendererTest.java
@@ -14,6 +14,7 @@ class WebShellPageRendererTest {
     String html =
         WebShellPageRenderer.render(
             WebShellBootstrap.nodeManagement(
+                "/security-custom/",
                 java.util.List.of(new WebShellBootstrap.LegacyLink("/friends/", "Friends"))));
 
     assertTrue(html.contains("Web Shell v1"));

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -111,7 +111,8 @@ class WebShellResourcesTest {
     assertTrue(stylesheet.contains(".metadata-link-list {"));
     assertTrue(stylesheet.contains(".permission-review-list {"));
     assertTrue(stylesheet.contains(".publisher-forms {"));
-    assertTrue(stylesheet.contains(".publisher-result-actions {"));
+    assertTrue(stylesheet.contains(".publisher-result-actions,"));
+    assertTrue(stylesheet.contains(".security-fallback-actions {"));
     assertTrue(stylesheet.contains(".status-pill.is-success::before {"));
   }
 
@@ -810,7 +811,11 @@ class WebShellResourcesTest {
     assertTrue(script.contains("const legacySecurityLevelsFallbackPath ="));
     assertTrue(script.contains("legacySecurityLevelsPath + \"?legacyFallback=security-levels\""));
     assertFalse(script.contains("\"/seclevels/?legacyFallback=security-levels\""));
+    assertTrue(script.contains("function securityLegacyFallbackLink(label)"));
     assertTrue(script.contains("function setSecurityLegacyFallbackStatus(message)"));
+    assertTrue(script.contains("function renderSecurityLegacyFallbackAction()"));
+    assertTrue(script.contains("sections.security.append(renderSecurityLegacyFallbackAction())"));
+    assertTrue(script.contains("Open legacy password and recovery forms"));
     assertTrue(script.contains("function securityErrorRequiresLegacyFallback(error)"));
     assertTrue(script.contains("physical_threat_level_password_required"));
     assertTrue(script.contains("physical_threat_level_master_password_cleanup_failed"));

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -133,6 +133,7 @@ class WebShellResourcesTest {
     assertTrue(script.contains("const apiRootUrl = new URL(apiRoot, window.location.origin);"));
     assertTrue(script.contains("const shellRootUrl = new URL(shellRoot, window.location.origin);"));
     assertTrue(script.contains("function normalizeLocalRootPath(value, fallback)"));
+    assertTrue(script.contains("function normalizeLocalPath(value, fallback)"));
     assertTrue(script.contains("function queuePriorityFieldName(submitterName)"));
     assertTrue(script.contains("function renderQueueHtmlFragment(html, className)"));
     assertTrue(script.contains("function sanitizeQueueNode(root)"));
@@ -806,7 +807,7 @@ class WebShellResourcesTest {
     assertTrue(script.contains("async function loadConfigSection()"));
     assertTrue(script.contains("async function loadWizardSection()"));
     assertTrue(script.contains("async function submitSecurityForm(event)"));
-    assertTrue(script.contains("const legacySecurityLevelsPath = normalizeLocalRootPath("));
+    assertTrue(script.contains("const legacySecurityLevelsPath = normalizeLocalPath("));
     assertTrue(script.contains("bootstrap.legacySecurityLevelsPath,"));
     assertTrue(script.contains("const legacySecurityLevelsFallbackPath ="));
     assertTrue(script.contains("legacySecurityLevelsPath + \"?legacyFallback=security-levels\""));

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -204,7 +204,9 @@ class WebShellResourcesTest {
     assertTrue(loadOptionalJsonIndex >= 0);
     assertTrue(loadBestEffortOptionalJsonIndex > loadOptionalJsonIndex);
     assertTrue(script.contains("optionalStatuses.includes(response.status)"));
-    assertTrue(script.contains("throw new Error(extractApiError(data, response));"));
+    assertTrue(script.contains("function createApiError(data, response)"));
+    assertTrue(script.contains("error.apiErrorCode = data.error.code;"));
+    assertTrue(script.contains("throw createApiError(data, response);"));
     assertTrue(script.contains("return await loadOptionalJson(url);"));
     assertTrue(snapshotAwaitIndex > queueLoadIndex);
     assertTrue(optionalAwaitIndex > snapshotAwaitIndex);
@@ -803,6 +805,17 @@ class WebShellResourcesTest {
     assertTrue(script.contains("async function loadConfigSection()"));
     assertTrue(script.contains("async function loadWizardSection()"));
     assertTrue(script.contains("async function submitSecurityForm(event)"));
+    assertTrue(script.contains("const legacySecurityLevelsPath = normalizeLocalRootPath("));
+    assertTrue(script.contains("bootstrap.legacySecurityLevelsPath,"));
+    assertTrue(script.contains("const legacySecurityLevelsFallbackPath ="));
+    assertTrue(script.contains("legacySecurityLevelsPath + \"?legacyFallback=security-levels\""));
+    assertFalse(script.contains("\"/seclevels/?legacyFallback=security-levels\""));
+    assertTrue(script.contains("function setSecurityLegacyFallbackStatus(message)"));
+    assertTrue(script.contains("function securityErrorRequiresLegacyFallback(error)"));
+    assertTrue(script.contains("physical_threat_level_password_required"));
+    assertTrue(script.contains("physical_threat_level_master_password_cleanup_failed"));
+    assertTrue(script.contains("if (securityErrorRequiresLegacyFallback(error))"));
+    assertTrue(script.contains("Open the legacy security page."));
     assertTrue(script.contains("async function submitConfigForm(event)"));
     assertTrue(script.contains("async function triggerCoreDownload()"));
     assertTrue(script.contains("async function submitWizardForm(event)"));

--- a/src/test/java/network/crypta/clients/http/PageMakerTest.java
+++ b/src/test/java/network/crypta/clients/http/PageMakerTest.java
@@ -281,21 +281,21 @@ class PageMakerTest {
   }
 
   @Test
-  void getPageNode_whenActiveToadletMissingAndRequestUriIsReplaced_rendersNotice() {
+  void getPageNode_whenActiveToadletMissingAndRequestUriRendersLegacyNotice_expectNotice() {
     PageMaker maker = newPageMaker();
     stubPageRenderingContext(false);
-    when(context.getUri()).thenReturn(URI.create(SecurityLevelsToadlet.PATH));
+    when(context.getUri()).thenReturn(URI.create(DiagnosticToadlet.TOADLET_URL));
 
     PageNode page =
         maker.getPageNode(
-            "Security",
+            "Diagnostic",
             context,
             new PageMaker.RenderParameters().renderNavigationLinks(false).renderModeSwitch(false));
 
     String html = page.generate();
 
     assertTrue(html.contains("legacy-admin-retirement-notice"));
-    assertTrue(html.contains("Web Shell security"));
+    assertTrue(html.contains("Web Shell diagnostics"));
   }
 
   @Test

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -117,12 +117,15 @@ reference-app.social-inbox-subscriptions
 reference-app.social-inbox-app-data
 reference-app.social-inbox-trust-annotations
 migration.social-mail-preview
+legacy-plugin.migration-guide
+legacy-plugin.social-inbox-spike
 reference-app.feed-reader
 reference-app.feed-reader-subscriptions
 reference-app.trust-graph
 legacy.retirement
 legacy-admin.removal-wave-1
 legacy-admin.removal-wave-2
+legacy-admin.removal-wave-3
 apphost.sandbox-provider
 app-update.lifecycle
 app-update.scheduler
@@ -231,9 +234,13 @@ blocker row becomes `warn`, never a silent `pass`.
 
 Required evidence that regresses from `pass` to `fail`, `missing`, or `skip` blocks
 release-candidate promotion unless a visible waiver applies. `pass` to `warn` is a warning.
-`legacy-admin.removal-wave-2` is required release-candidate evidence and remains deterministic:
-it verifies the wave-2 route ids, route-scope expansion metadata, retained browse safety, raw
-diagnostic export retention, and redacted diagnostics counters without a live node.
+`legacy-plugin.migration-guide`, `legacy-plugin.social-inbox-spike`, and
+`legacy-admin.removal-wave-3` are required release-candidate evidence. The migration evidence
+verifies that legacy plugin categories have a documented app-platform migration path without old
+plugin ABI or FCP command compatibility, and that Social Inbox remains the executable
+social/mail-like migration spike. Wave 3 verifies only the `security-levels` route, safe-read
+redirect behavior, mutating legacy fallback, retained browse/filter/diagnostic/wizard surfaces,
+and redacted diagnostics counters without a live node.
 Platform API contract version rollback, stable endpoint/capability removal, first-party app
 disappearance, missing Site Publisher evidence, strict first-party UI lint failure, review receipt
 regression, update rollback regression, vault capability/redaction regression, required enforced

--- a/tools/release-certification/app_platform_docs_check.py
+++ b/tools/release-certification/app_platform_docs_check.py
@@ -41,6 +41,7 @@ REQUIRED_DOCS = (
     "docs/feed-reader-reference-app.md",
     "docs/social-inbox-reference-app.md",
     "docs/trust-graph-preview.md",
+    "docs/legacy-plugin-migration-guide.md",
     "docs/release-certification.md",
     "docs/SECURITY.md",
 )

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -7624,6 +7624,10 @@ def collect_legacy_removal_wave_three_evidence(settings: Settings) -> EvidenceIt
         "securityLegacyFallbackMarkerDeclared": "legacyFallback=security-levels" in text["policy"]
         and "legacyFallback=security-levels" in text["webshell"]
         and "Open the legacy security page" in text["webshell"],
+        "securityFallbackLinkDiscoverable": "function renderSecurityLegacyFallbackAction()" in text["webshell"]
+        and "sections.security.append(renderSecurityLegacyFallbackAction())" in text["webshell"]
+        and "Open legacy password and recovery forms" in text["webshell"]
+        and "Security panel" in text["docs"],
         "securityFallbackPathFromBootstrap": "bootstrap.legacySecurityLevelsPath" in text["webshell"]
         and 'legacySecurityLevelsPath + "?legacyFallback=security-levels"' in text["webshell"]
         and "legacySecurityLevelsPath" in text["bootstrap"]
@@ -10774,6 +10778,8 @@ def make_self_test_workspace(workspace: Path) -> None:
         "const action = 'addRecommended';\n"
         "function appServiceGrantPath(){}\n"
         "function setSecurityLegacyFallbackStatus(){ return 'Open the legacy security page'; }\n"
+        "function renderSecurityLegacyFallbackAction(){ return 'Open legacy password and recovery forms'; }\n"
+        "sections.security.append(renderSecurityLegacyFallbackAction());\n"
         "const grants = 'App-service grants'; const approve = 'Approve'; const revoke = 'Revoke';\n"
         "apiUrl(\"app-services\"); apiUrl(\"app-services/grants\"); apiUrl(\"app-services/audit?limit=12\");\n",
         encoding="utf-8",
@@ -10919,8 +10925,8 @@ def make_self_test_workspace(workspace: Path) -> None:
         "available. Security-level mutating requests keep legacy fallback; legacy fallback remains "
         "for master-password, "
         "database/password-file, high physical security, and recovery flows. Wave 3 does not use "
-        "prefix-family matching for security routes. A bootstrap-resolved explicit fallback link remains for "
-        "legacy security forms, and arbitrary query strings still receive replacement redirects. "
+        "prefix-family matching for security routes. A bootstrap-resolved explicit fallback link remains in "
+        "the Security panel for legacy security forms, and arbitrary query strings still receive replacement redirects. "
         "Startup wizard and emergency fallback remain "
         "pending. Node-to-node messages remain pending. "
         "FProxy browse remains retained, FProxy browse and content rendering remain retained, "
@@ -11526,6 +11532,8 @@ const recommendedCatalogPath = "app-catalogs/recommended";
 const recommendedCatalogAction = "addRecommended";
 function appServiceGrantPath(){}
 function setSecurityLegacyFallbackStatus(){ return "Open the legacy security page"; }
+function renderSecurityLegacyFallbackAction(){ return "Open legacy password and recovery forms"; }
+sections.security.append(renderSecurityLegacyFallbackAction());
 const appServiceTitle = "App-service grants";
 const approve = "Approve";
 const revoke = "Revoke";

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -64,6 +64,9 @@ LEGACY_REMOVAL_WAVE_TWO_IDS = (
     "core-update",
     "statistics",
 )
+LEGACY_REMOVAL_WAVE_THREE_IDS = (
+    "security-levels",
+)
 LEGACY_REMOVAL_WAVE_TWO_SCOPE_EXPANSION_IDS = (
     "queue-downloads",
     "queue-uploads",
@@ -616,6 +619,43 @@ def sanitize_value(value: Any, workspace_root: Path, key_hint: str = "") -> Any:
 
 def is_local_live_host(host: str) -> bool:
     return host in {"127.0.0.1", "localhost", "::1"}
+
+
+DIRECT_LOCAL_ENDPOINT_RE = re.compile(
+    r"(?i)(?:"
+    r"\blocalhost\b|"
+    r"\b127(?:\.\d{1,3}){3}\b|"
+    r"\b0\.0\.0\.0\b|"
+    r"\[::1\]|"
+    r"(?<![0-9a-f:])::1(?![0-9a-f:])|"
+    r"\b0:0:0:0:0:0:0:1\b"
+    r")"
+)
+
+
+def has_direct_local_endpoint_reference(text: str) -> bool:
+    return DIRECT_LOCAL_ENDPOINT_RE.search(text) is not None
+
+
+def social_inbox_docs_frame_spike_non_goals(docs_text: str) -> bool:
+    normalized = re.sub(r"\s+", " ", docs_text.lower())
+    wot_non_goal = bool(
+        re.search(
+            r"\bnot\s+(?:a\s+)?(?:[^.]{0,160}\b)?full\s+(?:wot|web of trust)\b",
+            normalized,
+        )
+    )
+    daemon_store_non_goal = (
+        "daemon-core message store" in normalized or "daemon message store" in normalized
+    )
+    return (
+        wot_non_goal
+        and "freetalk" in normalized
+        and "sone" in normalized
+        and "freemail" in normalized
+        and "encrypted mail" in normalized
+        and daemon_store_non_goal
+    )
 
 
 def live_base_url_details(base_url: str) -> dict[str, Any]:
@@ -7029,12 +7069,165 @@ def collect_social_mail_migration_preview_evidence(settings: Settings) -> Eviden
     )
 
 
+def collect_legacy_plugin_migration_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    guide_path = workspace / "docs/legacy-plugin-migration-guide.md"
+    plugin_status_path = workspace / "docs/plugin-system.md"
+    portal_path = workspace / "docs/app-platform-developer-portal.md"
+    beta_limits_path = workspace / "docs/app-platform-beta-known-limitations.md"
+    guide_text = read_source(guide_path)
+    guide_lower = guide_text.lower()
+    developer_docs_text = read_source(portal_path) + "\n" + read_source(beta_limits_path)
+    checks = {
+        "guideExists": guide_path.is_file(),
+        "oldRuntimeRemoved": "old plugin runtime" in guide_lower and "removed" in guide_lower,
+        "noOldPluginAbiCompatibility": "old plugin ABI compatibility" in guide_text,
+        "noFcpPluginCommandCompatibility": "old FCP plugin command compatibility" in guide_text,
+        "webOfTrustMigration": "WebOfTrust-like" in guide_text or "WoT-like" in guide_text,
+        "freetalkSoneMigration": "Freetalk/Sone-like" in guide_text,
+        "freemailMigration": "Freemail-like" in guide_text,
+        "trustGraphPreview": "Trust Graph Preview" in guide_text,
+        "socialInboxPreview": "Social Inbox Preview" in guide_text,
+        "appVault": "app vault" in guide_lower or "AppVault" in guide_text,
+        "appData": "app data" in guide_lower or "app-data" in guide_lower,
+        "contentSubscriptions": "content subscriptions" in guide_lower,
+        "appServiceGrants": "app-service grant" in guide_lower,
+        "signedCatalog": "signed catalog" in guide_lower,
+        "reviewGovernance": "review receipt" in guide_lower
+        or "review governance" in guide_lower,
+        "pluginSystemLinksGuide": "legacy-plugin-migration-guide.md" in read_source(plugin_status_path),
+        "developerOrBetaDocsLinkGuide": "legacy-plugin-migration-guide.md" in developer_docs_text,
+    }
+    details = {
+        "guide": display_path(guide_path, workspace),
+        "linkedDocs": [
+            display_path(plugin_status_path, workspace),
+            display_path(portal_path, workspace),
+            display_path(beta_limits_path, workspace),
+        ],
+        "checks": checks,
+        "redaction": {
+            "privateInsertUrisExcluded": True,
+            "tokensExcluded": True,
+            "rawBodiesExcluded": True,
+            "rawSignaturesExcluded": True,
+            "localPathsExcluded": True,
+        },
+    }
+    errors = [name for name, passed in checks.items() if not passed]
+    if errors:
+        return EvidenceItem(
+            "legacy-plugin.migration-guide",
+            root_consequence(settings, "fail"),
+            True,
+            "Legacy plugin migration guide evidence found problems.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "legacy-plugin.migration-guide",
+        "pass",
+        True,
+        "Legacy plugin migration guide evidence passed.",
+        source,
+        details,
+    )
+
+
+def collect_legacy_plugin_social_inbox_spike_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    app_dir = workspace / "apps/social-inbox"
+    manifest_path = app_dir / "src/staged/cryptad-app.properties.template"
+    if not manifest_path.is_file():
+        manifest_path = app_dir / "build/cryptad-app/social-inbox/cryptad-app.properties"
+    manifest: dict[str, str] = {}
+    manifest_permissions: set[str] = set()
+    errors: list[str] = []
+    if manifest_path.is_file():
+        try:
+            manifest = parse_properties(manifest_path)
+            manifest_permissions = parse_permission_set(manifest.get("app.permissions", ""))
+        except ValueError as exc:
+            errors.append(str(exc))
+    social_app_js = read_source(app_dir / "src/staged/static/app.js")
+    social_readme = read_source(app_dir / "README.md")
+    social_doc = read_source(workspace / "docs/social-inbox-reference-app.md")
+    docs_text = social_readme + "\n" + social_doc
+    direct_local_endpoint_reference = has_direct_local_endpoint_reference(social_app_js)
+    checks = {
+        "appExists": app_dir.is_dir(),
+        "manifestPresent": manifest_path.is_file(),
+        "manifestDeclaresExpectedCapabilities": SOCIAL_INBOX_PERMISSIONS.issubset(
+            manifest_permissions
+        ),
+        "manifestRequestsTrustScoreService": (
+            manifest.get("app.services.requests") == "trust-score"
+            and manifest.get("app.service-request.trust-score.provider") == "trust-graph"
+            and manifest.get("app.service-request.trust-score.service") == "trust.score"
+            and manifest.get("app.service-request.trust-score.scopes") == "score.read"
+            and manifest.get("app.service-request.trust-score.contexts") == "message-author"
+        ),
+        "usesPlatformMediatedServiceGrant": (
+            "CryptaPlatform.services.get" in social_app_js
+            and "CryptaPlatform.services.grants.request" in social_app_js
+            and "CryptaPlatform.services.invoke" in social_app_js
+            and "trustScoreProviderAppId = \"trust-graph\"" in social_app_js
+            and "trustScoreServiceId = \"trust.score\"" in social_app_js
+            and "CryptaPlatform.trust.score" not in social_app_js
+            and not direct_local_endpoint_reference
+        ),
+        "noDirectLocalEndpointReference": not direct_local_endpoint_reference,
+        "docsFrameSpikeNonGoals": social_inbox_docs_frame_spike_non_goals(docs_text),
+    }
+    details = {
+        "appId": "social-inbox",
+        "manifest": display_path(manifest_path, workspace),
+        "expectedPermissions": sorted(SOCIAL_INBOX_PERMISSIONS),
+        "declaredPermissions": sorted(manifest_permissions),
+        "checks": checks,
+        "redaction": {
+            "ambientLocalhostTrustExcluded": not direct_local_endpoint_reference,
+            "rawMessageBodiesExcluded": True,
+            "rawFetchedContentExcluded": True,
+            "rawSignaturesExcluded": True,
+            "privateInsertUrisExcluded": True,
+            "tokensExcluded": True,
+            "localPathsExcluded": True,
+        },
+    }
+    errors.extend(name for name, passed in checks.items() if not passed)
+    if errors:
+        return EvidenceItem(
+            "legacy-plugin.social-inbox-spike",
+            root_consequence(settings, "fail"),
+            True,
+            "Legacy plugin Social Inbox migration spike evidence found problems.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "legacy-plugin.social-inbox-spike",
+        "pass",
+        True,
+        "Legacy plugin Social Inbox migration spike evidence passed.",
+        source,
+        details,
+    )
+
+
 def legacy_counts_from_registry_text(text: str) -> dict[str, int]:
     start = text.index("List.of(")
     end = text.index("private static final Map", start)
     block = text[start:end]
     return {
-        "PRIMARY_REPLACED": len(re.findall(r"\n\s+(?:replaced|wave\d+Redirect)\(", block)),
+        "PRIMARY_REPLACED": len(
+            re.findall(
+                r"\n\s+(?:diagnosticFallbackReplacement|securityLevelsWave3Redirect|replaced|wave\d+Redirect)\(",
+                block,
+            )
+        ),
         "PENDING": len(re.findall(r"\n\s+pendingWizard\(", block)) + len(re.findall(r"\n\s+pending\(", block)),
         "RETAINED": len(re.findall(r"\n\s+retained\(", block)),
         "INFRASTRUCTURE": len(re.findall(r"\n\s+infrastructure\(", block)),
@@ -7066,7 +7259,9 @@ def java_method_body(text: str, method_name: str) -> str:
 
 def legacy_fallback_link_checks(text: str) -> dict[str, bool]:
     fallback_body = java_method_body(text, "webShellFallbackSurfaces")
-    replaced_body = java_method_body(text, "replaced")
+    replaced_body = java_method_body(text, "diagnosticFallbackReplacement") or java_method_body(
+        text, "replaced"
+    )
     navigation_body = java_method_body(text, "shouldPromoteInLegacyNavigation")
     replaced_marks_no_fallback = "FALLBACK_POLICY_RENDER_LEGACY" in replaced_body and bool(
         re.search(r",\s*true\s*,\s*false\s*\)\s*;", replaced_body, re.DOTALL)
@@ -7141,6 +7336,13 @@ def legacy_removal_wave_one_ids(registry_text: str) -> list[str]:
 
 def legacy_removal_wave_two_ids(registry_text: str) -> list[str]:
     return re.findall(r"\n\s+wave2Redirect\(\s*\"([^\"]+)\"", registry_text)
+
+
+def legacy_removal_wave_three_ids(registry_text: str) -> list[str]:
+    ids = re.findall(r"\n\s+wave3Redirect\(\s*\"([^\"]+)\"", registry_text)
+    if re.search(r"\n\s+securityLevelsWave3Redirect\(\s*\)", registry_text):
+        ids.insert(0, "security-levels")
+    return ids
 
 
 def legacy_scope_expansion_wave_two_ids(registry_text: str) -> list[str]:
@@ -7370,6 +7572,140 @@ def collect_legacy_removal_wave_two_evidence(settings: Settings) -> EvidenceItem
         "pass",
         True,
         "Legacy-admin removal wave 2 replacement behavior is documented and observable.",
+        source,
+        details,
+    )
+
+
+def collect_legacy_removal_wave_three_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    root = settings.workspace_root
+    files = {
+        "registry": root / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java",
+        "policy": root / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRemovalPolicy.java",
+        "response": root / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminReplacementResponse.java",
+        "webshellToadlet": root
+        / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/WebShellToadlet.java",
+        "bootstrap": root
+        / "platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrap.java",
+        "bootstrapJson": root
+        / "platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap/WebShellBootstrapJson.java",
+        "webshell": root
+        / "platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js",
+        "docs": root / "docs/legacy-retirement-plan.md",
+    }
+    text: dict[str, str] = {}
+    missing = []
+    for key, path in files.items():
+        if not path.is_file():
+            missing.append(key)
+            text[key] = ""
+        else:
+            text[key] = path.read_text(encoding="utf-8")
+
+    wave_ids = legacy_removal_wave_three_ids(text["registry"])
+    docs_lower = text["docs"].lower()
+    checks = {
+        "waveThreeIdsMatch": wave_ids == list(LEGACY_REMOVAL_WAVE_THREE_IDS),
+        "waveOneIdsStable": legacy_removal_wave_one_ids(text["registry"]) == list(LEGACY_REMOVAL_WAVE_ONE_IDS),
+        "waveTwoIdsStable": legacy_removal_wave_two_ids(text["registry"]) == list(LEGACY_REMOVAL_WAVE_TWO_IDS),
+        "waveThreeConstantPresent": "REMOVAL_WAVE_3" in text["registry"],
+        "removedSinceMarkerPresent": "phase-8-pr-244" in text["registry"],
+        "securityReplacementUrl": (
+            "SHELL_SECURITY_URL" in text["registry"]
+            or "/app/node/#security" in text["registry"]
+        )
+        and "/app/node/#security" in text["docs"],
+        "securityMutatingFallbackDeclared": "security-levels" in text["registry"]
+        and (
+            "canonicalMutationFallback()" in text["registry"]
+            or "mutating-legacy-fallback" in text["registry"]
+        ),
+        "securityLegacyFallbackMarkerDeclared": "legacyFallback=security-levels" in text["policy"]
+        and "legacyFallback=security-levels" in text["webshell"]
+        and "Open the legacy security page" in text["webshell"],
+        "securityFallbackPathFromBootstrap": "bootstrap.legacySecurityLevelsPath" in text["webshell"]
+        and 'legacySecurityLevelsPath + "?legacyFallback=security-levels"' in text["webshell"]
+        and "legacySecurityLevelsPath" in text["bootstrap"]
+        and '"legacySecurityLevelsPath"' in text["bootstrapJson"],
+        "securityFallbackPathFromRegistry": 'LegacyAdminRetirementRegistry.require("security-levels").legacyPath()'
+        in text["webshellToadlet"]
+        and "WebShellBootstrap.nodeManagement(legacySecurityLevelsPath" in text["webshellToadlet"],
+        "securityFallbackPathNotHardCoded": '"/seclevels/?legacyFallback=security-levels"'
+        not in text["webshell"],
+        "securityCanonicalScopeOnly": "CANONICAL_AND_SLASHLESS_ALIAS" in text["registry"]
+        and "prefix-family matching" in docs_lower,
+        "policyRoutesSecurityThroughWebShell": '"security-levels"' in text["policy"]
+        and "webShellReplacementAvailable" in text["policy"],
+        "safeReadReplacementResponses": "GET" in text["policy"]
+        and "HEAD" in text["policy"]
+        and "redirect(" in text["policy"],
+        "mutatingFallbackDocumented": "master-password" in docs_lower
+        and "high physical security" in docs_lower
+        and "recovery" in docs_lower
+        and "legacy fallback remains" in docs_lower,
+        "safeReadFallbackDocumented": "bootstrap-resolved explicit fallback link" in docs_lower
+        and "arbitrary query strings still receive" in docs_lower,
+        "docsDescribeWave": "legacy-admin.removal-wave-3" in text["docs"],
+        "docsRetainBrowse": "FProxy browse" in text["docs"]
+        and "content rendering" in text["docs"],
+        "docsRetainContentFilter": "Content filter" in text["docs"]
+        or "content filter" in docs_lower,
+        "docsRetainDiagnosticExport": "raw diagnostic export" in docs_lower,
+        "docsRetainStartupWizard": "Startup wizard" in text["docs"]
+        and "emergency fallback" in docs_lower,
+        "docsLeaveNodeToNodePending": "Node-to-node messages" in text["docs"],
+        "liveNodeNotRequired": True,
+    }
+    retained_browse_safety = {
+        "fproxyBrowseRootOutOfScope": "/" not in wave_ids,
+        "contentFilterOutOfScope": "content-filter" not in wave_ids,
+        "wizardOutOfScope": "first-time-wizard" not in wave_ids,
+        "nodeToNodeMessageOutOfScope": "node-to-node-message" not in wave_ids,
+        "diagnosticPlainTextRetained": "diagnostic" not in wave_ids,
+    }
+    redaction = {
+        "queryStringsExcluded": True,
+        "formPasswordsExcluded": True,
+        "tokensExcluded": True,
+        "privateUrisExcluded": True,
+        "requestBodiesExcluded": True,
+        "rawFetchedBodiesExcluded": True,
+        "rawSignaturesExcluded": True,
+        "localPathsExcluded": True,
+    }
+    details = {
+        "removedByDefaultRouteIds": wave_ids,
+        "expectedRouteIds": list(LEGACY_REMOVAL_WAVE_THREE_IDS),
+        "replacementUrls": {"security-levels": "/app/node/#security"},
+        "fallbackUrlSource": "Web Shell bootstrap legacySecurityLevelsPath from the registry security-levels legacy path",
+        "statusBehavior": {
+            "safeRead": "303 See Other when Web Shell security is available; legacy fallback when unavailable",
+            "mutating": "legacy fallback remains for partial master-password, recovery, and high-physical-security flows",
+        },
+        "retainedBrowseSafety": retained_browse_safety,
+        "liveNodeRequired": False,
+        "checks": checks,
+        "redaction": redaction,
+        "missingSources": missing,
+    }
+    errors = [name for name, passed in checks.items() if not passed]
+    errors.extend(f"retainedBrowseSafety.{name}" for name, passed in retained_browse_safety.items() if not passed)
+    errors.extend(f"missing {name}" for name in missing)
+    if errors:
+        return EvidenceItem(
+            "legacy-admin.removal-wave-3",
+            "fail",
+            True,
+            "Legacy-admin removal wave 3 evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "legacy-admin.removal-wave-3",
+        "pass",
+        True,
+        "Legacy-admin removal wave 3 replacement behavior is documented and observable.",
         source,
         details,
     )
@@ -8304,6 +8640,8 @@ def run(settings: Settings) -> tuple[dict[str, Any], int]:
         collect_social_inbox_app_data_evidence(settings),
         collect_social_inbox_trust_annotation_evidence(settings),
         collect_social_mail_migration_preview_evidence(settings),
+        collect_legacy_plugin_migration_evidence(settings),
+        collect_legacy_plugin_social_inbox_spike_evidence(settings),
         collect_feed_reader_reference_app_evidence(settings),
         collect_feed_reader_subscription_evidence(settings),
         collect_feed_reader_app_data_evidence(settings),
@@ -8313,6 +8651,7 @@ def run(settings: Settings) -> tuple[dict[str, Any], int]:
         collect_legacy_evidence(settings),
         collect_legacy_removal_wave_one_evidence(settings),
         collect_legacy_removal_wave_two_evidence(settings),
+        collect_legacy_removal_wave_three_evidence(settings),
         collect_sandbox_provider_evidence(settings),
         collect_app_update_lifecycle_evidence(settings),
         collect_app_update_scheduler_evidence(settings),
@@ -8412,11 +8751,21 @@ def run_self_test(repo_root: Path) -> None:
     registry_text = registry_fixture.read_text(encoding="utf-8")
     counts = legacy_counts_from_registry_text(registry_text)
     assert counts == {
-        "PRIMARY_REPLACED": 12,
+        "PRIMARY_REPLACED": 13,
         "PENDING": 2,
         "RETAINED": 1,
         "INFRASTRUCTURE": 1,
     }, counts
+    assert legacy_removal_wave_three_ids(registry_text) == ["security-levels"]
+    extra_wave_three_text = registry_text.replace(
+        "securityLevelsWave3Redirect()",
+        'securityLevelsWave3Redirect(),\n'
+        '          wave3Redirect("diagnostic", "Diagnostic", "/diagnostic/", '
+        '"/app/node/#diagnostics", "Shell diagnostics", "Wrong.", false)',
+    )
+    assert legacy_removal_wave_three_ids(extra_wave_three_text) != list(
+        LEGACY_REMOVAL_WAVE_THREE_IDS
+    )
     fallback_checks = legacy_fallback_link_checks(registry_text)
     assert fallback_checks["primaryReplacedExcludedFromFallbackLinks"] is True, fallback_checks
     assert fallback_checks["primaryReplacedAbsentFromPrimaryNavigation"] is True, fallback_checks
@@ -8425,6 +8774,19 @@ def run_self_test(repo_root: Path) -> None:
     assert unsafe_fallback_checks["primaryReplacedExcludedFromFallbackLinks"] is False, unsafe_fallback_checks
     assert legacy_scope_expansion_wave_two_ids("") == []
     assert legacy_scope_expansion_wave_two_ids("final class LegacyAdminRetirementRegistry {}") == []
+    assert social_inbox_docs_frame_spike_non_goals(
+        "This is a migration spike, not a production social network, mail protocol, "
+        "full WoT implementation, Freetalk/Sone/Freemail compatibility layer, "
+        "encrypted mail transport, and daemon-core message store."
+    )
+    assert social_inbox_docs_frame_spike_non_goals(
+        "This is a migration spike, not a full Web of Trust, not Freetalk, not Sone, "
+        "not Freemail, not encrypted mail, and not a daemon message store."
+    )
+    assert not social_inbox_docs_frame_spike_non_goals(
+        "This is a migration spike with Freetalk, Sone, Freemail, encrypted mail, "
+        "and daemon-core message store non-goals but no WoT limitation."
+    )
     parser_options = {
         option
         for action in build_parser()._actions
@@ -8851,6 +9213,8 @@ def run_self_test(repo_root: Path) -> None:
         assert evidence_by_id["legacy-admin.removal-wave-1"]["requiredForReleaseCandidate"] is True
         assert evidence_by_id["legacy-admin.removal-wave-2"]["status"] == "pass"
         assert evidence_by_id["legacy-admin.removal-wave-2"]["requiredForReleaseCandidate"] is True
+        assert evidence_by_id["legacy-admin.removal-wave-3"]["status"] == "pass"
+        assert evidence_by_id["legacy-admin.removal-wave-3"]["requiredForReleaseCandidate"] is True
         contract_item = evidence_by_id["platform-api.contract"]
         assert contract_item["status"] == "pass", contract_item
         vault_item = evidence_by_id["app-vault.capabilities"]
@@ -8926,6 +9290,25 @@ def run_self_test(repo_root: Path) -> None:
         assert evidence_by_id["reference-app.social-inbox-app-data"]["status"] == "pass"
         assert evidence_by_id["reference-app.social-inbox-trust-annotations"]["status"] == "pass"
         assert evidence_by_id["migration.social-mail-preview"]["status"] == "pass"
+        assert evidence_by_id["legacy-plugin.migration-guide"]["status"] == "pass"
+        assert evidence_by_id["legacy-plugin.social-inbox-spike"]["status"] == "pass"
+        social_inbox_app_js = workspace / "apps/social-inbox/src/staged/static/app.js"
+        original_social_inbox_js = social_inbox_app_js.read_text(encoding="utf-8")
+        try:
+            social_inbox_app_js.write_text(
+                original_social_inbox_js
+                + "\nfetch('http://127.0.0.1:8888/api/v1/app-services');\n",
+                encoding="utf-8",
+            )
+            direct_local_endpoint_item = collect_legacy_plugin_social_inbox_spike_evidence(
+                dataclasses.replace(settings, mode="release-candidate")
+            )
+        finally:
+            social_inbox_app_js.write_text(original_social_inbox_js, encoding="utf-8")
+        assert direct_local_endpoint_item.status == "fail", direct_local_endpoint_item
+        assert "noDirectLocalEndpointReference" in direct_local_endpoint_item.details["errors"], (
+            direct_local_endpoint_item
+        )
         assert evidence_by_id["reference-app.feed-reader"]["status"] == "pass"
         assert evidence_by_id["reference-app.feed-reader-subscriptions"]["status"] == "pass"
         assert evidence_by_id["reference-app.feed-reader-app-data"]["status"] == "pass"
@@ -8937,6 +9320,41 @@ def run_self_test(repo_root: Path) -> None:
         assert evidence_by_id["app-platform.trust-graph-exchange"]["status"] == "pass"
         assert evidence_by_id["app-platform.trust-statement-signing"]["status"] == "pass"
         assert evidence_by_id["app-platform.social-message-signing"]["status"] == "pass"
+        migration_guide = workspace / "docs/legacy-plugin-migration-guide.md"
+        migration_guide_text = migration_guide.read_text(encoding="utf-8")
+        try:
+            migration_guide.unlink()
+            missing_guide_item = collect_legacy_plugin_migration_evidence(
+                dataclasses.replace(settings, mode="release-candidate")
+            )
+        finally:
+            migration_guide.write_text(migration_guide_text, encoding="utf-8")
+        assert missing_guide_item.status == "fail", missing_guide_item
+        assert "guideExists" in missing_guide_item.details["errors"], missing_guide_item
+        registry_source = (
+            workspace
+            / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java"
+        )
+        registry_source_text = registry_source.read_text(encoding="utf-8")
+        try:
+            registry_source.write_text(
+                registry_source_text.replace(
+                    "securityLevelsWave3Redirect(),",
+                    'securityLevelsWave3Redirect(),\n'
+                    '          wave3Redirect("diagnostic", "Diagnostic", "/diagnostic/", '
+                    '"/app/node/#diagnostics", "Shell diagnostics", "Wrong.", false),',
+                ),
+                encoding="utf-8",
+            )
+            extra_wave_three_item = collect_legacy_removal_wave_three_evidence(
+                dataclasses.replace(settings, mode="release-candidate")
+            )
+        finally:
+            registry_source.write_text(registry_source_text, encoding="utf-8")
+        assert extra_wave_three_item.status == "fail", extra_wave_three_item
+        assert "waveThreeIdsMatch" in extra_wave_three_item.details["errors"], (
+            extra_wave_three_item
+        )
         feed_reader_app_js = workspace / "apps/feed-reader/src/staged/static/app.js"
         original_feed_reader_js = feed_reader_app_js.read_text(encoding="utf-8")
         try:
@@ -9752,7 +10170,8 @@ def make_self_test_workspace(workspace: Path) -> None:
                 "It uses AppVault identities, profile-document metadata, bounded crypta.social.message.v1 "
                 "domain-separated signing, generated app-document outbox publication, content.subscribe "
                 "USK source metadata, durable app-data records, and Trust Graph Preview annotations. "
-                "It is not full WoT, not Freetalk, Sone, Freemail, encrypted mail, a daemon-core message store, "
+                "It is not a production social network, mail protocol, full WoT implementation, "
+                "Freetalk/Sone/Freemail compatibility layer, encrypted mail transport, daemon-core message store, "
                 "or a network protocol change, and it avoids private insert URIs, browser-session tokens, "
                 "raw fetched documents, and private identity material.\n",
                 encoding="utf-8",
@@ -10347,13 +10766,28 @@ def make_self_test_workspace(workspace: Path) -> None:
     shell = workspace / "platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js"
     shell.parent.mkdir(parents=True, exist_ok=True)
     shell.write_text(
+        'const legacySecurityLevelsPath = normalizeLocalRootPath(bootstrap.legacySecurityLevelsPath, "/seclevels/");\n'
+        'const legacySecurityLevelsFallbackPath = legacySecurityLevelsPath + "?legacyFallback=security-levels";\n'
         "function renderRecommendedCatalogs(){}\n"
         "function renderRecommendedCatalogCard(){}\n"
         "const path = 'app-catalogs/recommended';\n"
         "const action = 'addRecommended';\n"
         "function appServiceGrantPath(){}\n"
+        "function setSecurityLegacyFallbackStatus(){ return 'Open the legacy security page'; }\n"
         "const grants = 'App-service grants'; const approve = 'Approve'; const revoke = 'Revoke';\n"
         "apiUrl(\"app-services\"); apiUrl(\"app-services/grants\"); apiUrl(\"app-services/audit?limit=12\");\n",
+        encoding="utf-8",
+    )
+    web_shell_bootstrap_dir = (
+        workspace / "platform-web-shell/src/main/java/network/crypta/platform/webshell/bootstrap"
+    )
+    web_shell_bootstrap_dir.mkdir(parents=True, exist_ok=True)
+    (web_shell_bootstrap_dir / "WebShellBootstrap.java").write_text(
+        "record WebShellBootstrap(String legacySecurityLevelsPath) {}\n",
+        encoding="utf-8",
+    )
+    (web_shell_bootstrap_dir / "WebShellBootstrapJson.java").write_text(
+        'class WebShellBootstrapJson { String key = "legacySecurityLevelsPath"; }\n',
         encoding="utf-8",
     )
     web_shell_test = (
@@ -10419,6 +10853,7 @@ def make_self_test_workspace(workspace: Path) -> None:
         "reference-app.social-inbox, reference-app.social-inbox-signed-message, "
         "reference-app.social-inbox-subscriptions, reference-app.social-inbox-app-data, "
         "reference-app.social-inbox-trust-annotations, migration.social-mail-preview, "
+        "legacy-plugin.migration-guide, legacy-plugin.social-inbox-spike, "
         "reference-app.feed-reader, reference-app.feed-reader-subscriptions, "
         "app-platform.content-fetch, app-platform.content-subscriptions, "
         "network-content.subscription-scheduler, "
@@ -10429,6 +10864,7 @@ def make_self_test_workspace(workspace: Path) -> None:
         "app-platform.trust-graph-exchange, "
         "app-platform.trust-statement-signing, app-platform.social-message-signing, "
         "app-platform.identity-profile-publish, and app-platform.generated-document-insert. "
+        "Developers can find legacy-plugin-migration-guide.md from the app-platform portal. "
         "It excludes raw request bodies, private keys, private key material, raw signatures, private insert URIs, raw source URIs, and "
         "absolute staging paths. It also excludes raw feed bodies, raw message bodies, raw fetched content, raw fetched documents, raw trust statement bodies, browser-session tokens, "
         "form passwords, and local paths.\n"
@@ -10451,6 +10887,23 @@ def make_self_test_workspace(workspace: Path) -> None:
         "release-certification.md",
     ):
         (docs / doc_name).write_text(first_party_docs, encoding="utf-8")
+    (docs / "legacy-plugin-migration-guide.md").write_text(
+        "The old plugin runtime removed status is intentional. There is no old plugin ABI "
+        "compatibility and no old FCP plugin command compatibility. WebOfTrust-like and WoT-like "
+        "migration maps to Trust Graph Preview, durable trust graph storage, content subscriptions, "
+        "app vault identity grants, app data, and app-service grants for trust.score. "
+        "Freetalk/Sone-like migration maps to Social Inbox Preview, Profile Publisher, Feed Reader, "
+        "content subscriptions, app data, and Trust Graph annotations. Freemail-like migration uses "
+        "Social Inbox as a bounded spike and is not encrypted mail transport or Freemail protocol "
+        "compatibility. Distribution uses signed catalog entries, signed bundles, review receipt "
+        "evidence, and review governance. The guide links to social-inbox-reference-app.md.\n",
+        encoding="utf-8",
+    )
+    (docs / "plugin-system.md").write_text(
+        "The plugin runtime has been removed. Legacy plugin migrations should use "
+        "legacy-plugin-migration-guide.md and must not restore old plugin ABI compatibility.\n",
+        encoding="utf-8",
+    )
     registry = workspace / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/LegacyAdminRetirementRegistry.java"
     registry.parent.mkdir(parents=True, exist_ok=True)
     registry.write_text((Path(__file__).parent / "fixtures" / "self-test-legacy-registry.java-fragment").read_text(encoding="utf-8"), encoding="utf-8")
@@ -10461,8 +10914,18 @@ def make_self_test_workspace(workspace: Path) -> None:
         "when the replacement is reachable and render legacy fallback when the replacement is unavailable. "
         "legacy-admin.removal-wave-2 documents that safe reads redirect when the replacement is reachable, "
         "mutating legacy alert bulk actions and core-update installer and package-store actions remain fallback, "
-        "and raw diagnostic export remains retained. "
-        "FProxy browse remains retained, and retained and pending legacy routes remain reachable.\n",
+        "and raw diagnostic export remains retained. legacy-admin.removal-wave-3 documents that "
+        "/seclevels/ safe reads redirect to /app/node/#security when Web Shell security is "
+        "available. Security-level mutating requests keep legacy fallback; legacy fallback remains "
+        "for master-password, "
+        "database/password-file, high physical security, and recovery flows. Wave 3 does not use "
+        "prefix-family matching for security routes. A bootstrap-resolved explicit fallback link remains for "
+        "legacy security forms, and arbitrary query strings still receive replacement redirects. "
+        "Startup wizard and emergency fallback remain "
+        "pending. Node-to-node messages remain pending. "
+        "FProxy browse remains retained, FProxy browse and content rendering remain retained, "
+        "content filter remains retained, "
+        "and retained and pending legacy routes remain reachable.\n",
         encoding="utf-8",
     )
     legacy_admin_dir = workspace / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http"
@@ -10471,6 +10934,8 @@ def make_self_test_workspace(workspace: Path) -> None:
         'boolean matchesRemovalScope; boolean explicitRemovalChildPaths; '
         'boolean blockMutatingRequests; boolean replacementAvailable; '
         'boolean isStaticAppUiAvailable; boolean primaryUiRoot; '
+        'String legacyFallback = "legacyFallback=security-levels"; '
+        'String security = "security-levels"; boolean webShellReplacementAvailable; '
         'String s = "LegacyAdminRemovalScope EXPLICIT_CHILDREN PREFIX_FAMILY"; '
         'String m = "GET HEAD"; Object d = LegacyAdminRemovalDecision.redirect(null); '
         'Object b = LegacyAdminRemovalDecision.blockedMutation(null); }\n',
@@ -10478,6 +10943,12 @@ def make_self_test_workspace(workspace: Path) -> None:
     )
     (legacy_admin_dir / "LegacyAdminReplacementResponse.java").write_text(
         'class LegacyAdminReplacementResponse { String link = "replacementUrl"; }\n',
+        encoding="utf-8",
+    )
+    (legacy_admin_dir / "WebShellToadlet.java").write_text(
+        'class WebShellToadlet { Object create(Object links) { String legacySecurityLevelsPath = '
+        'LegacyAdminRetirementRegistry.require("security-levels").legacyPath(); '
+        'return WebShellBootstrap.nodeManagement(legacySecurityLevelsPath, links); } }\n',
         encoding="utf-8",
     )
     (legacy_admin_dir / "LegacyAdminUsageRecorder.java").write_text(
@@ -11049,9 +11520,12 @@ class CoreHttpShellRuntimeSupport {
         """
 function renderRecommendedCatalogs(){}
 function renderRecommendedCatalogCard(){}
+const legacySecurityLevelsPath = normalizeLocalRootPath(bootstrap.legacySecurityLevelsPath, "/seclevels/");
+const legacySecurityLevelsFallbackPath = legacySecurityLevelsPath + "?legacyFallback=security-levels";
 const recommendedCatalogPath = "app-catalogs/recommended";
 const recommendedCatalogAction = "addRecommended";
 function appServiceGrantPath(){}
+function setSecurityLegacyFallbackStatus(){ return "Open the legacy security page"; }
 const appServiceTitle = "App-service grants";
 const approve = "Approve";
 const revoke = "Revoke";

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -7632,6 +7632,9 @@ def collect_legacy_removal_wave_three_evidence(settings: Settings) -> EvidenceIt
         and 'legacySecurityLevelsPath + "?legacyFallback=security-levels"' in text["webshell"]
         and "legacySecurityLevelsPath" in text["bootstrap"]
         and '"legacySecurityLevelsPath"' in text["bootstrapJson"],
+        "securityFallbackAllowsSlashlessPath": "normalizeLocalPath(" in text["webshell"]
+        and "bootstrap.legacySecurityLevelsPath" in text["webshell"]
+        and "requireLegacySecurityLevelsPath(legacySecurityLevelsPath" in text["bootstrap"],
         "securityFallbackPathFromRegistry": 'LegacyAdminRetirementRegistry.require("security-levels").legacyPath()'
         in text["webshellToadlet"]
         and "WebShellBootstrap.nodeManagement(legacySecurityLevelsPath" in text["webshellToadlet"],
@@ -10770,7 +10773,7 @@ def make_self_test_workspace(workspace: Path) -> None:
     shell = workspace / "platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js"
     shell.parent.mkdir(parents=True, exist_ok=True)
     shell.write_text(
-        'const legacySecurityLevelsPath = normalizeLocalRootPath(bootstrap.legacySecurityLevelsPath, "/seclevels/");\n'
+        'const legacySecurityLevelsPath = normalizeLocalPath(bootstrap.legacySecurityLevelsPath, "/seclevels/");\n'
         'const legacySecurityLevelsFallbackPath = legacySecurityLevelsPath + "?legacyFallback=security-levels";\n'
         "function renderRecommendedCatalogs(){}\n"
         "function renderRecommendedCatalogCard(){}\n"
@@ -10789,7 +10792,8 @@ def make_self_test_workspace(workspace: Path) -> None:
     )
     web_shell_bootstrap_dir.mkdir(parents=True, exist_ok=True)
     (web_shell_bootstrap_dir / "WebShellBootstrap.java").write_text(
-        "record WebShellBootstrap(String legacySecurityLevelsPath) {}\n",
+        "record WebShellBootstrap(String legacySecurityLevelsPath) { "
+        "void compact(){ requireLegacySecurityLevelsPath(legacySecurityLevelsPath); } }\n",
         encoding="utf-8",
     )
     (web_shell_bootstrap_dir / "WebShellBootstrapJson.java").write_text(
@@ -11526,7 +11530,7 @@ class CoreHttpShellRuntimeSupport {
         """
 function renderRecommendedCatalogs(){}
 function renderRecommendedCatalogCard(){}
-const legacySecurityLevelsPath = normalizeLocalRootPath(bootstrap.legacySecurityLevelsPath, "/seclevels/");
+const legacySecurityLevelsPath = normalizeLocalPath(bootstrap.legacySecurityLevelsPath, "/seclevels/");
 const legacySecurityLevelsFallbackPath = legacySecurityLevelsPath + "?legacyFallback=security-levels";
 const recommendedCatalogPath = "app-catalogs/recommended";
 const recommendedCatalogAction = "addRecommended";

--- a/tools/release-certification/fixtures/self-test-app-platform-smoke.json
+++ b/tools/release-certification/fixtures/self-test-app-platform-smoke.json
@@ -1272,6 +1272,52 @@
     },
     {
       "details": {
+        "checks": {
+          "appData": true,
+          "appServiceGrants": true,
+          "appVault": true,
+          "contentSubscriptions": true,
+          "developerOrBetaDocsLinkGuide": true,
+          "freemailMigration": true,
+          "freetalkSoneMigration": true,
+          "guideExists": true,
+          "noFcpPluginCommandCompatibility": true,
+          "noOldPluginAbiCompatibility": true,
+          "oldRuntimeRemoved": true,
+          "pluginSystemLinksGuide": true,
+          "reviewGovernance": true,
+          "signedCatalog": true,
+          "socialInboxPreview": true,
+          "trustGraphPreview": true,
+          "webOfTrustMigration": true
+        }
+      },
+      "id": "legacy-plugin.migration-guide",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Legacy plugin migration guide evidence passed."
+    },
+    {
+      "details": {
+        "appId": "social-inbox",
+        "checks": {
+          "appExists": true,
+          "docsFrameSpikeNonGoals": true,
+          "manifestDeclaresExpectedCapabilities": true,
+          "manifestPresent": true,
+          "manifestRequestsTrustScoreService": true,
+          "usesPlatformMediatedServiceGrant": true
+        }
+      },
+      "id": "legacy-plugin.social-inbox-spike",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Legacy plugin Social Inbox migration spike evidence passed."
+    },
+    {
+      "details": {
         "appId": "trust-graph",
         "checks": {
           "docsDescribePreviewLimits": true,
@@ -1425,6 +1471,22 @@
       "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
       "status": "pass",
       "summary": "Legacy-admin removal wave 2 replacement behavior is documented and observable."
+    },
+    {
+      "details": {
+        "removedByDefaultRouteIds": [
+          "security-levels"
+        ],
+        "statusBehavior": {
+          "mutating": "legacy fallback remains for partial master-password, recovery, and high-physical-security flows",
+          "safeRead": "303 See Other when Web Shell security is available; legacy fallback when unavailable"
+        }
+      },
+      "id": "legacy-admin.removal-wave-3",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Legacy-admin removal wave 3 replacement behavior is documented and observable."
     },
     {
       "details": {

--- a/tools/release-certification/fixtures/self-test-legacy-registry.java-fragment
+++ b/tools/release-certification/fixtures/self-test-legacy-registry.java-fragment
@@ -12,6 +12,7 @@ final class LegacyAdminRetirementRegistry {
           wave1Redirect("strangers", "Strangers", "/strangers/", "/app/node/#peers", "Peers", "Done."),
           wave1Redirect("connectivity", "Connectivity", "/connectivity/", "/app/node/#connectivity", "Connectivity", "Done."),
           wave2Redirect("config", "Configuration", "/config/", "/app/node/#config", "Shell config", "Done.", LegacyAdminRemovalScope.PREFIX_FAMILY, List.of(), REMOVAL_WAVE_2, true),
+          securityLevelsWave3Redirect(),
           wave2Redirect("core-update", "Core update", "/core-update/", "/app/node/#updates", "Shell updates", "Done.", false),
           wave2Redirect("statistics", "Statistics", "/stats/", "/app/node/#diagnostics", "Shell diagnostics", "Done.", LegacyAdminRemovalScope.EXPLICIT_CHILDREN, List.of("/stats/requesters.html"), REMOVAL_WAVE_2, false),
           pendingWizard("first-time-wizard", "First-time wizard", "/wizard/", "Pending."),
@@ -20,6 +21,7 @@ final class LegacyAdminRetirementRegistry {
 
   private static final Map<String, LegacyAdminSurface> SURFACES_BY_ID = surfacesById();
   private static final int REMOVAL_WAVE_2 = 2;
+  private static final int REMOVAL_WAVE_3 = 3;
 
   public static List<LegacyAdminSurface> webShellFallbackSurfaces() {
     return SURFACES.stream().filter(LegacyAdminSurface::includeInWebShellFallbackLinks).toList();
@@ -31,25 +33,40 @@ final class LegacyAdminRetirementRegistry {
         .orElse(true);
   }
 
-  private static LegacyAdminSurface replaced(
-      String id,
-      String title,
-      String legacyPath,
-      String replacementUrl,
-      String replacementLabel,
-      String notes) {
+  private static LegacyAdminSurface diagnosticFallbackReplacement() {
     return new LegacyAdminSurface(
-        id,
-        title,
-        legacyPath,
+        "diagnostic",
+        "Diagnostic report",
+        "/diagnostic/",
         LegacyAdminRetirementState.PRIMARY_REPLACED,
-        replacementUrl,
-        replacementLabel,
-        notes,
+        "/app/node/#diagnostics",
+        "Shell diagnostics",
+        "Done.",
         LegacyAdminRemovalMode.RENDER_LEGACY,
         0,
         null,
         FALLBACK_POLICY_RENDER_LEGACY,
+        true,
+        false);
+  }
+
+  private static LegacyAdminSurface securityLevelsWave3Redirect() {
+    return new LegacyAdminSurface(
+        "security-levels",
+        "Security levels",
+        "/seclevels/",
+        LegacyAdminRetirementState.PRIMARY_REPLACED,
+        "/app/node/#security",
+        "Shell security",
+        "Done.",
+        LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT,
+        3,
+        "phase-8-pr-244",
+        "mutating-legacy-fallback",
+        LegacyAdminRemovalScope.CANONICAL_AND_SLASHLESS_ALIAS,
+        0,
+        List.of(),
+        false,
         true,
         false);
   }
@@ -124,6 +141,34 @@ final class LegacyAdminRetirementRegistry {
         removalScope,
         scopeExpandedInWave,
         explicitRemovalChildPaths,
+        blockMutatingRequests,
+        true,
+        false);
+  }
+
+  private static LegacyAdminSurface wave3Redirect(
+      String id,
+      String title,
+      String legacyPath,
+      String replacementUrl,
+      String replacementLabel,
+      String notes,
+      boolean blockMutatingRequests) {
+    return new LegacyAdminSurface(
+        id,
+        title,
+        legacyPath,
+        LegacyAdminRetirementState.PRIMARY_REPLACED,
+        replacementUrl,
+        replacementLabel,
+        notes,
+        LegacyAdminRemovalMode.REDIRECT_TO_REPLACEMENT,
+        3,
+        "phase-8-pr-244",
+        blockMutatingRequests ? "none" : "mutating-legacy-fallback",
+        LegacyAdminRemovalScope.CANONICAL_AND_SLASHLESS_ALIAS,
+        0,
+        List.of(),
         blockMutatingRequests,
         true,
         false);

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -996,9 +996,12 @@ def app_platform_evidence(
         "reference-app.social-inbox-app-data",
         "reference-app.social-inbox-trust-annotations",
         "migration.social-mail-preview",
+        "legacy-plugin.migration-guide",
+        "legacy-plugin.social-inbox-spike",
         "legacy.retirement",
         "legacy-admin.removal-wave-1",
         "legacy-admin.removal-wave-2",
+        "legacy-admin.removal-wave-3",
         "apphost.sandbox-provider",
         "app-update.lifecycle",
         "app-update.scheduler",
@@ -1756,6 +1759,23 @@ def ecosystem_matrix_row_specs() -> list[MatrixRowSpec]:
             first_party_apps=("social-inbox",),
         ),
         MatrixRowSpec(
+            id="legacy-plugin-migration",
+            category="legacy-retirement",
+            title="Legacy plugin-to-app migration guidance",
+            required_evidence_ids=(
+                "legacy-plugin.migration-guide",
+                "legacy-plugin.social-inbox-spike",
+            ),
+            gate_ids=("ecosystem.reference-content-apps",),
+            docs=(
+                "docs/legacy-plugin-migration-guide.md",
+                "docs/plugin-system.md",
+                "docs/social-inbox-reference-app.md",
+            ),
+            first_party_apps=("social-inbox", "trust-graph"),
+            phase="phase-8",
+        ),
+        MatrixRowSpec(
             id="legacy-retirement",
             category="legacy-retirement",
             title="Legacy admin retirement and removal waves",
@@ -1763,9 +1783,11 @@ def ecosystem_matrix_row_specs() -> list[MatrixRowSpec]:
                 "legacy.retirement",
                 "legacy-admin.removal-wave-1",
                 "legacy-admin.removal-wave-2",
+                "legacy-admin.removal-wave-3",
             ),
             gate_ids=("ecosystem.legacy-retirement",),
             docs=("docs/legacy-retirement-plan.md", "docs/release-certification.md"),
+            phase="phase-8",
         ),
         MatrixRowSpec(
             id="redaction-and-private-artifacts",
@@ -4157,6 +4179,7 @@ def evaluate_legacy_retirement_gate(
         "legacy.retirement",
         "legacy-admin.removal-wave-1",
         "legacy-admin.removal-wave-2",
+        "legacy-admin.removal-wave-3",
     ):
         status = evidence_status(current.get(evidence_id))
         previous_status = evidence_status(previous.get(evidence_id))
@@ -4170,7 +4193,11 @@ def evaluate_legacy_retirement_gate(
         if previous_status == "pass" and status in {"fail", "missing", "skip"}:
             failures.append(f"{evidence_id} regressed from pass to {status}")
             add_evidence_issue(details, "failureEvidenceIds", evidence_id)
-    for evidence_id in ("legacy-admin.removal-wave-1", "legacy-admin.removal-wave-2"):
+    for evidence_id in (
+        "legacy-admin.removal-wave-1",
+        "legacy-admin.removal-wave-2",
+        "legacy-admin.removal-wave-3",
+    ):
         current_wave = evidence_details(current.get(evidence_id))
         previous_wave = evidence_details(previous.get(evidence_id))
         current_routes = set(sorted_strings(current_wave.get("removedByDefaultRouteIds")))
@@ -4522,6 +4549,8 @@ def render_report(summary: dict[str, Any]) -> str:
         "reference-app.social-inbox-app-data",
         "reference-app.social-inbox-trust-annotations",
         "migration.social-mail-preview",
+        "legacy-plugin.migration-guide",
+        "legacy-plugin.social-inbox-spike",
         "apphost.sandbox-provider",
         "app-update.lifecycle",
         "app-update.scheduler",
@@ -4534,6 +4563,7 @@ def render_report(summary: dict[str, Any]) -> str:
     append_detail(lines, summary, "legacy.retirement")
     append_detail(lines, summary, "legacy-admin.removal-wave-1")
     append_detail(lines, summary, "legacy-admin.removal-wave-2")
+    append_detail(lines, summary, "legacy-admin.removal-wave-3")
     lines.extend(
         [
             "",
@@ -5198,6 +5228,7 @@ def run_self_test(repo_root: Path) -> None:
             "content-fetch-and-networked-content",
             "trust-graph-preview-platform",
             "social-inbox-preview",
+            "legacy-plugin-migration",
             "apphost-sandbox-provider",
             "platform-api-contract",
             "interop-smoke",
@@ -5231,7 +5262,10 @@ def run_self_test(repo_root: Path) -> None:
             "reference-app.trust-graph-durable-exchange",
             "reference-app.social-inbox",
             "migration.social-mail-preview",
+            "legacy-plugin.migration-guide",
+            "legacy-plugin.social-inbox-spike",
             "legacy-admin.removal-wave-2",
+            "legacy-admin.removal-wave-3",
             "app-platform.docs-portal",
             "app-platform.beta-program",
             "app-platform.beta-tutorials",
@@ -5346,6 +5380,8 @@ def run_self_test(repo_root: Path) -> None:
             "reference-app.social-inbox-trust-annotations",
             "reference-app.social-inbox-service-grant",
             "migration.social-mail-preview",
+            "legacy-plugin.migration-guide",
+            "legacy-plugin.social-inbox-spike",
         ):
             assert evidence_by_id[evidence_id]["status"] == "pass", evidence_by_id
             assert evidence_by_id[evidence_id]["requiredForReleaseCandidate"] is True
@@ -5362,6 +5398,8 @@ def run_self_test(repo_root: Path) -> None:
         assert evidence_by_id["legacy-admin.removal-wave-1"]["requiredForReleaseCandidate"] is True
         assert evidence_by_id["legacy-admin.removal-wave-2"]["status"] == "pass", evidence_by_id
         assert evidence_by_id["legacy-admin.removal-wave-2"]["requiredForReleaseCandidate"] is True
+        assert evidence_by_id["legacy-admin.removal-wave-3"]["status"] == "pass", evidence_by_id
+        assert evidence_by_id["legacy-admin.removal-wave-3"]["requiredForReleaseCandidate"] is True
         optional_skip_status, optional_skip_release_passed = determine_overall_status(
             "release-candidate",
             [
@@ -6625,6 +6663,30 @@ def run_self_test(repo_root: Path) -> None:
         assert legacy_wave_two_removed_exit_code == 1, legacy_wave_two_removed_summary
         assert (
             gate_by_id(legacy_wave_two_removed_summary, "ecosystem.legacy-retirement")["status"]
+            == "fail"
+        )
+
+        legacy_wave_three_removed_path = write_app_summary_variant(
+            "legacy-wave-three-removed",
+            lambda value: value.update(
+                {
+                    "evidence": [
+                        entry
+                        for entry in value["evidence"]
+                        if entry.get("id") != "legacy-admin.removal-wave-3"
+                    ]
+                }
+            ),
+        )
+        legacy_wave_three_removed_summary, legacy_wave_three_removed_exit_code = (
+            run_with_previous(
+                "legacy-wave-three-removed-cert",
+                app_platform_summary=legacy_wave_three_removed_path,
+            )
+        )
+        assert legacy_wave_three_removed_exit_code == 1, legacy_wave_three_removed_summary
+        assert (
+            gate_by_id(legacy_wave_three_removed_summary, "ecosystem.legacy-retirement")["status"]
             == "fail"
         )
 


### PR DESCRIPTION
## Summary

- Add `docs/legacy-plugin-migration-guide.md` and cross-link plugin migration guidance from the app-platform, beta, plugin-system, release-certification, Social Inbox, and legacy retirement docs.
- Move legacy admin removal Wave 3 to `security-levels` only, with safe-read redirects to Web Shell security and mutating/legacy-only password and recovery fallback retained.
- Pass the configured legacy security route through Web Shell bootstrap JSON and expose a persistent Security panel fallback link for retained legacy password/recovery forms.
- Add release-certification evidence for `legacy-plugin.migration-guide`, `legacy-plugin.social-inbox-spike`, and `legacy-admin.removal-wave-3`, including self-test fixtures and matrix coverage.
- Extend Java and Web Shell tests for Wave 3 policy, retained surfaces, bootstrap path wiring, fallback link discoverability, and notice behavior.

## How to test

- `./gradlew spotlessApply`
- `./gradlew :adapter-http-legacy-admin:test`
- `./gradlew :platform-web-shell:test :adapter-http-legacy-admin:test`
- `./gradlew :platform-web-shell:test --tests '*WebShellBootstrapTest'`
- `./gradlew :platform-web-shell:test --tests '*WebShellResourcesTest'`
- `python3 -m py_compile tools/release-certification/app_platform_smoke.py`
- `python3 tools/release-certification/app_platform_smoke.py --self-test`
- `python3 tools/release-certification/release_certification.py --self-test`
- `git diff --check origin/develop...HEAD`

## Notes

- FProxy browse/content rendering, content filter, raw diagnostic export, startup/emergency wizard routes, node-to-node messages, chat/help/translation, and local directory/file helper infrastructure remain retained or pending.
- The explicit security fallback link uses the configured registry path plus the fixed `legacyFallback=security-levels` marker; arbitrary query strings still redirect and are not reflected in evidence.
- A full `./gradlew test` was attempted earlier in this workspace and failed in `:adapter-fcp:test` with an environment `Cannot allocate memory` error, not a PR-244 assertion failure.