### PR TITLE
feat(cert): Add ecosystem RC gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,7 @@ jobs:
   release-certification-self-test:
     name: release certification self-test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -226,7 +226,7 @@ jobs:
           - os: macos-latest
             python_cmd: python3
           - os: windows-latest
-            python_cmd: py -3
+            python_cmd: py -3.12
 
     steps:
       - uses: actions/checkout@v6
@@ -234,7 +234,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Run release certification self-tests
         shell: bash

--- a/docs/cryptad-release-workflow-and-runbook.md
+++ b/docs/cryptad-release-workflow-and-runbook.md
@@ -2,8 +2,9 @@
 
 > Updated June 1, 2026, to cover the release certification report that aggregates interop,
 > performance, app-platform, beta documentation, public-beta hardening, operator beta recovery,
-> live-network beta certification, app-review governance, catalog, app-owned UI,
-> legacy-admin retirement, and CI evidence for a release candidate.
+> network-scale soak, ecosystem RC certification, optional live-network beta certification,
+> app-review governance, catalog, app-owned UI, legacy-admin retirement, and CI evidence for a
+> release candidate.
 
 ## Overview
 - Purpose: publish a Cryptad release so running nodes discover a new `info/<edition>` descriptor, download OS-specific installers, and guide operators through installation without self-replacing the running JAR.
@@ -72,6 +73,18 @@ Treat these as release blockers, in order:
    evidence coverage, ecosystem gate coverage, first-party app coverage, docs coverage, waivers,
    and row-level regressions. The workflow is documented in
    [release-certification.md](release-certification.md).
+   Confirm the final `ecosystem.rc-certification` gate and
+   `ecosystem-rc-certification-gate` matrix row match the release plan. That row is the
+   release-manager summary for required-evidence status, ecosystem gate status, matrix coverage,
+   network-scale soak, required live-network beta evidence, redaction, and waivers. Its scope and
+   non-claims are documented in
+   [ecosystem-rc-certification-gate.md](ecosystem-rc-certification-gate.md).
+   Confirm the `network-scale-soak-and-subscription-budget` row and
+   `network-scale.rc-soak-summary` evidence are present. The wrapper generates a fresh simulated
+   summary by default. Use `--network-scale-soak-summary <path>` or
+   `CRYPTAD_CERT_NETWORK_SCALE_SOAK_SUMMARY` only for an externally collected
+   `simulated-rc-soak` or `live-rc-soak` summary that uses the same redacted schema. Record any
+   external soak source and redaction status in the release log.
    Confirm `app-platform.docs-portal`, `app-platform.beta-program`,
    `app-platform.beta-tutorials`, `app-platform.docs-redaction`, and the
    `app-platform-beta-docs-and-program` matrix row are present. Docs-only gaps require an explicit
@@ -80,8 +93,9 @@ Treat these as release blockers, in order:
    evidence ids, `operator-rc.*` evidence ids, `operator-beta-ux-and-recovery` and
    `operator-rc-recovery-and-support-workflow` matrix rows, and disabled-or-passing
    `live-network-beta-certification` row match the release plan. Live-network beta evidence is
-   release-blocking only when the release manager explicitly enables required live-network beta
-   mode.
+   optional unless the release manager explicitly enables required live-network beta mode with
+   `--require-live-network-beta` or `CRYPTAD_CERT_REQUIRE_LIVE_NETWORK_BETA=1`; stale live-network
+   summaries must not be copied when the mode is disabled.
 3. **First-party app staging** - stage repo-owned AppHost bundles with the app module tasks or `./gradlew stageFirstPartyApps`. The app workflow source of truth is [app-distribution.md](app-distribution.md).
 4. **First-party app signing and verification** - sign with the intended release or staging key inputs, then verify with the matching trusted public key inputs. Gate promotion on successful `./gradlew signFirstPartyApps` and `./gradlew verifyFirstPartyApps` runs. Keep private signing keys outside the repository.
 5. **App catalog smoke, when catalog sources ship** - verify each signed catalog source refreshes,
@@ -94,7 +108,8 @@ Treat these as release blockers, in order:
    [app-catalogs.md](app-catalogs.md).
    PR-246 live-network beta certification is an explicit release-manager wrapper mode. Run it only
    with a localhost node, redacted environment variables, and disposable live fixtures unless the
-   release manager is intentionally publishing the candidate first-party beta catalog:
+   release manager is intentionally publishing the candidate first-party beta catalog. It becomes
+   release-blocking only when required live-network beta mode is enabled:
    ```bash
    CRYPTAD_CERT_LIVE_NETWORK_BETA=1 \
    CRYPTAD_CERT_REQUIRE_LIVE_NETWORK_BETA=1 \
@@ -373,8 +388,10 @@ Treat these as release blockers, in order:
   Missing required evidence, failed required evidence, missing signed bundle/catalog/review
   evidence, missing app UI design-system/lint evidence, missing beta documentation evidence,
   failing docs redaction, missing `apphost.sandbox-provider` evidence, required evidence
-  regressions, or failing ecosystem gates block release-candidate promotion unless a release
-  manager records an explicit waiver for a waivable gap. If the previous summary predates PR-231
+  regressions, failing ecosystem gates, missing or stale network-scale RC soak evidence, required
+  live-network beta failures, or a failing `ecosystem.rc-certification` gate block
+  release-candidate promotion unless a release manager records an explicit waiver for a waivable
+  gap. Redaction findings remain blockers. If the previous summary predates PR-231
   and the matrix
   reports `previousMatrixPresent=false`, record that baseline transition in the release log and
   continue only after the row-level evidence and gate coverage checks pass or have explicit

--- a/docs/ecosystem-rc-certification-gate.md
+++ b/docs/ecosystem-rc-certification-gate.md
@@ -1,0 +1,172 @@
+# Ecosystem RC certification gate
+
+This document defines the final ecosystem release-candidate certification gate used by release
+managers before promoting a Cryptad release candidate.
+
+## Gate identity
+
+PR-258 records final ecosystem release-candidate readiness with:
+
+| Item | Identifier | Purpose |
+| --- | --- | --- |
+| Ecosystem gate | `ecosystem.rc-certification` | Summarizes whether the release-candidate evidence set is complete enough to promote. |
+| Matrix row | `ecosystem-rc-certification-gate` | Shows the release-manager checklist result in `ecosystem-certification-matrix.json` and `ecosystem-certification-matrix.md`. |
+
+The gate is a summary over the existing release evidence. It does not replace the detailed matrix
+rows for interop, performance, app platform, app review, public-beta hardening, network-scale soak,
+operator RC recovery, live-network beta, legacy retirement, or redaction.
+
+## Release-candidate requirements
+
+A release-candidate run must produce the normal certification outputs:
+
+```text
+build/release-certification/release-certification-summary.json
+build/release-certification/release-certification-report.md
+build/release-certification/history-comparison.json
+build/release-certification/history-comparison.md
+build/release-certification/ecosystem-certification-matrix.json
+build/release-certification/ecosystem-certification-matrix.md
+build/release-certification/artifacts/
+```
+
+Run the wrapper in strict mode after the required source gates have produced their summaries:
+
+```bash
+tools/release-certification/run-release-certification.sh \
+  --mode release-candidate \
+  --previous-summary build/release-certification-history/latest-summary.json \
+  --out-dir build/release-certification
+```
+
+The `ecosystem.rc-certification` gate must treat these conditions as release-candidate blockers
+unless an allowed release-manager waiver applies:
+
+- required evidence is missing, skipped, malformed, or failing;
+- required evidence regresses from a previous certified `pass` to `fail`, `missing`, or `skip`;
+- an ecosystem gate reports a release-blocking failure;
+- the matrix leaves required evidence, emitted ecosystem gates, first-party apps, or required docs
+  unmapped;
+- a non-synthetic matrix row has no existing docs path;
+- the matrix, summary, report, or copied artifacts fail redaction checks;
+- the network-scale RC soak summary is missing, stale, malformed, failing, or uses an unsanitized
+  schema;
+- live-network beta is marked required but any required `live-network-beta.*` evidence is missing,
+  skipped, or failing.
+
+The `ecosystem-rc-certification-gate` row should make the final release-manager action obvious:
+promote, resolve blockers, attach missing evidence, or record an approved waiver for a waivable
+gap. A promoted release record should preserve the sanitized summary, report, matrix, history
+comparison, waiver records, and copied public artifacts.
+
+## Network-scale soak evidence
+
+The release wrapper generates a fresh deterministic
+`build/release-certification/network-scale-soak/summary.json` by default. That default simulated
+summary is required release-candidate evidence for `network-scale.rc-soak-summary` and the
+`network-scale-soak-and-subscription-budget` matrix row.
+
+Release managers may attach an external network-scale soak summary instead:
+
+```bash
+tools/release-certification/run-release-certification.sh \
+  --mode release-candidate \
+  --network-scale-soak-summary path/to/redacted-network-scale-summary.json \
+  --out-dir build/release-certification
+```
+
+`CRYPTAD_CERT_NETWORK_SCALE_SOAK_SUMMARY` is the environment-variable equivalent. The attached
+summary may be `simulated-rc-soak` or `live-rc-soak`, but it must use the same redacted schema as
+the deterministic collector: bounded app counts, budget skips, queue-pressure skips, update
+counts, Trust Graph import counts, budget enforcement booleans, and redaction booleans. It must
+not include raw fetched content, request bodies, queue HTML, browser-session tokens, app process
+tokens, private insert URIs, raw signatures, raw Trust Graph statement bodies, app-data values,
+backup payloads, rejected source strings, or absolute local paths.
+
+A literal 24-hour live soak is optional release-manager evidence. It is represented by the
+attached redacted summary and release-log notes, not by ordinary PR, nightly, unit-test, or
+Python-only self-test runs.
+
+## Live-network beta optional versus required
+
+Live-network beta certification remains explicit release-manager evidence. The final ecosystem RC
+gate treats it as optional when neither `--require-live-network-beta` nor
+`CRYPTAD_CERT_REQUIRE_LIVE_NETWORK_BETA=1` is set. In that disabled or optional state, stale live
+summaries must not be copied into the release record, and failing optional live evidence is a
+warning unless the release plan made live-network beta release-blocking.
+
+When live-network beta is required, the `ecosystem.live-network-beta` gate and
+`live-network-beta-certification` matrix row must pass. Required mode expects these evidence ids to
+pass:
+
+```text
+live-network-beta.preflight
+live-network-beta.catalog-usk-fetch
+live-network-beta.app-install-update-rollback
+live-network-beta.content-fetch
+live-network-beta.feed-subscription
+live-network-beta.profile-publish
+live-network-beta.trust-statement-publish-import
+live-network-beta.interop-perf-budget
+live-network-beta.redaction
+```
+
+`live-network-beta.app-service-score` is optional. It must not be reported as a pass claim when the
+score invocation was not requested.
+
+Live-network beta runs must use only a prepared localhost node and disposable fixtures. They must
+not route through proxies or record credentials, query strings, fragments, private insert material,
+form passwords, browser-session tokens, raw response bodies, or non-localhost endpoint metadata.
+
+## Waiver behavior
+
+Waivers are release-manager decisions, not evidence removal. An active waiver can downgrade an
+otherwise blocking evidence item, gate, row, or matrix coverage issue to `warn` when policy allows.
+The summary, report, matrix, and history comparison must keep the waiver id, reason, source, and
+affected row or evidence visible.
+
+Do not use waivers for redaction findings. Raw secret, raw payload, private URI, token, credential,
+or local-path findings remain release blockers even when a waiver references the evidence id, row
+id, gate id, or matrix issue id. Expired, unapproved, malformed, or release-candidate-disallowed
+structured waivers do not apply; malformed waiver files fail release-candidate mode.
+
+Docs-only presence or link gaps may be waived when release policy allows, but the waiver must name
+the accepted risk and expiration. Waivers for compatibility, performance, sandbox enforcement,
+review trust, operator RC recovery, network-scale soak, or live-network beta should cite the
+release plan and the replacement evidence being accepted.
+
+## Redaction sensitivity
+
+Final ecosystem RC certification artifacts are intended for release records and CI uploads. Do not
+publish:
+
+- private signing keys or reviewer keys;
+- raw trusted reviewer public key bytes;
+- form passwords, app process tokens, or browser-session tokens;
+- raw request bodies, feed bodies, social message bodies, trust documents, profile documents, or
+  fetched content;
+- raw signatures, raw app-service request bodies, raw subject URIs, provider app data, raw app
+  data, or backup payload values;
+- private insert URIs, private identity material, seed phrases, recovery phrases, catalog scratch
+  paths, staged bundle paths, rollback backup paths, store roots, queue HTML, or absolute local
+  filesystem paths;
+- non-localhost endpoint metadata from live-network beta fixtures.
+
+Use route names, evidence ids, capability labels, fixture presence booleans, counts, hashes,
+status labels, reason codes, and sanitized placeholders such as `<repo>`, `<workdir>`, `<home>`,
+and `<path>`.
+
+## Out-of-scope claims
+
+Passing `ecosystem.rc-certification` does not claim:
+
+- global network propagation, user adoption, or public availability of every fixture;
+- deletion or revocation of already published network bytes;
+- global moderation, blocking, routing policy, node-to-node trust propagation, or complete Web of
+  Trust behavior;
+- legacy WebOfTrust, Freetalk, Sone, Freemail, old plugin ABI, or `FCPPluginMessage`
+  compatibility;
+- safety of third-party apps beyond the signed catalog, signed bundle, app-review, sandbox,
+  permission, and redaction gates actually present in the release evidence;
+- production-key handling, real-user content handling, or non-localhost live-node operation;
+- performance guarantees beyond the recorded performance smoke and network-scale soak summaries.

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -2,8 +2,8 @@
 
 Release certification is the reproducible evidence bundle for a Cryptad release candidate. It
 aggregates compatibility, performance, app-platform, catalog, app-owned UI, operator beta recovery,
-optional live-network beta certification, legacy-admin retirement, and CI metadata into one
-redacted report.
+network-scale soak, ecosystem RC certification, optional live-network beta certification,
+legacy-admin retirement, and CI metadata into one redacted report.
 
 The generated artifacts are:
 
@@ -434,8 +434,10 @@ Freemail compatibility claim. Trust and app-service evidence must not include ra
 bodies from real users, raw fetched content, raw request bodies, raw signature values, private
 insert URIs, private identity material, app process tokens, browser-session tokens, form passwords,
 absolute staging paths, store roots, provider app data, raw subject URIs, app-data backup payloads,
-or local paths. Operator RC recovery workflows and final ecosystem RC certification remain deferred
-to later PRs.
+or local paths. Final ecosystem RC certification is covered by
+[ecosystem-rc-certification-gate.md](ecosystem-rc-certification-gate.md) through the
+`ecosystem.rc-certification` gate and the `ecosystem-rc-certification-gate` matrix row. Trust
+Graph evidence contributes to that final gate without expanding the Trust Graph non-goals above.
 
 ## Historical comparison
 
@@ -499,6 +501,8 @@ ecosystem.app-vault
 ecosystem.sandbox-provider
 ecosystem.reference-content-apps
 ecosystem.legacy-retirement
+ecosystem.live-network-beta
+ecosystem.rc-certification
 ```
 
 ## Ecosystem certification matrix
@@ -546,6 +550,15 @@ bounded budgets, queue pressure can delay polling without budget consumption, So
 multi-source refresh remains capped, and release evidence excludes raw content, queue HTML, tokens,
 private insert URIs, raw signatures, app-data payloads, and absolute local paths.
 
+The `ecosystem-rc-certification-gate` row records PR-258 final ecosystem release-candidate
+certification. It is the release-manager summary row for the `ecosystem.rc-certification` gate and
+is documented in [ecosystem-rc-certification-gate.md](ecosystem-rc-certification-gate.md). The row
+must remain sensitive to required-evidence failures, ecosystem-gate failures, matrix coverage gaps,
+network-scale RC soak status, live-network beta status when required, redaction failures, and
+waiver visibility. Passing the row means the release evidence is complete enough for promotion; it
+does not claim global network propagation, deletion of published bytes, legacy WebOfTrust or
+plugin compatibility, production-key handling, or third-party app safety beyond the recorded gates.
+
 ## Network-scale soak
 
 Normal PR and CI evidence uses deterministic simulated time, not a wall-clock 24-hour test:
@@ -570,8 +583,10 @@ request bodies, queue HTML, browser-session tokens, app process tokens, private 
 signatures, raw Trust Graph statement bodies, app-data values, app-data backup payloads, rejected
 source strings, or absolute local paths.
 
-A literal 24-hour live soak is a release-candidate activity. It is represented by an attached
-summary; it is not part of ordinary unit tests or Python self-tests.
+A literal 24-hour live soak is optional release-candidate evidence. It is represented by an
+attached redacted summary; it is not part of ordinary unit tests, nightly certification, or
+Python-only self-tests. Record the external soak source, collector mode, runner identity, and
+redaction status in the release log without copying raw node output into the release record.
 
 In `release-candidate` mode, unmapped required evidence, unmapped ecosystem gates, missing docs,
 or failed redaction make the matrix fail. In `pr` and `nightly` mode, coverage gaps warn unless
@@ -587,8 +602,11 @@ row-level regressions are compared directly.
 
 ## Ecosystem gate behavior
 
-The gates are intentionally conservative. Platform API compatibility blocks on contract status
-failure, contract version rollback, or available stable endpoint/capability removals. First-party
+The gates are intentionally conservative. Final ecosystem RC certification blocks on any unwaived
+required-evidence failure, release-blocking ecosystem gate, matrix coverage gap, stale or missing
+network-scale RC soak evidence, required live-network beta failure, or redaction failure. Platform
+API compatibility blocks on contract status failure, contract version rollback, or available stable
+endpoint/capability removals. First-party
 app gates require `queue-manager`, `publisher`, `site-publisher`, `profile-publisher`,
 `feed-reader`, and `trust-graph`, and
 block when a previously certified first-party app disappears without a waiver. App UI gates block failing or missing
@@ -753,6 +771,10 @@ The aggregator records the live evidence under `ecosystem.live-network-beta` and
 `live-network-beta.feed-subscription`, `live-network-beta.profile-publish`,
 `live-network-beta.trust-statement-publish-import`,
 `live-network-beta.interop-perf-budget`, and `live-network-beta.redaction` to pass.
+When live-network beta is disabled, stale `live-network-beta-smoke/` summaries must be ignored and
+must not be copied into the release record. When live-network beta is enabled but not required,
+failing, missing, or warning live evidence is visible as a warning. It becomes release-blocking
+only when `--require-live-network-beta` or `CRYPTAD_CERT_REQUIRE_LIVE_NETWORK_BETA=1` is set.
 
 ## Redaction
 

--- a/docs/trust-graph-preview.md
+++ b/docs/trust-graph-preview.md
@@ -22,9 +22,13 @@ The RC service has these release boundaries:
 | No routing decisions | Scores never change peer selection, request routing, FProxy browse behavior, content filters, or daemon-core protocols. |
 | No legacy compatibility promise | The service does not implement old WebOfTrust plugin APIs, `FCPPluginMessage`, PluginTalker, Freetalk, Sone, Freemail, or old WoT data formats. |
 
-PR-252 and later work remains out of scope here. Trust Graph Local RC does not add Social Inbox
-message threading, app-service dependency bundles, ecosystem advisory or denylist policy,
-operator RC recovery workflows, or the final ecosystem RC gate.
+Trust Graph Local RC does not by itself add Social Inbox message threading, ecosystem advisory or
+denylist policy, operator RC recovery workflows, or final ecosystem RC certification. Later
+release-candidate evidence composes Trust Graph with app-service dependency bundles, Social Inbox
+RC threading, network-scale soak, operator RC recovery, and the
+`ecosystem.rc-certification` gate. The final gate is documented in
+[ecosystem-rc-certification-gate.md](ecosystem-rc-certification-gate.md), and Trust Graph remains
+limited to the local RC trust-service scope described here.
 
 ## Components
 

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -1,6 +1,7 @@
 # Release certification tooling
 
-This directory contains the release-candidate evidence aggregator used by the release runbook.
+This directory contains the release-candidate evidence aggregator used by the release runbook,
+including the final ecosystem RC certification gate.
 
 The tooling requires Python 3.10 or newer and depends only on the Python standard library.  The
 self-tests do not start Cryptad, download a Hyphanet baseline, require signing keys, or contact the
@@ -39,6 +40,10 @@ performance summaries when they are present.  It also generates a fresh determin
 attached simulated or live soak summary.  In `pr` mode it skips Gradle by default so local and
 normal CI use stay lightweight.  Set `CRYPTAD_CERT_RUN_GRADLE=1` or pass `--mode nightly` or
 `--mode release-candidate` to run the app-platform Gradle staging and CLI checks.
+Attached network-scale summaries must use the same redacted schema as the deterministic collector.
+The summary kind may be `simulated-rc-soak` or `live-rc-soak`, but raw fetched content, queue HTML,
+tokens, private insert URIs, raw signatures, app-data values, backup payloads, rejected source
+strings, and absolute local paths must stay out of the release record.
 
 ## Outputs
 
@@ -261,6 +266,12 @@ stronger evidence. Extended interop is still required by the release runbook whe
 compatibility-sensitive behavior changed. Live AppHost lifecycle evidence is optional because
 normal PR CI must not require a running node or operator credentials.
 
+PR-258 final ecosystem RC certification is represented by the `ecosystem.rc-certification` gate
+and the `ecosystem-rc-certification-gate` matrix row. That row summarizes whether the
+release-candidate evidence set is complete enough for promotion. It is documented in
+[../../docs/ecosystem-rc-certification-gate.md](../../docs/ecosystem-rc-certification-gate.md) and
+does not replace the detailed required evidence listed above.
+
 Record an explicit waiver when a release manager accepts missing optional or replacement evidence:
 
 ```bash
@@ -306,6 +317,8 @@ ecosystem.app-vault
 ecosystem.sandbox-provider
 ecosystem.reference-content-apps
 ecosystem.legacy-retirement
+ecosystem.live-network-beta
+ecosystem.rc-certification
 ```
 
 The aggregator also writes `ecosystem-certification-matrix.json` and
@@ -330,6 +343,11 @@ app bundle row. `site-publisher` is covered by the reference content row, while
 `profile-publisher`, `feed-reader`, and `trust-graph` have app-specific rows for their distinct
 networked app-layer behavior. The `app-platform-beta-docs-and-program` row records Phase 7 docs
 portal, tutorials, beta program, issue-template, link, and redaction readiness.
+The `ecosystem-rc-certification-gate` row records final release-candidate readiness for
+`ecosystem.rc-certification`: required evidence, emitted ecosystem gates, matrix coverage,
+network-scale RC soak status, required live-network beta status, waiver visibility, and redaction.
+The row is documented in
+[../../docs/ecosystem-rc-certification-gate.md](../../docs/ecosystem-rc-certification-gate.md).
 
 In `release-candidate` mode, unmapped required evidence, unmapped ecosystem gates, missing docs,
 or failed redaction make the matrix fail. In `pr` and `nightly` mode, coverage gaps are warnings
@@ -419,6 +437,9 @@ emitted under `waiverRecords`. Active waivers downgrade matching evidence or eco
 blockers to `warn`; they do not remove the evidence, gate, or reason.
 Expired, unapproved, malformed, or release-candidate-disallowed waivers do not apply. A malformed
 waiver file fails `release-candidate` mode and warns in `pr` or `nightly` mode.
+Redaction findings are not waiver material. Raw secrets, private URIs, credentials, raw payloads,
+or local-path leaks keep the evidence, matrix row, and final ecosystem RC gate failing even when a
+waiver targets the same evidence id, row id, gate id, or issue id.
 
 ## App-platform smoke
 
@@ -539,7 +560,11 @@ can also invoke the read-only Trust Graph `trust.score` app-service when
 `CRYPTAD_CERT_LIVE_APP_SERVICE_SCORE=1` is set; otherwise
 `live-network-beta.app-service-score` is reported as optional skipped evidence, not a false pass.
 Aggregation records these results under the `ecosystem.live-network-beta` gate and the
-`live-network-beta-certification` matrix row.
+`live-network-beta-certification` matrix row. Live-network beta remains optional when
+`--require-live-network-beta` and `CRYPTAD_CERT_REQUIRE_LIVE_NETWORK_BETA=1` are absent; disabled
+runs must ignore stale live summaries and must not copy stale live artifacts. When live-network
+beta is enabled but not required, failing or missing live evidence is a warning. Required mode
+turns the required `live-network-beta.*` evidence into release blockers.
 Lifecycle cleanup deletes only an app that was absent before the smoke and installed successfully
 by this run. Use a disposable app id when the prepared node already has first-party apps installed.
 It does not prove global network propagation, app safety beyond signature/review policy, catalog

--- a/tools/release-certification/fixtures/self-test-app-platform-smoke.json
+++ b/tools/release-certification/fixtures/self-test-app-platform-smoke.json
@@ -109,6 +109,64 @@
     {
       "details": {
         "checks": {
+          "dependencyModelsPresent": true,
+          "dependencyParserStrictFieldsPresent": true,
+          "dependencyRoutesPresent": true,
+          "dependencyTestsPresent": true
+        }
+      },
+      "id": "app-services.dependency-graph",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "App-service dependency graph evidence passed deterministic checks."
+    },
+    {
+      "details": {
+        "checks": {
+          "bundleCoordinatorHostOnly": true,
+          "bundleModelsAndStorePresent": true,
+          "bundleRoutesPresent": true,
+          "bundleTestsPresent": true
+        }
+      },
+      "id": "app-services.grant-bundles",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "App-service grant-bundle evidence passed deterministic checks."
+    },
+    {
+      "details": {
+        "checks": {
+          "expiredGrantsFailClosed": true,
+          "grantExpiryFieldsPresent": true,
+          "renewalRevalidates": true
+        }
+      },
+      "id": "app-services.grant-expiry-renewal",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "App-service grant expiry and renewal evidence passed deterministic checks."
+    },
+    {
+      "details": {
+        "checks": {
+          "compatibilityFingerprintPresent": true,
+          "descriptorDriftNonAuthorizing": true,
+          "descriptorMatchingChecksVersionScopeContextKindAdapter": true
+        }
+      },
+      "id": "app-services.provider-revalidation",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "App-service provider descriptor revalidation evidence passed deterministic checks."
+    },
+    {
+      "details": {
+        "checks": {
           "adapterIsBoundedNotProxy": true,
           "adapterTestsCoverRedaction": true,
           "providerDocsAndUiDescribePreviewGrantBoundary": true,
@@ -140,6 +198,20 @@
     {
       "details": {
         "checks": {
+          "socialDegradesSafely": true,
+          "socialDependencyDocsPresent": true,
+          "socialManifestDeclaresOptionalDependency": true
+        }
+      },
+      "id": "reference-app.social-inbox-service-dependency",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "Social Inbox service dependency evidence passed deterministic checks."
+    },
+    {
+      "details": {
+        "checks": {
           "webShellLoadsAppServiceData": true,
           "webShellOmitsPrivateMaterial": true,
           "webShellRendersGrantActions": true,
@@ -167,6 +239,20 @@
       "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
       "status": "pass",
       "summary": "App-service redaction and boundary evidence passed deterministic checks."
+    },
+    {
+      "details": {
+        "checks": {
+          "bundlePublicJsonFieldsSafe": true,
+          "dependencyJsonPathFreeByConstruction": true,
+          "uiAndEvidenceAvoidRawSensitiveValues": true
+        }
+      },
+      "id": "app-services.dependency-redaction",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "App-service dependency and bundle redaction evidence passed deterministic checks."
     },
     {
       "details": {

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -1856,12 +1856,26 @@ def collect_ci_metadata(env: dict[str, str]) -> dict[str, str]:
     return metadata
 
 
-def determine_overall_status(mode: str, evidence: list[EvidenceItem]) -> tuple[str, bool]:
+def evidence_item_has_active_rc_waiver(
+    item: EvidenceItem, waiver_context: WaiverContext, mode: str
+) -> bool:
+    if item.details.get("waived"):
+        return True
+    if evidence_item_has_unwaivable_redaction_findings(item):
+        return False
+    return (
+        active_waiver_for_ecosystem_rc_evidence(waiver_context, item.id, mode) is not None
+    )
+
+
+def determine_overall_status(
+    mode: str, evidence: list[EvidenceItem], waiver_context: WaiverContext
+) -> tuple[str, bool]:
     required_bad = [
         item
         for item in evidence
         if item.required_for_release_candidate and item.status in {"fail", "missing", "skip"}
-        and not item.details.get("waived")
+        and not evidence_item_has_active_rc_waiver(item, waiver_context, mode)
     ]
     required_warn = [
         item
@@ -1882,7 +1896,8 @@ def determine_overall_status(mode: str, evidence: list[EvidenceItem]) -> tuple[s
         required_fail = [
             item
             for item in evidence
-            if item.required_for_release_candidate and item.status == "fail" and not item.details.get("waived")
+            if item.required_for_release_candidate and item.status == "fail"
+            and not evidence_item_has_active_rc_waiver(item, waiver_context, mode)
         ]
         if required_fail:
             return "fail", False
@@ -3584,9 +3599,15 @@ def classify_evidence_diff(
     issue_ids = [
         f"history.{classification}.{evidence_id}",
         f"history.evidence.{evidence_id}",
+        f"evidence.{evidence_id}",
+        *ecosystem_matrix_row_ids_for_evidence(evidence_id),
     ]
     waived = bool(current and evidence_details(current).get("waived"))
-    waiver = active_waiver_for(waiver_context, evidence_id, issue_ids, mode)
+    waiver = (
+        None
+        if evidence_entry_has_unwaivable_redaction_findings(current)
+        else active_waiver_for(waiver_context, evidence_id, issue_ids, mode)
+    )
     release_blocker = False
     reason = "Evidence status is unchanged."
     if classification == "new":
@@ -5578,6 +5599,22 @@ def gate_waiver_ids(gate: GateResult | None) -> list[str]:
     return detail_waiver_ids(gate.details)
 
 
+def ecosystem_matrix_row_ids_for_evidence(evidence_id: str) -> list[str]:
+    return unique_ids(
+        spec.id for spec in ecosystem_matrix_row_specs() if evidence_id in spec.evidence_ids()
+    )
+
+
+def active_waiver_for_ecosystem_rc_evidence(
+    context: WaiverContext, evidence_id: str, mode: str
+) -> WaiverRecord | None:
+    issue_ids = [
+        f"evidence.{evidence_id}",
+        *ecosystem_matrix_row_ids_for_evidence(evidence_id),
+    ]
+    return active_waiver_for(context, evidence_id, issue_ids, mode)
+
+
 def conditional_ecosystem_rc_required_evidence_ids(settings: Settings) -> list[str]:
     evidence_ids = list(ECOSYSTEM_RC_REQUIRED_EVIDENCE_IDS)
     if settings.live_network_beta_required:
@@ -5620,23 +5657,34 @@ def evaluate_ecosystem_rc_certification_gate(
     for evidence_id in required_evidence_ids:
         entry = current.get(evidence_id)
         status = evidence_status(entry)
-        waiver_id = evidence_detail_waiver_id(entry)
-        if waiver_id:
-            waived_evidence_ids.append(evidence_id)
-            waiver_ids.append(waiver_id)
         if evidence_entry_has_unwaivable_redaction_findings(entry):
             redaction_failure_ids.append(evidence_id)
             failed_evidence_ids.append(evidence_id)
             continue
+        waiver_id = evidence_detail_waiver_id(entry)
+        if not waiver_id and status in {"fail", "missing", "skip", "warn"}:
+            waiver = active_waiver_for_ecosystem_rc_evidence(
+                waiver_context, evidence_id, settings.mode
+            )
+            if waiver is not None:
+                waiver_id = waiver.id
+        if waiver_id:
+            waived_evidence_ids.append(evidence_id)
+            waiver_ids.append(waiver_id)
         if status == "fail":
             if waiver_id:
                 warning_evidence_ids.append(evidence_id)
             else:
                 failed_evidence_ids.append(evidence_id)
         elif status == "missing":
-            missing_evidence_ids.append(evidence_id)
+            if waiver_id:
+                warning_evidence_ids.append(evidence_id)
+            else:
+                missing_evidence_ids.append(evidence_id)
         elif status == "skip":
-            if settings.mode == "release-candidate":
+            if waiver_id:
+                warning_evidence_ids.append(evidence_id)
+            elif settings.mode == "release-candidate":
                 skipped_evidence_ids.append(evidence_id)
             else:
                 warning_evidence_ids.append(evidence_id)
@@ -5688,11 +5736,7 @@ def evaluate_ecosystem_rc_certification_gate(
             and not has_redaction_findings
         ):
             continue
-        if has_redaction_findings or status in {
-            "fail",
-            "missing",
-            "skip",
-        }:
+        if has_redaction_findings:
             redaction_evidence_passed = False
             if evidence_id not in redaction_failure_ids:
                 redaction_failure_ids.append(evidence_id)
@@ -5840,8 +5884,11 @@ def determine_certification_status(
     evidence: list[EvidenceItem],
     history_comparison: dict[str, Any],
     ecosystem_gates: list[GateResult],
+    waiver_context: WaiverContext,
 ) -> tuple[str, bool]:
-    evidence_status_value, evidence_release_passed = determine_overall_status(mode, evidence)
+    evidence_status_value, evidence_release_passed = determine_overall_status(
+        mode, evidence, waiver_context
+    )
     history_status = normalize_evidence_status(str(history_comparison.get("status", "missing")))
     gate_failures = [gate for gate in ecosystem_gates if gate.status == "fail" and gate.release_blocker]
     gate_warnings = [gate for gate in ecosystem_gates if gate.status in {"warn", "fail", "missing"}]
@@ -6004,7 +6051,7 @@ def build_summary(
     ecosystem_matrix: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     status, release_candidate_passed = determine_certification_status(
-        settings.mode, evidence, history_comparison, ecosystem_gates
+        settings.mode, evidence, history_comparison, ecosystem_gates, waiver_context
     )
     ecosystem_status = aggregate_gate_status(ecosystem_gates)
     cli_waivers = sanitized_cli_waivers(settings)
@@ -7246,6 +7293,7 @@ def run_self_test(repo_root: Path) -> None:
                 EvidenceItem("catalog.smoke", "pass", True, "passed", "<repo>/summary.json", {}),
                 EvidenceItem("apphost.live", "skip", False, "not requested", "<repo>/summary.json", {}),
             ],
+            WaiverContext(),
         )
         assert optional_skip_status == "pass", optional_skip_status
         assert optional_skip_release_passed is True, optional_skip_release_passed
@@ -7984,6 +8032,52 @@ def run_self_test(repo_root: Path) -> None:
                 "target": "missing-docs-only-link.md",
                 "reason": "missing",
             } in docs_link_evidence["details"]["brokenLinks"], docs_link_evidence
+            waived_docs_link_row_summary, waived_docs_link_row_exit_code = run_with_previous(
+                "waived-docs-link-row-cert",
+                waivers={
+                    "app-platform-beta-docs-and-program": (
+                        "Release manager accepted a temporary docs-only row gap."
+                    )
+                },
+            )
+            assert waived_docs_link_row_exit_code == 0, waived_docs_link_row_summary
+            assert waived_docs_link_row_summary["releaseCandidatePassed"] is True, (
+                waived_docs_link_row_summary
+            )
+            docs_link_row_evidence = {
+                item["id"]: item for item in waived_docs_link_row_summary["evidence"]
+            }
+            docs_link_row_docs_evidence = docs_link_row_evidence["app-platform.docs-redaction"]
+            assert docs_link_row_docs_evidence["status"] == "fail", docs_link_row_docs_evidence
+            assert docs_link_row_docs_evidence["details"]["redactionFindings"] == [], (
+                docs_link_row_docs_evidence
+            )
+            docs_link_row = matrix_row_by_id(
+                workspace / "build/waived-docs-link-row-cert",
+                "app-platform-beta-docs-and-program",
+            )
+            assert docs_link_row["status"] == "warn", docs_link_row
+            assert docs_link_row["releaseBlocker"] is False, docs_link_row
+            assert "app-platform-beta-docs-and-program" in docs_link_row["waiverIds"], (
+                docs_link_row
+            )
+            docs_link_row_rc_gate = gate_by_id(
+                waived_docs_link_row_summary, ECOSYSTEM_RC_GATE_ID
+            )
+            assert docs_link_row_rc_gate["status"] == "warn", docs_link_row_rc_gate
+            assert docs_link_row_rc_gate["releaseBlocker"] is False, docs_link_row_rc_gate
+            assert docs_link_row_rc_gate["details"]["redactionPassed"] is True, (
+                docs_link_row_rc_gate
+            )
+            assert "app-platform.docs-redaction" in docs_link_row_rc_gate["details"][
+                "waivedEvidenceIds"
+            ], docs_link_row_rc_gate
+            assert "app-platform.docs-redaction" not in docs_link_row_rc_gate["details"][
+                "failedEvidenceIds"
+            ], docs_link_row_rc_gate
+            assert "app-platform-beta-docs-and-program" in docs_link_row_rc_gate["details"][
+                "waiverIds"
+            ], docs_link_row_rc_gate
 
             portal_linked_doc.write_text(
                 original_portal_linked_doc
@@ -7999,6 +8093,9 @@ def run_self_test(repo_root: Path) -> None:
                     "evidence.app-platform.docs-redaction": (
                         "Release manager attempted to waive a docs redaction issue id."
                     ),
+                    "app-platform-beta-docs-and-program": (
+                        "Release manager attempted to waive a docs redaction row."
+                    ),
                 },
             )
             assert waived_docs_redaction_exit_code == 1, waived_docs_redaction_summary
@@ -8013,6 +8110,9 @@ def run_self_test(repo_root: Path) -> None:
             assert docs_redaction_rc_gate["details"]["redactionPassed"] is False, (
                 docs_redaction_rc_gate
             )
+            assert "app-platform-beta-docs-and-program" not in docs_redaction_rc_gate[
+                "details"
+            ].get("waiverIds", []), docs_redaction_rc_gate
             waived_docs_redaction_evidence = {
                 item["id"]: item for item in waived_docs_redaction_summary["evidence"]
             }
@@ -8035,6 +8135,9 @@ def run_self_test(repo_root: Path) -> None:
                 "waiverIds", []
             ), docs_redaction_row
             assert "evidence.app-platform.docs-redaction" not in docs_redaction_row.get(
+                "waiverIds", []
+            ), docs_redaction_row
+            assert "app-platform-beta-docs-and-program" not in docs_redaction_row.get(
                 "waiverIds", []
             ), docs_redaction_row
             assert "Waiver recorded" not in docs_redaction_row["summary"], docs_redaction_row

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -41,13 +41,6 @@ ECOSYSTEM_MATRIX_SCHEMA_VERSION = 1
 CERT_STATUSES = ("pass", "warn", "fail", "skip", "missing")
 MODES = ("pr", "nightly", "release-candidate")
 PRIVATE_ARTIFACT_NAMES = ("private-insert-uris.json",)
-REDACTION_FINDING_EVIDENCE_IDS = frozenset(
-    {
-        "app-platform.docs-redaction",
-        "ecosystem-security.advisory-revocation-redaction",
-        "live-network-beta.redaction",
-    }
-)
 PUBLIC_BETA_SECURITY_EVIDENCE_IDS = (
     "public-beta-security.app-ui-csp",
     "public-beta-security.app-origin-policy",
@@ -141,6 +134,132 @@ NETWORK_SCALE_SOAK_REDACTION_KEYS = (
     "tokensExcluded",
     "absolutePathsExcluded",
     "queueHtmlExcluded",
+)
+ECOSYSTEM_RC_GATE_ID = "ecosystem.rc-certification"
+ECOSYSTEM_RC_EVIDENCE_ID = "release-certification.ecosystem-rc-gate"
+ECOSYSTEM_RC_MATRIX_ROW_ID = "ecosystem-rc-certification-gate"
+APP_SERVICE_DEPENDENCY_AND_GRANT_BUNDLE_EVIDENCE_IDS = (
+    "app-services.dependency-graph",
+    "app-services.grant-bundles",
+    "app-services.grant-expiry-renewal",
+    "app-services.provider-revalidation",
+    "reference-app.social-inbox-service-dependency",
+    "app-services.dependency-redaction",
+)
+APP_SERVICE_DISCOVERY_AND_GRANT_EVIDENCE_IDS = (
+    "app-services.registry",
+    "app-services.grants",
+    *APP_SERVICE_DEPENDENCY_AND_GRANT_BUNDLE_EVIDENCE_IDS,
+    "app-services.trust-score-provider",
+    "reference-app.social-inbox-service-grant",
+    "app-services.web-shell",
+    "app-services.redaction",
+)
+ECOSYSTEM_RC_REQUIRED_GATE_IDS = (
+    "ecosystem.required-evidence-regressions",
+    "ecosystem.platform-api-compatibility",
+    "ecosystem.first-party-apps",
+    "ecosystem.app-ui-quality",
+    "ecosystem.app-review-trust",
+    "ecosystem.app-update-rollback",
+    "ecosystem.operator-rc-recovery",
+    "ecosystem.security-advisory-revocation",
+    "ecosystem.app-vault",
+    "ecosystem.sandbox-provider",
+    "ecosystem.reference-content-apps",
+    "ecosystem.legacy-retirement",
+)
+ECOSYSTEM_RC_REQUIRED_EVIDENCE_IDS = (
+    "interop.smoke",
+    "performance.smoke",
+    "release-certification.ecosystem-matrix",
+    "platform-api.contract",
+    "app-platform.first-party",
+    "app-platform.devtools-cli",
+    "app-platform.developer-beta-toolkit",
+    *app_platform_docs_check.EVIDENCE_IDS,
+    "catalog.smoke",
+    "catalog.live-usk-publication",
+    "catalog.live-usk-source-verification",
+    "app-catalog.first-party-beta",
+    "app-platform.signed-bundles",
+    "catalog.production-channels",
+    *ECOSYSTEM_SECURITY_EVIDENCE_IDS,
+    "app-review.trusted-receipts",
+    "app-review.policy",
+    "app-review.governance",
+    "app-review.reviewer-key-lifecycle",
+    "app-review.transparency-log",
+    "app-review.review-history-api",
+    "app-review.first-party-catalog",
+    "app-review.first-party-review-chain",
+    "app-update.lifecycle",
+    "app-update.scheduler",
+    "app-update.live-catalog-refresh",
+    "app-update.rollback",
+    "app-update.data-migration-contract",
+    "app-platform.durable-app-data-store",
+    "app-data.backup-restore-portability",
+    "operator-beta.app-data-backup-restore",
+    "app-vault.capabilities",
+    "app-platform.identity-profile-publish",
+    "app-platform.generated-document-insert",
+    "app-platform.content-fetch",
+    "app-platform.content-subscriptions",
+    "network-content.subscription-scheduler",
+    "app-platform.trust-graph-preview",
+    "app-platform.trust-graph-rc-scope-and-safety",
+    "app-platform.trust-graph-durable-store",
+    "app-platform.trust-graph-exchange",
+    "app-platform.trust-statement-signing",
+    "reference-app.trust-graph",
+    "reference-app.trust-graph-durable-exchange",
+    "reference-app.trust-graph-app-data-preview",
+    "app-platform.social-message-signing",
+    "reference-app.social-inbox",
+    "reference-app.social-inbox-signed-message",
+    "reference-app.social-inbox-subscriptions",
+    "reference-app.social-inbox-app-data",
+    "reference-app.social-inbox-trust-annotations",
+    "reference-app.social-inbox-rc-threading",
+    "reference-app.social-inbox-service-grant",
+    "reference-app.social-inbox-service-dependency",
+    "migration.social-mail-preview",
+    *APP_SERVICE_DISCOVERY_AND_GRANT_EVIDENCE_IDS,
+    *NETWORK_SCALE_EVIDENCE_IDS,
+    NETWORK_SCALE_SOAK_EVIDENCE_ID,
+    *OPERATOR_RC_EVIDENCE_IDS,
+    "legacy.retirement",
+    "legacy-admin.removal-wave-1",
+    "legacy-admin.removal-wave-2",
+    "legacy-admin.removal-wave-3",
+    "legacy-admin.removal-wave-4",
+    "legacy-plugin.freeze-policy",
+    "legacy-plugin.migration-guide",
+    "legacy-plugin.social-inbox-spike",
+    "app-ui.design-system",
+    "app-ui.lint",
+    "app-ui.first-party-adoption",
+    "app-ui.smoke",
+    "apphost.sandbox-provider",
+    *PUBLIC_BETA_SECURITY_EVIDENCE_IDS,
+    "reference-apps.content",
+    "reference-app.profile-publisher",
+    "reference-app.profile-publisher-app-data",
+    "reference-app.feed-reader",
+    "reference-app.feed-reader-subscriptions",
+    "reference-app.feed-reader-app-data",
+)
+ECOSYSTEM_RC_REDACTION_EVIDENCE_IDS = (
+    "app-platform.docs-redaction",
+    "ecosystem-security.advisory-revocation-redaction",
+    "live-network-beta.redaction",
+    "network-scale.redaction",
+    "app-services.redaction",
+    "app-services.dependency-redaction",
+    "operator-beta.support-bundle-redaction",
+    "operator-rc.redaction",
+    "public-beta-security.audit-redaction-fuzz",
 )
 SENSITIVE_KEY_PATTERN = (
     r"token|password|passwd|secret|credential|authorization|cookie|set-cookie|"
@@ -796,13 +915,9 @@ def unique_non_empty_strings(values: Any) -> list[str]:
     return result
 
 
-def has_unwaivable_redaction_findings(evidence_id: str, details: dict[str, Any]) -> bool:
+def has_unwaivable_redaction_findings(_evidence_id: str, details: dict[str, Any]) -> bool:
     redaction_findings = details.get("redactionFindings")
-    return (
-        evidence_id in REDACTION_FINDING_EVIDENCE_IDS
-        and isinstance(redaction_findings, list)
-        and bool(redaction_findings)
-    )
+    return isinstance(redaction_findings, list) and bool(redaction_findings)
 
 
 def evidence_item_has_unwaivable_redaction_findings(item: EvidenceItem) -> bool:
@@ -1101,12 +1216,7 @@ def app_platform_evidence(
         "app-platform.trust-graph-exchange",
         "app-platform.trust-statement-signing",
         "app-platform.social-message-signing",
-        "app-services.registry",
-        "app-services.grants",
-        "app-services.trust-score-provider",
-        "reference-app.social-inbox-service-grant",
-        "app-services.web-shell",
-        "app-services.redaction",
+        *APP_SERVICE_DISCOVERY_AND_GRANT_EVIDENCE_IDS,
         "app-platform.signed-bundles",
         "catalog.smoke",
         "catalog.live-usk-publication",
@@ -2020,6 +2130,20 @@ def ecosystem_matrix_row_specs() -> list[MatrixRowSpec]:
             ),
         ),
         MatrixRowSpec(
+            id=ECOSYSTEM_RC_MATRIX_ROW_ID,
+            category="release-operations",
+            title="Ecosystem RC certification gate",
+            required_evidence_ids=(ECOSYSTEM_RC_EVIDENCE_ID,),
+            gate_ids=(ECOSYSTEM_RC_GATE_ID,),
+            docs=(
+                "docs/release-certification.md",
+                "docs/ecosystem-rc-certification-gate.md",
+                "docs/cryptad-release-workflow-and-runbook.md",
+                "tools/release-certification/README.md",
+            ),
+            phase="phase-9",
+        ),
+        MatrixRowSpec(
             id="interop-smoke",
             category="network-compatibility",
             title="Hyphanet interop smoke certification",
@@ -2171,15 +2295,8 @@ def ecosystem_matrix_row_specs() -> list[MatrixRowSpec]:
         MatrixRowSpec(
             id="app-service-discovery-and-grants",
             category="app-platform",
-            title="App-service discovery, grants, and Trust Score Service",
-            required_evidence_ids=(
-                "app-services.registry",
-                "app-services.grants",
-                "app-services.trust-score-provider",
-                "reference-app.social-inbox-service-grant",
-                "app-services.web-shell",
-                "app-services.redaction",
-            ),
+            title="App-service discovery, grants, dependency graph, and grant bundles",
+            required_evidence_ids=APP_SERVICE_DISCOVERY_AND_GRANT_EVIDENCE_IDS,
             gate_ids=("ecosystem.reference-content-apps",),
             docs=(
                 "docs/app-service-discovery-and-grants.md",
@@ -2419,6 +2536,7 @@ def ecosystem_matrix_row_specs() -> list[MatrixRowSpec]:
                 "reference-app.social-inbox-trust-annotations",
                 "reference-app.social-inbox-rc-threading",
                 "reference-app.social-inbox-service-grant",
+                "reference-app.social-inbox-service-dependency",
                 "migration.social-mail-preview",
             ),
             gate_ids=("ecosystem.reference-content-apps",),
@@ -2770,6 +2888,8 @@ def evaluate_matrix_row(
                 and not bool(evidence_details_value.get("enabled"))
             )
             if live_beta_disabled_skip:
+                continue
+            if evidence_id == "apphost.live":
                 continue
             if evidence_id == "live-network-beta.app-service-score" and not bool(
                 evidence_details_value.get("enabled")
@@ -3298,6 +3418,86 @@ def placeholder_ecosystem_matrix_evidence(workspace_root: Path, out_dir: Path) -
                     out_dir,
                 ),
                 "schemaVersion": ECOSYSTEM_MATRIX_SCHEMA_VERSION,
+            },
+        ),
+        workspace_root,
+        out_dir,
+    )
+
+
+def ecosystem_rc_gate_evidence(
+    gate: GateResult | None,
+    workspace_root: Path,
+    out_dir: Path,
+) -> EvidenceItem:
+    if gate is None:
+        return placeholder_ecosystem_rc_gate_evidence(workspace_root, out_dir)
+    waiver_ids = gate_waiver_ids(gate)
+    compact_details = {
+        key: gate.details.get(key)
+        for key in (
+            "phase",
+            "requiredEvidenceIds",
+            "requiredGateIds",
+            "failedEvidenceIds",
+            "warningEvidenceIds",
+            "missingEvidenceIds",
+            "skippedEvidenceIds",
+            "blockingGateIds",
+            "warningGateIds",
+            "waivedEvidenceIds",
+            "waivedGateIds",
+            "historyComparisonStatus",
+            "liveNetworkRequired",
+            "liveNetworkSatisfied",
+            "networkScaleSoakSatisfied",
+            "redactionPassed",
+            "redactionFailureEvidenceIds",
+            "firstPartyAppsCovered",
+            "promotionReady",
+        )
+        if key in gate.details
+    }
+    if waiver_ids:
+        compact_details["waiverIds"] = waiver_ids
+    details = {
+        "gateId": gate.id,
+        "releaseBlocker": gate.release_blocker,
+        "promotionReady": bool(gate.details.get("promotionReady", not gate.release_blocker)),
+        "failedEvidenceCount": len(gate.details.get("failedEvidenceIds", [])),
+        "missingEvidenceCount": len(gate.details.get("missingEvidenceIds", [])),
+        "warningEvidenceCount": len(gate.details.get("warningEvidenceIds", [])),
+        "blockingGateCount": len(gate.details.get("blockingGateIds", [])),
+        "warningGateCount": len(gate.details.get("warningGateIds", [])),
+        "waiverCount": len(waiver_ids),
+        "details": compact_details,
+    }
+    return sanitize_evidence_item(
+        EvidenceItem(
+            ECOSYSTEM_RC_EVIDENCE_ID,
+            gate.status,
+            True,
+            gate.summary,
+            display_path(out_dir / SUMMARY_FILE_NAME, workspace_root, out_dir),
+            details,
+        ),
+        workspace_root,
+        out_dir,
+    )
+
+
+def placeholder_ecosystem_rc_gate_evidence(workspace_root: Path, out_dir: Path) -> EvidenceItem:
+    return sanitize_evidence_item(
+        EvidenceItem(
+            ECOSYSTEM_RC_EVIDENCE_ID,
+            "pass",
+            True,
+            "Ecosystem RC certification gate evaluation is pending.",
+            display_path(out_dir / SUMMARY_FILE_NAME, workspace_root, out_dir),
+            {
+                "gateId": ECOSYSTEM_RC_GATE_ID,
+                "phase": "phase-9",
+                "promotionReady": False,
             },
         ),
         workspace_root,
@@ -3864,6 +4064,7 @@ def evaluate_app_update_rollback_gate(
         "app-update.scheduler",
         "app-update.live-catalog-refresh",
         "app-update.rollback",
+        "app-update.data-migration-contract",
     ):
         status = evidence_status(current.get(evidence_id))
         previous_status = evidence_status(previous.get(evidence_id))
@@ -4271,16 +4472,34 @@ def evaluate_reference_content_gate(
     previous_app_services_registry_item = previous.get("app-services.registry")
     app_services_grants_item = current.get("app-services.grants")
     previous_app_services_grants_item = previous.get("app-services.grants")
+    app_services_dependency_graph_item = current.get("app-services.dependency-graph")
+    previous_app_services_dependency_graph_item = previous.get("app-services.dependency-graph")
+    app_services_grant_bundles_item = current.get("app-services.grant-bundles")
+    previous_app_services_grant_bundles_item = previous.get("app-services.grant-bundles")
+    app_services_grant_expiry_item = current.get("app-services.grant-expiry-renewal")
+    previous_app_services_grant_expiry_item = previous.get("app-services.grant-expiry-renewal")
+    app_services_provider_revalidation_item = current.get("app-services.provider-revalidation")
+    previous_app_services_provider_revalidation_item = previous.get("app-services.provider-revalidation")
     app_services_provider_item = current.get("app-services.trust-score-provider")
     previous_app_services_provider_item = previous.get("app-services.trust-score-provider")
     social_inbox_service_grant_item = current.get("reference-app.social-inbox-service-grant")
     previous_social_inbox_service_grant_item = previous.get(
         "reference-app.social-inbox-service-grant"
     )
+    social_inbox_service_dependency_item = current.get(
+        "reference-app.social-inbox-service-dependency"
+    )
+    previous_social_inbox_service_dependency_item = previous.get(
+        "reference-app.social-inbox-service-dependency"
+    )
     app_services_web_shell_item = current.get("app-services.web-shell")
     previous_app_services_web_shell_item = previous.get("app-services.web-shell")
     app_services_redaction_item = current.get("app-services.redaction")
     previous_app_services_redaction_item = previous.get("app-services.redaction")
+    app_services_dependency_redaction_item = current.get("app-services.dependency-redaction")
+    previous_app_services_dependency_redaction_item = previous.get(
+        "app-services.dependency-redaction"
+    )
     details = evidence_details(item)
     profile_details = evidence_details(profile_item)
     profile_app_data_details = evidence_details(profile_app_data_item)
@@ -4311,10 +4530,22 @@ def evaluate_reference_content_gate(
     trust_statement_signing_details = evidence_details(trust_statement_signing_item)
     app_services_registry_details = evidence_details(app_services_registry_item)
     app_services_grants_details = evidence_details(app_services_grants_item)
+    app_services_dependency_graph_details = evidence_details(app_services_dependency_graph_item)
+    app_services_grant_bundles_details = evidence_details(app_services_grant_bundles_item)
+    app_services_grant_expiry_details = evidence_details(app_services_grant_expiry_item)
+    app_services_provider_revalidation_details = evidence_details(
+        app_services_provider_revalidation_item
+    )
     app_services_provider_details = evidence_details(app_services_provider_item)
     social_inbox_service_grant_details = evidence_details(social_inbox_service_grant_item)
+    social_inbox_service_dependency_details = evidence_details(
+        social_inbox_service_dependency_item
+    )
     app_services_web_shell_details = evidence_details(app_services_web_shell_item)
     app_services_redaction_details = evidence_details(app_services_redaction_item)
+    app_services_dependency_redaction_details = evidence_details(
+        app_services_dependency_redaction_item
+    )
     checks = nested_dict(details, "checks")
     profile_checks = nested_dict(profile_details, "checks")
     profile_app_data_checks = nested_dict(profile_app_data_details, "checks")
@@ -4338,9 +4569,21 @@ def evaluate_reference_content_gate(
     social_mail_migration_checks = nested_dict(social_mail_migration_details, "checks")
     app_services_registry_checks = nested_dict(app_services_registry_details, "checks")
     app_services_grants_checks = nested_dict(app_services_grants_details, "checks")
+    app_services_dependency_graph_checks = nested_dict(app_services_dependency_graph_details, "checks")
+    app_services_grant_bundles_checks = nested_dict(app_services_grant_bundles_details, "checks")
+    app_services_grant_expiry_checks = nested_dict(app_services_grant_expiry_details, "checks")
+    app_services_provider_revalidation_checks = nested_dict(
+        app_services_provider_revalidation_details, "checks"
+    )
     app_services_provider_checks = nested_dict(app_services_provider_details, "checks")
     app_services_web_shell_checks = nested_dict(app_services_web_shell_details, "checks")
     app_services_redaction_checks = nested_dict(app_services_redaction_details, "checks")
+    social_inbox_service_dependency_checks = nested_dict(
+        social_inbox_service_dependency_details, "checks"
+    )
+    app_services_dependency_redaction_checks = nested_dict(
+        app_services_dependency_redaction_details, "checks"
+    )
     status = evidence_status(item)
     previous_status = evidence_status(previous_item)
     profile_status = evidence_status(profile_item)
@@ -4415,16 +4658,44 @@ def evaluate_reference_content_gate(
     previous_app_services_registry_status = evidence_status(previous_app_services_registry_item)
     app_services_grants_status = evidence_status(app_services_grants_item)
     previous_app_services_grants_status = evidence_status(previous_app_services_grants_item)
+    app_services_dependency_graph_status = evidence_status(app_services_dependency_graph_item)
+    previous_app_services_dependency_graph_status = evidence_status(
+        previous_app_services_dependency_graph_item
+    )
+    app_services_grant_bundles_status = evidence_status(app_services_grant_bundles_item)
+    previous_app_services_grant_bundles_status = evidence_status(
+        previous_app_services_grant_bundles_item
+    )
+    app_services_grant_expiry_status = evidence_status(app_services_grant_expiry_item)
+    previous_app_services_grant_expiry_status = evidence_status(
+        previous_app_services_grant_expiry_item
+    )
+    app_services_provider_revalidation_status = evidence_status(
+        app_services_provider_revalidation_item
+    )
+    previous_app_services_provider_revalidation_status = evidence_status(
+        previous_app_services_provider_revalidation_item
+    )
     app_services_provider_status = evidence_status(app_services_provider_item)
     previous_app_services_provider_status = evidence_status(previous_app_services_provider_item)
     social_inbox_service_grant_status = evidence_status(social_inbox_service_grant_item)
     previous_social_inbox_service_grant_status = evidence_status(
         previous_social_inbox_service_grant_item
     )
+    social_inbox_service_dependency_status = evidence_status(social_inbox_service_dependency_item)
+    previous_social_inbox_service_dependency_status = evidence_status(
+        previous_social_inbox_service_dependency_item
+    )
     app_services_web_shell_status = evidence_status(app_services_web_shell_item)
     previous_app_services_web_shell_status = evidence_status(previous_app_services_web_shell_item)
     app_services_redaction_status = evidence_status(app_services_redaction_item)
     previous_app_services_redaction_status = evidence_status(previous_app_services_redaction_item)
+    app_services_dependency_redaction_status = evidence_status(
+        app_services_dependency_redaction_item
+    )
+    previous_app_services_dependency_redaction_status = evidence_status(
+        previous_app_services_dependency_redaction_item
+    )
     gate_details: dict[str, Any] = {}
     failures: list[str] = []
     warnings: list[str] = []
@@ -4557,6 +4828,26 @@ def evaluate_reference_content_gate(
         ("app-services.registry", app_services_registry_status, previous_app_services_registry_status),
         ("app-services.grants", app_services_grants_status, previous_app_services_grants_status),
         (
+            "app-services.dependency-graph",
+            app_services_dependency_graph_status,
+            previous_app_services_dependency_graph_status,
+        ),
+        (
+            "app-services.grant-bundles",
+            app_services_grant_bundles_status,
+            previous_app_services_grant_bundles_status,
+        ),
+        (
+            "app-services.grant-expiry-renewal",
+            app_services_grant_expiry_status,
+            previous_app_services_grant_expiry_status,
+        ),
+        (
+            "app-services.provider-revalidation",
+            app_services_provider_revalidation_status,
+            previous_app_services_provider_revalidation_status,
+        ),
+        (
             "app-services.trust-score-provider",
             app_services_provider_status,
             previous_app_services_provider_status,
@@ -4567,6 +4858,11 @@ def evaluate_reference_content_gate(
             previous_social_inbox_service_grant_status,
         ),
         (
+            "reference-app.social-inbox-service-dependency",
+            social_inbox_service_dependency_status,
+            previous_social_inbox_service_dependency_status,
+        ),
+        (
             "app-services.web-shell",
             app_services_web_shell_status,
             previous_app_services_web_shell_status,
@@ -4575,6 +4871,11 @@ def evaluate_reference_content_gate(
             "app-services.redaction",
             app_services_redaction_status,
             previous_app_services_redaction_status,
+        ),
+        (
+            "app-services.dependency-redaction",
+            app_services_dependency_redaction_status,
+            previous_app_services_dependency_redaction_status,
         ),
     ):
         if current_status in {"fail", "missing", "skip"}:
@@ -4862,6 +5163,19 @@ def evaluate_reference_content_gate(
                     "failureEvidenceIds",
                     "reference-app.social-inbox-service-grant",
                 )
+    if social_inbox_service_dependency_checks:
+        for key in (
+            "socialManifestDeclaresOptionalDependency",
+            "socialDegradesSafely",
+            "socialDependencyDocsPresent",
+        ):
+            if social_inbox_service_dependency_checks.get(key) is not True:
+                failures.append(f"Social Inbox service-dependency check {key} failed")
+                add_evidence_issue(
+                    gate_details,
+                    "failureEvidenceIds",
+                    "reference-app.social-inbox-service-dependency",
+                )
     if app_services_registry_checks:
         for key in (
             "contractV12AndCapabilitiesPresent",
@@ -4885,6 +5199,52 @@ def evaluate_reference_content_gate(
             if app_services_grants_checks.get(key) is not True:
                 failures.append(f"App-service grant check {key} failed")
                 add_evidence_issue(gate_details, "failureEvidenceIds", "app-services.grants")
+    if app_services_dependency_graph_checks:
+        for key in (
+            "dependencyModelsPresent",
+            "dependencyParserStrictFieldsPresent",
+            "dependencyRoutesPresent",
+            "dependencyTestsPresent",
+        ):
+            if app_services_dependency_graph_checks.get(key) is not True:
+                failures.append(f"App-service dependency graph check {key} failed")
+                add_evidence_issue(
+                    gate_details, "failureEvidenceIds", "app-services.dependency-graph"
+                )
+    if app_services_grant_bundles_checks:
+        for key in (
+            "bundleModelsAndStorePresent",
+            "bundleRoutesPresent",
+            "bundleCoordinatorHostOnly",
+            "bundleTestsPresent",
+        ):
+            if app_services_grant_bundles_checks.get(key) is not True:
+                failures.append(f"App-service grant-bundle check {key} failed")
+                add_evidence_issue(
+                    gate_details, "failureEvidenceIds", "app-services.grant-bundles"
+                )
+    if app_services_grant_expiry_checks:
+        for key in (
+            "grantExpiryFieldsPresent",
+            "expiredGrantsFailClosed",
+            "renewalRevalidates",
+        ):
+            if app_services_grant_expiry_checks.get(key) is not True:
+                failures.append(f"App-service grant expiry check {key} failed")
+                add_evidence_issue(
+                    gate_details, "failureEvidenceIds", "app-services.grant-expiry-renewal"
+                )
+    if app_services_provider_revalidation_checks:
+        for key in (
+            "compatibilityFingerprintPresent",
+            "descriptorDriftNonAuthorizing",
+            "descriptorMatchingChecksVersionScopeContextKindAdapter",
+        ):
+            if app_services_provider_revalidation_checks.get(key) is not True:
+                failures.append(f"App-service provider revalidation check {key} failed")
+                add_evidence_issue(
+                    gate_details, "failureEvidenceIds", "app-services.provider-revalidation"
+                )
     if app_services_provider_checks:
         for key in (
             "trustGraphManifestAdvertisesService",
@@ -4918,6 +5278,17 @@ def evaluate_reference_content_gate(
             if app_services_redaction_checks.get(key) is not True:
                 failures.append(f"App-service redaction check {key} failed")
                 add_evidence_issue(gate_details, "failureEvidenceIds", "app-services.redaction")
+    if app_services_dependency_redaction_checks:
+        for key in (
+            "dependencyJsonPathFreeByConstruction",
+            "bundlePublicJsonFieldsSafe",
+            "uiAndEvidenceAvoidRawSensitiveValues",
+        ):
+            if app_services_dependency_redaction_checks.get(key) is not True:
+                failures.append(f"App-service dependency-redaction check {key} failed")
+                add_evidence_issue(
+                    gate_details, "failureEvidenceIds", "app-services.dependency-redaction"
+                )
     if social_mail_migration_checks:
         for key in (
             "migrationFramingPresent",
@@ -5069,6 +5440,24 @@ def evaluate_reference_content_gate(
             "previousTrustGraphPreviewStatus": previous_trust_graph_preview_status,
             "trustStatementSigningStatus": trust_statement_signing_status,
             "previousTrustStatementSigningStatus": previous_trust_statement_signing_status,
+            "appServicesDependencyGraphStatus": app_services_dependency_graph_status,
+            "previousAppServicesDependencyGraphStatus": previous_app_services_dependency_graph_status,
+            "appServicesGrantBundlesStatus": app_services_grant_bundles_status,
+            "previousAppServicesGrantBundlesStatus": previous_app_services_grant_bundles_status,
+            "appServicesGrantExpiryStatus": app_services_grant_expiry_status,
+            "previousAppServicesGrantExpiryStatus": previous_app_services_grant_expiry_status,
+            "appServicesProviderRevalidationStatus": app_services_provider_revalidation_status,
+            "previousAppServicesProviderRevalidationStatus": (
+                previous_app_services_provider_revalidation_status
+            ),
+            "socialInboxServiceDependencyStatus": social_inbox_service_dependency_status,
+            "previousSocialInboxServiceDependencyStatus": (
+                previous_social_inbox_service_dependency_status
+            ),
+            "appServicesDependencyRedactionStatus": app_services_dependency_redaction_status,
+            "previousAppServicesDependencyRedactionStatus": (
+                previous_app_services_dependency_redaction_status
+            ),
             "profilePublisherAppId": profile_details.get("appId"),
             "feedReaderAppId": feed_reader_details.get("appId"),
             "trustGraphAppId": trust_graph_details.get("appId"),
@@ -5155,6 +5544,245 @@ def evaluate_waiver_validation_gate(context: WaiverContext, mode: str) -> GateRe
     )
 
 
+def unique_ids(values: Any) -> list[str]:
+    return sorted(dict.fromkeys(str(value) for value in values if str(value).strip()))
+
+
+def evidence_detail_waiver_id(entry: dict[str, Any] | None) -> str:
+    details = evidence_details(entry)
+    waiver_id = details.get("waiverId")
+    return str(waiver_id) if waiver_id else ""
+
+
+def gate_detail_waiver_id(gate: GateResult | None) -> str:
+    if gate is None:
+        return ""
+    waiver_id = gate.details.get("waiverId")
+    return str(waiver_id) if waiver_id else ""
+
+
+def gate_waiver_ids(gate: GateResult | None) -> list[str]:
+    if gate is None:
+        return []
+    waiver_ids: list[Any] = []
+    details = gate.details
+    existing_ids = details.get("waiverIds", [])
+    if isinstance(existing_ids, list):
+        waiver_ids.extend(existing_ids)
+    elif existing_ids:
+        waiver_ids.append(existing_ids)
+    direct_waiver_id = details.get("waiverId")
+    if direct_waiver_id:
+        waiver_ids.append(direct_waiver_id)
+    return unique_ids(waiver_ids)
+
+
+def conditional_ecosystem_rc_required_evidence_ids(settings: Settings) -> list[str]:
+    evidence_ids = list(ECOSYSTEM_RC_REQUIRED_EVIDENCE_IDS)
+    if settings.live_network_beta_required:
+        evidence_ids.extend(LIVE_NETWORK_BETA_REQUIRED_EVIDENCE_IDS)
+    return unique_ids(evidence_ids)
+
+
+def conditional_ecosystem_rc_required_gate_ids(
+    settings: Settings, gate_entries: dict[str, GateResult]
+) -> list[str]:
+    gate_ids = list(ECOSYSTEM_RC_REQUIRED_GATE_IDS)
+    if settings.live_network_beta_required:
+        gate_ids.append("ecosystem.live-network-beta")
+    if "ecosystem.waivers" in gate_entries:
+        gate_ids.append("ecosystem.waivers")
+    return unique_ids(gate_ids)
+
+
+def evaluate_ecosystem_rc_certification_gate(
+    settings: Settings,
+    current_evidence: list[EvidenceItem],
+    child_gates: list[GateResult],
+    history_comparison: dict[str, Any],
+    waiver_context: WaiverContext,
+) -> GateResult:
+    current = evidence_map_from_items(current_evidence)
+    gate_entries = {gate.id: gate for gate in child_gates}
+    required_evidence_ids = conditional_ecosystem_rc_required_evidence_ids(settings)
+    required_gate_ids = conditional_ecosystem_rc_required_gate_ids(settings, gate_entries)
+    optional_gate_ids = [] if settings.live_network_beta_required else ["ecosystem.live-network-beta"]
+    failed_evidence_ids: list[str] = []
+    warning_evidence_ids: list[str] = []
+    missing_evidence_ids: list[str] = []
+    skipped_evidence_ids: list[str] = []
+    waived_evidence_ids: list[str] = []
+    waived_gate_ids: list[str] = []
+    waiver_ids: list[str] = []
+    redaction_failure_ids: list[str] = []
+
+    for evidence_id in required_evidence_ids:
+        entry = current.get(evidence_id)
+        status = evidence_status(entry)
+        waiver_id = evidence_detail_waiver_id(entry)
+        if waiver_id:
+            waived_evidence_ids.append(evidence_id)
+            waiver_ids.append(waiver_id)
+        if evidence_entry_has_unwaivable_redaction_findings(entry):
+            redaction_failure_ids.append(evidence_id)
+            failed_evidence_ids.append(evidence_id)
+            continue
+        if status == "fail":
+            if waiver_id:
+                warning_evidence_ids.append(evidence_id)
+            else:
+                failed_evidence_ids.append(evidence_id)
+        elif status == "missing":
+            missing_evidence_ids.append(evidence_id)
+        elif status == "skip":
+            if settings.mode == "release-candidate":
+                skipped_evidence_ids.append(evidence_id)
+            else:
+                warning_evidence_ids.append(evidence_id)
+        elif status == "warn":
+            warning_evidence_ids.append(evidence_id)
+
+    blocking_gate_ids: list[str] = []
+    warning_gate_ids: list[str] = []
+    for gate_id in required_gate_ids:
+        gate = gate_entries.get(gate_id)
+        if gate is None:
+            blocking_gate_ids.append(gate_id)
+            continue
+        waiver_id = gate_detail_waiver_id(gate)
+        if waiver_id:
+            waived_gate_ids.append(gate_id)
+            waiver_ids.append(waiver_id)
+        if gate.status == "fail" and gate.release_blocker:
+            blocking_gate_ids.append(gate_id)
+        elif gate.status in {"warn", "fail", "missing"}:
+            warning_gate_ids.append(gate_id)
+    for gate_id in optional_gate_ids:
+        gate = gate_entries.get(gate_id)
+        if gate is not None and gate.status in {"warn", "fail", "missing"}:
+            warning_gate_ids.append(gate_id)
+
+    history_status = normalize_evidence_status(str(history_comparison.get("status", "missing")))
+    if history_status == "fail":
+        blocking_gate_ids.append("history-comparison")
+    elif history_status in {"warn", "missing"}:
+        warning_gate_ids.append("history-comparison")
+
+    matrix_entry = current.get("release-certification.ecosystem-matrix")
+    matrix_coverage = evidence_details(matrix_entry).get("coverage", {})
+    matrix_redaction_passed = (
+        bool(matrix_coverage.get("redactionPassed", True))
+        if isinstance(matrix_coverage, dict)
+        else True
+    )
+    redaction_evidence_passed = True
+    for evidence_id in ECOSYSTEM_RC_REDACTION_EVIDENCE_IDS:
+        entry = current.get(evidence_id)
+        status = evidence_status(entry)
+        has_redaction_findings = evidence_entry_has_unwaivable_redaction_findings(entry)
+        if (
+            evidence_id == "live-network-beta.redaction"
+            and not settings.live_network_beta_required
+            and status in {"missing", "skip"}
+            and not has_redaction_findings
+        ):
+            continue
+        if has_redaction_findings or status in {
+            "fail",
+            "missing",
+            "skip",
+        }:
+            redaction_evidence_passed = False
+            if evidence_id not in redaction_failure_ids:
+                redaction_failure_ids.append(evidence_id)
+    redaction_passed = matrix_redaction_passed and redaction_evidence_passed
+
+    live_required = settings.live_network_beta_required
+    live_required_statuses = [
+        evidence_status(current.get(evidence_id))
+        for evidence_id in LIVE_NETWORK_BETA_REQUIRED_EVIDENCE_IDS
+    ]
+    live_network_satisfied = (not live_required) or not any(
+        status in {"fail", "missing", "skip"} for status in live_required_statuses
+    )
+    network_scale_soak_status = evidence_status(current.get(NETWORK_SCALE_SOAK_EVIDENCE_ID))
+    network_scale_soak_satisfied = network_scale_soak_status not in {"fail", "missing", "skip"}
+    first_party_gate = gate_entries.get("ecosystem.first-party-apps")
+    first_party_apps_covered = first_party_gate is not None and first_party_gate.status in {"pass", "warn"}
+
+    failed_evidence_ids = unique_ids(failed_evidence_ids)
+    warning_evidence_ids = unique_ids(warning_evidence_ids)
+    missing_evidence_ids = unique_ids(missing_evidence_ids)
+    skipped_evidence_ids = unique_ids(skipped_evidence_ids)
+    blocking_gate_ids = unique_ids(blocking_gate_ids)
+    warning_gate_ids = unique_ids(warning_gate_ids)
+    waived_evidence_ids = unique_ids(waived_evidence_ids)
+    waived_gate_ids = unique_ids(waived_gate_ids)
+    waiver_ids = unique_ids(waiver_ids)
+    redaction_failure_ids = unique_ids(redaction_failure_ids)
+
+    has_blockers = bool(
+        failed_evidence_ids
+        or missing_evidence_ids
+        or (settings.mode == "release-candidate" and skipped_evidence_ids)
+        or blocking_gate_ids
+        or not redaction_passed
+        or not network_scale_soak_satisfied
+        or not live_network_satisfied
+    )
+    has_warnings = bool(
+        warning_evidence_ids
+        or skipped_evidence_ids
+        or warning_gate_ids
+        or waiver_ids
+        or history_status in {"warn", "missing"}
+    )
+    release_blocker = has_blockers and (settings.mode == "release-candidate" or not redaction_passed)
+    status = "fail" if release_blocker else ("warn" if has_blockers or has_warnings else "pass")
+    promotion_ready = not release_blocker
+    details = {
+        "phase": "phase-9",
+        "requiredEvidenceIds": required_evidence_ids,
+        "requiredGateIds": required_gate_ids,
+        "optionalGateIds": optional_gate_ids,
+        "failedEvidenceIds": failed_evidence_ids,
+        "warningEvidenceIds": warning_evidence_ids,
+        "missingEvidenceIds": missing_evidence_ids,
+        "skippedEvidenceIds": skipped_evidence_ids,
+        "blockingGateIds": blocking_gate_ids,
+        "warningGateIds": warning_gate_ids,
+        "waiverIds": waiver_ids,
+        "waivedEvidenceIds": waived_evidence_ids,
+        "waivedGateIds": waived_gate_ids,
+        "historyComparisonStatus": history_status,
+        "liveNetworkRequired": live_required,
+        "liveNetworkSatisfied": live_network_satisfied,
+        "networkScaleSoakSatisfied": network_scale_soak_satisfied,
+        "redactionPassed": redaction_passed,
+        "redactionFailureEvidenceIds": redaction_failure_ids,
+        "firstPartyAppsCovered": first_party_apps_covered,
+        "promotionReady": promotion_ready,
+    }
+    if failed_evidence_ids or missing_evidence_ids or skipped_evidence_ids:
+        details["failureEvidenceIds"] = unique_ids(
+            failed_evidence_ids + missing_evidence_ids + skipped_evidence_ids
+        )
+    if redaction_failure_ids:
+        details["unwaivableFailureEvidenceIds"] = redaction_failure_ids
+    if warning_evidence_ids:
+        details["warningEvidenceIds"] = warning_evidence_ids
+    summary = (
+        "Ecosystem RC certification is ready for promotion."
+        if status == "pass"
+        else (
+            "Ecosystem RC certification has warnings or waived blockers."
+            if status == "warn"
+            else "Ecosystem RC certification has release-blocking failures."
+        )
+    )
+    return GateResult(ECOSYSTEM_RC_GATE_ID, status, release_blocker, summary, details)
+
+
 def evaluate_ecosystem_gates(
     settings: Settings,
     current_evidence: list[EvidenceItem],
@@ -5168,7 +5796,7 @@ def evaluate_ecosystem_gates(
     diffs = history_comparison.get("evidenceDiffs", [])
     if not isinstance(diffs, list):
         diffs = []
-    gates = [
+    child_gates = [
         evaluate_required_evidence_regressions([diff for diff in diffs if isinstance(diff, dict)]),
         evaluate_platform_api_gate(current, previous),
         evaluate_first_party_apps_gate(current, previous),
@@ -5185,8 +5813,21 @@ def evaluate_ecosystem_gates(
     ]
     waiver_gate = evaluate_waiver_validation_gate(waiver_context, settings.mode)
     if waiver_gate is not None:
-        gates.append(waiver_gate)
-    return [apply_waiver_to_gate(gate, waiver_context, settings.mode) for gate in gates]
+        child_gates.append(waiver_gate)
+    waived_child_gates = [
+        apply_waiver_to_gate(gate, waiver_context, settings.mode) for gate in child_gates
+    ]
+    final_gate = evaluate_ecosystem_rc_certification_gate(
+        settings,
+        current_evidence,
+        waived_child_gates,
+        history_comparison,
+        waiver_context,
+    )
+    return [
+        *waived_child_gates,
+        apply_waiver_to_gate(final_gate, waiver_context, settings.mode),
+    ]
 
 
 def history_status_affects_decision(status: str) -> bool:
@@ -5245,6 +5886,43 @@ def aggregate_gate_status(gates: list[GateResult]) -> str:
     if any(gate.status == "warn" for gate in gates):
         return "warn"
     return "pass"
+
+
+def ecosystem_rc_gate_summary(gates: list[GateResult]) -> dict[str, Any]:
+    gate = next((candidate for candidate in gates if candidate.id == ECOSYSTEM_RC_GATE_ID), None)
+    if gate is None:
+        return {
+            "id": ECOSYSTEM_RC_GATE_ID,
+            "status": "missing",
+            "releaseBlocker": True,
+            "promotionReady": False,
+            "failedEvidenceCount": 0,
+            "missingEvidenceCount": 0,
+            "blockingGateCount": 1,
+            "waiverCount": 0,
+        }
+    details = gate.details
+    waiver_ids = gate_waiver_ids(gate)
+    return {
+        "id": gate.id,
+        "status": gate.status,
+        "releaseBlocker": gate.release_blocker,
+        "promotionReady": bool(details.get("promotionReady", not gate.release_blocker)),
+        "failedEvidenceCount": len(details.get("failedEvidenceIds", [])),
+        "missingEvidenceCount": len(details.get("missingEvidenceIds", [])),
+        "warningEvidenceCount": len(details.get("warningEvidenceIds", [])),
+        "blockingGateCount": len(details.get("blockingGateIds", [])),
+        "warningGateCount": len(details.get("warningGateIds", [])),
+        "waiverCount": len(waiver_ids),
+    }
+
+
+def ecosystem_rc_decision(compact_gate: dict[str, Any]) -> str:
+    if compact_gate.get("releaseBlocker") or compact_gate.get("status") in {"fail", "missing"}:
+        return "FAIL"
+    if compact_gate.get("status") == "warn":
+        return "PASS_WITH_WARNINGS"
+    return "PASS"
 
 
 def collect_source_artifacts(settings: Settings, out_dir: Path) -> list[str]:
@@ -5330,6 +6008,13 @@ def build_summary(
     ecosystem_status = aggregate_gate_status(ecosystem_gates)
     cli_waivers = sanitized_cli_waivers(settings)
     compact_matrix = matrix_compact_summary(ecosystem_matrix)
+    compact_rc_gate = ecosystem_rc_gate_summary(ecosystem_gates)
+    compact_rc_gate_decision = ecosystem_rc_decision(compact_rc_gate)
+    compact_rc_decision = compact_rc_gate_decision if release_candidate_passed else "FAIL"
+    ecosystem_rc_passed = (
+        compact_rc_decision != "FAIL"
+        and bool(compact_rc_gate.get("promotionReady", False))
+    )
     return {
         "schemaVersion": SCHEMA_VERSION,
         "tool": TOOL_NAME,
@@ -5364,6 +6049,9 @@ def build_summary(
         "historyComparison": history_comparison,
         "ecosystemGateStatus": ecosystem_status,
         "ecosystemGates": [gate.to_json() for gate in ecosystem_gates],
+        "ecosystemRcGate": compact_rc_gate,
+        "ecosystemRcPassed": ecosystem_rc_passed,
+        "ecosystemRcDecision": compact_rc_decision,
         "ecosystemMatrix": compact_matrix,
         "copiedArtifacts": copied_artifacts,
         "redaction": {
@@ -5406,6 +6094,7 @@ def render_report(summary: dict[str, Any]) -> str:
         "",
     ]
     append_history_comparison(lines, summary)
+    append_ecosystem_rc_gate(lines, summary)
     append_ecosystem_gates(lines, summary)
     append_ecosystem_matrix_summary(lines, summary)
     append_waivers(lines, summary)
@@ -5422,6 +6111,9 @@ def render_report(summary: dict[str, Any]) -> str:
                 summary_text=str(item["summary"]).replace("|", "\\|"),
             )
         )
+    lines.extend(["", "## Release Operations", ""])
+    append_detail(lines, summary, "release-certification.ecosystem-matrix")
+    append_detail(lines, summary, ECOSYSTEM_RC_EVIDENCE_ID)
     lines.extend(["", "## Hyphanet Interop", ""])
     append_detail(lines, summary, "interop.smoke")
     append_detail(lines, summary, "interop.extended")
@@ -5488,6 +6180,7 @@ def render_report(summary: dict[str, Any]) -> str:
         "reference-app.social-inbox-trust-annotations",
         "reference-app.social-inbox-rc-threading",
         "migration.social-mail-preview",
+        *APP_SERVICE_DISCOVERY_AND_GRANT_EVIDENCE_IDS,
         "legacy-plugin.migration-guide",
         "legacy-plugin.social-inbox-spike",
         "apphost.sandbox-provider",
@@ -5496,6 +6189,7 @@ def render_report(summary: dict[str, Any]) -> str:
         "app-update.scheduler",
         "app-update.live-catalog-refresh",
         "app-update.rollback",
+        "app-update.data-migration-contract",
         *OPERATOR_BETA_EVIDENCE_IDS,
         *OPERATOR_RC_EVIDENCE_IDS,
         "apphost.live",
@@ -5658,6 +6352,41 @@ def append_ecosystem_matrix_summary(lines: list[str], summary: dict[str, Any]) -
             f"- Release blockers: `{matrix.get('releaseBlockerCount', 0)}`",
             f"- Required evidence covered: `{'yes' if coverage.get('requiredEvidenceCovered') else 'no'}`",
             f"- Ecosystem gates covered: `{'yes' if coverage.get('ecosystemGatesCovered') else 'no'}`",
+            "",
+        ]
+    )
+
+
+def append_ecosystem_rc_gate(lines: list[str], summary: dict[str, Any]) -> None:
+    compact = summary.get("ecosystemRcGate", {})
+    gates = summary.get("ecosystemGates", [])
+    gate = None
+    if isinstance(gates, list):
+        gate = next(
+            (
+                candidate
+                for candidate in gates
+                if isinstance(candidate, dict) and candidate.get("id") == ECOSYSTEM_RC_GATE_ID
+            ),
+            None,
+        )
+    details = gate.get("details", {}) if isinstance(gate, dict) and isinstance(gate.get("details"), dict) else {}
+    lines.extend(
+        [
+            "## Ecosystem RC Certification Gate",
+            "",
+            f"- Gate: `{ECOSYSTEM_RC_GATE_ID}`",
+            f"- Status: `{compact.get('status', 'missing')}`",
+            f"- Promotion decision: `{summary.get('ecosystemRcDecision', 'FAIL')}`",
+            f"- Release blocker: `{'yes' if compact.get('releaseBlocker') else 'no'}`",
+            f"- Blocking gates: {markdown_code_list(details.get('blockingGateIds'))}",
+            f"- Failed evidence: `{compact.get('failedEvidenceCount', 0)}`",
+            f"- Missing evidence: `{compact.get('missingEvidenceCount', 0)}`",
+            f"- Warning evidence: `{compact.get('warningEvidenceCount', 0)}`",
+            f"- Live-network required: `{'yes' if details.get('liveNetworkRequired') else 'no'}`",
+            f"- Network-scale soak satisfied: `{'yes' if details.get('networkScaleSoakSatisfied') else 'no'}`",
+            f"- Redaction passed: `{'yes' if details.get('redactionPassed') else 'no'}`",
+            f"- Waivers: `{compact.get('waiverCount', 0)}` {markdown_code_list(details.get('waiverIds'))}",
             "",
         ]
     )
@@ -5971,15 +6700,21 @@ def run(settings: Settings) -> tuple[dict[str, Any], int]:
         return comparison, sanitized_gates
 
     matrix_evidence = placeholder_ecosystem_matrix_evidence(settings.workspace_root, settings.out_dir)
-    evidence = [*base_evidence, matrix_evidence]
+    rc_gate_evidence = placeholder_ecosystem_rc_gate_evidence(settings.workspace_root, settings.out_dir)
+    evidence = [*base_evidence, matrix_evidence, rc_gate_evidence]
     history_comparison: dict[str, Any] = {}
     ecosystem_gates: list[GateResult] = []
     ecosystem_matrix: dict[str, Any] = {}
     for _ in range(5):
         history_comparison, ecosystem_gates = evaluate_history_and_gates(evidence)
+        final_gate = next((gate for gate in ecosystem_gates if gate.id == ECOSYSTEM_RC_GATE_ID), None)
+        next_rc_gate_evidence = ecosystem_rc_gate_evidence(
+            final_gate, settings.workspace_root, settings.out_dir
+        )
+        evidence_for_matrix = [*base_evidence, matrix_evidence, next_rc_gate_evidence]
         ecosystem_matrix = build_ecosystem_matrix(
             settings,
-            evidence,
+            evidence_for_matrix,
             previous_summary,
             history_comparison,
             ecosystem_gates,
@@ -5990,11 +6725,19 @@ def run(settings: Settings) -> tuple[dict[str, Any], int]:
             ecosystem_matrix, settings.workspace_root, settings.out_dir
         )
         if next_matrix_evidence == matrix_evidence:
-            break
+            if next_rc_gate_evidence == rc_gate_evidence:
+                evidence = evidence_for_matrix
+                break
         matrix_evidence = next_matrix_evidence
-        evidence = [*base_evidence, matrix_evidence]
+        rc_gate_evidence = next_rc_gate_evidence
+        evidence = [*base_evidence, matrix_evidence, rc_gate_evidence]
     else:
         history_comparison, ecosystem_gates = evaluate_history_and_gates(evidence)
+        final_gate = next((gate for gate in ecosystem_gates if gate.id == ECOSYSTEM_RC_GATE_ID), None)
+        rc_gate_evidence = ecosystem_rc_gate_evidence(
+            final_gate, settings.workspace_root, settings.out_dir
+        )
+        evidence = [*base_evidence, matrix_evidence, rc_gate_evidence]
         ecosystem_matrix = build_ecosystem_matrix(
             settings,
             evidence,
@@ -6225,6 +6968,10 @@ def run_self_test(repo_root: Path) -> None:
         assert summary["status"] == "warn", summary
         assert summary["promotionDecision"] == "PASS WITH WARNINGS", summary
         assert summary["releaseCandidatePassed"] is True, summary
+        assert summary["ecosystemRcDecision"] == "PASS_WITH_WARNINGS", summary
+        assert summary["ecosystemRcPassed"] is True, summary
+        assert summary["ecosystemRcGate"]["id"] == ECOSYSTEM_RC_GATE_ID, summary
+        assert summary["ecosystemRcGate"]["status"] == "warn", summary
         assert not any("live-network-beta" in artifact for artifact in summary["copiedArtifacts"]), summary[
             "copiedArtifacts"
         ]
@@ -6248,6 +6995,7 @@ def run_self_test(repo_root: Path) -> None:
         assert matrix["coverage"]["redactionPassed"] is True, matrix
         assert set(matrix["coverage"]["coveredFirstPartyApps"]) == set(EXPECTED_FIRST_PARTY_APPS), matrix
         matrix_rows_by_id = {row["id"]: row for row in matrix["rows"]}
+        pr253_app_service_evidence_ids = APP_SERVICE_DEPENDENCY_AND_GRANT_BUNDLE_EVIDENCE_IDS
         for row_id in (
             "app-update",
             "first-party-beta-catalog",
@@ -6272,8 +7020,16 @@ def run_self_test(repo_root: Path) -> None:
             "live-network-beta-certification",
             "legacy-retirement",
             "ecosystem-certification-matrix",
+            ECOSYSTEM_RC_MATRIX_ROW_ID,
+            "app-service-discovery-and-grants",
         ):
             assert row_id in matrix_rows_by_id, row_id
+        rc_gate_row = matrix_rows_by_id[ECOSYSTEM_RC_MATRIX_ROW_ID]
+        assert ECOSYSTEM_RC_EVIDENCE_ID in rc_gate_row["requiredEvidenceIds"], rc_gate_row
+        assert ECOSYSTEM_RC_GATE_ID in rc_gate_row["gateIds"], rc_gate_row
+        app_services_row = matrix_rows_by_id["app-service-discovery-and-grants"]
+        for evidence_id in pr253_app_service_evidence_ids:
+            assert evidence_id in app_services_row["requiredEvidenceIds"], app_services_row
         disabled_live_row = matrix_rows_by_id["live-network-beta-certification"]
         assert disabled_live_row["status"] == "pass", disabled_live_row
         assert disabled_live_row["releaseBlocker"] is False, disabled_live_row
@@ -6319,11 +7075,14 @@ def run_self_test(repo_root: Path) -> None:
             "app-platform.docs-redaction",
             "app-data.backup-restore-portability",
             "operator-beta.app-data-backup-restore",
+            *pr253_app_service_evidence_ids,
+            ECOSYSTEM_RC_EVIDENCE_ID,
             *OPERATOR_RC_EVIDENCE_IDS,
             *ECOSYSTEM_SECURITY_EVIDENCE_IDS,
         ):
             assert evidence_id in covered_evidence_ids, evidence_id
         gate_ids = {gate["id"] for gate in summary["ecosystemGates"]}
+        assert ECOSYSTEM_RC_GATE_ID in gate_ids, gate_ids
         covered_gate_ids = {gate_id for row in matrix["rows"] for gate_id in row.get("gateIds", [])}
         assert gate_ids <= covered_gate_ids, (gate_ids, covered_gate_ids)
         assert summary["ecosystemMatrixPath"].endswith(ECOSYSTEM_MATRIX_FILE_NAME), summary
@@ -6334,6 +7093,8 @@ def run_self_test(repo_root: Path) -> None:
         assert evidence_by_id["release-certification.ecosystem-matrix"][
             "requiredForReleaseCandidate"
         ] is True
+        assert evidence_by_id[ECOSYSTEM_RC_EVIDENCE_ID]["requiredForReleaseCandidate"] is True
+        assert evidence_by_id[ECOSYSTEM_RC_EVIDENCE_ID]["status"] == "warn", evidence_by_id
         assert evidence_by_id["app-update.lifecycle"]["status"] == "pass", evidence_by_id
         assert evidence_by_id["app-update.lifecycle"]["requiredForReleaseCandidate"] is True
         assert evidence_by_id["app-update.scheduler"]["status"] == "pass", evidence_by_id
@@ -6458,6 +7219,7 @@ def run_self_test(repo_root: Path) -> None:
         for evidence_id in (
             "app-services.registry",
             "app-services.grants",
+            *pr253_app_service_evidence_ids,
             "app-services.trust-score-provider",
             "app-services.web-shell",
             "app-services.redaction",
@@ -6485,6 +7247,7 @@ def run_self_test(repo_root: Path) -> None:
         matrix_report = (out_dir / ECOSYSTEM_MATRIX_REPORT_FILE_NAME).read_text(encoding="utf-8")
         assert "Release Certification Report" in report
         assert "Historical Comparison" in report
+        assert "Ecosystem RC Certification Gate" in report
         assert "Ecosystem Gates" in report
         assert "Ecosystem Certification Matrix" in report
         assert ECOSYSTEM_MATRIX_REPORT_FILE_NAME in report
@@ -6533,6 +7296,35 @@ def run_self_test(repo_root: Path) -> None:
         interop_item = next(item for item in summary["evidence"] if item["id"] == "interop.smoke")
         assert "artifacts/private-insert-uris.json" not in json.dumps(interop_item)
 
+        direct_rc_waiver_settings = dataclasses.replace(
+            settings,
+            out_dir=(workspace / "build/direct-rc-gate-waiver-cert").resolve(),
+            waivers={ECOSYSTEM_RC_GATE_ID: "Release manager accepted temporary RC gate warning."},
+        )
+        direct_rc_waiver_summary, direct_rc_waiver_exit_code = run(direct_rc_waiver_settings)
+        assert direct_rc_waiver_exit_code == 0, direct_rc_waiver_summary
+        assert direct_rc_waiver_summary["ecosystemRcGate"]["status"] == "warn", (
+            direct_rc_waiver_summary
+        )
+        assert direct_rc_waiver_summary["ecosystemRcGate"]["waiverCount"] == 1, (
+            direct_rc_waiver_summary
+        )
+        direct_rc_gate = next(
+            gate
+            for gate in direct_rc_waiver_summary["ecosystemGates"]
+            if gate["id"] == ECOSYSTEM_RC_GATE_ID
+        )
+        assert direct_rc_gate["details"]["waiverId"] == ECOSYSTEM_RC_GATE_ID, direct_rc_gate
+        direct_rc_evidence = next(
+            item
+            for item in direct_rc_waiver_summary["evidence"]
+            if item["id"] == ECOSYSTEM_RC_EVIDENCE_ID
+        )
+        assert direct_rc_evidence["details"]["waiverCount"] == 1, direct_rc_evidence
+        assert ECOSYSTEM_RC_GATE_ID in direct_rc_evidence["details"]["details"]["waiverIds"], (
+            direct_rc_evidence
+        )
+
         previous_good_path = workspace / "build/previous-good/release-certification-summary.json"
         previous_good = {
             "schemaVersion": SCHEMA_VERSION,
@@ -6573,7 +7365,8 @@ def run_self_test(repo_root: Path) -> None:
         assert with_previous_exit_code == 0, with_previous_summary
         assert with_previous_summary["status"] == "warn", with_previous_summary
         assert with_previous_summary["historyComparison"]["status"] == "pass", with_previous_summary
-        assert with_previous_summary["ecosystemGateStatus"] == "pass", with_previous_summary
+        assert with_previous_summary["ecosystemGateStatus"] == "warn", with_previous_summary
+        assert with_previous_summary["ecosystemRcGate"]["status"] == "warn", with_previous_summary
         assert with_previous_summary["ecosystemMatrix"]["coverage"]["requiredEvidenceCovered"] is True
         assert with_previous_summary["ecosystemMatrix"]["coverage"]["ecosystemGatesCovered"] is True
         with_previous_matrix = read_json(with_previous_settings.out_dir / ECOSYSTEM_MATRIX_FILE_NAME)
@@ -6648,6 +7441,167 @@ def run_self_test(repo_root: Path) -> None:
                 if isinstance(item, dict) and item.get("id") == evidence_id:
                     return item
             raise AssertionError(f"missing evidence {evidence_id}")
+
+        clean_happy_summary, clean_happy_exit_code = run_with_previous(
+            "clean-happy-cert",
+            previous_summary=previous_matrix_good_path,
+        )
+        assert clean_happy_exit_code == 0, clean_happy_summary
+        assert clean_happy_summary["status"] == "pass", clean_happy_summary
+        assert clean_happy_summary["promotionDecision"] == "PASS", clean_happy_summary
+        assert clean_happy_summary["releaseCandidatePassed"] is True, clean_happy_summary
+        assert clean_happy_summary["ecosystemGateStatus"] == "pass", clean_happy_summary
+        assert clean_happy_summary["ecosystemRcDecision"] == "PASS", clean_happy_summary
+        assert clean_happy_summary["ecosystemRcPassed"] is True, clean_happy_summary
+        assert clean_happy_summary["ecosystemRcGate"]["status"] == "pass", clean_happy_summary
+        clean_happy_row = matrix_row_by_id(
+            workspace / "build/clean-happy-cert",
+            ECOSYSTEM_RC_MATRIX_ROW_ID,
+        )
+        assert clean_happy_row["status"] == "pass", clean_happy_row
+        assert clean_happy_summary["ecosystemMatrix"]["status"] == "pass", clean_happy_summary
+
+        waived_rc_gate_missing_soak_summary, waived_rc_gate_missing_soak_exit_code = run_with_previous(
+            "waived-rc-gate-missing-network-scale-soak-cert",
+            previous_summary=previous_matrix_good_path,
+            network_scale_soak_summary=workspace / "build/missing-network-scale-soak/summary.json",
+            waivers={ECOSYSTEM_RC_GATE_ID: "Release manager waived aggregate RC gate."},
+        )
+        assert waived_rc_gate_missing_soak_exit_code == 1, waived_rc_gate_missing_soak_summary
+        assert waived_rc_gate_missing_soak_summary["releaseCandidatePassed"] is False, (
+            waived_rc_gate_missing_soak_summary
+        )
+        assert waived_rc_gate_missing_soak_summary["ecosystemRcDecision"] == "FAIL", (
+            waived_rc_gate_missing_soak_summary
+        )
+        assert waived_rc_gate_missing_soak_summary["ecosystemRcPassed"] is False, (
+            waived_rc_gate_missing_soak_summary
+        )
+        waived_rc_gate = gate_by_id(
+            waived_rc_gate_missing_soak_summary,
+            ECOSYSTEM_RC_GATE_ID,
+        )
+        assert waived_rc_gate["status"] == "warn", waived_rc_gate
+        assert waived_rc_gate["releaseBlocker"] is False, waived_rc_gate
+        assert waived_rc_gate["details"]["waiverId"] == ECOSYSTEM_RC_GATE_ID, waived_rc_gate
+
+        missing_pr253_path = write_app_summary_variant(
+            "missing-pr253-app-service-evidence",
+            lambda value: value.update(
+                {
+                    "evidence": [
+                        item
+                        for item in value["evidence"]
+                        if item.get("id") not in pr253_app_service_evidence_ids
+                    ]
+                }
+            ),
+        )
+        missing_pr253_items = app_platform_evidence(
+            missing_pr253_path,
+            workspace,
+            out_dir,
+            "release-candidate",
+        )
+        missing_pr253_by_id = {item.id: item for item in missing_pr253_items}
+        for evidence_id in pr253_app_service_evidence_ids:
+            assert missing_pr253_by_id[evidence_id].status == "missing", missing_pr253_by_id
+            assert missing_pr253_by_id[evidence_id].required_for_release_candidate is True
+        missing_pr253_summary, missing_pr253_exit_code = run_with_previous(
+            "missing-pr253-app-service-cert",
+            app_platform_summary=missing_pr253_path,
+            previous_summary=previous_matrix_good_path,
+        )
+        assert missing_pr253_exit_code == 1, missing_pr253_summary
+        assert missing_pr253_summary["status"] == "fail", missing_pr253_summary
+        assert missing_pr253_summary["releaseCandidatePassed"] is False, missing_pr253_summary
+        assert missing_pr253_summary["ecosystemRcGate"]["status"] == "fail", missing_pr253_summary
+        assert gate_by_id(missing_pr253_summary, "ecosystem.reference-content-apps")[
+            "status"
+        ] == "fail"
+        missing_pr253_row = matrix_row_by_id(
+            workspace / "build/missing-pr253-app-service-cert",
+            "app-service-discovery-and-grants",
+        )
+        assert missing_pr253_row["status"] == "fail", missing_pr253_row
+        assert missing_pr253_row["releaseBlocker"] is True, missing_pr253_row
+
+        dependency_redaction_findings_path = write_app_summary_variant(
+            "dependency-redaction-findings",
+            lambda value: update_evidence(
+                value,
+                "app-services.dependency-redaction",
+                lambda entry: (
+                    entry.update({"status": "fail"}),
+                    entry.setdefault("details", {}).update(
+                        {
+                            "redactionFindings": [
+                                {
+                                    "path": "tools/release-certification/app-platform-smoke/summary.json",
+                                    "issue": "raw-service-invocation-body",
+                                }
+                            ]
+                        }
+                    ),
+                ),
+            ),
+        )
+        waived_dependency_redaction_summary, waived_dependency_redaction_exit_code = run_with_previous(
+            "waived-dependency-redaction-findings-cert",
+            app_platform_summary=dependency_redaction_findings_path,
+            previous_summary=previous_matrix_good_path,
+            waivers={
+                ECOSYSTEM_RC_GATE_ID: (
+                    "Release manager attempted to waive aggregate RC gate redaction failure."
+                ),
+                "app-services.dependency-redaction": (
+                    "Release manager attempted to waive app-service dependency redaction findings."
+                )
+            },
+        )
+        assert waived_dependency_redaction_exit_code == 1, waived_dependency_redaction_summary
+        assert waived_dependency_redaction_summary["releaseCandidatePassed"] is False, (
+            waived_dependency_redaction_summary
+        )
+        assert waived_dependency_redaction_summary["ecosystemRcPassed"] is False, (
+            waived_dependency_redaction_summary
+        )
+        dependency_redaction_evidence = evidence_by_id(
+            waived_dependency_redaction_summary,
+            "app-services.dependency-redaction",
+        )
+        assert dependency_redaction_evidence["status"] == "fail", dependency_redaction_evidence
+        assert "waived" not in dependency_redaction_evidence["details"], (
+            dependency_redaction_evidence
+        )
+        dependency_redaction_rc_gate = gate_by_id(
+            waived_dependency_redaction_summary,
+            ECOSYSTEM_RC_GATE_ID,
+        )
+        assert dependency_redaction_rc_gate["status"] == "fail", dependency_redaction_rc_gate
+        assert dependency_redaction_rc_gate["releaseBlocker"] is True, dependency_redaction_rc_gate
+        assert "waived" not in dependency_redaction_rc_gate["details"], dependency_redaction_rc_gate
+        assert dependency_redaction_rc_gate["details"]["redactionPassed"] is False, (
+            dependency_redaction_rc_gate
+        )
+        assert "app-services.dependency-redaction" in dependency_redaction_rc_gate["details"][
+            "redactionFailureEvidenceIds"
+        ], dependency_redaction_rc_gate
+        assert dependency_redaction_rc_gate["details"]["unwaivableFailureEvidenceIds"] == [
+            "app-services.dependency-redaction"
+        ], dependency_redaction_rc_gate
+        dependency_redaction_row = matrix_row_by_id(
+            workspace / "build/waived-dependency-redaction-findings-cert",
+            "app-service-discovery-and-grants",
+        )
+        assert dependency_redaction_row["status"] == "fail", dependency_redaction_row
+        assert dependency_redaction_row["releaseBlocker"] is True, dependency_redaction_row
+        assert "app-services.dependency-redaction" not in dependency_redaction_row.get(
+            "waiverIds", []
+        ), dependency_redaction_row
+        assert dependency_redaction_row["details"]["unwaivableRedactionEvidenceIds"] == [
+            "app-services.dependency-redaction"
+        ], dependency_redaction_row
 
         def write_live_network_summary(
             name: str,
@@ -6841,6 +7795,9 @@ def run_self_test(repo_root: Path) -> None:
             live_network_beta_enabled=True,
         )
         assert optional_live_exit_code == 0, optional_live_summary
+        assert optional_live_summary["releaseCandidatePassed"] is True, optional_live_summary
+        assert optional_live_summary["promotionDecision"] == "PASS WITH WARNINGS", optional_live_summary
+        assert optional_live_summary["ecosystemRcDecision"] == "PASS_WITH_WARNINGS", optional_live_summary
         optional_live_gate = gate_by_id(optional_live_summary, "ecosystem.live-network-beta")
         assert optional_live_gate["status"] == "warn", optional_live_gate
         assert optional_live_gate["releaseBlocker"] is False, optional_live_gate
@@ -6851,6 +7808,44 @@ def run_self_test(repo_root: Path) -> None:
         assert optional_live_row["status"] == "warn", optional_live_row
         assert optional_live_row["releaseBlocker"] is False, optional_live_row
 
+        optional_missing_live_summary, optional_missing_live_exit_code = run_with_previous(
+            "live-network-optional-missing-cert",
+            live_network_summary=workspace / "build/missing-live-network-optional/summary.json",
+            live_network_beta_enabled=True,
+        )
+        assert optional_missing_live_exit_code == 0, optional_missing_live_summary
+        assert optional_missing_live_summary["releaseCandidatePassed"] is True, (
+            optional_missing_live_summary
+        )
+        assert optional_missing_live_summary["ecosystemRcDecision"] == "PASS_WITH_WARNINGS", (
+            optional_missing_live_summary
+        )
+        optional_missing_rc_gate = gate_by_id(
+            optional_missing_live_summary,
+            ECOSYSTEM_RC_GATE_ID,
+        )
+        assert optional_missing_rc_gate["status"] == "warn", optional_missing_rc_gate
+        assert optional_missing_rc_gate["releaseBlocker"] is False, optional_missing_rc_gate
+        assert optional_missing_rc_gate["details"]["redactionPassed"] is True, optional_missing_rc_gate
+        assert "live-network-beta.redaction" not in optional_missing_rc_gate["details"].get(
+            "redactionFailureEvidenceIds", []
+        ), optional_missing_rc_gate
+        optional_missing_live_gate = gate_by_id(
+            optional_missing_live_summary,
+            "ecosystem.live-network-beta",
+        )
+        assert optional_missing_live_gate["status"] == "warn", optional_missing_live_gate
+        assert optional_missing_live_gate["releaseBlocker"] is False, optional_missing_live_gate
+        optional_missing_live_evidence = {
+            item["id"]: item for item in optional_missing_live_summary["evidence"]
+        }
+        assert optional_missing_live_evidence["live-network-beta.redaction"]["status"] == "missing", (
+            optional_missing_live_evidence
+        )
+        assert optional_missing_live_evidence["live-network-beta.redaction"][
+            "requiredForReleaseCandidate"
+        ] is False
+
         required_missing_summary, required_missing_exit_code = run_with_previous(
             "live-network-required-missing-cert",
             live_network_summary=workspace / "build/missing-live-network/summary.json",
@@ -6858,6 +7853,8 @@ def run_self_test(repo_root: Path) -> None:
             live_network_beta_required=True,
         )
         assert required_missing_exit_code == 1, required_missing_summary
+        assert required_missing_summary["releaseCandidatePassed"] is False, required_missing_summary
+        assert required_missing_summary["ecosystemRcGate"]["status"] == "fail", required_missing_summary
         required_missing_gate = gate_by_id(required_missing_summary, "ecosystem.live-network-beta")
         assert required_missing_gate["status"] == "fail", required_missing_gate
         assert required_missing_gate["releaseBlocker"] is True, required_missing_gate
@@ -6881,6 +7878,8 @@ def run_self_test(repo_root: Path) -> None:
             live_network_beta_required=True,
         )
         assert required_failing_exit_code == 1, required_failing_summary
+        assert required_failing_summary["releaseCandidatePassed"] is False, required_failing_summary
+        assert required_failing_summary["ecosystemRcGate"]["status"] == "fail", required_failing_summary
         required_failing_gate = gate_by_id(required_failing_summary, "ecosystem.live-network-beta")
         assert required_failing_gate["status"] == "fail", required_failing_gate
         assert required_failing_gate["details"]["failureEvidenceIds"] == [
@@ -6906,6 +7905,7 @@ def run_self_test(repo_root: Path) -> None:
             live_network_beta_required=True,
         )
         assert required_passing_exit_code == 0, required_passing_summary
+        assert required_passing_summary["releaseCandidatePassed"] is True, required_passing_summary
         required_passing_gate = gate_by_id(required_passing_summary, "ecosystem.live-network-beta")
         assert required_passing_gate["status"] == "pass", required_passing_gate
         required_passing_evidence = {item["id"]: item for item in required_passing_summary["evidence"]}
@@ -6993,6 +7993,14 @@ def run_self_test(repo_root: Path) -> None:
             assert (
                 waived_docs_redaction_summary["releaseCandidatePassed"] is False
             ), waived_docs_redaction_summary
+            docs_redaction_rc_gate = gate_by_id(
+                waived_docs_redaction_summary, ECOSYSTEM_RC_GATE_ID
+            )
+            assert docs_redaction_rc_gate["status"] == "fail", docs_redaction_rc_gate
+            assert docs_redaction_rc_gate["releaseBlocker"] is True, docs_redaction_rc_gate
+            assert docs_redaction_rc_gate["details"]["redactionPassed"] is False, (
+                docs_redaction_rc_gate
+            )
             waived_docs_redaction_evidence = {
                 item["id"]: item for item in waived_docs_redaction_summary["evidence"]
             }
@@ -7954,6 +8962,26 @@ def run_self_test(repo_root: Path) -> None:
         assert waived_vault_row["status"] == "warn", waived_vault_row
         assert waived_vault_row["releaseBlocker"] is False, waived_vault_row
         assert "app-vault.capabilities" in waived_vault_row["waiverIds"], waived_vault_row
+        waived_vault_clean_summary, waived_vault_clean_exit_code = run_with_previous(
+            "waived-vault-clean-history-cert",
+            app_platform_summary=vault_missing_capability_path,
+            previous_summary=previous_matrix_good_path,
+            waivers={"app-vault.capabilities": "Release manager accepted vault evidence gap."},
+        )
+        assert waived_vault_clean_exit_code == 0, waived_vault_clean_summary
+        assert waived_vault_clean_summary["status"] == "warn", waived_vault_clean_summary
+        assert waived_vault_clean_summary["promotionDecision"] == "PASS WITH WARNINGS", (
+            waived_vault_clean_summary
+        )
+        assert waived_vault_clean_summary["releaseCandidatePassed"] is True, (
+            waived_vault_clean_summary
+        )
+        assert waived_vault_clean_summary["ecosystemRcGate"]["status"] == "warn", (
+            waived_vault_clean_summary
+        )
+        assert waived_vault_clean_summary["ecosystemRcGate"]["waiverCount"] == 1, (
+            waived_vault_clean_summary
+        )
 
         vault_missing_redaction_path = write_app_summary_variant(
             "vault-missing-redaction",

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -942,6 +942,18 @@ def active_waivers_for_all(
     return records
 
 
+def active_waivers_for_all_ecosystem_rc_evidence(
+    context: WaiverContext, evidence_ids: list[str], mode: str
+) -> list[WaiverRecord]:
+    records: list[WaiverRecord] = []
+    for evidence_id in evidence_ids:
+        waiver = active_waiver_for_ecosystem_rc_evidence(context, evidence_id, mode)
+        if waiver is None:
+            return []
+        records.append(waiver)
+    return records
+
+
 def with_waiver_record(item: EvidenceItem, waiver: WaiverRecord | None) -> EvidenceItem:
     if waiver is None or item.status == "pass":
         return item
@@ -986,7 +998,7 @@ def apply_waiver_to_gate(gate: GateResult, context: WaiverContext, mode: str) ->
         evidence_waivers = (
             []
             if unwaivable_failure_evidence_ids.intersection(failure_evidence_ids)
-            else active_waivers_for_all(context, failure_evidence_ids, mode)
+            else active_waivers_for_all_ecosystem_rc_evidence(context, failure_evidence_ids, mode)
         )
         if evidence_waivers:
             waiver = evidence_waivers[-1]
@@ -3603,9 +3615,10 @@ def classify_evidence_diff(
         *ecosystem_matrix_row_ids_for_evidence(evidence_id),
     ]
     waived = bool(current and evidence_details(current).get("waived"))
+    unwaivable_redaction_findings = evidence_entry_has_unwaivable_redaction_findings(current)
     waiver = (
         None
-        if evidence_entry_has_unwaivable_redaction_findings(current)
+        if unwaivable_redaction_findings
         else active_waiver_for(waiver_context, evidence_id, issue_ids, mode)
     )
     release_blocker = False
@@ -3646,6 +3659,7 @@ def classify_evidence_diff(
         "requiredForReleaseCandidate": bool(current_required or previous_required),
         "releaseBlocker": release_blocker,
         "reason": reason,
+        "unwaivableRedactionFindings": unwaivable_redaction_findings,
     }
 
 
@@ -3800,6 +3814,8 @@ def evaluate_required_evidence_regressions(diffs: list[dict[str, Any]]) -> GateR
             if diff.get("releaseBlocker"):
                 failures.append(f"{diff['id']} regressed from {diff['previousStatus']} to {current_status}")
                 add_evidence_issue(details, "failureEvidenceIds", str(diff["id"]))
+                if diff.get("unwaivableRedactionFindings"):
+                    add_evidence_issue(details, "unwaivableFailureEvidenceIds", str(diff["id"]))
             else:
                 warnings.append(f"{diff['id']} regressed from {diff['previousStatus']} to {current_status}")
                 add_evidence_issue(details, "warningEvidenceIds", str(diff["id"]))
@@ -3812,6 +3828,8 @@ def evaluate_required_evidence_regressions(diffs: list[dict[str, Any]]) -> GateR
             if current_status in {"fail", "missing", "skip"}:
                 failures.append(f"New required evidence {diff['id']} is {current_status}")
                 add_evidence_issue(details, "failureEvidenceIds", str(diff["id"]))
+                if diff.get("unwaivableRedactionFindings"):
+                    add_evidence_issue(details, "unwaivableFailureEvidenceIds", str(diff["id"]))
             elif current_status == "warn":
                 warnings.append(f"New required evidence {diff['id']} is warning")
                 add_evidence_issue(details, "warningEvidenceIds", str(diff["id"]))
@@ -5615,6 +5633,34 @@ def active_waiver_for_ecosystem_rc_evidence(
     return active_waiver_for(context, evidence_id, issue_ids, mode)
 
 
+def ecosystem_rc_evidence_waiver_id(
+    entry: dict[str, Any] | None,
+    context: WaiverContext,
+    evidence_id: str,
+    mode: str,
+) -> str:
+    if evidence_entry_has_unwaivable_redaction_findings(entry):
+        return ""
+    waiver_id = evidence_detail_waiver_id(entry)
+    if waiver_id:
+        return waiver_id
+    waiver = active_waiver_for_ecosystem_rc_evidence(context, evidence_id, mode)
+    return waiver.id if waiver is not None else ""
+
+
+def ecosystem_rc_evidence_satisfied(
+    entries: dict[str, dict[str, Any]],
+    context: WaiverContext,
+    evidence_id: str,
+    mode: str,
+) -> bool:
+    entry = entries.get(evidence_id)
+    status = evidence_status(entry)
+    if status not in {"fail", "missing", "skip"}:
+        return True
+    return bool(ecosystem_rc_evidence_waiver_id(entry, context, evidence_id, mode))
+
+
 def conditional_ecosystem_rc_required_evidence_ids(settings: Settings) -> list[str]:
     evidence_ids = list(ECOSYSTEM_RC_REQUIRED_EVIDENCE_IDS)
     if settings.live_network_beta_required:
@@ -5661,13 +5707,11 @@ def evaluate_ecosystem_rc_certification_gate(
             redaction_failure_ids.append(evidence_id)
             failed_evidence_ids.append(evidence_id)
             continue
-        waiver_id = evidence_detail_waiver_id(entry)
-        if not waiver_id and status in {"fail", "missing", "skip", "warn"}:
-            waiver = active_waiver_for_ecosystem_rc_evidence(
-                waiver_context, evidence_id, settings.mode
-            )
-            if waiver is not None:
-                waiver_id = waiver.id
+        waiver_id = (
+            ecosystem_rc_evidence_waiver_id(entry, waiver_context, evidence_id, settings.mode)
+            if status in {"fail", "missing", "skip", "warn"}
+            else evidence_detail_waiver_id(entry)
+        )
         if waiver_id:
             waived_evidence_ids.append(evidence_id)
             waiver_ids.append(waiver_id)
@@ -5743,15 +5787,21 @@ def evaluate_ecosystem_rc_certification_gate(
     redaction_passed = matrix_redaction_passed and redaction_evidence_passed
 
     live_required = settings.live_network_beta_required
-    live_required_statuses = [
-        evidence_status(current.get(evidence_id))
+    live_network_satisfied = (not live_required) or all(
+        ecosystem_rc_evidence_satisfied(
+            current,
+            waiver_context,
+            evidence_id,
+            settings.mode,
+        )
         for evidence_id in LIVE_NETWORK_BETA_REQUIRED_EVIDENCE_IDS
-    ]
-    live_network_satisfied = (not live_required) or not any(
-        status in {"fail", "missing", "skip"} for status in live_required_statuses
     )
-    network_scale_soak_status = evidence_status(current.get(NETWORK_SCALE_SOAK_EVIDENCE_ID))
-    network_scale_soak_satisfied = network_scale_soak_status not in {"fail", "missing", "skip"}
+    network_scale_soak_satisfied = ecosystem_rc_evidence_satisfied(
+        current,
+        waiver_context,
+        NETWORK_SCALE_SOAK_EVIDENCE_ID,
+        settings.mode,
+    )
     first_party_gate = gate_entries.get("ecosystem.first-party-apps")
     first_party_apps_covered = first_party_gate is not None and first_party_gate.status in {"pass", "warn"}
 
@@ -7544,6 +7594,41 @@ def run_self_test(repo_root: Path) -> None:
         assert waived_rc_gate["status"] == "warn", waived_rc_gate
         assert waived_rc_gate["releaseBlocker"] is False, waived_rc_gate
         assert waived_rc_gate["details"]["waiverId"] == ECOSYSTEM_RC_GATE_ID, waived_rc_gate
+        waived_soak_row_summary, waived_soak_row_exit_code = run_with_previous(
+            "waived-network-scale-soak-row-cert",
+            previous_summary=previous_matrix_good_path,
+            network_scale_soak_summary=workspace / "build/missing-network-scale-soak/summary.json",
+            waivers={
+                "network-scale-soak-and-subscription-budget": (
+                    "Release manager accepted temporary missing network-scale soak evidence."
+                )
+            },
+        )
+        assert waived_soak_row_exit_code == 0, waived_soak_row_summary
+        assert waived_soak_row_summary["releaseCandidatePassed"] is True, (
+            waived_soak_row_summary
+        )
+        assert waived_soak_row_summary["promotionDecision"] == "PASS WITH WARNINGS", (
+            waived_soak_row_summary
+        )
+        waived_soak_rc_gate = gate_by_id(waived_soak_row_summary, ECOSYSTEM_RC_GATE_ID)
+        assert waived_soak_rc_gate["status"] == "warn", waived_soak_rc_gate
+        assert waived_soak_rc_gate["releaseBlocker"] is False, waived_soak_rc_gate
+        assert waived_soak_rc_gate["details"]["networkScaleSoakSatisfied"] is True, (
+            waived_soak_rc_gate
+        )
+        assert NETWORK_SCALE_SOAK_EVIDENCE_ID in waived_soak_rc_gate["details"][
+            "waivedEvidenceIds"
+        ], waived_soak_rc_gate
+        assert NETWORK_SCALE_SOAK_EVIDENCE_ID not in waived_soak_rc_gate["details"][
+            "failedEvidenceIds"
+        ], waived_soak_rc_gate
+        waived_soak_row = matrix_row_by_id(
+            workspace / "build/waived-network-scale-soak-row-cert",
+            "network-scale-soak-and-subscription-budget",
+        )
+        assert waived_soak_row["status"] == "warn", waived_soak_row
+        assert waived_soak_row["releaseBlocker"] is False, waived_soak_row
 
         missing_pr253_path = write_app_summary_variant(
             "missing-pr253-app-service-evidence",
@@ -7924,6 +8009,60 @@ def run_self_test(repo_root: Path) -> None:
             assert required_missing_evidence[evidence_id]["requiredForReleaseCandidate"] is True, (
                 required_missing_evidence
             )
+        waived_required_missing_live_summary, waived_required_missing_live_exit_code = (
+            run_with_previous(
+                "live-network-required-missing-row-waived-cert",
+                live_network_summary=workspace / "build/missing-live-network-waived/summary.json",
+                live_network_beta_enabled=True,
+                live_network_beta_required=True,
+                waivers={
+                    "live-network-beta-certification": (
+                        "Release manager accepted temporary missing required live-network beta evidence."
+                    )
+                },
+            )
+        )
+        assert waived_required_missing_live_exit_code == 0, waived_required_missing_live_summary
+        assert waived_required_missing_live_summary["releaseCandidatePassed"] is True, (
+            waived_required_missing_live_summary
+        )
+        assert waived_required_missing_live_summary["promotionDecision"] == "PASS WITH WARNINGS", (
+            waived_required_missing_live_summary
+        )
+        waived_required_missing_live_gate = gate_by_id(
+            waived_required_missing_live_summary,
+            "ecosystem.live-network-beta",
+        )
+        assert waived_required_missing_live_gate["status"] == "warn", (
+            waived_required_missing_live_gate
+        )
+        assert waived_required_missing_live_gate["releaseBlocker"] is False, (
+            waived_required_missing_live_gate
+        )
+        waived_required_missing_rc_gate = gate_by_id(
+            waived_required_missing_live_summary,
+            ECOSYSTEM_RC_GATE_ID,
+        )
+        assert waived_required_missing_rc_gate["status"] == "warn", (
+            waived_required_missing_rc_gate
+        )
+        assert waived_required_missing_rc_gate["releaseBlocker"] is False, (
+            waived_required_missing_rc_gate
+        )
+        assert waived_required_missing_rc_gate["details"]["liveNetworkSatisfied"] is True, (
+            waived_required_missing_rc_gate
+        )
+        assert set(LIVE_NETWORK_BETA_REQUIRED_EVIDENCE_IDS).issubset(
+            set(waived_required_missing_rc_gate["details"]["waivedEvidenceIds"])
+        ), waived_required_missing_rc_gate
+        waived_required_missing_live_row = matrix_row_by_id(
+            workspace / "build/live-network-required-missing-row-waived-cert",
+            "live-network-beta-certification",
+        )
+        assert waived_required_missing_live_row["status"] == "warn", waived_required_missing_live_row
+        assert waived_required_missing_live_row["releaseBlocker"] is False, (
+            waived_required_missing_live_row
+        )
 
         required_failing_path = write_live_network_summary(
             "live-network-required-failing",

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -2728,8 +2728,7 @@ def row_waivers(
     for evidence_id in spec.evidence_ids():
         if evidence_id in unwaivable_evidence_ids:
             continue
-        waiver_id = evidence_details(evidence_entries.get(evidence_id)).get("waiverId")
-        if waiver_id:
+        for waiver_id in detail_waiver_ids(evidence_details(evidence_entries.get(evidence_id))):
             waiver = active_waiver_for(context, str(waiver_id), waivable_issue_ids, mode)
             if waiver is not None:
                 records[waiver.id] = waiver
@@ -2737,8 +2736,7 @@ def row_waivers(
         gate = gate_entries.get(gate_id)
         details = gate.get("details", {}) if isinstance(gate, dict) else {}
         if isinstance(details, dict):
-            waiver_id = details.get("waiverId")
-            if waiver_id:
+            for waiver_id in detail_waiver_ids(details):
                 if str(waiver_id) in unwaivable_issue_ids:
                     continue
                 waiver = active_waiver_for(context, str(waiver_id), waivable_issue_ids, mode)
@@ -5548,6 +5546,19 @@ def unique_ids(values: Any) -> list[str]:
     return sorted(dict.fromkeys(str(value) for value in values if str(value).strip()))
 
 
+def detail_waiver_ids(details: dict[str, Any]) -> list[str]:
+    waiver_ids: list[Any] = []
+    existing_ids = details.get("waiverIds", [])
+    if isinstance(existing_ids, list):
+        waiver_ids.extend(existing_ids)
+    elif existing_ids:
+        waiver_ids.append(existing_ids)
+    direct_waiver_id = details.get("waiverId")
+    if direct_waiver_id:
+        waiver_ids.append(direct_waiver_id)
+    return unique_ids(waiver_ids)
+
+
 def evidence_detail_waiver_id(entry: dict[str, Any] | None) -> str:
     details = evidence_details(entry)
     waiver_id = details.get("waiverId")
@@ -5564,17 +5575,7 @@ def gate_detail_waiver_id(gate: GateResult | None) -> str:
 def gate_waiver_ids(gate: GateResult | None) -> list[str]:
     if gate is None:
         return []
-    waiver_ids: list[Any] = []
-    details = gate.details
-    existing_ids = details.get("waiverIds", [])
-    if isinstance(existing_ids, list):
-        waiver_ids.extend(existing_ids)
-    elif existing_ids:
-        waiver_ids.append(existing_ids)
-    direct_waiver_id = details.get("waiverId")
-    if direct_waiver_id:
-        waiver_ids.append(direct_waiver_id)
-    return unique_ids(waiver_ids)
+    return detail_waiver_ids(gate.details)
 
 
 def conditional_ecosystem_rc_required_evidence_ids(settings: Settings) -> list[str]:
@@ -6370,7 +6371,12 @@ def append_ecosystem_rc_gate(lines: list[str], summary: dict[str, Any]) -> None:
             ),
             None,
         )
-    details = gate.get("details", {}) if isinstance(gate, dict) and isinstance(gate.get("details"), dict) else {}
+    details = (
+        gate.get("details", {})
+        if isinstance(gate, dict) and isinstance(gate.get("details"), dict)
+        else {}
+    )
+    waiver_ids = detail_waiver_ids(details)
     lines.extend(
         [
             "## Ecosystem RC Certification Gate",
@@ -6386,7 +6392,7 @@ def append_ecosystem_rc_gate(lines: list[str], summary: dict[str, Any]) -> None:
             f"- Live-network required: `{'yes' if details.get('liveNetworkRequired') else 'no'}`",
             f"- Network-scale soak satisfied: `{'yes' if details.get('networkScaleSoakSatisfied') else 'no'}`",
             f"- Redaction passed: `{'yes' if details.get('redactionPassed') else 'no'}`",
-            f"- Waivers: `{compact.get('waiverCount', 0)}` {markdown_code_list(details.get('waiverIds'))}",
+            f"- Waivers: `{compact.get('waiverCount', 0)}` {markdown_code_list(waiver_ids)}",
             "",
         ]
     )
@@ -7324,6 +7330,12 @@ def run_self_test(repo_root: Path) -> None:
         assert ECOSYSTEM_RC_GATE_ID in direct_rc_evidence["details"]["details"]["waiverIds"], (
             direct_rc_evidence
         )
+        direct_rc_report = (
+            direct_rc_waiver_settings.out_dir / REPORT_FILE_NAME
+        ).read_text(encoding="utf-8")
+        assert (
+            f"- Waivers: `1` `{ECOSYSTEM_RC_GATE_ID}`" in direct_rc_report
+        ), direct_rc_report
 
         previous_good_path = workspace / "build/previous-good/release-certification-summary.json"
         previous_good = {
@@ -8982,6 +8994,13 @@ def run_self_test(repo_root: Path) -> None:
         assert waived_vault_clean_summary["ecosystemRcGate"]["waiverCount"] == 1, (
             waived_vault_clean_summary
         )
+        waived_vault_rc_row = matrix_row_by_id(
+            workspace / "build/waived-vault-clean-history-cert",
+            ECOSYSTEM_RC_MATRIX_ROW_ID,
+        )
+        assert waived_vault_rc_row["status"] == "warn", waived_vault_rc_row
+        assert waived_vault_rc_row["releaseBlocker"] is False, waived_vault_rc_row
+        assert "app-vault.capabilities" in waived_vault_rc_row["waiverIds"], waived_vault_rc_row
 
         vault_missing_redaction_path = write_app_summary_variant(
             "vault-missing-redaction",


### PR DESCRIPTION
## Summary
- Add the final `ecosystem.rc-certification` release-blocking gate, compact RC summary fields, synthetic evidence, and the `ecosystem-rc-certification-gate` matrix row.
- Aggregate Phase 9 required evidence and gate semantics across catalog channels, app update/rollback, app-data portability, Trust Graph, Social Inbox, app-service grant bundles, network-scale soak, operator RC recovery, legacy retirement, sandbox/UI, redaction, history, and waivers.
- Expand PR-253 app-service dependency/grant-bundle evidence coverage in the certification matrix and self-tests.
- Update release certification docs/runbooks, including `docs/ecosystem-rc-certification-gate.md`, and remove deferred final RC gate wording.
- Preserve waiver visibility in summary/report/matrix artifacts while keeping redaction findings non-waivable.

## How to test
- `./gradlew spotlessApply`
- `python3 -m py_compile tools/release-certification/release_certification.py`
- `python3 tools/release-certification/release_certification.py --self-test`
- `python3 tools/release-certification/app_platform_smoke.py --self-test`
- `python3 tools/release-certification/network_scale_soak.py --self-test`
- `python3 tools/release-certification/app_platform_docs_check.py --self-test`
- `git diff --check`

## Notes
- Full Gradle test and a full release-candidate certification run were not run locally for this PR; the verification above covers the Python-only release-certification paths changed here.