### PR TITLE
feat(codex): Add Playwright Docker stack

### DIFF
--- a/.agents/skills/cryptad-build-tooling/SKILL.md
+++ b/.agents/skills/cryptad-build-tooling/SKILL.md
@@ -16,6 +16,9 @@ Use this skill when you:
 - Run or adjust SonarLint / SonarCloud / JaCoCo coverage tasks.
 - Need to analyze a single file with SonarLint.
 
+For the tracked Codex Docker stack, Playwright remote browser service, or helper scripts under
+`tools/codex-docker`, use `$cryptad-codex-docker` instead.
+
 ## Gradle wrapper and build-logic toolchains
 - The wrapper is pinned in `gradle/wrapper/gradle-wrapper.properties` and currently uses Gradle
   `9.4.1`.

--- a/.agents/skills/cryptad-codex-docker/SKILL.md
+++ b/.agents/skills/cryptad-codex-docker/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: cryptad-codex-docker
+description: Maintain Cryptad's tracked Codex Docker stack, Playwright remote browser server, helper scripts, and related docs under tools/codex-docker.
+---
+
+# Cryptad Codex Docker
+
+Use this skill before changing `tools/codex-docker`, the Codex Docker helper scripts, the
+Playwright remote browser service, or docs that describe this stack.
+
+## Source of truth
+
+- Runbook: `tools/codex-docker/README.md`
+- Compose file: `tools/codex-docker/compose.yaml`
+- Codex image: `tools/codex-docker/Dockerfile`
+- Tailscale shell helpers: `tools/codex-docker/tailscale-shell/`
+
+## Guardrails
+
+- Never commit `.env`, Tailscale auth keys, SSH keys, GitHub tokens, OpenAI keys, or host-specific
+  private paths.
+- Keep the Playwright Docker image version and the Playwright npm package version exactly aligned.
+- Keep browser binaries in the Playwright container. The Codex image owns only the CLI/test runner
+  npm packages and the `playwright-remote` wrapper.
+- Keep the internal Playwright endpoint stable at `ws://playwright:3000/` unless the runbook and
+  Compose environment are updated together.
+- Keep host exposure bound to loopback unless the user explicitly asks for a wider bind address and
+  accepts the local security impact.
+
+## Workflow
+
+1. Read `tools/codex-docker/README.md` before editing Compose, Dockerfile, or helper scripts.
+2. Inspect the current Compose shape with `docker compose --env-file ../../.env config` from
+   `tools/codex-docker`.
+3. Make the smallest change to the Docker stack and update the runbook in the same change.
+4. Validate that root `.env` and any local generated outputs remain ignored.
+5. Run a Playwright remote-connection smoke test when the Playwright service, image version,
+   endpoint, or wrapper changes.
+
+## Validation
+
+From `tools/codex-docker`:
+
+```bash
+docker compose --env-file ../../.env config
+docker compose --env-file ../../.env up -d codex playwright
+docker compose --env-file ../../.env exec codex playwright --version
+docker compose --env-file ../../.env exec playwright node --version
+```
+
+For a browser smoke test, connect from the Codex container to `ws://playwright:3000/` with the
+matching Playwright package and open a simple `data:text/html` page.

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ debian/seednodes.fref
 output.*
 /split-file-inserter-storage-test
 .DS_Store
+/.env
 qodana*
 /.claude
 /.gemini

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **$cryptad-architecture** — Navigate Cryptad’s module/package architecture, key subsystems, design patterns, security model, and versioning scheme.
 - **$cryptad-build-test** — Build, test, and run Cryptad safely using the Gradle wrapper (Java 25+, JUnit 6).
 - **$cryptad-build-tooling** — Maintain formatting and code-quality tooling: Spotless, SpotBugs, Gradle dependency verification (verification-metadata), SonarLint, Error Prone, JaCoCo coverage, and SonarCloud uploads.
+- **$cryptad-codex-docker** — Maintain the tracked Codex Docker stack, Playwright remote browser server, helper scripts, and `tools/codex-docker` docs.
 - **$cryptad-core-updater** — Understand and modify the package-based CoreUpdater update system: /core-update/ endpoints, descriptor format, UI wiring, and platform behaviors.
 - **$cryptad-crypto-aead** — Work safely on AEAD streams and persistent formats (AES-GCM migration + legacy OCB compatibility notes).
 - **$cryptad-git-workflow** — Canonical guide for branch/release policy: GitFlow naming, integer build version/tags, merge rules, PR policy, and strict git identity safeguards.
@@ -49,6 +50,7 @@ Load only what you need. It’s normal to load multiple skills for one task.
 - **OpenCode LSP:** Treat LSP/typechecker diagnostics as blockers for touched files.
   - If the OpenCode `lsp` tool is enabled, prefer it for definition/reference/hover instead of guessing
 - **Repository discovery:** If the task does not provide exact paths/symbols, identify the relevant files with deterministic local search before making code changes.
+- **Codex Docker / Playwright:** For `tools/codex-docker`, Codex container helpers, Playwright remote browser server wiring, or related docs, load `$cryptad-codex-docker`.
 - **Compatibility:** Avoid breaking persistent formats, on-disk layouts, and wire protocols without an explicit migration plan.
   - For AEAD stream / format changes, load `$cryptad-crypto-aead` first.
 - **Environment detection:** Treat `AppEnv` as the single source of truth. Load `$cryptad-appenv` before touching OS/arch/sandbox/service detection code.

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,6 +3,7 @@
 This directory contains official, optional utilities and packaging assets that support development, ops, and distribution. These are not part of the core daemon runtime.
 
 - generator: Client-side utility code and assets (GWT/JS) historically used to generate/update web UI helpers. See the [generator README](generator/README.md) for details and usage.
+- codex-docker: Tracked Codex Docker and Playwright remote-browser debugging stack. See the [codex-docker README](codex-docker/README.md).
 - stats: Network size and churn probe utilities (scripts + small Java tool) to sample a local node, summarize data, and plot/upload graphs. See the [stats README](stats/README.md).
 - packaging/debian: Debian/Ubuntu packaging metadata and rules for building `.deb` packages (control, rules, maintainer scripts, defaults). Build Debian packages using debhelper from within `tools/packaging/debian` so paths like `debian/*` resolve correctly.
 

--- a/tools/codex-docker/.env.example
+++ b/tools/codex-docker/.env.example
@@ -1,0 +1,34 @@
+# Copy this file to ../../.env only when that file does not already exist.
+# Edit local values there. Do not commit ../../.env.
+
+PLAYWRIGHT_VERSION=1.60.0
+PLAYWRIGHT_HOST_PORT=3000
+
+CODEX_IMAGE_TAG=0.138.0
+GITHUB_MCP_VERSION=v1.2.0
+GITHUB_MCP_ARCH=arm64
+ACTIONLINT_VERSION=1.7.12
+ACTIONLINT_ARCH=arm64
+
+CRYPTAD_DOCKER_SUBNET=172.30.70.0/24
+CRYPTAD_TAILSCALE_IPV4=172.30.70.2
+CRYPTAD_CODEX_IPV4=172.30.70.10
+CRYPTAD_PLAYWRIGHT_IPV4=172.30.70.20
+
+# Relative to this directory by default.
+CRYPTAD_REPO_ROOT=../..
+
+# Host mounts used by the Codex container.
+CRYPTAD_CODEX_HOME_MOUNT=${HOME}/.codex_docker
+CRYPTAD_SSH_DIR=${HOME}/.ssh
+CRYPTAD_GH_CONFIG_DIR=${HOME}/.config/gh
+
+# Optional SSH public keys for the container's root account.
+# Example: CODEX_SSH_AUTHORIZED_KEYS=ssh-ed25519 AAAA... user@example
+CODEX_SSH_AUTHORIZED_KEYS=
+
+# Optional Tailscale settings for tailscale-shell.
+TAILSCALE_VERSION=latest
+CRYPTAD_TAILSCALE_AUTHKEY=
+CRYPTAD_TAILSCALE_HOSTNAME=cryptad-codex-docker
+CRYPTAD_TAILSCALE_EXTRA_ARGS=--ssh

--- a/tools/codex-docker/.gitignore
+++ b/tools/codex-docker/.gitignore
@@ -1,0 +1,4 @@
+.env
+.tmp/
+playwright-report/
+test-results/

--- a/tools/codex-docker/Dockerfile
+++ b/tools/codex-docker/Dockerfile
@@ -1,0 +1,142 @@
+FROM docker.io/benyamin/codex-sandbox:latest
+
+ARG GITHUB_MCP_VERSION
+ARG GITHUB_MCP_ARCH=arm64
+ARG ACTIONLINT_VERSION
+ARG ACTIONLINT_ARCH=arm64
+ARG PLAYWRIGHT_VERSION=1.60.0
+ARG NCURSES_VERSION=6.6
+ARG NCURSES_SHA256=355b4cbbed880b0381a04c46617b7656e362585d52e9cf84a67e2009b749ff11
+ARG CODEX_SSH_AUTHORIZED_KEYS=""
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    VISUAL=nvim \
+    PLAYWRIGHT_REMOTE_WS_ENDPOINT=ws://playwright:3000/ \
+    PW_TEST_CONNECT_WS_ENDPOINT=ws://playwright:3000/ \
+    UV_INSTALL_DIR=/usr/local/bin \
+    UV_NO_MODIFY_PATH=1
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN set -eux; \
+    mkdir -p -m 755 /etc/apt/keyrings /etc/apt/sources.list.d; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list; \
+    apt-get update; \
+    apt-get upgrade -y; \
+    apt-get install -y --no-install-recommends \
+      bubblewrap \
+      build-essential \
+      libharfbuzz0b \
+      libfontconfig1 \
+      libfreetype6 \
+      fonts-dejavu-core \
+      openjdk-25-jdk-headless \
+      wget \
+      openssh-client \
+      openssh-server \
+      file \
+      yq \
+      fd-find \
+      gh \
+      binutils \
+      fakeroot \
+      tmux \
+      neovim; \
+    ln -sf /usr/bin/fdfind /usr/local/bin/fd; \
+    npm install --global @ast-grep/cli; \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install --global "playwright@${PLAYWRIGHT_VERSION}"; \
+    cd /tmp; \
+    curl -fsSL -o github-mcp-server.tar.gz \
+      "https://github.com/github/github-mcp-server/releases/download/${GITHUB_MCP_VERSION}/github-mcp-server_Linux_${GITHUB_MCP_ARCH}.tar.gz"; \
+    tar xzf github-mcp-server.tar.gz; \
+    install -m 0755 github-mcp-server /usr/local/bin/github-mcp-server; \
+    rm -f github-mcp-server.tar.gz github-mcp-server; \
+    ACTIONLINT_ARCHIVE="actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz"; \
+    curl -fsSL -o "${ACTIONLINT_ARCHIVE}" \
+      "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${ACTIONLINT_ARCHIVE}"; \
+    curl -fsSL -o actionlint_checksums.txt \
+      "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt"; \
+    grep "  ${ACTIONLINT_ARCHIVE}$" actionlint_checksums.txt | sha256sum -c -; \
+    tar xzf "${ACTIONLINT_ARCHIVE}" actionlint; \
+    install -m 0755 actionlint /usr/local/bin/actionlint; \
+    rm -f "${ACTIONLINT_ARCHIVE}" actionlint_checksums.txt actionlint; \
+    curl -LsSf https://astral.sh/uv/install.sh | sh; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN set -eux; \
+    cd /tmp; \
+    curl -fsSL -o ncurses.tar.gz \
+      "https://ftp.gnu.org/pub/gnu/ncurses/ncurses-${NCURSES_VERSION}.tar.gz"; \
+    printf '%s  %s\n' "${NCURSES_SHA256}" ncurses.tar.gz | sha256sum -c -; \
+    tar xzf ncurses.tar.gz; \
+    cd "ncurses-${NCURSES_VERSION}"; \
+    ./configure \
+      --prefix=/usr/local \
+      --without-ada \
+      --without-cxx-binding \
+      --without-debug \
+      --without-manpages \
+      --without-shared \
+      --without-tests; \
+    make -j"$(nproc)"; \
+    make install.progs install.data; \
+    tic -x -o /usr/local/share/terminfo misc/terminfo.src; \
+    infocmp -x -A /usr/local/share/terminfo ghostty \
+      | awk 'BEGIN { done = 0 } !done && /^ghostty[|,]/ { sub(/^ghostty[|,]/, "xterm-ghostty|"); done = 1 } { print }' \
+      | tic -x -o /usr/local/share/terminfo -; \
+    mkdir -p /usr/share/terminfo/g /usr/share/terminfo/x; \
+    cp /usr/local/share/terminfo/g/ghostty /usr/share/terminfo/g/ghostty; \
+    cp /usr/local/share/terminfo/x/xterm-ghostty /usr/share/terminfo/x/xterm-ghostty; \
+    infocmp -A /usr/share/terminfo ghostty >/dev/null; \
+    infocmp -A /usr/share/terminfo xterm-ghostty >/dev/null; \
+    rm -rf /tmp/*
+
+RUN set -eux; \
+    PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm install --global --force "@playwright/test@${PLAYWRIGHT_VERSION}"
+
+RUN set -eux; \
+    if [ -f /usr/local/bin/zai-codex-entrypoint ]; then \
+      sed -i \
+        -e 's/^ClientAliveInterval 60$/ClientAliveInterval 0/' \
+        -e 's/^ClientAliveCountMax 3$/ClientAliveCountMax 0/' \
+        /usr/local/bin/zai-codex-entrypoint; \
+    fi; \
+    mkdir -p /etc/ssh/authorized_keys /etc/ssh/sshd_config.d /run/sshd; \
+    printf '%s\n' \
+      'PermitRootLogin prohibit-password' \
+      'PasswordAuthentication no' \
+      'KbdInteractiveAuthentication no' \
+      'PubkeyAuthentication yes' \
+      'AuthorizedKeysFile /etc/ssh/authorized_keys/%u .ssh/authorized_keys' \
+      'ClientAliveInterval 0' \
+      'ClientAliveCountMax 0' \
+      > /etc/ssh/sshd_config.d/99-codex.conf; \
+    if [ -n "${CODEX_SSH_AUTHORIZED_KEYS}" ]; then \
+      printf '%s\n' "${CODEX_SSH_AUTHORIZED_KEYS}" > /etc/ssh/authorized_keys/root; \
+    else \
+      touch /etc/ssh/authorized_keys/root; \
+    fi; \
+    chmod 0755 /etc/ssh/authorized_keys /run/sshd; \
+    chmod 0644 /etc/ssh/authorized_keys/root; \
+    ssh-keygen -A; \
+    sshd -t
+
+WORKDIR /work
+
+COPY tmux.conf /etc/tmux.conf
+COPY playwright-remote /usr/local/bin/playwright-remote
+COPY start-codex-remote-control-daemon.sh /usr/local/bin/start-codex-remote-control-daemon
+RUN chmod 0755 \
+    /usr/local/bin/playwright-remote \
+    /usr/local/bin/start-codex-remote-control-daemon
+
+EXPOSE 22
+
+CMD ["start-codex-remote-control-daemon"]

--- a/tools/codex-docker/README.md
+++ b/tools/codex-docker/README.md
@@ -1,0 +1,121 @@
+# Codex Docker stack
+
+Use this stack to run the Cryptad Codex container and a remote Playwright browser server from a
+tracked repository configuration.
+
+## Prerequisites
+
+- Docker with Compose v2.
+- Network access to pull `docker.io/benyamin/codex-sandbox` and
+  `mcr.microsoft.com/playwright`.
+- Optional Tailscale auth state in repo-root `.env`. The root `.env` file is ignored and must not
+  be committed.
+
+## Configure
+
+From this directory:
+
+```bash
+test -f ../../.env || cp .env.example ../../.env
+```
+
+Edit `../../.env` for local values. Keep `PLAYWRIGHT_VERSION` aligned across the Playwright image
+and the Playwright npm package. The default is `1.60.0`.
+
+If you need SSH access to the Codex container, set `CODEX_SSH_AUTHORIZED_KEYS` to one or more
+public keys in `../../.env`. Do not commit private keys or local tokens.
+
+## Start the stack
+
+Run from `tools/codex-docker`:
+
+```bash
+docker compose --env-file ../../.env up -d --build codex playwright
+```
+
+Start Tailscale only when you need the remote shell helper:
+
+```bash
+docker compose --env-file ../../.env up -d tailscale-shell
+```
+
+List services:
+
+```bash
+docker compose --env-file ../../.env ps
+```
+
+## Playwright endpoints
+
+| Caller | Endpoint |
+| --- | --- |
+| Codex container | `ws://playwright:3000/` |
+| Host | `ws://127.0.0.1:${PLAYWRIGHT_HOST_PORT:-3000}/` |
+
+The Playwright service publishes only to host loopback. Other containers in the Compose network use
+the service name `playwright`.
+
+## Use Playwright from Codex
+
+The Codex image installs the matching `playwright` and `@playwright/test` npm packages without
+browser binaries. Browser binaries live in the `mcr.microsoft.com/playwright` container.
+
+Check the CLI:
+
+```bash
+docker compose --env-file ../../.env exec codex playwright --version
+```
+
+Run a Playwright test through the remote server:
+
+```bash
+docker compose --env-file ../../.env exec codex playwright-remote test <spec>
+```
+
+The `playwright-remote` wrapper sets `PW_TEST_CONNECT_WS_ENDPOINT` to `ws://playwright:3000/` when
+the variable is not already set.
+
+From the host, use a matching Playwright version:
+
+```bash
+PW_TEST_CONNECT_WS_ENDPOINT=ws://127.0.0.1:${PLAYWRIGHT_HOST_PORT:-3000}/ npx -y playwright@1.60.0 test
+```
+
+## Target URL rules
+
+- Use `http://codex:<port>/` for servers running inside the Codex container. Bind those servers to
+  `0.0.0.0`, not only `127.0.0.1`.
+- Use `http://host.docker.internal:<port>/` for servers running on the host.
+- Do not use `localhost` from inside the Playwright browser container unless the target server is
+  inside that same container.
+
+## Validation
+
+Static checks:
+
+```bash
+docker compose --env-file ../../.env config
+git status --short --ignored . ../../.env
+rg -n "tskey-auth-[A-Za-z0-9]{8,}|OPENAI_API_KEY=|GITHUB_TOKEN=|BEGIN OPENSSH|PRIVATE KEY" \
+  AGENTS.md .gitignore .agents/skills/cryptad-codex-docker tools/codex-docker tools/README.md \
+  --glob '!tools/codex-docker/README.md'
+```
+
+Container checks:
+
+```bash
+docker compose --env-file ../../.env build codex tailscale-shell
+docker compose --env-file ../../.env up -d codex playwright
+docker compose --env-file ../../.env exec codex playwright --version
+docker compose --env-file ../../.env exec playwright node --version
+```
+
+Use the root project test commands only when a code change also touches Java or Gradle behavior.
+
+## Troubleshooting
+
+- If Chromium crashes under load, confirm the `playwright` service still uses `ipc: host`.
+- If a test cannot reach a local server, check whether the server is on the host, the Codex
+  container, or the Playwright container and use the matching target URL rule above.
+- If `docker compose` ignores values from `../../.env`, pass `--env-file ../../.env` explicitly.
+- If the host port is busy, change `PLAYWRIGHT_HOST_PORT` in `../../.env`.

--- a/tools/codex-docker/compose.yaml
+++ b/tools/codex-docker/compose.yaml
@@ -1,0 +1,104 @@
+name: codex-crypta
+
+services:
+  tailscale-shell:
+    build:
+      context: tailscale-shell
+      args:
+        TAILSCALE_VERSION: ${TAILSCALE_VERSION:-latest}
+    image: codex-crypta-tailscale-shell:${TAILSCALE_VERSION:-latest}
+    environment:
+      TS_AUTH_ONCE: "true"
+      TS_STATE_DIR: /var/lib/tailscale
+      TS_ROUTES: ${CRYPTAD_DOCKER_SUBNET:-172.30.70.0/24}
+      TS_USERSPACE: "false"
+      CRYPTAD_DOCKER_PROJECT: codex-crypta
+      CRYPTAD_DOCKER_NETWORK: codex-crypta_default
+      CRYPTAD_CODEX_SERVICE: codex
+      CRYPTAD_CODEX_WORKDIR: /work/cryptad
+    volumes:
+      - tailscale-state:/var/lib/tailscale
+      - ../../.env:/run/cryptad/root.env:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    sysctls:
+      net.ipv4.ip_forward: "1"
+    restart: unless-stopped
+    networks:
+      default:
+        ipv4_address: ${CRYPTAD_TAILSCALE_IPV4:-172.30.70.2}
+
+  codex:
+    hostname: crypta-codex
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        GITHUB_MCP_VERSION: ${GITHUB_MCP_VERSION:-v1.2.0}
+        GITHUB_MCP_ARCH: ${GITHUB_MCP_ARCH:-arm64}
+        ACTIONLINT_VERSION: ${ACTIONLINT_VERSION:-1.7.12}
+        ACTIONLINT_ARCH: ${ACTIONLINT_ARCH:-arm64}
+        PLAYWRIGHT_VERSION: ${PLAYWRIGHT_VERSION:-1.60.0}
+        CODEX_SSH_AUTHORIZED_KEYS: ${CODEX_SSH_AUTHORIZED_KEYS:-}
+    image: codex-crypta:${CODEX_IMAGE_TAG:-0.138.0}
+    pull_policy: build
+    container_name: codex-crypta-0
+    restart: unless-stopped
+    working_dir: /work/cryptad
+
+    environment:
+      VISUAL: nvim
+      CODEX_HOME: /root/.codex
+      PLAYWRIGHT_REMOTE_WS_ENDPOINT: ws://playwright:3000/
+      PW_TEST_CONNECT_WS_ENDPOINT: ws://playwright:3000/
+
+    volumes:
+      - ${CRYPTAD_REPO_ROOT:-../..}:/work/cryptad
+      - ${CRYPTAD_CODEX_HOME_MOUNT:-${HOME}/.codex_docker}:/root/.codex
+      - ${CRYPTAD_SSH_DIR:-${HOME}/.ssh}:/root/.ssh:ro
+      - ${CRYPTAD_GH_CONFIG_DIR:-${HOME}/.config/gh}:/root/.config/gh
+
+    cpus: 8.0
+    mem_limit: 12g
+
+    healthcheck:
+      test: ["CMD-SHELL", "codex app-server daemon version >/dev/null 2>&1 || exit 1"]
+      interval: 15s
+      timeout: 3s
+      retries: 10
+      start_period: 20s
+    networks:
+      default:
+        ipv4_address: ${CRYPTAD_CODEX_IPV4:-172.30.70.10}
+
+  playwright:
+    image: mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION:-1.60.0}-noble
+    init: true
+    user: pwuser
+    working_dir: /home/pwuser
+    command:
+      - /bin/sh
+      - -lc
+      - npx -y playwright@${PLAYWRIGHT_VERSION:-1.60.0} run-server --port 3000 --host 0.0.0.0
+    restart: unless-stopped
+    ipc: host
+    ports:
+      - "127.0.0.1:${PLAYWRIGHT_HOST_PORT:-3000}:3000"
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      default:
+        ipv4_address: ${CRYPTAD_PLAYWRIGHT_IPV4:-172.30.70.20}
+
+volumes:
+  tailscale-state:
+
+networks:
+  default:
+    ipam:
+      config:
+        - subnet: ${CRYPTAD_DOCKER_SUBNET:-172.30.70.0/24}

--- a/tools/codex-docker/playwright-remote
+++ b/tools/codex-docker/playwright-remote
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PW_TEST_CONNECT_WS_ENDPOINT="${PW_TEST_CONNECT_WS_ENDPOINT:-${PLAYWRIGHT_REMOTE_WS_ENDPOINT:-ws://playwright:3000/}}"
+
+global_node_modules="$(npm root --global 2>/dev/null || true)"
+if [ -n "${global_node_modules}" ]; then
+  export NODE_PATH="${NODE_PATH:+${NODE_PATH}:}${global_node_modules}"
+fi
+
+exec playwright "$@"

--- a/tools/codex-docker/start-codex-remote-control-daemon.sh
+++ b/tools/codex-docker/start-codex-remote-control-daemon.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+codex_home="${CODEX_HOME:-/root/.codex}"
+standalone_codex="${codex_home}/packages/standalone/current/codex"
+
+ensure_standalone_codex() {
+  if [[ -x "${standalone_codex}" ]]; then
+    return
+  fi
+
+  local codex_on_path
+  codex_on_path="$(command -v codex)"
+  if [[ -z "${codex_on_path}" ]]; then
+    echo "codex executable not found on PATH" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "${standalone_codex}")"
+  ln -sf "${codex_on_path}" "${standalone_codex}"
+}
+
+daemon_is_running() {
+  codex app-server daemon version >/dev/null 2>&1
+}
+
+start_sshd() {
+  if [[ ! -x /usr/sbin/sshd ]]; then
+    echo "sshd executable not found" >&2
+    exit 1
+  fi
+
+  mkdir -p /run/sshd
+  ssh-keygen -A >/dev/null
+  sshd -t
+
+  local pid_file="/run/sshd.pid"
+  if [[ -s "${pid_file}" ]]; then
+    local sshd_pid
+    sshd_pid="$(cat "${pid_file}")"
+    if [[ "${sshd_pid}" =~ ^[0-9]+$ ]] && kill -0 "${sshd_pid}" >/dev/null 2>&1; then
+      return
+    fi
+    rm -f "${pid_file}"
+  fi
+
+  /usr/sbin/sshd
+}
+
+wait_for_daemon() {
+  for _ in {1..30}; do
+    if daemon_is_running; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+cleanup_stale_daemon_state() {
+  local control_dir="${codex_home}/app-server-control"
+  if daemon_is_running || [[ ! -d "${control_dir}" ]]; then
+    return
+  fi
+
+  rm -f \
+    "${control_dir}/app-server-control.sock" \
+    "${control_dir}/desktop-ssh-websocket-v0.sock" \
+    "${control_dir}/app-server-startup.lock"
+}
+
+stop_daemon() {
+  trap - INT TERM
+  codex remote-control stop >/dev/null 2>&1 || codex app-server daemon stop >/dev/null 2>&1 || true
+  cleanup_stale_daemon_state
+}
+
+start_daemon() {
+  if codex remote-control start; then
+    return 0
+  fi
+
+  echo "Initial Codex remote-control start failed; stopping stale daemon state and retrying" >&2
+  codex remote-control stop >/dev/null 2>&1 || codex app-server daemon stop >/dev/null 2>&1 || true
+  cleanup_stale_daemon_state
+  sleep 1
+  codex remote-control start
+}
+
+ensure_daemon_started() {
+  local attempt
+  for attempt in {1..12}; do
+    if start_daemon; then
+      return 0
+    fi
+
+    echo "Codex remote-control start failed; retrying in 5 seconds" >&2
+    sleep 5
+  done
+
+  return 1
+}
+
+trap 'stop_daemon; exit 0' INT TERM
+
+ensure_standalone_codex
+start_sshd
+ensure_daemon_started
+
+if ! wait_for_daemon; then
+  echo "Codex remote-control daemon did not become ready" >&2
+  exit 1
+fi
+
+while true; do
+  if ! daemon_is_running; then
+    echo "Codex remote-control daemon stopped; restarting without stopping SSH" >&2
+    start_daemon || echo "Codex remote-control restart failed; retrying" >&2
+  fi
+
+  sleep 5 &
+  wait "$!"
+done

--- a/tools/codex-docker/tailscale-shell/Dockerfile
+++ b/tools/codex-docker/tailscale-shell/Dockerfile
@@ -1,0 +1,13 @@
+ARG TAILSCALE_VERSION=latest
+FROM tailscale/tailscale:${TAILSCALE_VERSION}
+
+RUN apk add --no-cache bash docker-cli jq
+
+COPY codex cryptad-containers cryptad-shell cryptad-tailscale-entrypoint /usr/local/bin/
+RUN chmod +x \
+  /usr/local/bin/codex \
+  /usr/local/bin/cryptad-containers \
+  /usr/local/bin/cryptad-shell \
+  /usr/local/bin/cryptad-tailscale-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/cryptad-tailscale-entrypoint"]

--- a/tools/codex-docker/tailscale-shell/codex
+++ b/tools/codex-docker/tailscale-shell/codex
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project="${CRYPTAD_DOCKER_PROJECT:-codex-crypta}"
+service="${CRYPTAD_CODEX_SERVICE:-codex}"
+workdir="${CRYPTAD_CODEX_WORKDIR:-/work/cryptad}"
+
+container_id="$(
+  docker ps \
+    --filter "label=com.docker.compose.project=${project}" \
+    --filter "label=com.docker.compose.service=${service}" \
+    --format '{{.Names}} {{.ID}}' \
+    | sort \
+    | awk 'NR == 1 {print $2}'
+)"
+
+if [ -z "${container_id}" ]; then
+  echo "No running container found for compose service '${service}' in project '${project}'." >&2
+  exit 1
+fi
+
+tty_args=(-i)
+if [ "${1:-}" != "app-server" ] || [ "${2:-}" != "proxy" ]; then
+  if [ -t 0 ] && [ -t 1 ]; then
+    tty_args=(-it)
+  fi
+fi
+
+exec docker exec "${tty_args[@]}" -w "${workdir}" "${container_id}" codex "$@"

--- a/tools/codex-docker/tailscale-shell/cryptad-containers
+++ b/tools/codex-docker/tailscale-shell/cryptad-containers
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project="${CRYPTAD_DOCKER_PROJECT:-codex-crypta}"
+network="${CRYPTAD_DOCKER_NETWORK:-codex-crypta_default}"
+
+docker ps \
+  --filter "label=com.docker.compose.project=${project}" \
+  --format '{{.Label "com.docker.compose.service"}}|{{.Names}}|{{.Status}}|{{.ID}}' \
+  | sort \
+  | while IFS='|' read -r service name status container_id; do
+      ip_address="$(docker inspect \
+        --format "{{with index .NetworkSettings.Networks \"${network}\"}}{{.IPAddress}}{{end}}" \
+        "${container_id}")"
+      printf '%-18s %-32s %-15s %s\n' "${service}" "${name}" "${ip_address:-"-"}" "${status}"
+    done

--- a/tools/codex-docker/tailscale-shell/cryptad-shell
+++ b/tools/codex-docker/tailscale-shell/cryptad-shell
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  cryptad-shell <service> [shell-args...]
+
+Services:
+  codex
+  playwright
+  tailscale-shell
+
+Examples:
+  cryptad-shell codex
+  cryptad-shell codex -c 'pwd'
+  cryptad-shell playwright -c 'node --version'
+USAGE
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+service="${1:-}"
+if [ -z "${service}" ]; then
+  usage
+  exit 2
+fi
+shift
+
+case "${service}" in
+  codex|playwright|tailscale-shell)
+    ;;
+  *)
+    echo "Unsupported service: ${service}" >&2
+    usage
+    exit 2
+    ;;
+esac
+
+project="${CRYPTAD_DOCKER_PROJECT:-codex-crypta}"
+container_id="$(
+  docker ps \
+    --filter "label=com.docker.compose.project=${project}" \
+    --filter "label=com.docker.compose.service=${service}" \
+    --format '{{.Names}} {{.ID}}' \
+    | sort \
+    | awk 'NR == 1 {print $2}'
+)"
+
+if [ -z "${container_id}" ]; then
+  echo "No running container found for compose service '${service}' in project '${project}'." >&2
+  echo "Running containers:" >&2
+  cryptad-containers >&2 || true
+  exit 1
+fi
+
+shell_path="$(
+  docker exec "${container_id}" sh -lc 'if command -v bash >/dev/null 2>&1; then command -v bash; elif command -v sh >/dev/null 2>&1; then command -v sh; else printf "%s\n" /bin/sh; fi'
+)"
+
+workdir_args=()
+case "${service}" in
+  codex)
+    workdir_args=(-w "${CRYPTAD_CODEX_WORKDIR:-/work/cryptad}")
+    ;;
+esac
+
+tty_args=()
+if [ -t 0 ] && [ -t 1 ]; then
+  tty_args=(-it)
+else
+  tty_args=(-i)
+fi
+
+if [ "$#" -gt 0 ]; then
+  exec docker exec "${tty_args[@]}" "${workdir_args[@]}" "${container_id}" "${shell_path}" "$@"
+fi
+
+shell_args=()
+if [ "$(basename "${shell_path}")" = "bash" ]; then
+  shell_args=(-l)
+fi
+
+exec docker exec "${tty_args[@]}" "${workdir_args[@]}" "${container_id}" "${shell_path}" "${shell_args[@]}"

--- a/tools/codex-docker/tailscale-shell/cryptad-tailscale-entrypoint
+++ b/tools/codex-docker/tailscale-shell/cryptad-tailscale-entrypoint
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_env="/run/cryptad/root.env"
+if [ -f "${root_env}" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "${root_env}"
+  set +a
+fi
+
+export TS_HOSTNAME="${TS_HOSTNAME:-${CRYPTAD_TAILSCALE_HOSTNAME:-cryptad-codex-docker}}"
+export TS_EXTRA_ARGS="${TS_EXTRA_ARGS:-${CRYPTAD_TAILSCALE_EXTRA_ARGS:---ssh}}"
+
+if [ -z "${TS_AUTHKEY:-}" ] && [ -n "${CRYPTAD_TAILSCALE_AUTHKEY:-}" ]; then
+  export TS_AUTHKEY="${CRYPTAD_TAILSCALE_AUTHKEY}"
+fi
+
+exec /usr/local/bin/containerboot "$@"

--- a/tools/codex-docker/tmux.conf
+++ b/tools/codex-docker/tmux.conf
@@ -1,0 +1,10 @@
+set -g mouse on
+
+bind-key -T root WheelUpPane copy-mode -e \; send-keys -X -N 3 scroll-up
+bind-key -T root WheelDownPane {}
+
+bind-key -T copy-mode WheelUpPane send-keys -X -N 3 scroll-up
+bind-key -T copy-mode WheelDownPane send-keys -X -N 3 scroll-down
+
+bind-key -T copy-mode-vi WheelUpPane send-keys -X -N 3 scroll-up
+bind-key -T copy-mode-vi WheelDownPane send-keys -X -N 3 scroll-down


### PR DESCRIPTION
## Summary

- Add a tracked `tools/codex-docker` Compose stack for the Codex container, Tailscale shell helper, and a remote Playwright browser server.
- Install matching `playwright` / `@playwright/test` client packages in the Codex image without bundling browser binaries there.
- Document setup, endpoints, validation, root `.env` handling, and add the `cryptad-codex-docker` skill.

## Test plan

- `./gradlew spotlessApply`
- `docker compose --env-file ../../.env config` from `tools/codex-docker`
- `docker compose --env-file ../../.env build codex tailscale-shell`
- `docker compose --env-file ../../.env up -d codex playwright`
- `docker compose --env-file ../../.env exec -T codex playwright --version`
- `docker compose --env-file ../../.env exec -T playwright node --version`
- `docker compose --env-file ../../.env exec -T codex playwright-remote test smoke.spec.js --reporter=line`
- Node API smoke test from the Codex container using `chromium.connect("ws://playwright:3000/")`
- Host loopback WebSocket smoke test against `ws://127.0.0.1:3000/`
- Temporary `PLAYWRIGHT_HOST_PORT=3001` remap smoke test, then restored to default `3000`
- Secret scan for committed files excluding the README command example: no real token/key hits

## Notes

The repo-root `.env` is ignored and is used for local/private values only. The old local `.codex/docker/.env` was moved to repo-root `.env` and was not committed.