### PR TITLE
chore(codex-docker): Improve container access

### DIFF
--- a/tools/codex-docker/Dockerfile
+++ b/tools/codex-docker/Dockerfile
@@ -110,14 +110,22 @@ RUN set -eux; \
     fi; \
     mkdir -p /etc/ssh/authorized_keys /etc/ssh/sshd_config.d /run/sshd; \
     printf '%s\n' \
-      'PermitRootLogin prohibit-password' \
-      'PasswordAuthentication no' \
-      'KbdInteractiveAuthentication no' \
+      'PermitRootLogin yes' \
+      'PasswordAuthentication yes' \
+      'KbdInteractiveAuthentication yes' \
       'PubkeyAuthentication yes' \
       'AuthorizedKeysFile /etc/ssh/authorized_keys/%u .ssh/authorized_keys' \
       'ClientAliveInterval 0' \
       'ClientAliveCountMax 0' \
       > /etc/ssh/sshd_config.d/99-codex.conf; \
+    printf 'root:root\n' | chpasswd; \
+    printf '%s\n' \
+      'if [ -d /work/cryptad ]; then' \
+      '  case "$-" in' \
+      '    *i*) cd /work/cryptad || true ;;' \
+      '  esac' \
+      'fi' \
+      > /etc/profile.d/99-cryptad-workdir.sh; \
     if [ -n "${CODEX_SSH_AUTHORIZED_KEYS}" ]; then \
       printf '%s\n' "${CODEX_SSH_AUTHORIZED_KEYS}" > /etc/ssh/authorized_keys/root; \
     else \

--- a/tools/codex-docker/README.md
+++ b/tools/codex-docker/README.md
@@ -22,8 +22,10 @@ test -f ../../.env || cp .env.example ../../.env
 Edit `../../.env` for local values. Keep `PLAYWRIGHT_VERSION` aligned across the Playwright image
 and the Playwright npm package. The default is `1.60.0`.
 
-If you need SSH access to the Codex container, set `CODEX_SSH_AUTHORIZED_KEYS` to one or more
-public keys in `../../.env`. Do not commit private keys or local tokens.
+The Codex container permits root SSH login with password `root`. It also supports key-based login:
+set `CODEX_SSH_AUTHORIZED_KEYS` to one or more public keys in `../../.env`. Do not commit private
+keys or local tokens, and keep SSH access limited to the Docker/Tailscale paths you intend to use.
+Interactive SSH login shells start in `/work/cryptad`.
 
 ## Start the stack
 

--- a/tools/codex-docker/compose.yaml
+++ b/tools/codex-docker/compose.yaml
@@ -38,7 +38,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        GITHUB_MCP_VERSION: ${GITHUB_MCP_VERSION:-v1.2.0}
+        GITHUB_MCP_VERSION: ${GITHUB_MCP_VERSION:-v1.3.0}
         GITHUB_MCP_ARCH: ${GITHUB_MCP_ARCH:-arm64}
         ACTIONLINT_VERSION: ${ACTIONLINT_VERSION:-1.7.12}
         ACTIONLINT_ARCH: ${ACTIONLINT_ARCH:-arm64}
@@ -55,6 +55,10 @@ services:
       CODEX_HOME: /root/.codex
       PLAYWRIGHT_REMOTE_WS_ENDPOINT: ws://playwright:3000/
       PW_TEST_CONNECT_WS_ENDPOINT: ws://playwright:3000/
+      TERM: xterm-256color
+      COLORTERM: truecolor
+      FORCE_COLOR: "3"
+      CLICOLOR_FORCE: "1"
 
     volumes:
       - ${CRYPTAD_REPO_ROOT:-../..}:/work/cryptad


### PR DESCRIPTION
## Summary
- Permit root SSH password login in the Codex container while preserving key-based login support.
- Start interactive SSH login shells in `/work/cryptad`.
- Add terminal color environment defaults for the Codex service.
- Update the default GitHub MCP server image argument from `v1.2.0` to `v1.3.0`.
- Update the Codex Docker runbook to document the SSH behavior.

## How to test
- `./gradlew spotlessApply`
- Not run: `docker compose --env-file ../../.env config` because this container does not have the `docker` CLI installed (`docker: command not found`).