### PR TITLE
feat(platform-api): Add app-platform consent workflow

### DIFF
--- a/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
+++ b/adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java
@@ -86,6 +86,7 @@ public final class PlatformApiToadlet extends Toadlet {
   private static final String ALERTS_SEGMENT = "alerts";
   private static final String APP_CATALOGS_SEGMENT = "app-catalogs";
   private static final String APP_SERVICES_SEGMENT = "app-services";
+  private static final String CONSENT_SEGMENT = "consent";
   private static final String FORM_PASSWORD_PARAMETER = "formPassword";
   private static final String GRANT_BUNDLES_SEGMENT = "grant-bundles";
   private static final String GRANTS_SEGMENT = "grants";
@@ -100,6 +101,7 @@ public final class PlatformApiToadlet extends Toadlet {
   private static final String TRUST_GRAPH_SEGMENT = "trust-graph";
   private static final String UPDATES_SEGMENT = "updates";
   private static final String WIZARD_SEGMENT = "wizard";
+  private static final String APPROVE_ACTION = "approve";
 
   /**
    * Transport-neutral router that owns endpoint selection, validation, and JSON payload creation.
@@ -637,6 +639,7 @@ public final class PlatformApiToadlet extends Toadlet {
         || requiresSecurityLevelsFormPassword(method, pathSegments)
         || requiresUpdatesFormPassword(method, pathSegments)
         || requiresAppServicesFormPassword(method, pathSegments)
+        || requiresConsentFormPassword(method, pathSegments)
         || requiresOperatorFormPassword(method, pathSegments)
         || requiresIdentityVaultFormPassword(method, pathSegments)
         || requiresTrustGraphFormPassword(method, pathSegments)
@@ -682,12 +685,22 @@ public final class PlatformApiToadlet extends Toadlet {
       return false;
     }
     if (GRANTS_SEGMENT.equals(pathSegments.get(1))) {
-      return "approve".equals(pathSegments.get(3)) || "revoke".equals(pathSegments.get(3));
+      return APPROVE_ACTION.equals(pathSegments.get(3)) || "revoke".equals(pathSegments.get(3));
     }
     return GRANT_BUNDLES_SEGMENT.equals(pathSegments.get(1))
-        && ("approve".equals(pathSegments.get(3))
+        && (APPROVE_ACTION.equals(pathSegments.get(3))
             || "reject".equals(pathSegments.get(3))
             || "renew".equals(pathSegments.get(3)));
+  }
+
+  private static boolean requiresConsentFormPassword(String method, List<String> pathSegments) {
+    return "POST".equals(method)
+        && pathSegments.size() == 2
+        && CONSENT_SEGMENT.equals(pathSegments.getFirst())
+        && (APPROVE_ACTION.equals(pathSegments.get(1))
+            || "reject".equals(pathSegments.get(1))
+            || "defer".equals(pathSegments.get(1))
+            || "update-preview".equals(pathSegments.get(1)));
   }
 
   private static boolean requiresOperatorFormPassword(String method, List<String> pathSegments) {

--- a/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
+++ b/adapter-http-legacy-admin/src/test/java/network/crypta/clients/http/PlatformApiToadletTest.java
@@ -49,6 +49,21 @@ class PlatformApiToadletTest {
         requiresFormPassword("POST", "/api/v1/app-services/grant-bundles/" + BUNDLE_ID + "/renew"));
   }
 
+  @Test
+  void requiresFormPassword_whenPostingConsentDecisionActions_expectProtected() throws Exception {
+    assertTrue(requiresFormPassword("POST", "/api/v1/consent/approve"));
+    assertTrue(requiresFormPassword("POST", "/api/v1/consent/reject"));
+    assertTrue(requiresFormPassword("POST", "/api/v1/consent/defer"));
+    assertTrue(requiresFormPassword("POST", "/api/v1/consent/update-preview"));
+  }
+
+  @Test
+  void requiresFormPassword_whenReadingConsentPreviews_expectNotProtected() throws Exception {
+    assertFalse(requiresFormPassword("GET", "/api/v1/consent/install-preview"));
+    assertFalse(requiresFormPassword("GET", "/api/v1/consent/update-preview"));
+    assertFalse(requiresFormPassword("GET", "/api/v1/consent/audit"));
+  }
+
   private static boolean requiresFormPassword(String method, String path) throws Exception {
     Method guard =
         PlatformApiToadlet.class.getDeclaredMethod("requiresFormPassword", String.class, URI.class);

--- a/docs/app-catalogs.md
+++ b/docs/app-catalogs.md
@@ -35,6 +35,14 @@ be installed, updated, staged, applied, or applied by automatic policy, and warn
 advisories require the independent `securityAcknowledged=true` acknowledgement for manual
 install/update. See [ecosystem-security-advisories.md](ecosystem-security-advisories.md).
 
+The host/operator consent layer groups catalog trust metadata into one install or update preview
+before a material mutation. Permission rationales, review receipt state, reviewer-key lifecycle,
+channel/support changes, deprecation and replacement notices, security advisories, app-service
+dependencies, and app-data migration declarations are summarized with a snapshot digest. Manual
+install/update mutations that require consent must carry an approval for that exact digest; stale
+approvals are rejected. See
+[user-consent-and-permission-upgrade-ux.md](user-consent-and-permission-upgrade-ux.md).
+
 For third-party app authors, `crypta-app catalog entry` can generate the descriptor input for
 `catalog create`, `crypta-app publish-usk --dry-run` can produce an offline publication checklist,
 and `crypta-app publish-usk --live` can publish a verified signed catalog through a configured

--- a/docs/app-data-store.md
+++ b/docs/app-data-store.md
@@ -158,6 +158,13 @@ namespace validation, import size limits, record and value caps, namespace caps,
 preflight checks. The operator routes do not grant app principals cross-app read or write access,
 and they are separate from the app-facing Platform API compatibility contract.
 
+Schema-changing app updates also participate in the operator consent flow. Update consent previews
+show current and target schema versions, migration status, dry-run state when available, rollback
+compatibility, and backup-before-update recommendation or requirement. If a migration requires
+operator review or a required backup is missing, automatic staging/apply is blocked until an
+operator approves a fresh consent snapshot. See
+[user-consent-and-permission-upgrade-ux.md](user-consent-and-permission-upgrade-ux.md).
+
 ## Browser SDK
 
 Static browser apps should use `CryptaPlatform.data` helpers:

--- a/docs/app-dev-cli.md
+++ b/docs/app-dev-cli.md
@@ -562,6 +562,10 @@ submission review metadata generate `catalog.version=6`.
 verification. `minimumCryptaVersion` is advisory and does not block install/update by itself;
 integer Cryptad build labels are the comparable form used by Platform API responses. Permission
 rationales explain declared permissions; they do not grant capabilities.
+Install and update consent previews display permission rationales, review metadata, channel and
+support metadata, security advisory status, service dependencies, and app-data migration metadata
+before a material operation proceeds. See
+[user-consent-and-permission-upgrade-ux.md](user-consent-and-permission-upgrade-ux.md).
 
 Production channel metadata is strict and deterministic. `channel` must be one of `stable`,
 `beta`, `nightly`, or `deprecated`; omitted descriptors default to stable when read by the runtime.

--- a/docs/app-platform-developer-portal.md
+++ b/docs/app-platform-developer-portal.md
@@ -35,6 +35,7 @@ Use this portal first, then follow the detailed source-of-truth pages for the ar
 | AppVault secret and identity material | [app-secret-and-identity-vault.md](app-secret-and-identity-vault.md) |
 | AppHost runtime hardening | [apphost-runtime-hardening.md](apphost-runtime-hardening.md) |
 | App update lifecycle and rollback | [app-update-lifecycle.md](app-update-lifecycle.md) |
+| User consent and permission upgrade UX | [user-consent-and-permission-upgrade-ux.md](user-consent-and-permission-upgrade-ux.md) |
 | App upgrade data migrations | [app-upgrade-data-migrations.md](app-upgrade-data-migrations.md) |
 | App-data backup, restore, and portability | [app-data-backup-restore-portability.md](app-data-backup-restore-portability.md) |
 | App review governance | [app-review-governance.md](app-review-governance.md) |
@@ -151,6 +152,7 @@ Public beta readiness treats these workstreams as one ecosystem beta release sto
 | Network-scale budgets and soak | [network-scale-soak-and-subscription-budget.md](network-scale-soak-and-subscription-budget.md), [release-certification.md](release-certification.md), `network-scale.*` evidence, `network-scale-soak-and-subscription-budget` matrix row |
 | Review governance | [app-review-governance.md](app-review-governance.md), `review receipt`, `reviewer key lifecycle`, `transparency log` evidence |
 | Updates, migrations, and rollback | [app-update-lifecycle.md](app-update-lifecycle.md), [app-upgrade-data-migrations.md](app-upgrade-data-migrations.md), `app-update.scheduler`, `app-update.rollback`, `app-update.data-migration-contract` evidence |
+| User consent | [user-consent-and-permission-upgrade-ux.md](user-consent-and-permission-upgrade-ux.md), `app-platform.user-consent-flow` evidence |
 | Public beta hardening | [app-platform-beta-known-limitations.md](app-platform-beta-known-limitations.md), `public-beta-security.*` evidence |
 | Legacy plugin freeze and migration | [legacy-plugin-freeze-policy.md](legacy-plugin-freeze-policy.md), [legacy-plugin-migration-guide.md](legacy-plugin-migration-guide.md), `legacy-plugin.freeze-policy`, `legacy-plugin.migration-guide`, `legacy-plugin.social-inbox-spike` |
 | Legacy admin status | [legacy-retirement-plan.md](legacy-retirement-plan.md), `legacy-admin.removal-wave-1`, `legacy-admin.removal-wave-2`, `legacy-admin.removal-wave-3`, `legacy-admin.removal-wave-4`; FProxy browse/content rendering, content filter, startup wizard, and security recovery remain retained or pending |

--- a/docs/app-platform-developer-portal.md
+++ b/docs/app-platform-developer-portal.md
@@ -61,13 +61,13 @@ The current source declares:
 
 ```text
 PlatformApiContract.CURRENT_API_VERSION = "v1"
-PlatformApiContract.CURRENT_CONTRACT_VERSION = 20
+PlatformApiContract.CURRENT_CONTRACT_VERSION = 21
 ```
 
 In docs, manifests, and catalog descriptors:
 
 - `/api/v1` identifies the transport route family.
-- `contractVersion=20` identifies the current Platform API compatibility contract snapshot.
+- `contractVersion=21` identifies the current Platform API compatibility contract snapshot.
 - `api.minimumVersion` and `api.maximumTestedVersion` compare against the integer contract
   version, not against the URL route prefix or the Cryptad build number.
 - `api.targetStability=stable` selects the Platform API 1.0 stable baseline for third-party app

--- a/docs/app-service-discovery-and-grants.md
+++ b/docs/app-service-discovery-and-grants.md
@@ -147,18 +147,18 @@ include local paths, raw provider data, raw request bodies, launch tokens, beare
 insert URIs, private keys, app-data backup payloads, raw Trust Graph statements, raw subject URIs,
 or raw signatures.
 
-## Install and update review
+## Consent, install, and update review
 
 PR-253 exposes deterministic dependency graph and grant-bundle APIs for install, update, and app
 review surfaces. Web Shell uses the same path-free graph and bundle records that app principals see
-under their own scope. Required missing dependencies are marked with blocking metadata; optional
-missing dependencies are marked as degraded.
+under their own scope. The unified consent layer now includes those graph and bundle records in
+install, update, and service-grant previews. Required missing dependencies are marked with blocking
+metadata; optional missing dependencies are marked as degraded.
 
-The update scheduler does not yet auto-apply dependency policy decisions from this graph. Until
-that wiring is added, operator review must use the dependency graph and bundle status before
-installing or updating an app that introduces new required services, missing providers, version
-mismatches, grant-required state, or `revalidation-required` state. This preserves the default-deny
-service boundary and keeps PR-248 channel policy and PR-249 migration gates unchanged.
+Automatic update policy must not stage or apply a candidate that introduces a required service
+dependency, a new grant bundle, provider descriptor drift, or `revalidation-required` state without
+operator consent. Bundle approve, renew, reject, and defer decisions write redacted consent audit
+events. See [user-consent-and-permission-upgrade-ux.md](user-consent-and-permission-upgrade-ux.md).
 
 ## Grant bundles
 

--- a/docs/app-update-lifecycle.md
+++ b/docs/app-update-lifecycle.md
@@ -15,6 +15,7 @@ The v1 policy is:
 | Detect | Catalog detail and listing responses compare the installed app version with the verified catalog entry. | `app-update.lifecycle` |
 | Schedule | The background scheduler refreshes configured signed catalogs and checks installed apps. It delegates app checks to the same lifecycle service used by manual requests. | `app-update.scheduler` |
 | Review | Web Shell and API callers can review signed catalog metadata, compatibility hints, publisher-advisory review notes, trusted review receipt decisions, changelog text, and permission deltas before acting. | `app-update.lifecycle` |
+| Consent | Material permission, trust, API stability, service-grant, migration, backup, channel, deprecation, replacement, and security changes require a consent snapshot approval tied to a digest. | `app-platform.user-consent-flow` |
 | Security policy | Catalog-level security decisions can inform, warn, block install, block update, or denylist an exact app version before any install/update mutation. | `app-update.security-denylist-gates` |
 | Stage | Local and catalog-backed updates prepare a copied, verified staged bundle before AppHost mutates the installed bundle. | `app-update.lifecycle` |
 | App-data migration | A candidate that changes durable app-data schema must declare a signed migration contract, pass dry-run before bundle replacement, and create an internal app-data snapshot before apply. | `app-update.data-migration-contract` |
@@ -28,6 +29,13 @@ preserves the last verified catalog when a later refresh fails. Scheduler-trigge
 delegate to `AppUpdateService.check(...)`. Applying an update requires an operator or explicit API
 caller unless the operator selected a policy mode that allows automatic staging or apply. Manual
 remains the default policy for every app.
+
+Automatic policy is additionally gated by consent. The scheduler must surface a pending-consent
+state instead of staging or applying a candidate when the preview contains material permission
+deltas, app-service grant changes, app-data migration review, backup-before-update requirements,
+stable-to-experimental API changes, review/trust degradation, channel/support degradation,
+deprecation/replacement metadata, new advisories, or a denylist decision. See
+[user-consent-and-permission-upgrade-ux.md](user-consent-and-permission-upgrade-ux.md).
 
 For release evidence, manual remains the default.
 Applying an update requires an operator or explicit API caller.
@@ -43,6 +51,9 @@ form-password guard. App principals remain default-deny and must carry the route
 published by the Platform API contract. Catalog-backed update lifecycle mutations require both
 `apps.manage` and `catalogs.manage` for app principals because `check`, `stage`, and `apply` can
 refresh signed catalogs, prepare catalog install plans, or apply catalog-staged bundles.
+When material consent is required, the host/operator mutation must include the consent request id
+and snapshot digest from an approved preview. A changed candidate, catalog entry, review receipt,
+permission set, service dependency, or migration plan rejects the stale approval.
 
 Policy modes are explicit:
 

--- a/docs/platform-api-contract.md
+++ b/docs/platform-api-contract.md
@@ -9,7 +9,7 @@ The current app-facing values are:
 
 ```text
 apiVersion=v1
-contractVersion=20
+contractVersion=21
 ```
 
 The contract does not change Platform API behavior. It publishes metadata that answers which
@@ -421,6 +421,11 @@ rejected, and resubmitted state, pre-review outcome, reviewer key status, receip
 redacted transparency-log status when present. It remains metadata-only and must not expose
 submission package bodies, rationale text, local paths, tokens, private keys, private insert URIs,
 raw app data, or raw fetched content.
+
+Contract version 21 adds host/operator-only consent route descriptors for install, update,
+catalog-update, service-grant, decision, and audit workflows. These descriptors make the existing
+local `/api/v1/consent/*` surface discoverable through `/api/v1/platform/contract` while keeping
+the routes outside the Platform API 1.0 app-facing stable baseline.
 
 App-update summaries also include scheduler metadata for background catalog refresh and app update
 checks. The scheduler fields are path-free and token-free: they expose enabled/status, last and

--- a/docs/production-beta-release-pipeline.md
+++ b/docs/production-beta-release-pipeline.md
@@ -9,8 +9,8 @@ The production beta pipeline is a release-manager workflow for first-party app e
 It does not rewrite the app platform, change peer protocols, or publish a public app store by
 itself. It combines the existing Gradle build, first-party app staging tasks, `crypta-app` signing
 and catalog tools, app-platform smoke checks, live-network beta evidence, network-scale soak
-evidence, first-party app maintenance policy metadata, ecosystem RC certification, and final
-artifact redaction.
+evidence, first-party app maintenance policy metadata, user-consent flow evidence, ecosystem RC
+certification, and final artifact redaction.
 
 The entrypoint is:
 
@@ -138,6 +138,12 @@ directories are kept outside the public artifact tree.
 | `artifacts.firstPartyMaintenancePolicy` | Redacted copy of the checked-in first-party maintenance policy source used to generate signed catalog descriptors. |
 | `redaction` | Final artifact scanner result and findings. |
 | `commands` | Redacted command metadata, exit codes, durations, and scrubbed output tails. |
+
+Production beta promotion includes `app-platform.user-consent-flow` evidence. That evidence proves
+that install/update previews, service-grant consent, migration and backup consent, automatic update
+gating, stale snapshot protection, audit redaction, Web Shell UI, tests, and docs are present
+without requiring a live node. Consent evidence must not include private insert URI values, secret
+inputs, raw fetched content, raw app data, backup payloads, or host-local paths.
 
 `reports/production-beta-summary.md` is the human-readable companion. It lists failed gates, artifact
 paths, known limitations, and the production beta readiness decision.

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -192,6 +192,7 @@ Release-candidate mode requires these evidence ids:
 | `app-services.web-shell` | App-platform smoke summary. | Web Shell lists advertised services, dependencies, grant bundles, grants, expiry, revalidation warnings, and redacted audit events, and lets the operator approve/reject/renew bundles or revoke active grants. |
 | `app-services.redaction` | App-platform smoke summary. | App-service evidence excludes raw tokens, raw subject URIs, raw request bodies, private insert URIs, local paths, provider app data, and generic proxy behavior. |
 | `app-services.dependency-redaction` | App-platform smoke summary. | Dependency graph, bundle, Web Shell, and release evidence exclude raw service request bodies, raw subject URIs, raw Trust Graph data, raw signatures, tokens, private insert URIs, private keys, local paths, and app-data backup payloads. |
+| `app-platform.user-consent-flow` | App-platform smoke summary. | Unified install/update/service-grant/app-data consent model, digest-tied approvals, stale approval rejection, auto-update gating, redacted audit decisions, Web Shell consent UI, docs, and tests are present. |
 | `app-ui.design-system` | App-platform smoke summary. | Canonical app UI design-system assets exist and first-party staged bundles contain matching local copies. |
 | `app-update.live-catalog-refresh` | App-platform smoke summary. | App-update scheduler evidence shows configured signed catalog refresh, including live USK catalog refresh, before candidate discovery while keeping manual update policy as the default. |
 | `app-update.data-migration-contract` | App-platform smoke summary. | Signed app manifests declare app-data schema and migration metadata; update summaries expose path-free migration plans; dry-run, snapshot, missing-path, rollback-incompatible, Feed Reader, Trust Graph Local RC UI-state, and redaction checks are present. |
@@ -351,6 +352,12 @@ app-version denylists, warning acknowledgements, install/update/stage/apply/sche
 review receipt revocation, reviewer-key compromise, Web Shell warning rendering, safe uninstall
 guidance, and redaction. See
 [ecosystem-security-advisories.md](ecosystem-security-advisories.md).
+
+`app-platform.user-consent-flow` verifies the unified consent layer for material install, update,
+app-service grant, app-data migration, backup, channel/support, deprecation/replacement,
+review/trust, security, and automatic-update decisions. It also checks digest-tied approvals,
+stale approval rejection, redacted consent audit records, Web Shell rendering, docs, and tests. See
+[user-consent-and-permission-upgrade-ux.md](user-consent-and-permission-upgrade-ux.md).
 
 `catalog.live-usk-publication` and `catalog.live-usk-source-verification` are offline source
 evidence by default. They prove live publication support, redaction behavior, same USK sibling

--- a/docs/user-consent-and-permission-upgrade-ux.md
+++ b/docs/user-consent-and-permission-upgrade-ux.md
@@ -1,0 +1,245 @@
+# User consent and permission upgrade UX
+
+This document describes the unified operator consent layer for app install, app update,
+app-service grant, and app-data migration decisions.
+
+## Scope
+
+Consent applies when an app operation would change material trust, permission, support, security,
+service, or data-handling state. It gives Web Shell and host/operator API clients one preview and
+decision flow instead of separate prompts for every subsystem.
+
+Consent covers:
+
+- new app installation from a signed catalog;
+- catalog-backed app updates;
+- permission additions and changed permission rationales;
+- Platform API target stability and experimental capability acceptance changes;
+- third-party review, reviewer-key, receipt, and trust-status changes;
+- catalog channel, support level, deprecation, and replacement metadata;
+- catalog security advisories, denylist decisions, and revoked review receipts;
+- app-service dependency bundles and grant renewal or revalidation;
+- app-data schema migration plans and backup-before-update recommendations;
+- automatic update gating when material review is required;
+- audit records for approve, reject, defer, and expired decisions.
+
+The consent layer is a local operator policy surface. It does not change bundle signatures, catalog
+signatures, review receipt verification, app sandboxing, AppHost process launch, peer protocols, or
+the app-facing Platform API contract.
+
+## Consent Preview
+
+Operators review a deterministic consent snapshot before a material operation. A snapshot includes
+the action, app id, candidate version and digest when available, catalog id/source/channel, risk
+level, blocking reasons, grouped human-readable sections, and a snapshot digest.
+
+The snapshot digest binds the decision to the exact preview. Mutating routes that require consent
+must receive the same consent request id and digest that Web Shell approved. If the candidate,
+catalog entry, review receipt, permission set, service grant, security policy, or migration plan
+changes after preview, the mutation rejects the stale approval and asks the operator to refresh the
+preview. This stale consent protection prevents an operator decision from authorizing a later,
+different candidate.
+
+Approved consent requests are single-use and process-local. The platform consumes an approval after
+one successful digest check, and unconsumed approvals expire from the in-memory decision cache after
+15 minutes so an old request id cannot be replayed if the same snapshot digest appears later.
+
+Snapshots and audit records are redacted summaries. They must not include private insert URIs,
+private keys, bearer tokens, browser session tokens, authorization headers, raw fetched content,
+raw app data, backup payloads, vault secret material, or host-local filesystem paths.
+
+## Install Consent
+
+Install preview summarizes the candidate app before the bundle is installed:
+
+- app id, name, version, and bundle digest;
+- catalog id, source, channel, first-party or third-party status, support level, and maintenance
+  owner;
+- review status, reviewer-key status, receipt fingerprint, submission id, and submission digest
+  when available;
+- stable, beta, nightly, deprecated, replacement, and deprecation metadata;
+- security advisory status and blocking security decisions;
+- required permissions with declared rationales;
+- Platform API target stability, target API range, and experimental acceptance flag;
+- sandbox requirement;
+- app-data schema, migration, and backup declarations;
+- app-service dependencies and requested grant bundles;
+- explicit risk level and blocking reasons.
+
+Install mutations can proceed without a consent approval only when the preview has no material or
+blocking findings. Denylisted candidates and non-overridable security blocks remain blocked even
+when an operator tries to approve the snapshot.
+
+## Update Consent
+
+Update preview compares the installed app with the candidate bundle or catalog entry. It shows:
+
+- old and new app versions;
+- old and new bundle digests;
+- added and removed permissions;
+- changed permission rationales when available;
+- stable-to-experimental target changes, target API range changes, and experimental acceptance
+  changes;
+- reviewer changes, review status changes, receipt changes, caution decisions, and revoked
+  receipts;
+- channel changes, support degradation, deprecation, and replacement app suggestions;
+- new security advisories, denylisted candidates, and vulnerable installed versions;
+- app-data schema migration from and to versions, dry-run status, rollback compatibility, and
+  backup recommendation or requirement;
+- new service dependencies, changed provider descriptors, and grants requiring renewal or
+  revalidation;
+- whether the update is eligible for automatic staging or apply.
+
+The update route validates the approved snapshot before staging a candidate. Review, security, and
+migration acknowledgements are derived from the verified consent approval so Web Shell does not
+need to present separate raw acknowledgement checkboxes for the same operation.
+
+## Permission Delta
+
+Permission changes are grouped by added, removed, and changed rationale. Added permissions and
+expanded rationales are material because they alter what the app can request from the local node.
+Removed permissions are still visible so operators can verify that an update reduces authority, but
+they do not normally block automatic policy by themselves.
+
+Permission rationales are display text, not grants. Runtime authorization still comes from the
+signed manifest and the authenticated app principal.
+
+## API Stability Change
+
+Platform API stability changes are material when an update moves from the stable baseline to
+experimental target stability, widens accepted experimental capability use, or changes the declared
+target API range in a way the operator should review. This keeps Platform API 1.0 stable-baseline
+expectations visible before operators accept an update that depends on experimental app-facing
+behavior.
+
+## Review And Trust Delta
+
+Review and trust findings summarize the current trusted review status without exposing raw receipt
+payloads or raw key material. The consent preview highlights reviewer changes, receipt fingerprint
+changes, `caution` review results, receipt revocations, reviewer-key lifecycle degradation, and
+publisher-advisory-only review metadata.
+
+A revoked review receipt or revoked reviewer key is treated as a high-risk or blocking condition
+according to local policy. The preview should fail closed for operations that cannot be made safe
+with an operator acknowledgement.
+
+## Service Grants
+
+App-service dependency grant bundles use the same consent language as install and update. A
+service-grant preview explains:
+
+- the requesting app;
+- the provider app and service;
+- service id, capability, scopes, contexts, and feature name;
+- whether the dependency is required or optional;
+- expiry and renewal behavior when present;
+- audit impact and revocation behavior;
+- provider descriptor revalidation state.
+
+Approving, renewing, rejecting, or deferring a grant bundle writes a consent audit event. Approval
+does not create ambient localhost trust; the app still needs the authenticated principal,
+`app.services.call`, and an active grant record for invocation.
+
+## App-Data Migration And Backup
+
+App-data migration findings summarize metadata only:
+
+- current and target schema versions;
+- migration path or platform migration status;
+- dry-run status when available;
+- whether a backup exists;
+- whether backup-before-update is recommended or required;
+- rollback compatibility;
+- known data-loss risk and blocking migration errors.
+
+When a migration requires operator review, rollback compatibility is missing, or backup is required
+but absent, the update cannot be silently applied by scheduler policy. The preview must never show
+raw app-data values, backup contents, migration logs, command paths, process tokens, or private
+content identifiers.
+
+## Security, Deprecation, And Replacement
+
+Catalog security, deprecation, and replacement metadata is visible before install and update.
+
+Rules:
+
+- denylisted candidates are not installable, stageable, applyable, or auto-updatable;
+- warning-level advisories require explicit consent before manual install or update;
+- revoked receipts and reviewer-key compromise states fail closed or require blocking warnings
+  according to local policy;
+- deprecated apps show replacement information when the catalog provides it;
+- security advisory text is summarized and redacted.
+
+Consent approval can acknowledge warning-level metadata. It cannot override denylist or
+non-overridable block decisions.
+
+## Auto-Update Gating
+
+Automatic update policy must not bypass material consent. Scheduler-driven staging or apply is
+blocked when a candidate introduces:
+
+- new permissions or expanded permission rationale;
+- required app-service dependency grants or provider revalidation;
+- app-data migration with backup required or operator review required;
+- stable-to-experimental Platform API target changes;
+- newly accepted experimental capabilities;
+- review caution, revoked receipt, reviewer-key degradation, or receipt changes;
+- stable-to-beta, nightly, or deprecated channel movement;
+- support degradation, deprecation, or replacement metadata;
+- new security advisories;
+- denylist or other non-overridable catalog security blocks.
+
+The scheduler surfaces pending consent state through update summaries instead of silently applying
+the candidate.
+
+## Audit Records
+
+Every consent approve, reject, defer, or expiry decision records:
+
+- decision id;
+- consent request id;
+- local operator marker or actor identity when available;
+- app id;
+- action type;
+- decision status;
+- timestamp;
+- consent snapshot digest;
+- material risk summary.
+
+Audit records are safe summaries. They redact tokens, private URI forms, raw content, raw app data,
+backup payloads, vault secret material, and host-local paths. Audit records must be useful for
+support and release evidence without becoming a secret-bearing log.
+
+## API Surface
+
+The consent routes are host/operator routes under the local Platform API transport. App principals
+do not receive ambient authority to approve their own install, update, service-grant, or migration
+decisions.
+
+The current route family includes preview and decision endpoints for install, catalog update, app
+update, service grants, approve, reject, defer, and audit listing. Clients should always fetch a
+fresh preview immediately before asking the operator for approval and should submit the returned
+request id plus snapshot digest with the mutation.
+
+## Web Shell UX
+
+Web Shell renders consent previews as grouped sections with concise labels. It does not dump raw
+manifest JSON. The install, update, and service-grant buttons fetch a preview when needed, show the
+material findings, and then submit the approved request id and snapshot digest with the original
+mutation.
+
+If the mutation reports a stale approval, Web Shell asks the operator to refresh the preview. The
+operator can approve the new snapshot, reject the decision, or leave the candidate pending.
+
+## Release Evidence
+
+Release certification records this work as `app-platform.user-consent-flow`. The deterministic
+smoke evidence checks that the consent model, route wiring, auto-update gating, audit redaction,
+stale snapshot protection, Web Shell UI, docs, and tests are present without requiring a live
+Crypta node.
+
+## Non-Goals
+
+This layer does not implement Trust Graph or Social Inbox beta hardening. It does not add a public
+remote app store, replace signed catalog verification, bypass review receipt validation, weaken
+denylist decisions, expose raw app data to operators, or make automatic updates the default.

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppRoutes.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppRoutes.java
@@ -9,6 +9,8 @@ import network.crypta.platform.api.apps.AppsApiHandler;
 import network.crypta.platform.api.appservices.AppServiceCoordinator;
 import network.crypta.platform.api.appupdates.AppUpdateService;
 import network.crypta.platform.api.appupdates.AppUpdatesApiHandler;
+import network.crypta.platform.api.consent.ConsentApiHandler;
+import network.crypta.platform.api.consent.ConsentService;
 import network.crypta.platform.api.content.subscriptions.ContentSubscriptionService;
 import network.crypta.platform.appcatalog.AppCatalogManager;
 import network.crypta.platform.apphost.AppHost;
@@ -51,6 +53,8 @@ final class PlatformApiAppRoutes {
   private final AppDataService appDataService;
   private final AppServiceCoordinator appServiceCoordinator;
   private final AppCatalogsApiHandler appCatalogsApiHandler;
+  private final ConsentService consentService;
+  private final ConsentApiHandler consentApiHandler;
   private final PlatformApiVaultRouter vaultRouter;
 
   /**
@@ -120,6 +124,11 @@ final class PlatformApiAppRoutes {
             ? null
             : new AppCatalogsApiHandler(
                 appCatalogManager, appHost, dependencies.currentCryptaVersion(), appVaultService);
+    consentService =
+        appCatalogsApiHandler == null && appUpdateService == null && appServiceCoordinator == null
+            ? null
+            : new ConsentService(appCatalogsApiHandler, appUpdateService, appServiceCoordinator);
+    consentApiHandler = consentService == null ? null : new ConsentApiHandler(consentService);
     vaultRouter = appVaultService == null ? null : new PlatformApiVaultRouter(appVaultService);
   }
 
@@ -150,6 +159,17 @@ final class PlatformApiAppRoutes {
     }
     requireHostOperator(request);
     return vaultRouter.routeIdentityVaultRequest(segments, request);
+  }
+
+  PlatformApiResponse routeConsentRequest(List<String> segments, PlatformApiRequest request) {
+    if (consentApiHandler == null) {
+      throw notFound();
+    }
+    return consentApiHandler.route(segments, request);
+  }
+
+  ConsentService consentService() {
+    return consentService;
   }
 
   /**
@@ -445,10 +465,13 @@ final class PlatformApiAppRoutes {
         if (!METHOD_POST.equals(request.method())) {
           yield methodNotAllowed(METHOD_POST, POST_ONLY_MESSAGE);
         }
+        Map<String, List<String>> queryParameters =
+            consentService == null
+                ? request.queryParameters()
+                : consentService.requireApprovedUpdateIfRequired(
+                    appId, request.queryParameters(), request.principal());
         yield PlatformApiResponse.ok(
-            envelope(
-                UPDATES_ROUTE_SEGMENT,
-                appUpdatesApiHandler.stage(appId, request.queryParameters())));
+            envelope(UPDATES_ROUTE_SEGMENT, appUpdatesApiHandler.stage(appId, queryParameters)));
       }
       case "apply" -> {
         if (!METHOD_POST.equals(request.method())) {
@@ -586,16 +609,47 @@ final class PlatformApiAppRoutes {
     return switch (action) {
       case "install" ->
           PlatformApiResponse.created(
-              envelope(
-                  "app",
-                  appCatalogsApiHandler.install(catalogId, appId, request.queryParameters())));
+              envelope("app", installCatalogApp(catalogId, appId, request)));
       case "update" ->
-          PlatformApiResponse.ok(
-              envelope(
-                  "app",
-                  appCatalogsApiHandler.update(catalogId, appId, request.queryParameters())));
+          PlatformApiResponse.ok(envelope("app", updateCatalogApp(catalogId, appId, request)));
       default -> throw notFound();
     };
+  }
+
+  private Map<String, Object> installCatalogApp(
+      String catalogId, String appId, PlatformApiRequest request) {
+    if (consentService == null) {
+      return appCatalogsApiHandler.install(catalogId, appId, request.queryParameters());
+    }
+    appCatalogsApiHandler.requireInstallPreconditions(catalogId, appId);
+    Map<String, List<String>> consentParameters =
+        consentService.requireApprovedInstallIfRequired(
+            catalogId, appId, request.queryParameters(), request.principal());
+    return appCatalogsApiHandler.install(
+        catalogId,
+        appId,
+        consentParameters,
+        (preparedCatalogId, preparedEntry) ->
+            consentService.requireApprovedPreparedInstallIfRequired(
+                preparedCatalogId, preparedEntry, consentParameters, request.principal()));
+  }
+
+  private Map<String, Object> updateCatalogApp(
+      String catalogId, String appId, PlatformApiRequest request) {
+    if (consentService == null) {
+      return appCatalogsApiHandler.update(catalogId, appId, request.queryParameters());
+    }
+    appCatalogsApiHandler.requireUpdatePreconditions(catalogId, appId);
+    Map<String, List<String>> consentParameters =
+        consentService.requireApprovedCatalogUpdateIfRequired(
+            catalogId, appId, request.queryParameters(), request.principal());
+    return appCatalogsApiHandler.update(
+        catalogId,
+        appId,
+        consentParameters,
+        (preparedCatalogId, preparedEntry) ->
+            consentService.requireApprovedPreparedCatalogUpdateIfRequired(
+                preparedCatalogId, preparedEntry, consentParameters, request.principal()));
   }
 
   private static String requireAppPrincipal(PlatformApiRequest request) {

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppServiceRoutes.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppServiceRoutes.java
@@ -4,6 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import network.crypta.platform.api.appservices.AppServiceCoordinator;
+import network.crypta.platform.api.consent.ConsentService;
 
 /**
  * Routes local app-service discovery, grant lifecycle, audit, and invocation endpoints.
@@ -43,8 +44,10 @@ import network.crypta.platform.api.appservices.AppServiceCoordinator;
  * release-certification fixtures.
  *
  * @param coordinator shared coordinator, or {@code null} when app services are unavailable
+ * @param consentService shared consent coordinator, or {@code null} when unavailable
  */
-record PlatformApiAppServiceRoutes(AppServiceCoordinator coordinator) {
+record PlatformApiAppServiceRoutes(
+    AppServiceCoordinator coordinator, ConsentService consentService) {
   /** HTTP method token for discovery, list, and audit routes. */
   private static final String METHOD_GET = "GET";
 
@@ -329,15 +332,31 @@ record PlatformApiAppServiceRoutes(AppServiceCoordinator coordinator) {
       return methodNotAllowed(METHOD_POST, POST_ONLY_MESSAGE);
     }
     return switch (action) {
-      case "approve" ->
-          PlatformApiResponse.ok(
-              envelope(RESOURCE_BUNDLE, service.approveBundle(request.principal(), bundleId)));
-      case "reject" ->
-          PlatformApiResponse.ok(
-              envelope(RESOURCE_BUNDLE, service.rejectBundle(request.principal(), bundleId)));
-      case "renew" ->
-          PlatformApiResponse.ok(
-              envelope(RESOURCE_BUNDLE, service.renewBundle(request.principal(), bundleId)));
+      case "approve" -> {
+        if (consentService != null) {
+          service.requireBundleApprovalPreconditions(request.principal(), bundleId);
+          consentService.requireApprovedServiceGrantIfRequired(
+              bundleId, request.queryParameters(), request.principal());
+        }
+        yield PlatformApiResponse.ok(
+            envelope(RESOURCE_BUNDLE, service.approveBundle(request.principal(), bundleId)));
+      }
+      case "reject" -> {
+        Map<String, Object> rejected = service.rejectBundle(request.principal(), bundleId);
+        if (consentService != null) {
+          consentService.recordServiceGrantRejection(bundleId, request.principal());
+        }
+        yield PlatformApiResponse.ok(envelope(RESOURCE_BUNDLE, rejected));
+      }
+      case "renew" -> {
+        if (consentService != null) {
+          service.requireBundleRenewalPreconditions(request.principal(), bundleId);
+          consentService.requireApprovedServiceGrantIfRequired(
+              bundleId, request.queryParameters(), request.principal());
+        }
+        yield PlatformApiResponse.ok(
+            envelope(RESOURCE_BUNDLE, service.renewBundle(request.principal(), bundleId)));
+      }
       default -> throw notFound();
     };
   }

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiContract.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiContract.java
@@ -56,11 +56,11 @@ public record PlatformApiContract(
   /**
    * Integer compatibility contract version used by app manifests and catalogs.
    *
-   * <p>The value increases only when the app-facing Platform API compatibility surface changes in a
-   * way that tooling should be able to compare. It is not the Cryptad build number, and it is not
-   * the URL API version.
+   * <p>The value increases when published Platform API compatibility metadata changes in a way that
+   * tooling should be able to compare. It is not the Cryptad build number, and it is not the URL
+   * API version.
    */
-  public static final int CURRENT_CONTRACT_VERSION = 20;
+  public static final int CURRENT_CONTRACT_VERSION = 21;
 
   /** Stable app-facing Platform API baseline name published in contract snapshots. */
   public static final String PLATFORM_API_STABLE_BASELINE_NAME = "1.0";
@@ -98,6 +98,7 @@ public record PlatformApiContract(
   private static final int NETWORK_SCALE_BUDGET_CONTRACT_VERSION = 18;
   private static final int FIRST_PARTY_MAINTENANCE_CONTRACT_VERSION = 19;
   private static final int THIRD_PARTY_REVIEW_METADATA_CONTRACT_VERSION = 20;
+  private static final int CONSENT_CONTRACT_VERSION = 21;
 
   /**
    * Stable producer label written into generated contract snapshots.
@@ -131,6 +132,9 @@ public record PlatformApiContract(
           + ". Contract version "
           + THIRD_PARTY_REVIEW_METADATA_CONTRACT_VERSION
           + " adds third-party submission review metadata to catalog app summaries"
+          + ". Contract version "
+          + CONSENT_CONTRACT_VERSION
+          + " adds host/operator-only consent preview, decision, and audit route descriptors"
           + ". Endpoint descriptors retain the contract version where each route first appeared. "
           + "Experimental, deprecated, scheduled-for-removal, and internal entries are flagged for "
           + "developer tooling and release review before behavior changes.";
@@ -141,6 +145,7 @@ public record PlatformApiContract(
   private static final String ROUTE_FAMILY_APP_CATALOGS = "app-catalogs";
   private static final String ROUTE_FAMILY_APP_VAULT = "app-vault";
   private static final String ROUTE_FAMILY_CONFIG = "config";
+  private static final String ROUTE_FAMILY_CONSENT = "consent";
   private static final String ROUTE_FAMILY_CONTENT = "content";
   private static final String ROUTE_FAMILY_IDENTITY_VAULT = "identity-vault";
   private static final String ROUTE_FAMILY_PEERS = "peers";
@@ -612,6 +617,7 @@ public record PlatformApiContract(
     builder.contentSubscriptionEndpoints();
     builder.appDataEndpoints();
     builder.appServiceEndpoints();
+    builder.consentEndpoints();
     builder.trustGraphPreviewEndpoints();
     builder.post(
         ROUTE_FAMILY_QUEUE,
@@ -1552,6 +1558,54 @@ public record PlatformApiContract(
               "Invoke one bounded local app service through an active grant."));
     }
 
+    private void consentEndpoints() {
+      consentEndpoint(
+          METHOD_GET,
+          "/consent/install-preview",
+          "consent.install-preview",
+          "Preview material install consent for a catalog app.");
+      consentEndpoint(
+          METHOD_GET,
+          "/consent/update-preview",
+          "consent.update-preview.read",
+          "Read a material update consent preview without refreshing catalogs.");
+      consentEndpoint(
+          METHOD_POST,
+          "/consent/update-preview",
+          "consent.update-preview.refresh",
+          "Refresh catalogs and preview material update consent.");
+      consentEndpoint(
+          METHOD_GET,
+          "/consent/catalog-update-preview",
+          "consent.catalog-update-preview",
+          "Preview catalog-backed update consent for a catalog app.");
+      consentEndpoint(
+          METHOD_GET,
+          "/consent/service-grant-preview",
+          "consent.service-grant-preview",
+          "Preview material consent for one app-service grant bundle.");
+      consentEndpoint(
+          METHOD_POST,
+          "/consent/approve",
+          "consent.approve",
+          "Approve one digest-bound consent request.");
+      consentEndpoint(
+          METHOD_POST,
+          "/consent/reject",
+          "consent.reject",
+          "Reject one digest-bound consent request.");
+      consentEndpoint(
+          METHOD_POST,
+          "/consent/defer",
+          "consent.defer",
+          "Defer one digest-bound consent request.");
+      consentEndpoint(
+          METHOD_GET,
+          "/consent/audit",
+          "consent.audit",
+          "List recent redacted consent audit events.");
+    }
+
     private void appServiceEndpoint(AppServiceEndpointSpec spec) {
       endpoint(
           new EndpointSpec(
@@ -1568,6 +1622,23 @@ public record PlatformApiContract(
                   ? PlatformApiStabilityLevel.OPERATOR_ONLY
                   : PlatformApiStabilityLevel.EXPERIMENTAL,
               spec.description()));
+    }
+
+    private void consentEndpoint(
+        String method, String routeTemplate, String actionLabel, String description) {
+      endpoint(
+          new EndpointSpec(
+              ROUTE_FAMILY_CONSENT,
+              method,
+              routeTemplate,
+              actionLabel,
+              List.of(),
+              CONSENT_CONTRACT_VERSION,
+              true,
+              false,
+              false,
+              PlatformApiStabilityLevel.OPERATOR_ONLY,
+              description));
     }
 
     private void trustGraphPreviewEndpoints() {

--- a/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java
@@ -328,7 +328,9 @@ public final class PlatformApiRouter {
             checkedAppServices.contentSubscriptionService(),
             checkedAppServices.networkBudgetService());
     appDataRoutes = new PlatformApiAppDataRoutes(checkedAppServices.appDataService());
-    appServiceRoutes = new PlatformApiAppServiceRoutes(checkedAppServices.appServiceCoordinator());
+    appServiceRoutes =
+        new PlatformApiAppServiceRoutes(
+            checkedAppServices.appServiceCoordinator(), appRoutes.consentService());
   }
 
   /**
@@ -445,6 +447,7 @@ public final class PlatformApiRouter {
       case "content" -> contentRoutes.route(segments, request);
       case "app-data" -> appDataRoutes.route(segments, request);
       case "app-services" -> appServiceRoutes.route(segments, request);
+      case "consent" -> appRoutes.routeConsentRequest(segments, request);
       case "operator" -> operatorRoutes.route(segments, request);
       case "trust-graph" -> trustGraphRoutes.route(segments, request);
       case "node", "connectivity", "diagnostics", "updates", "wizard", "alerts" ->

--- a/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
@@ -77,6 +77,7 @@ import network.crypta.platform.appvault.AppVaultService;
  */
 public final class AppCatalogsApiHandler {
   private static final System.Logger LOG = System.getLogger(AppCatalogsApiHandler.class.getName());
+  private static final PreparedPlanConsentVerifier NO_PREPARED_PLAN_CONSENT_VERIFIER = (_, _) -> {};
 
   private static final String APP_ALREADY_INSTALLED_PREFIX = "app already installed: ";
   private static final String APP_NOT_INSTALLED_PREFIX = "app is not installed: ";
@@ -87,6 +88,7 @@ public final class AppCatalogsApiHandler {
   private static final String APPHOST_BUNDLE_VALIDATION_MESSAGE =
       "Catalog app bundle failed AppHost validation.";
   private static final String VERSION_STATUS_NOT_INSTALLED = "not_installed";
+  private static final String VERSION_STATUS_INSTALLED = "installed";
   private static final String VERSION_STATUS_CURRENT = "current";
   private static final String VERSION_STATUS_DIFFERENT = "different";
   private static final String VERSION_STATUS_UNKNOWN = "unknown";
@@ -99,6 +101,7 @@ public final class AppCatalogsApiHandler {
   private static final String SOURCE_KIND_FIELD = "sourceKind";
   private static final String CATALOG_ID_FIELD = "catalogId";
   private static final String APP_ID_FIELD = "appId";
+  private static final String INSTALLED_FIELD = VERSION_STATUS_INSTALLED;
   private static final String INSTALLED_VERSION_FIELD = "installedVersion";
   private static final String LAST_ATTEMPT_AT_FIELD = "lastAttemptAt";
   private static final String LAST_SUCCESSFUL_REFRESH_AT_FIELD = "lastSuccessfulRefreshAt";
@@ -305,6 +308,18 @@ public final class AppCatalogsApiHandler {
      * @throws IOException if configured key material cannot be read
      */
     TrustedReviewerKeys trustedReviewerKeys() throws IOException;
+  }
+
+  /** Verifies consent against a prepared catalog plan entry before install or update commits. */
+  @FunctionalInterface
+  public interface PreparedPlanConsentVerifier {
+    /**
+     * Verifies that the prepared plan entry still matches the approved operator consent snapshot.
+     *
+     * @param catalogId catalog identifier attached to the prepared plan
+     * @param entry prepared catalog entry
+     */
+    void verify(String catalogId, AppCatalogEntry entry);
   }
 
   /**
@@ -634,6 +649,48 @@ public final class AppCatalogsApiHandler {
   }
 
   /**
+   * Returns catalog app metadata for update consent without blocking corrupt-install repair.
+   *
+   * <p>The catalog update mutation intentionally allows AppHost to repair an installed app whose
+   * manifest is unreadable by applying a valid signed catalog bundle. Consent preview and
+   * validation must preserve that repair path, so this summary is conservative when the installed
+   * manifest cannot be read: it avoids exposing the raw failure, treats the app as locally present
+   * with an unknown version, and reports catalog permissions as added.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @param appId catalog app identifier from the request path
+   * @return JSON-compatible app entry suitable for catalog update consent
+   */
+  public Map<String, Object> getAppForCatalogUpdateConsent(String catalogId, String appId) {
+    try {
+      return summarizeEntry(catalogId, catalogManager.getApp(catalogId, appId), true);
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError("Failed to read catalog app.");
+    }
+  }
+
+  /**
+   * Summarizes a prepared catalog plan entry for a final consent digest check.
+   *
+   * <p>The installation/update routes call this after the catalog manager has downloaded and
+   * verified the candidate bundle. The resulting summary uses the same redacted, path-free shape as
+   * catalog preview responses so the consent layer can reject stale approvals when prepared
+   * metadata no longer matches the operator-reviewed snapshot.
+   *
+   * @param catalogId catalog identifier attached to the prepared plan
+   * @param entry prepared catalog entry
+   * @param tolerateInstalledReadFailure whether corrupt installed manifests should remain
+   *     repairable through update
+   * @return path-free catalog entry summary suitable for consent digesting
+   */
+  public Map<String, Object> summarizePreparedPlanForConsent(
+      String catalogId, AppCatalogEntry entry, boolean tolerateInstalledReadFailure) {
+    return summarizeEntry(catalogId, entry, tolerateInstalledReadFailure);
+  }
+
+  /**
    * Returns redacted app-review governance state.
    *
    * @return review policy, reviewer registry, and transparency-log status
@@ -746,6 +803,49 @@ public final class AppCatalogsApiHandler {
    */
   public Map<String, Object> install(
       String catalogId, String appId, Map<String, List<String>> queryParameters) {
+    return install(catalogId, appId, queryParameters, NO_PREPARED_PLAN_CONSENT_VERIFIER);
+  }
+
+  /**
+   * Validates the fast catalog-install state preconditions without preparing or installing a
+   * bundle.
+   *
+   * <p>Consent-gated transport routes call this before asking for approval so impossible
+   * installations retain the same conflict and catalog lookup errors as the mutation path. The full
+   * {@link #install(String, String, Map, PreparedPlanConsentVerifier)} method rechecks these
+   * conditions before it mutates state.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @param appId catalog app identifier from the request path
+   */
+  public void requireInstallPreconditions(String catalogId, String appId) {
+    try {
+      AppCatalogEntry entry = catalogManager.getApp(catalogId, appId);
+      if (appHost.describe(entry.appId()).isPresent()) {
+        throw conflict(APP_ALREADY_INSTALLED_PREFIX + entry.appId());
+      }
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError(INSTALL_FAILED_MESSAGE);
+    }
+  }
+
+  /**
+   * Installs one catalog app with optional acknowledgement and prepared-plan consent verification.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @param appId catalog app identifier from the request path
+   * @param queryParameters decoded request query parameters
+   * @param preparedPlanConsentVerifier verifier invoked after bundle preparation and before install
+   * @return installed app summary without launch tokens or staging paths
+   */
+  public Map<String, Object> install(
+      String catalogId,
+      String appId,
+      Map<String, List<String>> queryParameters,
+      PreparedPlanConsentVerifier preparedPlanConsentVerifier) {
+    Objects.requireNonNull(preparedPlanConsentVerifier, "preparedPlanConsentVerifier");
     String normalizedAppId;
     AppReviewTrustDecision initialReviewTrust;
     AppCatalogSecurityDecision initialSecurityDecision;
@@ -776,6 +876,7 @@ public final class AppCatalogsApiHandler {
     AppCatalogInstallPlan plan = null;
     try {
       plan = catalogManager.prepareInstallPlan(catalogId, normalizedAppId);
+      preparedPlanConsentVerifier.verify(plan.catalogId(), plan.entry());
       AppCatalogSecurityDecision preparedSecurityDecision =
           targetSecurityDecision(plan.catalogId(), plan.entry());
       requireSecurityGate(
@@ -836,6 +937,57 @@ public final class AppCatalogsApiHandler {
    */
   public Map<String, Object> update(
       String catalogId, String appId, Map<String, List<String>> queryParameters) {
+    return update(catalogId, appId, queryParameters, NO_PREPARED_PLAN_CONSENT_VERIFIER);
+  }
+
+  /**
+   * Validates the fast catalog-update state preconditions without preparing or updating a bundle.
+   *
+   * <p>Consent-gated transport routes call this before asking for approval so impossible updates
+   * retain the same running-app, missing-app, and catalog lookup errors as the mutation path. The
+   * full {@link #update(String, String, Map, PreparedPlanConsentVerifier)} method rechecks these
+   * conditions before it mutates state.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @param appId catalog app identifier from the request path
+   */
+  public void requireUpdatePreconditions(String catalogId, String appId) {
+    String normalizedAppId;
+    try {
+      AppCatalogEntry entry = catalogManager.getApp(catalogId, appId);
+      normalizedAppId = entry.appId();
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw internalError(UPDATE_FAILED_MESSAGE);
+    }
+    if (appHost.status(normalizedAppId).isPresent()) {
+      throw conflict(CANNOT_UPDATE_RUNNING_APP_PREFIX + normalizedAppId);
+    }
+    try {
+      if (appHost.describe(normalizedAppId).isEmpty()) {
+        throw new PlatformApiException(404, "app_not_found", "App not found.");
+      }
+    } catch (IOException _) {
+      // Allow AppHost to repair installs whose manifest is unreadable.
+    }
+  }
+
+  /**
+   * Updates one installed app with optional acknowledgement and prepared-plan consent verification.
+   *
+   * @param catalogId catalog identifier from the request path
+   * @param appId catalog app identifier from the request path
+   * @param queryParameters decoded request query parameters
+   * @param preparedPlanConsentVerifier verifier invoked after bundle preparation and before update
+   * @return updated installed app summary without launch tokens or staging paths
+   */
+  public Map<String, Object> update(
+      String catalogId,
+      String appId,
+      Map<String, List<String>> queryParameters,
+      PreparedPlanConsentVerifier preparedPlanConsentVerifier) {
+    Objects.requireNonNull(preparedPlanConsentVerifier, "preparedPlanConsentVerifier");
     String normalizedAppId;
     AppCatalogEntry entry;
     try {
@@ -872,6 +1024,7 @@ public final class AppCatalogsApiHandler {
     AppCatalogInstallPlan plan = null;
     try {
       plan = catalogManager.prepareInstallPlan(catalogId, normalizedAppId);
+      preparedPlanConsentVerifier.verify(plan.catalogId(), plan.entry());
       AppCatalogSecurityDecision preparedSecurityDecision =
           targetSecurityDecision(plan.catalogId(), plan.entry());
       requireSecurityGate(
@@ -1231,10 +1384,18 @@ public final class AppCatalogsApiHandler {
   }
 
   private Map<String, Object> summarizeEntry(String catalogId, AppCatalogEntry entry) {
-    InstalledAppSnapshot installed = installed(entry.appId());
+    return summarizeEntry(catalogId, entry, false);
+  }
+
+  private Map<String, Object> summarizeEntry(
+      String catalogId, AppCatalogEntry entry, boolean tolerateInstalledReadFailure) {
+    InstalledSummary installedSummary =
+        installedForSummary(entry.appId(), tolerateInstalledReadFailure);
+    InstalledAppSnapshot installed = installedSummary.snapshot();
     RunningAppSnapshot running = appHost.status(entry.appId()).orElse(null);
     String installedVersion = installed == null ? null : installed.manifest().appVersion();
-    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(28);
+    boolean installedPresent = installed != null || installedSummary.readFailed();
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(29);
     json.put(APP_ID_FIELD, entry.appId());
     json.put("name", entry.name());
     json.put("version", entry.version());
@@ -1266,14 +1427,15 @@ public final class AppCatalogsApiHandler {
     json.put("changelog", summarizeChangelog(entry.changelog()));
     json.put("screenshots", entry.screenshots().stream().map(URI::toString).toList());
     json.put("bundle", summarizeBundle(entry));
-    json.put("installed", installed != null);
+    json.put(INSTALLED_FIELD, installedPresent);
+    json.put("installedState", installedState(installedSummary, installed));
     json.put(INSTALLED_VERSION_FIELD, installedVersion);
     json.put(
-        "versionDifferent", versionDifferent(entry.version(), installedVersion, installed != null));
+        "versionDifferent", versionDifferent(entry.version(), installedVersion, installedPresent));
     json.put(
         "updateAvailable",
-        updateAvailable(entry.version(), installedVersion, installed != null).orElse(null));
-    json.put("versionStatus", versionStatus(entry.version(), installedVersion, installed != null));
+        updateAvailable(entry.version(), installedVersion, installedPresent).orElse(null));
+    json.put("versionStatus", versionStatus(entry.version(), installedVersion, installedPresent));
     json.put("permissionDelta", summarizePermissionDelta(entry.permissions(), installed));
     json.put("running", running != null);
     json.put("pid", running == null ? null : running.pid());
@@ -1282,12 +1444,29 @@ public final class AppCatalogsApiHandler {
   }
 
   private InstalledAppSnapshot installed(String appId) {
+    return installedForSummary(appId, false).snapshot();
+  }
+
+  private static String installedState(
+      InstalledSummary installedSummary, InstalledAppSnapshot installed) {
+    if (installedSummary.readFailed()) {
+      return "unreadable_manifest";
+    }
+    return installed == null ? VERSION_STATUS_NOT_INSTALLED : VERSION_STATUS_INSTALLED;
+  }
+
+  private InstalledSummary installedForSummary(String appId, boolean tolerateReadFailure) {
     try {
-      return appHost.describe(appId).orElse(null);
+      return new InstalledSummary(appHost.describe(appId).orElse(null), false);
     } catch (IOException _) {
+      if (tolerateReadFailure) {
+        return new InstalledSummary(null, true);
+      }
       throw internalError("Failed to read installed apps.");
     }
   }
+
+  private record InstalledSummary(InstalledAppSnapshot snapshot, boolean readFailed) {}
 
   private static Map<String, Object> summarizeBundle(AppCatalogEntry entry) {
     LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(4);
@@ -1580,7 +1759,7 @@ public final class AppCatalogsApiHandler {
     json.put("permissions", manifest.permissions());
     json.put(
         "apiCompatibility", apiCompatibility(manifest.apiCompatibility(), manifest.permissions()));
-    json.put("installed", true);
+    json.put(INSTALLED_FIELD, true);
     json.put("running", false);
     json.put("pid", null);
     json.put("startedAt", null);

--- a/platform-api/src/main/java/network/crypta/platform/api/appservices/AppServiceCoordinator.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appservices/AppServiceCoordinator.java
@@ -310,6 +310,28 @@ public final class AppServiceCoordinator {
     return approveOrRenewBundle(bundle, false);
   }
 
+  /**
+   * Validates grant-bundle approval state without creating grants or changing the bundle.
+   *
+   * <p>Consent-gated routes call this before asking for approval so already-approved or rejected
+   * bundles keep the same state-machine errors as {@link #approveBundle(PlatformApiPrincipal,
+   * String)}. The mutation method still rechecks these conditions before writing state.
+   *
+   * @param principal request principal, which must be a host/operator
+   * @param bundleId stable bundle identifier from the request path
+   */
+  public synchronized void requireBundleApprovalPreconditions(
+      PlatformApiPrincipal principal, String bundleId) {
+    requireHostOperator(principal, "App principals cannot approve app-service grant bundles.");
+    AppServiceGrantBundle bundle = bundleRequired(bundleId);
+    if (bundle.status() != AppServiceGrantBundleStatus.PENDING) {
+      throw new PlatformApiException(
+          409,
+          "app_service_bundle_not_pending",
+          "Only pending app-service grant bundles can be approved.");
+    }
+  }
+
   /** Rejects a pending grant bundle without creating active grants. */
   public synchronized Map<String, Object> rejectBundle(
       PlatformApiPrincipal principal, String bundleId) {
@@ -355,6 +377,31 @@ public final class AppServiceCoordinator {
           "Only approved, expired, or revalidation-required bundles can be renewed.");
     }
     return approveOrRenewBundle(bundle, true);
+  }
+
+  /**
+   * Validates grant-bundle renewal state without creating grants or changing the bundle.
+   *
+   * <p>Consent-gated routes call this before asking for approval so pending, rejected, or missing
+   * bundles keep the same state-machine errors as {@link #renewBundle(PlatformApiPrincipal,
+   * String)}. The mutation method still rechecks these conditions before writing state.
+   *
+   * @param principal request principal, which must be a host/operator
+   * @param bundleId stable bundle identifier from the request path
+   */
+  public synchronized void requireBundleRenewalPreconditions(
+      PlatformApiPrincipal principal, String bundleId) {
+    requireHostOperator(principal, "App principals cannot renew app-service grant bundles.");
+    AppServiceGrantBundle bundle = bundleRequired(bundleId);
+    AppServiceGrantBundleStatus effective = effectiveBundleStatus(bundle, readGrants());
+    if (effective != AppServiceGrantBundleStatus.APPROVED
+        && effective != AppServiceGrantBundleStatus.EXPIRED
+        && effective != AppServiceGrantBundleStatus.REVALIDATION_REQUIRED) {
+      throw new PlatformApiException(
+          409,
+          "app_service_bundle_not_renewable",
+          "Only approved, expired, or revalidation-required bundles can be renewed.");
+    }
   }
 
   /**

--- a/platform-api/src/main/java/network/crypta/platform/api/appupdates/AppDataMigrationPlan.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appupdates/AppDataMigrationPlan.java
@@ -171,6 +171,32 @@ public record AppDataMigrationPlan(
   }
 
   /**
+   * Returns a copy that keeps the discovered migration path but clears lifecycle dry-run state.
+   *
+   * <p>Consent previews can inspect a prepared candidate manifest before the staging lifecycle has
+   * executed dry-run commands. This copy lets the preview explain the required path and review risk
+   * without reporting a dry-run result that has not actually occurred.
+   *
+   * @return migration plan with dry-run status cleared
+   */
+  AppDataMigrationPlan withoutDryRunResult() {
+    if (dryRunStatus == null) {
+      return this;
+    }
+    return new AppDataMigrationPlan(
+        required,
+        status,
+        currentSchemaVersion,
+        targetSchemaVersion,
+        namespaces,
+        operatorReviewRequired,
+        blockReason,
+        null,
+        snapshotStatus,
+        applyStatus);
+  }
+
+  /**
    * Returns a required migration plan that cannot proceed without operator or system action.
    *
    * <p>Blocked plans keep the discovered namespace steps when they are safe to reveal. The blocker

--- a/platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateCandidate.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateCandidate.java
@@ -271,11 +271,14 @@ public record AppUpdateCandidate(
     json.put("dataMigration", dataMigration);
     json.put("running", running);
     json.put("detectedAt", detectedAt.toString());
-    json.put("autoStageAllowed", eligibleForAutomaticStage());
-    json.put("autoApplyAllowed", eligibleForAutomaticApply());
-    json.put("blocksAutoUpdate", !eligibleForAutomaticStage());
+    boolean autoStageAllowed = eligibleForAutomaticStage();
+    boolean autoApplyAllowed = eligibleForAutomaticApply();
+    boolean operatorActionRequired = operatorActionRequired();
+    json.put("autoStageAllowed", autoStageAllowed);
+    json.put("autoApplyAllowed", autoApplyAllowed);
+    json.put("blocksAutoUpdate", operatorActionRequired);
     json.put("materialConsentReasons", materialConsentReasons());
-    json.put("operatorActionRequired", operatorActionRequired());
+    json.put("operatorActionRequired", operatorActionRequired);
     return json;
   }
 

--- a/platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateCandidate.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateCandidate.java
@@ -85,6 +85,9 @@ public record AppUpdateCandidate(
   private static final String API_STATUS_COMPATIBLE = "compatible";
   private static final String REVIEW_STATUS_REVIEWED = "reviewed";
   private static final String REVIEW_TRUST_STATUS_PUBLISHER_CLAIM_ONLY = "publisher_claim_only";
+  private static final String CHANNEL_STABLE = "stable";
+  private static final String SUPPORT_STATUS_SUPPORTED = "supported";
+  private static final String DEPRECATION_STATUS_NONE = "none";
 
   /**
    * Creates a validated candidate.
@@ -173,7 +176,8 @@ public record AppUpdateCandidate(
         && channelPolicyAllowed
         && policyBlockReason == null
         && securityDecisionAllowsAutomaticStage()
-        && dataMigrationAllowsAutomaticStage();
+        && dataMigrationAllowsAutomaticStage()
+        && materialConsentAllowsAutomaticStage();
   }
 
   /**
@@ -213,7 +217,24 @@ public record AppUpdateCandidate(
 
   boolean dataMigrationAllowsAutomaticStage() {
     Object blockReason = dataMigration.get("blockReason");
-    return blockReason == null;
+    return blockReason == null && !Boolean.TRUE.equals(dataMigration.get("operatorReviewRequired"));
+  }
+
+  boolean materialConsentAllowsAutomaticStage() {
+    return permissionDeltaAllowsAutomaticStage()
+        && apiStabilityAllowsAutomaticStage()
+        && !reviewTrustRequiresMaterialConsent()
+        && securityAdvisoriesAllowAutomaticStage()
+        && dataMigrationAllowsAutomaticStage()
+        && supportAndDeprecationAllowAutomaticStage();
+  }
+
+  boolean materialConsentBlocksAutomaticStage() {
+    return eligibleByDefault()
+        && channelPolicyAllowed
+        && policyBlockReason == null
+        && securityDecisionAllowsAutomaticStage()
+        && !materialConsentAllowsAutomaticStage();
   }
 
   /**
@@ -252,6 +273,8 @@ public record AppUpdateCandidate(
     json.put("detectedAt", detectedAt.toString());
     json.put("autoStageAllowed", eligibleForAutomaticStage());
     json.put("autoApplyAllowed", eligibleForAutomaticApply());
+    json.put("blocksAutoUpdate", !eligibleForAutomaticStage());
+    json.put("materialConsentReasons", materialConsentReasons());
     json.put("operatorActionRequired", operatorActionRequired());
     return json;
   }
@@ -276,10 +299,79 @@ public record AppUpdateCandidate(
             || dataMigration.get("blockReason") != null)) {
       return true;
     }
+    if (status == AppUpdateCandidateStatus.AVAILABLE && !materialConsentAllowsAutomaticStage()) {
+      return true;
+    }
     return switch (status) {
       case AMBIGUOUS, BLOCKED, INCOMPATIBLE -> true;
       default -> false;
     };
+  }
+
+  private List<String> materialConsentReasons() {
+    java.util.ArrayList<String> reasons = new java.util.ArrayList<>();
+    if (!permissionDeltaAllowsAutomaticStage()) {
+      reasons.add("new_permission");
+    }
+    if (!apiStabilityAllowsAutomaticStage()) {
+      reasons.add("platform_api_stability_change");
+    }
+    if (reviewTrustRequiresMaterialConsent()) {
+      reasons.add("review_trust_delta");
+    }
+    if (!securityAdvisoriesAllowAutomaticStage()) {
+      reasons.add("security_advisory");
+    }
+    if (!dataMigrationAllowsAutomaticStage()) {
+      reasons.add("app_data_migration");
+    }
+    if (!supportAndDeprecationAllowAutomaticStage()) {
+      reasons.add("catalog_support_or_deprecation_change");
+    }
+    return List.copyOf(reasons);
+  }
+
+  private boolean permissionDeltaAllowsAutomaticStage() {
+    return jsonList(permissionDelta.get("added")).isEmpty();
+  }
+
+  private boolean apiStabilityAllowsAutomaticStage() {
+    Object statusValue = apiCompatibility.get(JSON_STATUS);
+    if (!(statusValue instanceof String compatibilityStatus)
+        || (!API_STATUS_COMPATIBLE.equals(compatibilityStatus)
+            && !"satisfied".equals(compatibilityStatus))) {
+      return false;
+    }
+    boolean experimentalAccepted =
+        Boolean.TRUE.equals(apiCompatibility.get("experimentalCapabilitiesAccepted"));
+    Object stability = apiCompatibility.get("targetStability");
+    boolean stableTargetDeclared =
+        Boolean.TRUE.equals(apiCompatibility.get("targetStabilityDeclared"))
+            && CHANNEL_STABLE.equals(stability);
+    if (!stableTargetDeclared) {
+      return false;
+    }
+    return !experimentalAccepted;
+  }
+
+  private boolean reviewTrustRequiresMaterialConsent() {
+    return !Boolean.TRUE.equals(reviewTrust.get(JSON_POSITIVE))
+        || Boolean.TRUE.equals(reviewTrust.get(JSON_REQUIRES_ACKNOWLEDGEMENT))
+        || Boolean.TRUE.equals(reviewTrust.get(JSON_BLOCKS_UPDATE))
+        || Boolean.TRUE.equals(reviewTrust.get(JSON_BLOCKS_POLICY_APPLY));
+  }
+
+  private boolean securityAdvisoriesAllowAutomaticStage() {
+    return securityAdvisories.isEmpty();
+  }
+
+  private boolean supportAndDeprecationAllowAutomaticStage() {
+    if (!CHANNEL_STABLE.equals(channel) || !SUPPORT_STATUS_SUPPORTED.equals(supportStatus)) {
+      return false;
+    }
+    Object deprecationStatus = deprecation.get(JSON_STATUS);
+    return DEPRECATION_STATUS_NONE.equals(deprecationStatus)
+        && deprecation.get("replacementAppId") == null;
   }
 
   private Map<String, Object> bundleSummary() {
@@ -364,5 +456,9 @@ public record AppUpdateCandidate(
     return value.stream()
         .map(item -> copyInOrder(item, JSON_SECURITY_ADVISORIES + " item"))
         .toList();
+  }
+
+  private static List<?> jsonList(Object value) {
+    return value instanceof List<?> list ? list : List.of();
   }
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateService.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateService.java
@@ -91,6 +91,8 @@ public final class AppUpdateService {
   private static final String ACTION_STAGE = "stage";
   private static final String ACTION_APPLY = "apply";
   private static final String ACTION_ROLLBACK = "rollback";
+  private static final String EVENT_STATUS_POLICY_PREFIX = "policy_";
+  private static final String EVENT_STATUS_BLOCKED_SUFFIX = "_blocked:";
   private static final String APP_NOT_INSTALLED_PREFIX = "app is not installed: ";
   private static final String CANNOT_UPDATE_RUNNING_APP_PREFIX = "cannot update a running app: ";
   private static final String CANNOT_ROLLBACK_RUNNING_APP_PREFIX =
@@ -103,6 +105,7 @@ public final class AppUpdateService {
   private static final String ERROR_UPDATE_INCOMPATIBLE = "update_incompatible";
   private static final String ERROR_UPDATE_POLICY_BLOCKED = "update_policy_blocked";
   private static final String ERROR_CHANNEL_POLICY_BLOCKED = "channel_policy_blocked";
+  private static final String ERROR_CONSENT_REQUIRED = "consent_required";
   private static final String ERROR_UPDATE_CANDIDATE_CHANGED = "update_candidate_changed";
   private static final String ERROR_ROLLBACK_NOT_AVAILABLE = "rollback_not_available";
   private static final String ERROR_ROLLBACK_APP_RUNNING = "rollback_app_running";
@@ -504,6 +507,68 @@ public final class AppUpdateService {
   public synchronized Map<String, Object> summary(String appId) {
     String normalizedAppId = normalizeInstalledAppId(appId);
     InstalledAppSnapshot installed = requireInstalled(normalizedAppId);
+    return summary(normalizedAppId, installed);
+  }
+
+  /**
+   * Detects the current catalog update candidate for operator consent without following policy.
+   *
+   * <p>This path is used by the unified consent preview. It refreshes and stores the same path-free
+   * candidate summary as {@link #check(String, boolean)}, but it deliberately does not invoke
+   * policy-driven stage or apply. Consent review therefore cannot cause an unattended update as a
+   * side effect.
+   *
+   * @param appId app id from the request path
+   * @param refreshCatalogs whether to refresh catalog sidecars before detection
+   * @return path-free update summary with the detected candidate
+   */
+  public synchronized Map<String, Object> preview(String appId, boolean refreshCatalogs) {
+    String normalizedAppId = normalizeInstalledAppId(appId);
+    InstalledAppSnapshot installed = requireInstalled(normalizedAppId);
+    AppUpdateCandidate candidate = detectCandidate(normalizedAppId, installed, refreshCatalogs);
+    candidates.put(normalizedAppId, candidate);
+    invalidateStaleStage(normalizedAppId, candidate);
+    return summary(normalizedAppId, installed);
+  }
+
+  /**
+   * Detects the current catalog update candidate without mutating candidate or staged state.
+   *
+   * <p>GET consent previews use this path so an operator refresh cannot invalidate an existing
+   * staged update or write cached candidate state without the form-password guard. The response
+   * still includes the currently staged summary, last check, scheduler status, and history, but the
+   * candidate object comes from a fresh in-memory detection pass.
+   *
+   * @param appId app id from the request path
+   * @return path-free update summary with the detected candidate and no state writes
+   */
+  public synchronized Map<String, Object> previewReadOnly(String appId) {
+    String normalizedAppId = normalizeInstalledAppId(appId);
+    InstalledAppSnapshot installed = requireInstalled(normalizedAppId);
+    AppUpdateCandidate candidate = detectCandidate(normalizedAppId, installed, false);
+    return summaryReadOnly(normalizedAppId, installed, candidate);
+  }
+
+  /**
+   * Detects the current catalog update candidate and prepares migration metadata for consent.
+   *
+   * <p>This method may prepare and immediately close the candidate install plan so it can inspect
+   * the signed target manifest and build the same path-free migration summary that staging later
+   * revalidates. It does not stage, dry-run, apply, retain catalog scratch paths, or change update
+   * policy. Transport bridges should expose this only through form-password guarded host/operator
+   * routes because preparing the candidate can consume catalog and bundle resources.
+   *
+   * @param appId app id from the request path
+   * @param refreshCatalogs whether to refresh catalog sidecars before detection
+   * @return path-free update summary with consent-ready migration metadata when available
+   */
+  public synchronized Map<String, Object> previewForConsent(String appId, boolean refreshCatalogs) {
+    String normalizedAppId = normalizeInstalledAppId(appId);
+    InstalledAppSnapshot installed = requireInstalled(normalizedAppId);
+    AppUpdateCandidate candidate = detectCandidate(normalizedAppId, installed, refreshCatalogs);
+    candidate = candidateWithConsentMigrationPlan(normalizedAppId, installed, candidate);
+    candidates.put(normalizedAppId, candidate);
+    invalidateStaleStage(normalizedAppId, candidate);
     return summary(normalizedAppId, installed);
   }
 
@@ -1400,6 +1465,10 @@ public final class AppUpdateService {
       String appId, AppUpdateCandidate candidate, AppUpdatePolicyMode policyMode) {
     if (securityGateRequiresOperator(candidate)) {
       appendSecurityGateHistory(appId, automaticAction(policyMode), candidate);
+    } else if (reviewGateRequiresOperator(candidate)) {
+      appendReviewGateHistory(appId, automaticAction(policyMode), candidate);
+    } else if (candidate.materialConsentBlocksAutomaticStage()) {
+      appendMaterialConsentHistory(appId, automaticAction(policyMode), candidate);
     } else {
       appendChannelPolicyHistory(appId, policyMode, candidate);
     }
@@ -1411,7 +1480,7 @@ public final class AppUpdateService {
       appendReviewGateHistory(appId, ACTION_STAGE, candidate);
       return;
     }
-    stageCandidateForAutomaticPolicy(appId, installed, candidate);
+    stageCandidateForAutomaticPolicy(appId, installed, candidate, ACTION_STAGE);
   }
 
   private void followApplyWhenStoppedPolicyAfterCheck(
@@ -1436,7 +1505,7 @@ public final class AppUpdateService {
           "policy_apply_blocked:" + ERROR_UPDATE_INCOMPATIBLE);
       return;
     }
-    if (!stageCandidateForAutomaticPolicy(appId, installed, candidate)) {
+    if (!stageCandidateForAutomaticPolicy(appId, installed, candidate, ACTION_APPLY)) {
       return;
     }
     apply(appId, ApplyOptions.policyDefault());
@@ -1458,15 +1527,29 @@ public final class AppUpdateService {
   }
 
   private boolean stageCandidateForAutomaticPolicy(
-      String appId, InstalledAppSnapshot installed, AppUpdateCandidate candidate) {
+      String appId,
+      InstalledAppSnapshot installed,
+      AppUpdateCandidate candidate,
+      String automaticAction) {
     try {
       stageCandidate(appId, installed, candidate, false);
       return true;
     } catch (PlatformApiException exception) {
       if (isAutomaticPolicyMigrationSkip(exception.errorCode())) {
+        appendAutomaticPolicyMigrationSkipHistory(appId, automaticAction, candidate, exception);
         return false;
       }
       throw exception;
+    }
+  }
+
+  private void appendAutomaticPolicyMigrationSkipHistory(
+      String appId,
+      String automaticAction,
+      AppUpdateCandidate candidate,
+      PlatformApiException exception) {
+    if (ERROR_APP_DATA_MIGRATION_REVIEW_REQUIRED.equals(exception.errorCode())) {
+      appendMaterialConsentHistory(appId, automaticAction, candidate);
     }
   }
 
@@ -2153,6 +2236,47 @@ public final class AppUpdateService {
         candidate.detectedAt());
   }
 
+  private AppUpdateCandidate candidateWithConsentMigrationPlan(
+      String appId, InstalledAppSnapshot installed, AppUpdateCandidate candidate) {
+    if (!candidate.eligibleByDefault() || updateGateBlocksConsentPreparation(candidate)) {
+      return candidate;
+    }
+    AppCatalogInstallPlan plan = null;
+    try {
+      plan = catalogManager.prepareInstallPlan(candidate.catalogId(), appId);
+      if (planDiffersFromCandidate(candidate, installed, plan)) {
+        throw lifecycleFailure(
+            409,
+            ERROR_UPDATE_CANDIDATE_CHANGED,
+            "Catalog candidate changed since consent preview generation.");
+      }
+      AppManifest targetManifest = stagedManifestForConsentPreview(plan);
+      return candidateWithMigrationPlan(
+          candidate,
+          buildMigrationPlan(appId, installed.manifest(), targetManifest).withoutDryRunResult());
+    } catch (AppCatalogException exception) {
+      throw catalogFailure(exception);
+    } catch (IOException _) {
+      throw lifecycleFailure(
+          400, ERROR_INVALID_APP_BUNDLE, "Candidate app bundle manifest is invalid.");
+    } finally {
+      if (plan != null) {
+        closePlan(plan);
+      }
+    }
+  }
+
+  private static boolean updateGateBlocksConsentPreparation(AppUpdateCandidate candidate) {
+    return Boolean.TRUE.equals(candidate.securityDecision().get(JSON_BLOCKS_UPDATE))
+        || Boolean.TRUE.equals(candidate.reviewTrust().get(JSON_BLOCKS_UPDATE));
+  }
+
+  private static AppManifest stagedManifestForConsentPreview(AppCatalogInstallPlan plan)
+      throws IOException {
+    return AppManifestParser.parse(
+        plan.stagedBundleDirectory().resolve(AppManifestParser.MANIFEST_FILE_NAME));
+  }
+
   private AppUpdateCandidate candidateOrDetect(String appId, InstalledAppSnapshot installed) {
     return candidates.computeIfAbsent(appId, _ -> detectCandidate(appId, installed, false));
   }
@@ -2662,7 +2786,7 @@ public final class AppUpdateService {
             ? AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE
             : AppReviewTransparencyEventKind.REVIEW_GATE_POLICY_APPLY,
         candidate,
-        "policy_" + action + "_blocked:" + reviewGateFailureCode(candidate.reviewTrust()));
+        policyBlockedEventStatus(action, reviewGateFailureCode(candidate.reviewTrust())));
   }
 
   private void appendChannelPolicyHistory(
@@ -2681,7 +2805,29 @@ public final class AppUpdateService {
             ? AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE
             : AppReviewTransparencyEventKind.REVIEW_GATE_POLICY_APPLY,
         candidate,
-        "policy_" + action + "_blocked:" + ERROR_CHANNEL_POLICY_BLOCKED);
+        policyBlockedEventStatus(action, ERROR_CHANNEL_POLICY_BLOCKED));
+  }
+
+  private void appendMaterialConsentHistory(
+      String appId, String action, AppUpdateCandidate candidate) {
+    appendHistory(
+        appId,
+        action,
+        STATUS_FAILED,
+        candidate.catalogId(),
+        candidate.targetVersion(),
+        ERROR_CONSENT_REQUIRED,
+        "Policy skipped update because material consent is required.");
+    recordUpdateReviewGate(
+        ACTION_STAGE.equals(action)
+            ? AppReviewTransparencyEventKind.REVIEW_GATE_UPDATE
+            : AppReviewTransparencyEventKind.REVIEW_GATE_POLICY_APPLY,
+        candidate,
+        policyBlockedEventStatus(action, ERROR_CONSENT_REQUIRED));
+  }
+
+  private static String policyBlockedEventStatus(String action, String errorCode) {
+    return EVENT_STATUS_POLICY_PREFIX + action + EVENT_STATUS_BLOCKED_SUFFIX + errorCode;
   }
 
   private void appendSecurityGateHistory(
@@ -2756,13 +2902,23 @@ public final class AppUpdateService {
 
   private Map<String, Object> summary(String appId, InstalledAppSnapshot installed) {
     invalidateStaleSummaryState(appId, installed);
+    return summaryJson(appId, installed, candidateSummary(appId, installed));
+  }
+
+  private Map<String, Object> summaryReadOnly(
+      String appId, InstalledAppSnapshot installed, AppUpdateCandidate candidate) {
+    return summaryJson(appId, installed, candidate.toJsonValue());
+  }
+
+  private Map<String, Object> summaryJson(
+      String appId, InstalledAppSnapshot installed, Map<String, Object> candidate) {
     RunningAppSnapshot running = appHost.status(appId).orElse(null);
     LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(10);
     json.put(JSON_APP_ID, appId);
     json.put("installedVersion", installed.manifest().appVersion());
     json.put("running", running != null);
     json.put("policy", policyFor(appId).toJsonValue());
-    json.put("candidate", candidateSummary(appId, installed));
+    json.put("candidate", candidate);
     json.put(
         "installedSecurityDecision",
         installedSecurityDecision(appId, installed.manifest().appVersion()).toJsonValue());

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentActionType.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentActionType.java
@@ -1,0 +1,74 @@
+package network.crypta.platform.api.consent;
+
+/**
+ * Operator-visible action families that can require an explicit consent decision.
+ *
+ * <p>The consent layer groups several Platform API mutations behind one preview and decision model.
+ * This enum is the stable vocabulary shared by previews, decisions, audit records, and Web Shell
+ * rendering. It deliberately names the local management action rather than the transport route, so
+ * stale approval checks can compare the operator's decision with the mutation that later consumes
+ * it. Adding a new value extends the consent contract and should be paired with route, digest, and
+ * audit handling.
+ *
+ * <p>Each value serializes to a lower-case token that is safe to persist in process-local audit
+ * records and to expose through the Platform API JSON surface.
+ *
+ * @see ConsentSnapshot
+ * @see ConsentDecision
+ */
+public enum ConsentActionType {
+  /**
+   * Installing an app from a signed catalog entry.
+   *
+   * <p>The preview summarizes the catalog entry, bundle digest, permissions, API target stability,
+   * review receipt state, security policy, service dependencies, and app-data declarations before
+   * AppHost receives an installation request.
+   */
+  INSTALL_APP("install_app"),
+
+  /**
+   * Updating an installed app to a catalog or prepared update candidate.
+   *
+   * <p>The preview compares installed and candidate metadata. It is also used to derive legacy
+   * acknowledgement flags for review, security, and app-data migration gates after the approved
+   * digest has been verified.
+   */
+  UPDATE_APP("update_app"),
+
+  /**
+   * Reviewing an app-service dependency grant bundle.
+   *
+   * <p>The preview explains the requesting app, provider app, service id, scopes, contexts, expiry,
+   * dependency kind, and audit impact before a host/operator approves, renews, rejects, or defers
+   * the bundle.
+   */
+  APP_SERVICE_GRANT("app_service_grant"),
+
+  /**
+   * Reviewing app-data migration and backup requirements before an update.
+   *
+   * <p>This action is represented separately in JSON so clients can explain migration risk even
+   * when the final mutation is an app update. It does not authorize raw backup payload access or
+   * expose migration command paths.
+   */
+  APP_DATA_MIGRATION("app_data_migration");
+
+  private final String jsonValue;
+
+  ConsentActionType(String jsonValue) {
+    this.jsonValue = jsonValue;
+  }
+
+  /**
+   * Returns the stable JSON token used in consent previews and audit records.
+   *
+   * <p>The token is intentionally independent of enum names so Java refactors do not alter the
+   * Platform API response shape. Callers should compare this value only as a protocol token, not as
+   * a localized label for operator-facing text.
+   *
+   * @return lower-case consent action token for API JSON fields
+   */
+  public String jsonValue() {
+    return jsonValue;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentApiHandler.java
@@ -1,0 +1,178 @@
+package network.crypta.platform.api.consent;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.platform.api.PlatformApiRequest;
+import network.crypta.platform.api.PlatformApiResponse;
+
+/**
+ * Host/operator route handler for Platform API v1 consent previews, decisions, and audit reads.
+ *
+ * <p>The handler exposes only local operator endpoints beneath {@code /api/v1/consent}. It
+ * translates HTTP method and path validation into Platform API responses, delegates consent
+ * semantics to {@link ConsentService}, and wraps successful payloads in the stable response
+ * envelopes consumed by Web Shell and other host UI clients. App principals are rejected before
+ * dispatch so apps cannot approve their own install, update, migration, or service-grant decisions.
+ */
+public final class ConsentApiHandler {
+  private static final String METHOD_GET = "GET";
+  private static final String METHOD_POST = "POST";
+  private static final String GET_ONLY_MESSAGE = "Platform API v1 supports GET requests only.";
+  private static final String POST_ONLY_MESSAGE = "Platform API v1 supports POST requests only.";
+  private static final String PARAM_APP_ID = "appId";
+  private static final String ENVELOPE_CONSENT = "consent";
+  private static final String ENVELOPE_DECISION = "decision";
+
+  private final ConsentService consentService;
+
+  /**
+   * Creates a route handler backed by the shared consent service.
+   *
+   * <p>The supplied service owns preview construction, decision storage, stale-digest checks, and
+   * audit persistence. The handler keeps no per-request state beyond method/path dispatch.
+   *
+   * @param consentService service that implements the consent policy and audit workflow
+   */
+  public ConsentApiHandler(ConsentService consentService) {
+    this.consentService = Objects.requireNonNull(consentService, "consentService");
+  }
+
+  /**
+   * Dispatches a host/operator consent request.
+   *
+   * <p>Expected routes use a two-segment consent path, such as {@code consent/install-preview} or
+   * {@code consent/approve}. Preview routes return a freshly registered snapshot and decision
+   * routes record an approval, rejection, or deferral for an existing snapshot digest.
+   *
+   * @param segments path segments beneath the Platform API version prefix
+   * @param request request metadata, query parameters, and authenticated principal
+   * @return Platform API response containing a {@code consent}, {@code decision}, or {@code audit}
+   *     envelope
+   */
+  public PlatformApiResponse route(List<String> segments, PlatformApiRequest request) {
+    requireHostOperator(request);
+    if (segments.size() != 2) {
+      throw notFound();
+    }
+    String action = segments.get(1);
+    return switch (action) {
+      case "install-preview" -> installPreview(request);
+      case "catalog-update-preview" -> catalogUpdatePreview(request);
+      case "update-preview" -> updatePreview(request);
+      case "service-grant-preview" -> serviceGrantPreview(request);
+      case "approve" -> approve(request);
+      case "reject" -> reject(request);
+      case "defer" -> defer(request);
+      case "audit" -> audit(request);
+      default -> throw notFound();
+    };
+  }
+
+  private PlatformApiResponse installPreview(PlatformApiRequest request) {
+    if (!METHOD_GET.equals(request.method())) {
+      return methodNotAllowed(METHOD_GET, GET_ONLY_MESSAGE);
+    }
+    String catalogId = PlatformApiParameters.requireString(request.queryParameters(), "catalogId");
+    String appId = PlatformApiParameters.requireString(request.queryParameters(), PARAM_APP_ID);
+    return PlatformApiResponse.ok(
+        envelope(ENVELOPE_CONSENT, consentService.installPreview(catalogId, appId)));
+  }
+
+  private PlatformApiResponse updatePreview(PlatformApiRequest request) {
+    if (METHOD_GET.equals(request.method())) {
+      String appId = PlatformApiParameters.requireString(request.queryParameters(), PARAM_APP_ID);
+      return PlatformApiResponse.ok(
+          envelope(ENVELOPE_CONSENT, consentService.updatePreviewReadOnly(appId)));
+    }
+    if (!METHOD_POST.equals(request.method())) {
+      return methodNotAllowed("GET, POST", "Platform API v1 supports GET or POST requests.");
+    }
+    String appId = PlatformApiParameters.requireString(request.queryParameters(), PARAM_APP_ID);
+    boolean refreshCatalogs =
+        PlatformApiParameters.readBoolean(request.queryParameters(), "refreshCatalogs", false);
+    return PlatformApiResponse.ok(
+        envelope(ENVELOPE_CONSENT, consentService.updatePreview(appId, refreshCatalogs)));
+  }
+
+  private PlatformApiResponse catalogUpdatePreview(PlatformApiRequest request) {
+    if (!METHOD_GET.equals(request.method())) {
+      return methodNotAllowed(METHOD_GET, GET_ONLY_MESSAGE);
+    }
+    String catalogId = PlatformApiParameters.requireString(request.queryParameters(), "catalogId");
+    String appId = PlatformApiParameters.requireString(request.queryParameters(), PARAM_APP_ID);
+    return PlatformApiResponse.ok(
+        envelope(ENVELOPE_CONSENT, consentService.catalogUpdatePreview(catalogId, appId)));
+  }
+
+  private PlatformApiResponse serviceGrantPreview(PlatformApiRequest request) {
+    if (!METHOD_GET.equals(request.method())) {
+      return methodNotAllowed(METHOD_GET, GET_ONLY_MESSAGE);
+    }
+    String bundleId = PlatformApiParameters.requireString(request.queryParameters(), "bundleId");
+    return PlatformApiResponse.ok(
+        envelope(ENVELOPE_CONSENT, consentService.serviceGrantPreview(bundleId)));
+  }
+
+  private PlatformApiResponse approve(PlatformApiRequest request) {
+    if (!METHOD_POST.equals(request.method())) {
+      return methodNotAllowed(METHOD_POST, POST_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(
+        envelope(
+            ENVELOPE_DECISION,
+            consentService.approve(request.queryParameters(), request.principal())));
+  }
+
+  private PlatformApiResponse reject(PlatformApiRequest request) {
+    if (!METHOD_POST.equals(request.method())) {
+      return methodNotAllowed(METHOD_POST, POST_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(
+        envelope(
+            ENVELOPE_DECISION,
+            consentService.reject(request.queryParameters(), request.principal())));
+  }
+
+  private PlatformApiResponse defer(PlatformApiRequest request) {
+    if (!METHOD_POST.equals(request.method())) {
+      return methodNotAllowed(METHOD_POST, POST_ONLY_MESSAGE);
+    }
+    return PlatformApiResponse.ok(
+        envelope(
+            ENVELOPE_DECISION,
+            consentService.defer(request.queryParameters(), request.principal())));
+  }
+
+  private PlatformApiResponse audit(PlatformApiRequest request) {
+    if (!METHOD_GET.equals(request.method())) {
+      return methodNotAllowed(METHOD_GET, GET_ONLY_MESSAGE);
+    }
+    String appId =
+        PlatformApiParameters.readOptionalString(request.queryParameters(), PARAM_APP_ID);
+    return PlatformApiResponse.ok(envelope("audit", consentService.audit(appId)));
+  }
+
+  private static void requireHostOperator(PlatformApiRequest request) {
+    if (request.principal().isApp()) {
+      throw new PlatformApiException(
+          403,
+          "host_operator_required",
+          "This Platform API route requires a host/operator principal.");
+    }
+  }
+
+  private static Map<String, Object> envelope(String key, Object value) {
+    return Map.of(key, value);
+  }
+
+  private static PlatformApiResponse methodNotAllowed(String allow, String message) {
+    return PlatformApiResponse.error(405, Map.of("Allow", allow), "method_not_allowed", message);
+  }
+
+  private static PlatformApiException notFound() {
+    return new PlatformApiException(404, "not_found", "Platform API route not found.");
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentAuditEvent.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentAuditEvent.java
@@ -1,0 +1,98 @@
+package network.crypta.platform.api.consent;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Redacted audit record for an approval, reject, defer, or expiry decision.
+ *
+ * <p>Consent audit events are the support-safe trail for operator decisions. They record which app
+ * and action were reviewed, the final decision status, the snapshot digest, and a short material
+ * risk summary. They intentionally do not store raw manifest JSON, app-service request bodies,
+ * app-data values, backup payloads, migration logs, private insert URIs, tokens, or local paths.
+ *
+ * <p>Events are immutable after construction. The material risk summary is redacted before storage
+ * so both in-memory and file-backed stores can expose the same bounded JSON shape to Web Shell,
+ * release evidence, and local support tooling.
+ *
+ * @param decisionId opaque id of the decision being audited
+ * @param consentRequestId request id of the reviewed preview
+ * @param actor redacted local actor marker, usually the host/operator principal
+ * @param appId app id affected by the reviewed operation
+ * @param action consent action family that was reviewed
+ * @param decision final decision state recorded for the request
+ * @param timestamp time when the decision or expiry was recorded
+ * @param snapshotDigest digest of the reviewed consent snapshot
+ * @param materialRiskSummary redacted stable reason codes or short summaries for material findings
+ * @see ConsentAuditStore
+ */
+public record ConsentAuditEvent(
+    String decisionId,
+    String consentRequestId,
+    String actor,
+    String appId,
+    ConsentActionType action,
+    ConsentDecisionStatus decision,
+    Instant timestamp,
+    String snapshotDigest,
+    List<String> materialRiskSummary) {
+  /**
+   * Creates a normalized audit event.
+   *
+   * <p>Identifiers, actor, app id, and digest are trimmed and must be non-blank. The risk summary
+   * is copied into an immutable list after applying consent redaction to each element. This keeps
+   * file append and in-memory stores from retaining caller-owned mutable lists or sensitive text.
+   *
+   * @throws IllegalArgumentException when a required string component is blank
+   * @throws NullPointerException when any required component or risk-summary list is null
+   */
+  public ConsentAuditEvent {
+    decisionId = requireText(decisionId, "decisionId");
+    consentRequestId = requireText(consentRequestId, "consentRequestId");
+    actor = requireText(actor, "actor");
+    appId = requireText(appId, "appId");
+    Objects.requireNonNull(action, "action");
+    Objects.requireNonNull(decision, "decision");
+    Objects.requireNonNull(timestamp, "timestamp");
+    snapshotDigest = requireText(snapshotDigest, "snapshotDigest");
+    materialRiskSummary =
+        List.copyOf(
+            Objects.requireNonNull(materialRiskSummary, "materialRiskSummary").stream()
+                .map(ConsentRedactor::redact)
+                .toList());
+  }
+
+  /**
+   * Converts this event to a safe audit JSON record.
+   *
+   * <p>The returned map is ordered for deterministic JSON-lines output and contains only bounded,
+   * redacted fields. It can be returned from {@code /consent/audit} or appended to the local audit
+   * store without additional filtering.
+   *
+   * @return ordered JSON-compatible audit event
+   */
+  public Map<String, Object> toJsonValue() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(9);
+    json.put("decisionId", decisionId);
+    json.put("consentRequestId", consentRequestId);
+    json.put("actor", actor);
+    json.put("appId", appId);
+    json.put("action", action.jsonValue());
+    json.put("decision", decision.jsonValue());
+    json.put("timestamp", timestamp.toString());
+    json.put("snapshotDigest", snapshotDigest);
+    json.put("materialRiskSummary", materialRiskSummary);
+    return json;
+  }
+
+  private static String requireText(String value, String fieldName) {
+    String text = Objects.requireNonNull(value, fieldName).trim();
+    if (text.isEmpty()) {
+      throw new IllegalArgumentException(fieldName + " must not be blank");
+    }
+    return text;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentAuditStore.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentAuditStore.java
@@ -1,0 +1,43 @@
+package network.crypta.platform.api.consent;
+
+import java.util.List;
+
+/**
+ * Stores redacted consent audit records.
+ *
+ * <p>The consent service writes one event for approve, reject, defer, and expiry decisions. Store
+ * implementations are intentionally narrow: they append bounded, already-redacted {@link
+ * ConsentAuditEvent} values and return recent events for Web Shell or Platform API audit views.
+ * They do not own snapshot matching, approval consumption, or retention policy beyond their local
+ * storage limits.
+ *
+ * <p>Implementations should avoid exposing request bodies, form passwords, raw app-data values,
+ * private insert URIs, local paths, or token material. The provided implementations keep data
+ * process-local or append-only JSON-lines, which is sufficient for local operator evidence without
+ * creating a durable secret-bearing log.
+ *
+ * @see InMemoryConsentAuditStore
+ * @see FileConsentAuditStore
+ */
+public interface ConsentAuditStore {
+  /**
+   * Appends one audit event.
+   *
+   * <p>Callers pass normalized, redacted events. Implementations may apply retention limits, but
+   * they should preserve event order for records that remain available.
+   *
+   * @param event redacted audit event to store
+   */
+  void append(ConsentAuditEvent event);
+
+  /**
+   * Lists audit events, optionally filtering by app id.
+   *
+   * <p>A {@code null} app id returns all retained events. A non-null app id returns only entries
+   * for that app and must not reveal whether unrelated apps have events in the store.
+   *
+   * @param appId app id to filter by, or {@code null} to list all retained events
+   * @return retained audit events in store order
+   */
+  List<ConsentAuditEvent> list(String appId);
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentDecision.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentDecision.java
@@ -1,0 +1,83 @@
+package network.crypta.platform.api.consent;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Operator decision for one consent request and snapshot digest.
+ *
+ * <p>A decision records what a host/operator did after reviewing a consent snapshot. It stores the
+ * request id, the digest that was approved or rejected, the actor marker, and the decision time.
+ * Mutating routes accept only an approved decision whose request id, digest, app id, and action
+ * still match the current prepared snapshot. Rejections and deferrals are returned to clients and
+ * audited, but they never satisfy a consent gate.
+ *
+ * <p>The record is immutable and contains no raw manifest, app-data, service-call, or catalog
+ * payloads. It is suitable for process-local decision caches and for conversion into bounded audit
+ * events.
+ *
+ * @param decisionId opaque local id assigned to this operator decision
+ * @param consentRequestId request id from the preview that was reviewed
+ * @param status stable decision state, such as approved or rejected
+ * @param actor redacted local actor marker recorded for audit context
+ * @param snapshotDigest digest of the preview the operator acted on
+ * @param decidedAt timestamp when the decision was recorded
+ * @see ConsentDecisionStatus
+ * @see ConsentAuditEvent
+ */
+public record ConsentDecision(
+    String decisionId,
+    String consentRequestId,
+    ConsentDecisionStatus status,
+    String actor,
+    String snapshotDigest,
+    Instant decidedAt) {
+  /**
+   * Creates a normalized decision record.
+   *
+   * <p>All identifiers are trimmed and must be non-blank because they are used as stable cache and
+   * response fields. The constructor does not validate that the digest is current; that check
+   * occurs when a route asks {@link ConsentService} to consume an approved decision.
+   *
+   * @throws IllegalArgumentException when an identifier, actor, or digest is blank
+   * @throws NullPointerException when any required component is null
+   */
+  public ConsentDecision {
+    decisionId = requireText(decisionId, "decisionId");
+    consentRequestId = requireText(consentRequestId, "consentRequestId");
+    Objects.requireNonNull(status, "status");
+    actor = requireText(actor, "actor");
+    snapshotDigest = requireText(snapshotDigest, "snapshotDigest");
+    Objects.requireNonNull(decidedAt, "decidedAt");
+  }
+
+  /**
+   * Converts this decision to the public Platform API JSON shape.
+   *
+   * <p>The returned map preserves insertion order for deterministic responses. It exposes stable
+   * ids, the status token, the actor marker, the digest, and the decision timestamp, but never the
+   * full reviewed snapshot.
+   *
+   * @return ordered JSON-compatible decision summary for Platform API responses
+   */
+  public Map<String, Object> toJsonValue() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(6);
+    json.put("decisionId", decisionId);
+    json.put("consentRequestId", consentRequestId);
+    json.put("decision", status.jsonValue());
+    json.put("actor", actor);
+    json.put("snapshotDigest", snapshotDigest);
+    json.put("timestamp", decidedAt.toString());
+    return json;
+  }
+
+  private static String requireText(String value, String fieldName) {
+    String text = Objects.requireNonNull(value, fieldName).trim();
+    if (text.isEmpty()) {
+      throw new IllegalArgumentException(fieldName + " must not be blank");
+    }
+    return text;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentDecisionStatus.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentDecisionStatus.java
@@ -1,0 +1,70 @@
+package network.crypta.platform.api.consent;
+
+/**
+ * Stable decision state recorded for one consent request.
+ *
+ * <p>Decision status is the small state machine behind the process-local approval cache and consent
+ * audit log. A request starts as a preview in {@link ConsentService}; an operator can approve,
+ * reject, or defer the exact snapshot digest; and pruning can mark stale requests expired. Only an
+ * approved decision can be consumed by mutating install, update, or service-grant routes, and that
+ * consumption is single-use.
+ *
+ * <p>The values are persisted as stable lower-case JSON tokens. They are intentionally local
+ * operator decisions, not app-authentication state and not a replacement for signed bundle,
+ * catalog, review receipt, or security-policy verification.
+ *
+ * @see ConsentDecision
+ * @see ConsentAuditEvent
+ */
+public enum ConsentDecisionStatus {
+  /**
+   * The operator approved the exact consent snapshot digest.
+   *
+   * <p>An approved decision authorizes only the matching request id, digest, action, and app id.
+   * The first successful verification consumes it so later mutations cannot replay the same
+   * approval.
+   */
+  APPROVED("approved"),
+
+  /**
+   * The operator rejected the proposed action.
+   *
+   * <p>Rejected decisions are audit evidence and never satisfy a mutating route. A client must
+   * create a fresh preview and obtain a separate approval before trying the operation again.
+   */
+  REJECTED("rejected"),
+
+  /**
+   * The operator deferred the decision without approving the mutation.
+   *
+   * <p>Deferred decisions let Web Shell and API clients record that the operator intentionally left
+   * the candidate pending. They do not grant authority and are useful for audit timelines.
+   */
+  DEFERRED("deferred"),
+
+  /**
+   * The request expired before an approval was used.
+   *
+   * <p>Expiry is derived from cache pruning rather than a direct operator action. It prevents old
+   * request ids from remaining valid after the preview lifetime has elapsed.
+   */
+  EXPIRED("expired");
+
+  private final String jsonValue;
+
+  ConsentDecisionStatus(String jsonValue) {
+    this.jsonValue = jsonValue;
+  }
+
+  /**
+   * Returns the stable lower-case JSON token.
+   *
+   * <p>The returned value is the wire-format status stored in audit records and returned from
+   * decision endpoints. It should remain stable across Java enum refactors.
+   *
+   * @return protocol token for this decision status
+   */
+  public String jsonValue() {
+    return jsonValue;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentFinding.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentFinding.java
@@ -1,0 +1,74 @@
+package network.crypta.platform.api.consent;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * One human-readable consent item inside a grouped consent section.
+ *
+ * <p>A finding is the smallest unit of review shown to an operator. It carries a stable reason code
+ * for stale-consent and automation decisions, a short label for UI grouping, a redacted summary, an
+ * optional change direction, and the risk level that contributes to section and snapshot severity.
+ * Findings are immutable after construction and expose only JSON-compatible scalar fields.
+ *
+ * <p>The constructor trims stable identifiers and redacts the summary so previews and audit records
+ * do not carry tokens, private insert URIs, or host-local paths. It does not localize labels or
+ * summaries; callers should provide concise English text suitable for the local Web Shell and API
+ * clients.
+ *
+ * @param code stable machine-readable reason code, such as {@code permission_required}
+ * @param label short operator-facing label for the finding
+ * @param summary redacted human-readable summary of the reviewed condition
+ * @param change optional side of the comparison, such as {@code installed} or {@code candidate}
+ * @param riskLevel severity contributed by this finding
+ * @see ConsentSection
+ */
+public record ConsentFinding(
+    String code, String label, String summary, String change, ConsentRiskLevel riskLevel) {
+  /**
+   * Creates a normalized finding.
+   *
+   * <p>Blank codes and labels are rejected because downstream clients use them as stable selectors.
+   * The summary may be absent and is normalized to an empty redacted string. A blank change label
+   * is normalized to {@code null} so JSON output can distinguish no comparison side from a
+   * meaningful side value.
+   *
+   * @throws IllegalArgumentException when {@code code} or {@code label} is blank
+   * @throws NullPointerException when {@code code}, {@code label}, or {@code riskLevel} is null
+   */
+  public ConsentFinding {
+    code = requireText(code, "code");
+    label = requireText(label, "label");
+    summary = ConsentRedactor.redact(Objects.requireNonNullElse(summary, ""));
+    change = change == null || change.isBlank() ? null : change.trim();
+    Objects.requireNonNull(riskLevel, "riskLevel");
+  }
+
+  /**
+   * Converts this finding to the public Platform API JSON shape.
+   *
+   * <p>The returned map preserves insertion order for deterministic snapshots and digest input. It
+   * contains only redacted strings and stable tokens; callers can pass it directly to {@code
+   * PlatformApiJsonWriter}.
+   *
+   * @return ordered JSON-compatible map for API responses and digest snapshots
+   */
+  public Map<String, Object> toJsonValue() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(5);
+    json.put("code", code);
+    json.put("label", label);
+    json.put("summary", summary);
+    json.put("change", change);
+    json.put("riskLevel", riskLevel.jsonValue());
+    return json;
+  }
+
+  private static String requireText(String value, String fieldName) {
+    String text = Objects.requireNonNull(value, fieldName).trim();
+    if (text.isEmpty()) {
+      throw new IllegalArgumentException(fieldName + " must not be blank");
+    }
+    return text;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentJson.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentJson.java
@@ -1,0 +1,149 @@
+package network.crypta.platform.api.consent;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * Small helpers for reading and canonicalizing Platform API JSON-compatible maps.
+ *
+ * <p>Consent previews are assembled from several existing API summaries rather than from a single
+ * strongly typed model. This helper centralizes the narrow, defensive reads needed for those maps:
+ * non-blank strings, scalar values that should be displayed as text, booleans with defaults, nested
+ * objects, and nested lists. Missing or wrongly typed values degrade to {@code null}, defaults, or
+ * empty collections so preview generation can choose an explicit risk outcome.
+ *
+ * <p>The canonicalization path is used by {@link ConsentSnapshotDigest}. It sorts object keys
+ * recursively, preserves list order, and redacts strings before digesting or writing audit-safe
+ * summaries. That makes approvals stable across map insertion order while still preventing secrets
+ * and local paths from entering the consent artifact.
+ */
+public final class ConsentJson {
+  private ConsentJson() {}
+
+  /**
+   * Returns a non-blank string value from a JSON-compatible map.
+   *
+   * <p>This method intentionally accepts only Java {@link String} values. Use {@link
+   * #scalarString(Map, String)} when numeric or boolean schema metadata should be displayed as text
+   * in an operator preview.
+   *
+   * @param json JSON-compatible map to read
+   * @param key map key to inspect
+   * @return trimmed string-compatible value, or {@code null} when absent, blank, or not a string
+   */
+  public static String string(Map<String, Object> json, String key) {
+    Object value = json.get(key);
+    return value instanceof String text && !text.isBlank() ? text : null;
+  }
+
+  /**
+   * Returns a string form of a scalar JSON-compatible value.
+   *
+   * <p>Migration schema versions and similar API summaries can arrive as numbers. This helper keeps
+   * those values visible in consent text without accepting objects or arrays as accidental display
+   * strings.
+   *
+   * @param json JSON-compatible map to read
+   * @param key map key to inspect
+   * @return non-blank string, number, or boolean rendered as text, or {@code null} otherwise
+   */
+  public static String scalarString(Map<String, Object> json, String key) {
+    Object value = json.get(key);
+    if (value instanceof String text) {
+      return text.isBlank() ? null : text;
+    }
+    if (value instanceof Number || value instanceof Boolean) {
+      return String.valueOf(value);
+    }
+    return null;
+  }
+
+  /**
+   * Returns a boolean value from a JSON-compatible map.
+   *
+   * <p>Only Java {@link Boolean} values are accepted. String forms such as {@code "true"} are
+   * ignored so callers do not accidentally treat malformed summaries as policy decisions.
+   *
+   * @param json JSON-compatible map to read
+   * @param key map key to inspect
+   * @param defaultValue value returned when the map has no boolean at the key
+   * @return boolean stored in the map, or the supplied default
+   */
+  public static boolean bool(Map<String, Object> json, String key, boolean defaultValue) {
+    Object value = json.get(key);
+    return value instanceof Boolean bool ? bool : defaultValue;
+  }
+
+  /**
+   * Returns a nested object from a JSON-compatible map.
+   *
+   * <p>The returned map is a view of the existing object when the value is a map. Missing or
+   * mismatched values return an immutable empty map, which lets preview builders fail closed
+   * without additional null checks.
+   *
+   * @param json JSON-compatible map to read
+   * @param key map key to inspect
+   * @return nested object map, or an empty map when no object is present
+   */
+  @SuppressWarnings("unchecked")
+  public static Map<String, Object> object(Map<String, Object> json, String key) {
+    Object value = json.get(key);
+    return value instanceof Map<?, ?> map ? (Map<String, Object>) map : Map.of();
+  }
+
+  /**
+   * Returns a nested list from a JSON-compatible map.
+   *
+   * <p>The returned list is the existing JSON-compatible list when present. Missing, scalar, or
+   * object values return an immutable empty list so callers can count findings or advisories
+   * deterministically.
+   *
+   * @param json JSON-compatible map to read
+   * @param key map key to inspect
+   * @return nested list, or an empty list when no list is present
+   */
+  @SuppressWarnings("unchecked")
+  public static List<Object> list(Map<String, Object> json, String key) {
+    Object value = json.get(key);
+    return value instanceof List<?> list ? (List<Object>) list : List.of();
+  }
+
+  /**
+   * Returns a canonical JSON-compatible value with map keys sorted recursively.
+   *
+   * <p>Map keys that are not strings are ignored because Platform API JSON objects use string keys.
+   * Iterable values are copied in iteration order, and strings are passed through {@link
+   * ConsentRedactor} before they reach digest input or persisted audit output. Scalar numbers,
+   * booleans, and {@code null} are returned unchanged.
+   *
+   * @param value JSON-compatible value to canonicalize
+   * @return recursively sorted, copied, and redacted value suitable for deterministic JSON writing
+   */
+  public static Object canonicalize(Object value) {
+    if (value instanceof Map<?, ?> source) {
+      TreeMap<String, Object> sorted = new TreeMap<>();
+      for (Map.Entry<?, ?> entry : source.entrySet()) {
+        if (entry.getKey() instanceof String key) {
+          sorted.put(key, canonicalize(entry.getValue()));
+        }
+      }
+      LinkedHashMap<String, Object> copy = LinkedHashMap.newLinkedHashMap(sorted.size());
+      copy.putAll(sorted);
+      return copy;
+    }
+    if (value instanceof Iterable<?> source) {
+      ArrayList<Object> copy = new ArrayList<>();
+      for (Object item : source) {
+        copy.add(canonicalize(item));
+      }
+      return List.copyOf(copy);
+    }
+    if (value instanceof String text) {
+      return ConsentRedactor.redact(text);
+    }
+    return value;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentPolicy.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentPolicy.java
@@ -1,0 +1,58 @@
+package network.crypta.platform.api.consent;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Shared policy helpers for deriving snapshot risk and automation gates from consent sections.
+ *
+ * <p>The consent service builds findings in feature-specific helpers, then uses this class to apply
+ * the small cross-cutting policy that every snapshot needs: maximum risk and stable reason codes
+ * for material or blocking findings. Keeping this logic in one place avoids Web Shell, scheduler,
+ * and route code disagreeing about which findings require an operator approval.
+ *
+ * <p>The helper is stateless and deterministic. It reads already-normalized sections and does not
+ * inspect raw app manifests, catalog entries, service request bodies, or migration plans.
+ */
+public final class ConsentPolicy {
+  private ConsentPolicy() {}
+
+  /**
+   * Returns the maximum section risk.
+   *
+   * <p>Snapshots use this rollup to decide whether the action is informational, material, or
+   * blocking. Empty section lists produce {@link ConsentRiskLevel#NONE}.
+   *
+   * @param sections consent sections to aggregate in display order
+   * @return highest risk level present in the sections
+   */
+  public static ConsentRiskLevel riskLevel(List<ConsentSection> sections) {
+    ConsentRiskLevel risk = ConsentRiskLevel.NONE;
+    for (ConsentSection section : sections) {
+      risk = ConsentRiskLevel.max(risk, section.riskLevel());
+    }
+    return risk;
+  }
+
+  /**
+   * Returns stable reason codes for material or blocking findings.
+   *
+   * <p>The returned list preserves first-seen order while removing duplicates. These codes become
+   * the snapshot's blocking or consent-required reasons and are safe to expose as machine-readable
+   * API fields.
+   *
+   * @param sections consent sections whose findings should be scanned
+   * @return unique finding codes whose risk level requires approval or blocks the action
+   */
+  public static List<String> blockingReasons(List<ConsentSection> sections) {
+    LinkedHashSet<String> reasons = new LinkedHashSet<>();
+    for (ConsentSection section : sections) {
+      for (ConsentFinding item : section.items()) {
+        if (item.riskLevel().requiresApproval()) {
+          reasons.add(item.code());
+        }
+      }
+    }
+    return List.copyOf(reasons);
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRedactor.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRedactor.java
@@ -1,0 +1,233 @@
+package network.crypta.platform.api.consent;
+
+import java.util.regex.Pattern;
+
+/**
+ * Redacts sensitive material before it can reach consent previews or audit summaries.
+ *
+ * <p>The consent layer intentionally works with summaries from catalogs, app manifests, update
+ * plans, and service descriptors. Some of that text is supplied by apps or catalog authors, so this
+ * helper applies a conservative last-pass scrub before values become preview JSON, snapshot digest
+ * input, or audit records. It masks private insert URI forms, simple secret assignments, and
+ * obvious host-local absolute paths.
+ *
+ * <p>This is not a general data-loss-prevention engine. Callers must still avoid passing raw
+ * request bodies, backup payloads, app-data values, private keys, or command lines into consent
+ * summaries. Redaction is a defense-in-depth boundary for short display strings.
+ */
+final class ConsentRedactor {
+  /** Matches common one-token secret assignment forms in catalog or migration summary text. */
+  private static final Pattern TOKEN_ASSIGNMENT =
+      Pattern.compile(
+          "(?i)\\b(?:bearer|token|secret|authorization|password|key)\\b\\s*[:=]\\s*\\S+");
+
+  private static final String REDACTED_PRIVATE_URI = "[redacted-private-uri]";
+  private static final String REDACTED_LOCAL_PATH = "[redacted-local-path]";
+
+  /** Utility class; instances are not needed. */
+  private ConsentRedactor() {}
+
+  /**
+   * Redacts supported sensitive patterns from one display string.
+   *
+   * <p>{@code null} and empty input are returned unchanged so record constructors can preserve
+   * existing optional-field semantics. Non-empty text is processed in a fixed order and can contain
+   * more than one redacted token.
+   *
+   * @param value display text or summary text to scrub
+   * @return redacted text with supported sensitive patterns replaced by stable placeholders
+   */
+  static String redact(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+    String redacted = redactPrivateInsertUris(value);
+    redacted = TOKEN_ASSIGNMENT.matcher(redacted).replaceAll("[redacted-secret]");
+    return redactLocalPaths(redacted);
+  }
+
+  private static String redactPrivateInsertUris(String value) {
+    StringBuilder redacted = null;
+    int copyFrom = 0;
+    int index = 0;
+    while (index < value.length()) {
+      int uriEnd = privateInsertUriEnd(value, index);
+      if (uriEnd > index) {
+        if (redacted == null) {
+          redacted = new StringBuilder(value.length());
+        }
+        redacted.append(value, copyFrom, index).append(REDACTED_PRIVATE_URI);
+        index = uriEnd;
+        copyFrom = uriEnd;
+      } else {
+        index++;
+      }
+    }
+    if (redacted == null) {
+      return value;
+    }
+    return redacted.append(value, copyFrom, value.length()).toString();
+  }
+
+  private static int privateInsertUriEnd(String value, int start) {
+    if (!startsPrivateInsertUri(value, start)) {
+      return -1;
+    }
+    int index = start + 4;
+    while (index < value.length() && isPrivateUriCharacter(value.charAt(index))) {
+      index++;
+    }
+    return index > start + 4 ? index : -1;
+  }
+
+  private static boolean startsPrivateInsertUri(String value, int start) {
+    return start + 4 <= value.length()
+        && hasAsciiWordBoundaryBefore(value, start)
+        && (value.regionMatches(true, start, "CHK@", 0, 4)
+            || value.regionMatches(true, start, "SSK@", 0, 4)
+            || value.regionMatches(true, start, "USK@", 0, 4)
+            || value.regionMatches(true, start, "KSK@", 0, 4));
+  }
+
+  private static boolean isPrivateUriCharacter(char value) {
+    return isAsciiAlphanumeric(value)
+        || value == '~'
+        || value == '_'
+        || value == '.'
+        || value == ','
+        || value == '%'
+        || value == ':'
+        || value == '/'
+        || value == '+'
+        || value == '-';
+  }
+
+  private static String redactLocalPaths(String value) {
+    StringBuilder redacted = null;
+    int copyFrom = 0;
+    int index = 0;
+    while (index < value.length()) {
+      int pathEnd = localPathEnd(value, index);
+      if (pathEnd > index) {
+        if (redacted == null) {
+          redacted = new StringBuilder(value.length());
+        }
+        redacted.append(value, copyFrom, index).append(REDACTED_LOCAL_PATH);
+        index = pathEnd;
+        copyFrom = pathEnd;
+      } else {
+        index++;
+      }
+    }
+    if (redacted == null) {
+      return value;
+    }
+    return redacted.append(value, copyFrom, value.length()).toString();
+  }
+
+  private static int localPathEnd(String value, int start) {
+    int windowsEnd = windowsPathEnd(value, start);
+    return windowsEnd > start ? windowsEnd : unixPathEnd(value, start);
+  }
+
+  private static int windowsPathEnd(String value, int start) {
+    if (!startsWindowsPath(value, start)) {
+      return -1;
+    }
+    int index = start + 3;
+    int segments = 0;
+    boolean readingSegments = true;
+    while (index < value.length() && readingSegments) {
+      int segmentStart = index;
+      index = windowsSegmentEnd(value, index);
+      if (index == segmentStart) {
+        return -1;
+      }
+      segments++;
+      readingSegments = hasWindowsSegmentAfterSeparator(value, index);
+      index += readingSegments ? 1 : 0;
+    }
+    return segments >= 2 ? index : -1;
+  }
+
+  private static int windowsSegmentEnd(String value, int start) {
+    int index = start;
+    while (index < value.length()
+        && value.charAt(index) != '\\'
+        && !Character.isWhitespace(value.charAt(index))) {
+      index++;
+    }
+    return index;
+  }
+
+  private static boolean hasWindowsSegmentAfterSeparator(String value, int separatorIndex) {
+    return separatorIndex < value.length()
+        && value.charAt(separatorIndex) == '\\'
+        && separatorIndex + 1 < value.length()
+        && value.charAt(separatorIndex + 1) != '\\'
+        && !Character.isWhitespace(value.charAt(separatorIndex + 1));
+  }
+
+  private static boolean startsWindowsPath(String value, int start) {
+    return start + 2 < value.length()
+        && hasAsciiWordBoundaryBefore(value, start)
+        && isAsciiLetter(value.charAt(start))
+        && value.charAt(start + 1) == ':'
+        && value.charAt(start + 2) == '\\';
+  }
+
+  private static int unixPathEnd(String value, int start) {
+    if (value.charAt(start) != '/' || (start > 0 && isAsciiAlphanumeric(value.charAt(start - 1)))) {
+      return -1;
+    }
+    int index = start + 1;
+    int segments = 0;
+    boolean readingSegments = true;
+    while (index < value.length() && readingSegments) {
+      int segmentStart = index;
+      index = unixSegmentEnd(value, index);
+      if (index == segmentStart) {
+        return -1;
+      }
+      segments++;
+      readingSegments = hasUnixSegmentAfterSeparator(value, index);
+      index += readingSegments ? 1 : 0;
+    }
+    return segments >= 3 ? index : -1;
+  }
+
+  private static int unixSegmentEnd(String value, int start) {
+    int index = start;
+    while (index < value.length() && isUnixPathCharacter(value.charAt(index))) {
+      index++;
+    }
+    return index;
+  }
+
+  private static boolean hasUnixSegmentAfterSeparator(String value, int separatorIndex) {
+    return separatorIndex < value.length()
+        && value.charAt(separatorIndex) == '/'
+        && separatorIndex + 1 < value.length()
+        && isUnixPathCharacter(value.charAt(separatorIndex + 1));
+  }
+
+  private static boolean isUnixPathCharacter(char value) {
+    return isAsciiAlphanumeric(value) || value == '.' || value == '_' || value == '-';
+  }
+
+  private static boolean hasAsciiWordBoundaryBefore(String value, int start) {
+    return start == 0 || isAsciiWordBoundary(value.charAt(start - 1));
+  }
+
+  private static boolean isAsciiWordBoundary(char value) {
+    return !isAsciiAlphanumeric(value) && value != '_';
+  }
+
+  private static boolean isAsciiAlphanumeric(char value) {
+    return isAsciiLetter(value) || ('0' <= value && value <= '9');
+  }
+
+  private static boolean isAsciiLetter(char value) {
+    return ('A' <= value && value <= 'Z') || ('a' <= value && value <= 'z');
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRedactor.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRedactor.java
@@ -17,9 +17,13 @@ import java.util.regex.Pattern;
  */
 final class ConsentRedactor {
   /** Matches common one-token secret assignment forms in catalog or migration summary text. */
-  private static final Pattern TOKEN_ASSIGNMENT =
+  private static final Pattern AUTHORIZATION_ASSIGNMENT =
       Pattern.compile(
-          "(?i)\\b(?:bearer|token|secret|authorization|password|key)\\b\\s*[:=]\\s*\\S+");
+          "(?i)\\b(?:authorization|proxy-authorization)\\b\\s*[:=]\\s*(?:\\S+\\s+)?\\S+");
+
+  /** Matches non-authorization one-token secret assignment forms in summary text. */
+  private static final Pattern TOKEN_ASSIGNMENT =
+      Pattern.compile("(?i)\\b(?:bearer|token|secret|password|key)\\b\\s*[:=]\\s*\\S+");
 
   private static final String REDACTED_PRIVATE_URI = "[redacted-private-uri]";
   private static final String REDACTED_LOCAL_PATH = "[redacted-local-path]";
@@ -42,6 +46,7 @@ final class ConsentRedactor {
       return value;
     }
     String redacted = redactPrivateInsertUris(value);
+    redacted = AUTHORIZATION_ASSIGNMENT.matcher(redacted).replaceAll("[redacted-secret]");
     redacted = TOKEN_ASSIGNMENT.matcher(redacted).replaceAll("[redacted-secret]");
     return redactLocalPaths(redacted);
   }

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRedactor.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRedactor.java
@@ -177,7 +177,9 @@ final class ConsentRedactor {
   }
 
   private static int unixPathEnd(String value, int start) {
-    if (value.charAt(start) != '/' || (start > 0 && isAsciiAlphanumeric(value.charAt(start - 1)))) {
+    if (value.charAt(start) != '/'
+        || isUriAuthoritySlash(value, start)
+        || (start > 0 && isAsciiAlphanumeric(value.charAt(start - 1)))) {
       return -1;
     }
     int index = start + 1;
@@ -194,6 +196,29 @@ final class ConsentRedactor {
       index += readingSegments ? 1 : 0;
     }
     return segments >= 3 ? index : -1;
+  }
+
+  private static boolean isUriAuthoritySlash(String value, int start) {
+    return start >= 2
+        && value.charAt(start - 1) == '/'
+        && value.charAt(start - 2) == ':'
+        && hasUriSchemeBefore(value, start - 2);
+  }
+
+  private static boolean hasUriSchemeBefore(String value, int colonIndex) {
+    int schemeStart = colonIndex - 1;
+    while (schemeStart >= 0 && isUriSchemeCharacter(value.charAt(schemeStart))) {
+      schemeStart--;
+    }
+    schemeStart++;
+    if (schemeStart == colonIndex || !isAsciiLetter(value.charAt(schemeStart))) {
+      return false;
+    }
+    return schemeStart == 0 || isAsciiWordBoundary(value.charAt(schemeStart - 1));
+  }
+
+  private static boolean isUriSchemeCharacter(char value) {
+    return isAsciiAlphanumeric(value) || value == '+' || value == '-' || value == '.';
   }
 
   private static int unixSegmentEnd(String value, int start) {

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRequest.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRequest.java
@@ -1,0 +1,47 @@
+package network.crypta.platform.api.consent;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Process-local consent request bound to one immutable preview snapshot.
+ *
+ * <p>A request is created when a host/operator client asks for an installation, update, app-data
+ * migration, or app-service grant preview. The request id is returned with the preview and must be
+ * supplied with the snapshot digest when a later mutation consumes an approval. Requests are not
+ * durable across process restarts and do not grant authority by themselves; they are the lookup key
+ * used to compare the operator decision with the exact snapshot that was reviewed.
+ *
+ * <p>Instances are immutable and safe to keep in the in-memory request cache. Expiry and single-use
+ * consumption are enforced by {@link ConsentService}, not by this record.
+ *
+ * @param requestId stable opaque request id returned to the local client
+ * @param snapshot immutable preview contents reviewed by the operator
+ * @param createdAt time when the request entered the process-local cache
+ * @see ConsentDecision
+ */
+public record ConsentRequest(String requestId, ConsentSnapshot snapshot, Instant createdAt) {
+  /**
+   * Creates a normalized request record.
+   *
+   * <p>The request id is trimmed and must remain non-blank. The snapshot and creation timestamp are
+   * required because pruning, stale-checking, and decision matching depend on both values.
+   *
+   * @throws IllegalArgumentException when {@code requestId} is blank
+   * @throws NullPointerException when {@code requestId}, {@code snapshot}, or {@code createdAt} is
+   *     null
+   */
+  public ConsentRequest {
+    requestId = requireRequestId(requestId);
+    Objects.requireNonNull(snapshot, "snapshot");
+    Objects.requireNonNull(createdAt, "createdAt");
+  }
+
+  private static String requireRequestId(String value) {
+    String text = Objects.requireNonNull(value, "requestId").trim();
+    if (text.isEmpty()) {
+      throw new IllegalArgumentException("requestId must not be blank");
+    }
+    return text;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRiskLevel.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRiskLevel.java
@@ -1,0 +1,102 @@
+package network.crypta.platform.api.consent;
+
+/**
+ * Severity assigned to a consent snapshot, section, or finding.
+ *
+ * <p>Risk levels let the consent service combine many independent findings into one operator
+ * outcome. Low-level findings can be displayed without stopping automation, material findings
+ * require an explicit approval, and blocking findings describe actions that cannot proceed until
+ * catalog, review, security, or migration state changes. The rank is local policy logic; the JSON
+ * token is the stable Platform API surface.
+ *
+ * <p>The enum is intentionally ordered from least severe to most severe so callers can aggregate a
+ * section or snapshot with {@link #max(ConsentRiskLevel, ConsentRiskLevel)}. It does not replace
+ * lower-level verification. Signed catalog, bundle, review receipt, and AppHost checks still run at
+ * the mutation boundary.
+ *
+ * @see ConsentFinding
+ * @see ConsentSection
+ * @see ConsentSnapshot
+ */
+public enum ConsentRiskLevel {
+  /**
+   * Informational preview with no operator decision required.
+   *
+   * <p>This level is used when the consent route can return a stable preview but the operation does
+   * not introduce reviewable or blocking changes.
+   */
+  NONE("none", 0),
+
+  /**
+   * Reviewable metadata that does not require approval by itself.
+   *
+   * <p>Low-risk findings are still useful in Web Shell and audit previews. They usually describe
+   * unchanged state, removed authority, or informational compatibility details.
+   */
+  LOW("low", 1),
+
+  /**
+   * Material trust, permission, migration, service-grant, or catalog change.
+   *
+   * <p>Material findings require an approved consent request before the corresponding mutation can
+   * proceed. Scheduler automation must surface pending consent instead of silently staging or
+   * applying these candidates.
+   */
+  MATERIAL("material", 2),
+
+  /**
+   * Candidate cannot proceed until policy or catalog state changes.
+   *
+   * <p>Blocking findings cover denylist decisions, non-overridable review or security failures, and
+   * incompatible candidates. Operators can review these snapshots, but approval is rejected because
+   * the requested action is not authorizable in the current state.
+   */
+  BLOCKING("blocking", 3);
+
+  private final String jsonValue;
+  private final int rank;
+
+  ConsentRiskLevel(String jsonValue, int rank) {
+    this.jsonValue = jsonValue;
+    this.rank = rank;
+  }
+
+  /**
+   * Returns the stable lower-case JSON token.
+   *
+   * <p>The token is used in preview, section, and finding JSON. It should remain stable even if
+   * enum names or internal ranks are refactored.
+   *
+   * @return protocol token for the risk level
+   */
+  public String jsonValue() {
+    return jsonValue;
+  }
+
+  /**
+   * Returns whether this level is material enough to require explicit approval.
+   *
+   * <p>Both material and blocking findings require operator attention. Blocking findings are not
+   * approvable, but they still return {@code true} here so snapshots can report that an unattended
+   * mutation is not allowed.
+   *
+   * @return {@code true} when the level requires approval or blocks the action
+   */
+  public boolean requiresApproval() {
+    return rank >= MATERIAL.rank;
+  }
+
+  /**
+   * Returns the higher-severity level.
+   *
+   * <p>This helper is used when rolling up finding risk into section risk and section risk into
+   * snapshot risk. Both arguments must be non-null enum values.
+   *
+   * @param left first risk level to compare
+   * @param right second risk level to compare
+   * @return the argument with the greater or equal internal severity rank
+   */
+  public static ConsentRiskLevel max(ConsentRiskLevel left, ConsentRiskLevel right) {
+    return left.rank >= right.rank ? left : right;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentSection.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentSection.java
@@ -1,0 +1,72 @@
+package network.crypta.platform.api.consent;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Group of consent findings rendered as one operator-facing preview section.
+ *
+ * <p>Sections keep consent previews scannable. The service groups related findings into stable
+ * buckets such as permissions, review trust, security, API stability, app-data migration, and
+ * service dependencies. Each section carries its own rolled-up risk level so clients can highlight
+ * high-risk groups without reimplementing policy logic.
+ *
+ * <p>Instances are immutable snapshots. The list of findings is copied at construction time, and
+ * JSON output preserves deterministic field order for stable API responses and digest generation.
+ * Section ids are stable machine-readable tokens; titles are short English labels for local UI
+ * display.
+ *
+ * @param id stable section identifier used by clients and tests
+ * @param title concise operator-facing section title
+ * @param riskLevel maximum risk level contributed by the section's findings
+ * @param items immutable ordered findings shown inside this section
+ * @see ConsentFinding
+ * @see ConsentSnapshot
+ */
+public record ConsentSection(
+    String id, String title, ConsentRiskLevel riskLevel, List<ConsentFinding> items) {
+  /**
+   * Creates a normalized section.
+   *
+   * <p>The constructor trims and validates stable identifiers, requires an explicit risk level, and
+   * copies the item list so later caller mutation cannot alter a stored preview or digest input.
+   * Empty item lists are allowed for callers that need a present but informational section.
+   *
+   * @throws IllegalArgumentException when {@code id} or {@code title} is blank
+   * @throws NullPointerException when {@code id}, {@code title}, {@code riskLevel}, or {@code
+   *     items} is null
+   */
+  public ConsentSection {
+    id = requireText(id, "id");
+    title = requireText(title, "title");
+    Objects.requireNonNull(riskLevel, "riskLevel");
+    items = List.copyOf(Objects.requireNonNull(items, "items"));
+  }
+
+  /**
+   * Converts this section to the public Platform API JSON shape.
+   *
+   * <p>The returned map preserves insertion order and contains a JSON-compatible copy of every
+   * finding. It is safe to include in response bodies, audit previews, and canonical digest input.
+   *
+   * @return ordered JSON-compatible map for this consent section
+   */
+  public Map<String, Object> toJsonValue() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(4);
+    json.put("id", id);
+    json.put("title", title);
+    json.put("riskLevel", riskLevel.jsonValue());
+    json.put("items", items.stream().map(ConsentFinding::toJsonValue).toList());
+    return json;
+  }
+
+  private static String requireText(String value, String fieldName) {
+    String text = Objects.requireNonNull(value, fieldName).trim();
+    if (text.isEmpty()) {
+      throw new IllegalArgumentException(fieldName + " must not be blank");
+    }
+    return text;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentService.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentService.java
@@ -14,6 +14,7 @@ import network.crypta.platform.api.PlatformApiParameters;
 import network.crypta.platform.api.PlatformApiPrincipal;
 import network.crypta.platform.api.appcatalogs.AppCatalogsApiHandler;
 import network.crypta.platform.api.appservices.AppServiceCoordinator;
+import network.crypta.platform.api.appupdates.AppDataMigrationPlan;
 import network.crypta.platform.api.appupdates.AppUpdateService;
 import network.crypta.platform.appcatalog.AppCatalogEntry;
 
@@ -51,6 +52,7 @@ public final class ConsentService {
   private static final String FIELD_CATALOG_SOURCE_ID = "catalogSourceId";
   private static final String FIELD_CHANNEL = "channel";
   private static final String FIELD_CONSUMER_APP_ID = "consumerAppId";
+  private static final String FIELD_DATA_MIGRATION = "dataMigration";
   private static final String FIELD_DEPRECATION = "deprecation";
   private static final String FIELD_EXPERIMENTAL_CAPABILITIES_ACCEPTED =
       "experimentalCapabilitiesAccepted";
@@ -80,6 +82,7 @@ public final class ConsentService {
   private static final String SUMMARY_NO_BUNDLE_DIGEST = "No bundle digest declared.";
   private static final String TITLE_UPDATE_CANDIDATE = "Update candidate";
   private static final String VALUE_ADDED = "added";
+  private static final String VALUE_AVAILABLE = "available";
   private static final String VALUE_CANDIDATE = "candidate";
   private static final String VALUE_CHANGED = "changed";
   private static final String VALUE_NONE = "none";
@@ -349,10 +352,20 @@ public final class ConsentService {
    */
   public synchronized Map<String, List<String>> requireApprovedUpdateIfRequired(
       String appId, Map<String, List<String>> queryParameters, PlatformApiPrincipal principal) {
-    ConsentSnapshot readOnly = buildUpdateSnapshot(appId, false, false);
-    if (!readOnly.requiresApproval() && !hasConsentApprovalParameters(queryParameters)) {
+    UpdateConsentSnapshot readOnlyResult = buildUpdateSnapshotWithCandidate(appId, false, false);
+    ConsentSnapshot readOnly = readOnlyResult.snapshot();
+    boolean approvalSupplied = hasConsentApprovalParameters(queryParameters);
+    boolean preparedConsentRequired = preparedUpdateConsentRequired(readOnlyResult.candidate());
+    if (!readOnly.requiresApproval() && !approvalSupplied && !preparedConsentRequired) {
       requireApprovedIfNeeded(readOnly, queryParameters, principal);
       return withoutAcknowledgements(queryParameters);
+    }
+    if (!readOnly.requiresApproval() && !approvalSupplied && !principal.isApp()) {
+      ConsentSnapshot current = buildUpdateSnapshot(appId, false, true);
+      requireApprovedIfNeeded(current, queryParameters, principal);
+      return current.requiresApproval()
+          ? acknowledged(queryParameters)
+          : withoutAcknowledgements(queryParameters);
     }
     requireApprovedBeforePreparingUpdatePreview(readOnly, queryParameters, principal);
     ConsentSnapshot current = buildUpdateSnapshot(appId, false, true);
@@ -718,6 +731,12 @@ public final class ConsentService {
 
   private ConsentSnapshot buildUpdateSnapshot(
       String appId, boolean refreshCatalogs, boolean includePreparedMigrationPlan) {
+    return buildUpdateSnapshotWithCandidate(appId, refreshCatalogs, includePreparedMigrationPlan)
+        .snapshot();
+  }
+
+  private UpdateConsentSnapshot buildUpdateSnapshotWithCandidate(
+      String appId, boolean refreshCatalogs, boolean includePreparedMigrationPlan) {
     requireUpdateService();
     Map<String, Object> summary =
         includePreparedMigrationPlan
@@ -726,7 +745,7 @@ public final class ConsentService {
     Map<String, Object> candidate = ConsentJson.object(summary, VALUE_CANDIDATE);
     String requestId = nextRequestId();
     if (!isDetectedUpdateCandidate(candidate)) {
-      return noUpdateSnapshot(requestId, appId);
+      return new UpdateConsentSnapshot(noUpdateSnapshot(requestId, appId), candidate);
     }
     List<ConsentSection> sections = new ArrayList<>();
     sections.add(updateIdentitySection(candidate));
@@ -740,24 +759,35 @@ public final class ConsentService {
     sections.add(updateServiceGrantDeltaSection(candidate));
     ConsentRiskLevel risk = ConsentPolicy.riskLevel(sections);
     boolean requiresApproval = risk.requiresApproval();
-    return new ConsentSnapshot(
-        requestId,
-        ConsentActionType.UPDATE_APP,
-        ConsentJson.string(candidate, FIELD_APP_ID),
-        null,
-        ConsentJson.string(candidate, FIELD_INSTALLED_VERSION),
-        ConsentJson.string(candidate, FIELD_TARGET_VERSION),
-        null,
-        bundleDigest(candidate),
-        ConsentJson.string(candidate, FIELD_CATALOG_ID),
-        ConsentJson.string(candidate, FIELD_CATALOG_SOURCE_ID),
-        risk,
-        requiresApproval,
-        requiresApproval,
-        ConsentPolicy.blockingReasons(sections),
-        recommendedAction(risk, ConsentActionType.UPDATE_APP),
-        sections,
-        Instant.now(clock));
+    return new UpdateConsentSnapshot(
+        new ConsentSnapshot(
+            requestId,
+            ConsentActionType.UPDATE_APP,
+            ConsentJson.string(candidate, FIELD_APP_ID),
+            null,
+            ConsentJson.string(candidate, FIELD_INSTALLED_VERSION),
+            ConsentJson.string(candidate, FIELD_TARGET_VERSION),
+            null,
+            bundleDigest(candidate),
+            ConsentJson.string(candidate, FIELD_CATALOG_ID),
+            ConsentJson.string(candidate, FIELD_CATALOG_SOURCE_ID),
+            risk,
+            requiresApproval,
+            requiresApproval,
+            ConsentPolicy.blockingReasons(sections),
+            recommendedAction(risk, ConsentActionType.UPDATE_APP),
+            sections,
+            Instant.now(clock)),
+        candidate);
+  }
+
+  private static boolean preparedUpdateConsentRequired(Map<String, Object> candidate) {
+    if (!VALUE_AVAILABLE.equals(ConsentJson.string(candidate, FIELD_STATUS))) {
+      return false;
+    }
+    Map<String, Object> migration = ConsentJson.object(candidate, FIELD_DATA_MIGRATION);
+    return AppDataMigrationPlan.STATUS_NOT_CHECKED.equals(
+        ConsentJson.string(migration, FIELD_STATUS));
   }
 
   private ConsentSnapshot noUpdateSnapshot(String requestId, String appId) {
@@ -1208,7 +1238,7 @@ public final class ConsentService {
   }
 
   private ConsentSection updateMigrationSection(Map<String, Object> candidate) {
-    Map<String, Object> migration = ConsentJson.object(candidate, "dataMigration");
+    Map<String, Object> migration = ConsentJson.object(candidate, FIELD_DATA_MIGRATION);
     return section(
         "app-data-migration",
         "App-data migration",
@@ -1221,7 +1251,7 @@ public final class ConsentService {
   }
 
   private ConsentSection updateBackupSection(Map<String, Object> candidate) {
-    Map<String, Object> migration = ConsentJson.object(candidate, "dataMigration");
+    Map<String, Object> migration = ConsentJson.object(candidate, FIELD_DATA_MIGRATION);
     ConsentRiskLevel risk =
         migrationRisk(migration).requiresApproval()
             ? ConsentRiskLevel.MATERIAL
@@ -1722,4 +1752,6 @@ public final class ConsentService {
           503, "app_services_unavailable", "App-service coordinator is unavailable.");
     }
   }
+
+  private record UpdateConsentSnapshot(ConsentSnapshot snapshot, Map<String, Object> candidate) {}
 }

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentService.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentService.java
@@ -353,7 +353,7 @@ public final class ConsentService {
   public synchronized Map<String, List<String>> requireApprovedUpdateIfRequired(
       String appId, Map<String, List<String>> queryParameters, PlatformApiPrincipal principal) {
     UpdateConsentSnapshot readOnlyResult = buildUpdateSnapshotWithCandidate(appId, false, false);
-    if (!isStageableUpdateCandidate(readOnlyResult.candidate())) {
+    if (isNonStageableUpdateCandidate(readOnlyResult.candidate())) {
       return withoutAcknowledgements(queryParameters);
     }
     ConsentSnapshot readOnly = readOnlyResult.snapshot();
@@ -587,8 +587,12 @@ public final class ConsentService {
             actor(principal),
             suppliedDigest,
             Instant.now(clock));
-    decisionsByRequestId.put(requestId, decision);
     auditStore.append(toAuditEvent(snapshot, decision));
+    if (status == ConsentDecisionStatus.APPROVED) {
+      decisionsByRequestId.put(requestId, decision);
+    } else {
+      consumeConsentRequest(requestId);
+    }
     return decision;
   }
 
@@ -785,7 +789,7 @@ public final class ConsentService {
   }
 
   private static boolean preparedUpdateConsentRequired(Map<String, Object> candidate) {
-    if (!isStageableUpdateCandidate(candidate)) {
+    if (isNonStageableUpdateCandidate(candidate)) {
       return false;
     }
     Map<String, Object> migration = ConsentJson.object(candidate, FIELD_DATA_MIGRATION);
@@ -830,8 +834,8 @@ public final class ConsentService {
     return status != null && !VALUE_NONE.equals(status);
   }
 
-  private static boolean isStageableUpdateCandidate(Map<String, Object> candidate) {
-    return VALUE_AVAILABLE.equals(ConsentJson.string(candidate, FIELD_STATUS));
+  private static boolean isNonStageableUpdateCandidate(Map<String, Object> candidate) {
+    return !VALUE_AVAILABLE.equals(ConsentJson.string(candidate, FIELD_STATUS));
   }
 
   private ConsentSnapshot buildCatalogUpdateSnapshot(String catalogId, String appId) {

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentService.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentService.java
@@ -353,6 +353,9 @@ public final class ConsentService {
   public synchronized Map<String, List<String>> requireApprovedUpdateIfRequired(
       String appId, Map<String, List<String>> queryParameters, PlatformApiPrincipal principal) {
     UpdateConsentSnapshot readOnlyResult = buildUpdateSnapshotWithCandidate(appId, false, false);
+    if (!isStageableUpdateCandidate(readOnlyResult.candidate())) {
+      return withoutAcknowledgements(queryParameters);
+    }
     ConsentSnapshot readOnly = readOnlyResult.snapshot();
     boolean approvalSupplied = hasConsentApprovalParameters(queryParameters);
     boolean preparedConsentRequired = preparedUpdateConsentRequired(readOnlyResult.candidate());
@@ -782,7 +785,7 @@ public final class ConsentService {
   }
 
   private static boolean preparedUpdateConsentRequired(Map<String, Object> candidate) {
-    if (!VALUE_AVAILABLE.equals(ConsentJson.string(candidate, FIELD_STATUS))) {
+    if (!isStageableUpdateCandidate(candidate)) {
       return false;
     }
     Map<String, Object> migration = ConsentJson.object(candidate, FIELD_DATA_MIGRATION);
@@ -825,6 +828,10 @@ public final class ConsentService {
   private static boolean isDetectedUpdateCandidate(Map<String, Object> candidate) {
     String status = ConsentJson.string(candidate, FIELD_STATUS);
     return status != null && !VALUE_NONE.equals(status);
+  }
+
+  private static boolean isStageableUpdateCandidate(Map<String, Object> candidate) {
+    return VALUE_AVAILABLE.equals(ConsentJson.string(candidate, FIELD_STATUS));
   }
 
   private ConsentSnapshot buildCatalogUpdateSnapshot(String catalogId, String appId) {

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentService.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentService.java
@@ -1,0 +1,1725 @@
+package network.crypta.platform.api.consent;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.platform.api.PlatformApiParameters;
+import network.crypta.platform.api.PlatformApiPrincipal;
+import network.crypta.platform.api.appcatalogs.AppCatalogsApiHandler;
+import network.crypta.platform.api.appservices.AppServiceCoordinator;
+import network.crypta.platform.api.appupdates.AppUpdateService;
+import network.crypta.platform.appcatalog.AppCatalogEntry;
+
+/**
+ * Coordinates operator consent for material app-platform mutations.
+ *
+ * <p>The service builds redacted, JSON-compatible consent snapshots for app installs,
+ * catalog-backed updates, app-update staging, app-service grant bundles, and app-data migration
+ * review. Each snapshot is assigned a request id and a digest over the material review surface.
+ * Later mutation routes use those values to prove that the operator approved the same catalog
+ * entry, candidate bundle, review evidence, permission delta, advisory set, and migration plan they
+ * are about to apply.
+ *
+ * <p>Stored requests and decisions are intentionally short-lived and process local. Approvals are
+ * consumed when a protected mutation succeeds, expire after the consent TTL if unused, and are
+ * written to the configured {@link ConsentAuditStore} with only redacted identifiers and reason
+ * codes. Domain services remain responsible for their own state-machine checks; consent here only
+ * decides whether an otherwise valid material action needs an operator decision.
+ */
+public final class ConsentService {
+  private static final String PARAM_CONSENT_REQUEST_ID = "consentRequestId";
+  private static final String PARAM_SNAPSHOT_DIGEST = "snapshotDigest";
+  private static final String PARAM_CONSENT_SNAPSHOT_DIGEST = "consentSnapshotDigest";
+  private static final String PARAM_REVIEW_ACKNOWLEDGED = "reviewAcknowledged";
+  private static final String PARAM_SECURITY_ACKNOWLEDGED = "securityAcknowledged";
+  private static final String PARAM_MIGRATION_ACKNOWLEDGED = "migrationAcknowledged";
+  private static final String LOCAL_OPERATOR = "local_operator";
+  private static final Duration STORED_CONSENT_TTL = Duration.ofMinutes(15);
+  private static final int MAX_STORED_REQUESTS = 512;
+  private static final int MAX_STORED_DECISIONS = 512;
+  private static final String FIELD_APP_ID = "appId";
+  private static final String FIELD_BLOCKS_INSTALL = "blocksInstall";
+  private static final String FIELD_BLOCKS_UPDATE = "blocksUpdate";
+  private static final String FIELD_CATALOG_ID = "catalogId";
+  private static final String FIELD_CATALOG_SOURCE_ID = "catalogSourceId";
+  private static final String FIELD_CHANNEL = "channel";
+  private static final String FIELD_CONSUMER_APP_ID = "consumerAppId";
+  private static final String FIELD_DEPRECATION = "deprecation";
+  private static final String FIELD_EXPERIMENTAL_CAPABILITIES_ACCEPTED =
+      "experimentalCapabilitiesAccepted";
+  private static final String FIELD_INSTALLED_VERSION = "installedVersion";
+  private static final String FIELD_NAME = "name";
+  private static final String FIELD_PERMISSION_DELTA = "permissionDelta";
+  private static final String FIELD_POSITIVE = "positive";
+  private static final String FIELD_REQUIRED = "required";
+  private static final String FIELD_REQUIRES_ACKNOWLEDGEMENT = "requiresAcknowledgement";
+  private static final String FIELD_REVIEWER_KEY_ID = "reviewerKeyId";
+  private static final String FIELD_SECURITY_ADVISORIES = "securityAdvisories";
+  private static final String FIELD_SECURITY_DECISION = "securityDecision";
+  private static final String FIELD_STATUS = "status";
+  private static final String FIELD_SUPPORT_STATUS = "supportStatus";
+  private static final String FIELD_TARGET_STABILITY = "targetStability";
+  private static final String FIELD_TARGET_VERSION = "targetVersion";
+  private static final String FIELD_VERSION = "version";
+  private static final String ERROR_CONSENT_BLOCKED = "consent_blocked";
+  private static final String ERROR_STALE_CONSENT_SNAPSHOT = "stale_consent_snapshot";
+  private static final String FINDING_BUNDLE_DIGEST = "bundle_digest";
+  private static final String LABEL_BUNDLE_DIGEST = "Bundle digest";
+  private static final String MESSAGE_CONSENT_BLOCKED =
+      "This app-platform action is blocked by the current consent policy.";
+  private static final String MESSAGE_STALE_CONSENT =
+      "This approval is stale. Refresh the consent preview.";
+  private static final String SECTION_IDENTITY = "identity";
+  private static final String SUMMARY_NO_BUNDLE_DIGEST = "No bundle digest declared.";
+  private static final String TITLE_UPDATE_CANDIDATE = "Update candidate";
+  private static final String VALUE_ADDED = "added";
+  private static final String VALUE_CANDIDATE = "candidate";
+  private static final String VALUE_CHANGED = "changed";
+  private static final String VALUE_NONE = "none";
+  private static final String VALUE_STABLE = "stable";
+  private static final String VALUE_SUPPORTED = "supported";
+  private static final String VALUE_UNCHANGED = "unchanged";
+  private static final String VALUE_UNKNOWN = "unknown";
+
+  private final AppCatalogsApiHandler catalogHandler;
+  private final AppUpdateService updateService;
+  private final AppServiceCoordinator appServiceCoordinator;
+  private final ConsentAuditStore auditStore;
+  private final Clock clock;
+  private final AtomicLong requestSequence = new AtomicLong();
+  private final AtomicLong decisionSequence = new AtomicLong();
+  private final Map<String, ConsentRequest> requests = new LinkedHashMap<>();
+  private final Map<String, ConsentDecision> decisionsByRequestId = new LinkedHashMap<>();
+
+  /**
+   * Creates a consent service backed by process-local audit storage and the system UTC clock.
+   *
+   * <p>This constructor is used by the default Platform API wiring when durable audit persistence
+   * is not configured. Preview requests and approval decisions are still retained only in memory,
+   * so a daemon restart clears pending approvals and forces the operator to refresh consent
+   * snapshots.
+   *
+   * @param catalogHandler catalog handler used to summarize install and catalog-update candidates
+   * @param updateService app-update service used to summarize read-only and prepared update
+   *     candidates
+   * @param appServiceCoordinator coordinator used to summarize app-service grant bundles
+   */
+  public ConsentService(
+      AppCatalogsApiHandler catalogHandler,
+      AppUpdateService updateService,
+      AppServiceCoordinator appServiceCoordinator) {
+    this(
+        catalogHandler,
+        updateService,
+        appServiceCoordinator,
+        new InMemoryConsentAuditStore(),
+        Clock.systemUTC());
+  }
+
+  /**
+   * Creates a consent service with explicit audit and clock dependencies.
+   *
+   * <p>Tests and alternate host embeddings use this constructor to provide deterministic time and a
+   * durable or inspectable audit sink. The catalog, update, and app-service dependencies may be
+   * absent in embeddings that expose only part of the app platform; routes that require a missing
+   * dependency fail closed with a service-unavailable Platform API error.
+   *
+   * @param catalogHandler catalog handler used for install and catalog-update consent snapshots
+   * @param updateService app-update service used for update consent snapshots
+   * @param appServiceCoordinator coordinator used for app-service grant consent snapshots
+   * @param auditStore store that receives redacted decision and expiry audit events
+   * @param clock clock used for request ids, decision timestamps, and TTL pruning
+   */
+  public ConsentService(
+      AppCatalogsApiHandler catalogHandler,
+      AppUpdateService updateService,
+      AppServiceCoordinator appServiceCoordinator,
+      ConsentAuditStore auditStore,
+      Clock clock) {
+    this.catalogHandler = catalogHandler;
+    this.updateService = updateService;
+    this.appServiceCoordinator = appServiceCoordinator;
+    this.auditStore = Objects.requireNonNull(auditStore, "auditStore");
+    this.clock = Objects.requireNonNull(clock, "clock");
+  }
+
+  /**
+   * Builds and registers an installation consent preview.
+   *
+   * <p>The preview describes the catalog entry's identity, bundle digest, channel/support metadata,
+   * independent review evidence, security advisories, permissions, API stability, and declared data
+   * policies. The returned map is safe to serialize directly as a Platform API JSON response.
+   *
+   * @param catalogId catalog that contains the candidate app entry
+   * @param appId app id being installed
+   * @return registered consent snapshot as a JSON-compatible map
+   */
+  public synchronized Map<String, Object> installPreview(String catalogId, String appId) {
+    return register(buildInstallSnapshot(catalogId, appId)).snapshot().toJsonValue();
+  }
+
+  /**
+   * Builds and registers an update consent preview using the prepared candidate path.
+   *
+   * <p>Prepared previews may refresh catalogs and ask the update service to prepare the
+   * installation plan so app-data migration and backup requirements are included in the digest. Use
+   * this path when an operator explicitly opens the review flow and expects the preview to match
+   * the subsequent stage request.
+   *
+   * @param appId installed app id being updated
+   * @param refreshCatalogs whether the update service should refresh catalogs before summarizing
+   * @return registered consent snapshot as a JSON-compatible map
+   */
+  public synchronized Map<String, Object> updatePreview(String appId, boolean refreshCatalogs) {
+    return register(buildUpdateSnapshot(appId, refreshCatalogs, true)).snapshot().toJsonValue();
+  }
+
+  /**
+   * Builds and registers an update preview without catalog refresh or bundle preparation.
+   *
+   * <p>The read-only preview is used for status and discovery views where rendering consent
+   * information must not download bundles, allocate staging resources, or invalidate existing
+   * staged state. It can still report catalog, review, permission, security, and compatibility risk
+   * that is already available from the detected candidate.
+   *
+   * @param appId installed app id whose current update candidate should be summarized
+   * @return registered read-only consent snapshot as a JSON-compatible map
+   */
+  public synchronized Map<String, Object> updatePreviewReadOnly(String appId) {
+    return register(buildUpdateSnapshot(appId, false, false)).snapshot().toJsonValue();
+  }
+
+  /**
+   * Builds and registers a catalog-update consent preview.
+   *
+   * <p>This preview is for catalog-driven replacement of an installed app entry outside the update
+   * scheduler path. It compares installed and candidate metadata, then records the same
+   * digest-bound review surface used by installation consent before the catalog handler prepares
+   * the final plan.
+   *
+   * @param catalogId catalog containing the replacement entry
+   * @param appId installed app id being updated from the catalog
+   * @return registered consent snapshot as a JSON-compatible map
+   */
+  public synchronized Map<String, Object> catalogUpdatePreview(String catalogId, String appId) {
+    return register(buildCatalogUpdateSnapshot(catalogId, appId)).snapshot().toJsonValue();
+  }
+
+  /**
+   * Builds and registers an app-service grant-bundle preview.
+   *
+   * <p>The preview summarizes the requesting app, dependency providers, requested scopes, expiry
+   * metadata, and audit impact for a pending grant bundle. Approving this preview authorizes the
+   * corresponding service-grant state transition only if the bundle still matches the digest.
+   *
+   * @param bundleId grant bundle id to review
+   * @return registered consent snapshot as a JSON-compatible map
+   */
+  public synchronized Map<String, Object> serviceGrantPreview(String bundleId) {
+    return register(buildServiceGrantSnapshot(bundleId)).snapshot().toJsonValue();
+  }
+
+  /**
+   * Records an approval decision for a registered preview request.
+   *
+   * <p>The request id and supplied snapshot digest must identify a live preview. Blocking snapshots
+   * cannot be approved, and stale digests are rejected so catalog or candidate changes force a
+   * fresh review.
+   *
+   * @param queryParameters Platform API query parameters containing the consent request id and
+   *     snapshot digest
+   * @param principal authenticated actor recording the decision
+   * @return recorded decision as a JSON-compatible map
+   */
+  public synchronized Map<String, Object> approve(
+      Map<String, List<String>> queryParameters, PlatformApiPrincipal principal) {
+    return decide(queryParameters, principal, ConsentDecisionStatus.APPROVED).toJsonValue();
+  }
+
+  /**
+   * Records a rejection decision for a registered preview request.
+   *
+   * <p>Rejections are retained in the audit stream for operator traceability but do not authorize
+   * any protected mutation. A later attempt to continue must create and approve a fresh preview.
+   *
+   * @param queryParameters Platform API query parameters containing the consent request id and
+   *     snapshot digest
+   * @param principal authenticated actor recording the decision
+   * @return recorded decision as a JSON-compatible map
+   */
+  public synchronized Map<String, Object> reject(
+      Map<String, List<String>> queryParameters, PlatformApiPrincipal principal) {
+    return decide(queryParameters, principal, ConsentDecisionStatus.REJECTED).toJsonValue();
+  }
+
+  /**
+   * Records a deferral decision for a registered preview request.
+   *
+   * <p>Deferral preserves the fact that the operator saw the preview without turning it into an
+   * approval. It is useful for UI flows that need an explicit "not now" audit event.
+   *
+   * @param queryParameters Platform API query parameters containing the consent request id and
+   *     snapshot digest
+   * @param principal authenticated actor recording the decision
+   * @return recorded decision as a JSON-compatible map
+   */
+  public synchronized Map<String, Object> defer(
+      Map<String, List<String>> queryParameters, PlatformApiPrincipal principal) {
+    return decide(queryParameters, principal, ConsentDecisionStatus.DEFERRED).toJsonValue();
+  }
+
+  /**
+   * Lists redacted consent audit events.
+   *
+   * <p>The returned events contain decision ids, actors, app ids, action types, status values,
+   * digests, timestamps, and blocking reason codes. They intentionally omit raw catalog JSON,
+   * app-data paths, local file locations, service tokens, and other sensitive preview details.
+   *
+   * @param appId optional app id filter; {@code null} lists all retained events
+   * @return audit events as JSON-compatible maps in store order
+   */
+  public synchronized List<Map<String, Object>> audit(String appId) {
+    return auditStore.list(appId).stream().map(ConsentAuditEvent::toJsonValue).toList();
+  }
+
+  /**
+   * Verifies the current installation preview if material consent is required.
+   *
+   * <p>When verification succeeds, legacy review/security acknowledgement parameters are added so
+   * the existing catalog gate can continue to fail closed on hard blocks and prepared-plan drift.
+   *
+   * @param catalogId catalog containing the app entry about to be installed
+   * @param appId app id about to be installed
+   * @param queryParameters original mutation query parameters
+   * @param principal authenticated caller attempting the mutation
+   * @return query parameters augmented with legacy acknowledgement flags when consent was required
+   */
+  public synchronized Map<String, List<String>> requireApprovedInstallIfRequired(
+      String catalogId,
+      String appId,
+      Map<String, List<String>> queryParameters,
+      PlatformApiPrincipal principal) {
+    ConsentSnapshot current = buildInstallSnapshot(catalogId, appId);
+    requireApprovedIfNeeded(current, queryParameters, principal, false);
+    return current.requiresApproval() ? acknowledged(queryParameters) : queryParameters;
+  }
+
+  /**
+   * Verifies that the prepared installation plan still matches the approved installation snapshot.
+   *
+   * <p>This second check runs after the catalog handler has materialized the installation plan,
+   * catching bundle digest, review evidence, advisory, permission, or metadata drift between the
+   * operator preview and the prepared app entry.
+   *
+   * @param catalogId catalog containing the prepared entry
+   * @param entry prepared app catalog entry about to be committed
+   * @param queryParameters original mutation query parameters
+   * @param principal authenticated caller attempting the mutation
+   */
+  public synchronized void requireApprovedPreparedInstallIfRequired(
+      String catalogId,
+      AppCatalogEntry entry,
+      Map<String, List<String>> queryParameters,
+      PlatformApiPrincipal principal) {
+    ConsentSnapshot current = buildPreparedInstallSnapshot(catalogId, entry);
+    requireApprovedIfNeeded(current, queryParameters, principal);
+  }
+
+  /**
+   * Verifies update consent before an app update is staged.
+   *
+   * <p>The method first evaluates a read-only snapshot to avoid preparing update resources for
+   * callers that have not supplied a valid approval. If material or prepared-only risk is possible,
+   * it then requires a matching approval before building the prepared snapshot that includes
+   * app-data migration and backup details. Successful material approvals are translated into the
+   * legacy acknowledgement flags expected by the update service.
+   *
+   * @param appId installed app id being staged for update
+   * @param queryParameters original mutation query parameters
+   * @param principal authenticated caller attempting the mutation
+   * @return query parameters with stale acknowledgement flags stripped or fresh acknowledgement
+   *     flags added as appropriate
+   */
+  public synchronized Map<String, List<String>> requireApprovedUpdateIfRequired(
+      String appId, Map<String, List<String>> queryParameters, PlatformApiPrincipal principal) {
+    ConsentSnapshot readOnly = buildUpdateSnapshot(appId, false, false);
+    if (!readOnly.requiresApproval() && !hasConsentApprovalParameters(queryParameters)) {
+      requireApprovedIfNeeded(readOnly, queryParameters, principal);
+      return withoutAcknowledgements(queryParameters);
+    }
+    requireApprovedBeforePreparingUpdatePreview(readOnly, queryParameters, principal);
+    ConsentSnapshot current = buildUpdateSnapshot(appId, false, true);
+    requireApprovedIfNeeded(current, queryParameters, principal);
+    return current.requiresApproval()
+        ? acknowledged(queryParameters)
+        : withoutAcknowledgements(queryParameters);
+  }
+
+  /**
+   * Verifies catalog-update consent before a catalog-backed replacement starts.
+   *
+   * <p>The check preserves the catalog handler's own install/update state validation while ensuring
+   * any material catalog, review, security, permission, or API-stability risk has a matching
+   * operator approval for the current snapshot.
+   *
+   * @param catalogId catalog containing the replacement entry
+   * @param appId installed app id being updated
+   * @param queryParameters original mutation query parameters
+   * @param principal authenticated caller attempting the mutation
+   * @return query parameters augmented with legacy acknowledgement flags when consent was required
+   */
+  public synchronized Map<String, List<String>> requireApprovedCatalogUpdateIfRequired(
+      String catalogId,
+      String appId,
+      Map<String, List<String>> queryParameters,
+      PlatformApiPrincipal principal) {
+    ConsentSnapshot current = buildCatalogUpdateSnapshot(catalogId, appId);
+    requireApprovedIfNeeded(current, queryParameters, principal, false);
+    return current.requiresApproval() ? acknowledged(queryParameters) : queryParameters;
+  }
+
+  /**
+   * Verifies that the prepared catalog-update plan still matches the approved snapshot.
+   *
+   * <p>The prepared check binds the final app entry to the same consent digest the operator
+   * approved before the catalog handler commits the replacement.
+   *
+   * @param catalogId catalog containing the prepared replacement entry
+   * @param entry prepared app catalog entry about to be committed
+   * @param queryParameters original mutation query parameters
+   * @param principal authenticated caller attempting the mutation
+   */
+  public synchronized void requireApprovedPreparedCatalogUpdateIfRequired(
+      String catalogId,
+      AppCatalogEntry entry,
+      Map<String, List<String>> queryParameters,
+      PlatformApiPrincipal principal) {
+    ConsentSnapshot current = buildPreparedCatalogUpdateSnapshot(catalogId, entry);
+    requireApprovedIfNeeded(current, queryParameters, principal);
+  }
+
+  /**
+   * Verifies app-service grant-bundle consent before approval or renewal.
+   *
+   * <p>The current bundle summary is hashed at verification time so dependency, scope, status, or
+   * expiry changes after the preview invalidate the approval and force a fresh operator review.
+   *
+   * @param bundleId grant bundle id being approved or renewed
+   * @param queryParameters original mutation query parameters
+   * @param principal authenticated caller attempting the mutation
+   */
+  public synchronized void requireApprovedServiceGrantIfRequired(
+      String bundleId, Map<String, List<String>> queryParameters, PlatformApiPrincipal principal) {
+    ConsentSnapshot current = buildServiceGrantSnapshot(bundleId);
+    requireApprovedIfNeeded(current, queryParameters, principal);
+  }
+
+  /**
+   * Adds a redacted audit event for a direct service-grant rejection path.
+   *
+   * <p>Some service-grant state transitions can reject a bundle without first creating an explicit
+   * consent decision through the consent routes. This method records an equivalent rejection event
+   * using the current bundle snapshot so operator audit history remains complete.
+   *
+   * @param bundleId grant bundle id rejected by the app-service route
+   * @param principal authenticated actor that rejected the bundle
+   */
+  public synchronized void recordServiceGrantRejection(
+      String bundleId, PlatformApiPrincipal principal) {
+    ConsentSnapshot snapshot = buildServiceGrantSnapshot(bundleId);
+    ConsentDecision decision =
+        new ConsentDecision(
+            nextDecisionId(),
+            snapshot.consentRequestId(),
+            ConsentDecisionStatus.REJECTED,
+            actor(principal),
+            snapshot.snapshotDigest(),
+            Instant.now(clock));
+    auditStore.append(toAuditEvent(snapshot, decision));
+  }
+
+  private void requireApprovedIfNeeded(
+      ConsentSnapshot current,
+      Map<String, List<String>> queryParameters,
+      PlatformApiPrincipal principal) {
+    requireApprovedIfNeeded(current, queryParameters, principal, true);
+  }
+
+  private void requireApprovedIfNeeded(
+      ConsentSnapshot current,
+      Map<String, List<String>> queryParameters,
+      PlatformApiPrincipal principal,
+      boolean consumeDecision) {
+    pruneStoredConsent(Instant.now(clock));
+    if (!current.requiresApproval()) {
+      consumeApprovedDecisionIfSupplied(queryParameters);
+      return;
+    }
+    if (current.riskLevel() == ConsentRiskLevel.BLOCKING) {
+      throw new PlatformApiException(409, ERROR_CONSENT_BLOCKED, MESSAGE_CONSENT_BLOCKED);
+    }
+    String requestId =
+        PlatformApiParameters.readOptionalString(queryParameters, PARAM_CONSENT_REQUEST_ID);
+    String suppliedDigest = snapshotDigestParameter(queryParameters);
+    if (requestId == null || suppliedDigest == null) {
+      throw new PlatformApiException(
+          409,
+          "consent_required",
+          "This app-platform action requires an approved consent preview.");
+    }
+    ConsentDecision decision = decisionsByRequestId.get(requestId);
+    if (decision == null || decision.status() != ConsentDecisionStatus.APPROVED) {
+      throw new PlatformApiException(
+          409, "consent_not_approved", "The consent request has not been approved.");
+    }
+    if (!suppliedDigest.equals(decision.snapshotDigest())
+        || !suppliedDigest.equals(current.snapshotDigest())) {
+      throw new PlatformApiException(409, ERROR_STALE_CONSENT_SNAPSHOT, MESSAGE_STALE_CONSENT);
+    }
+    if (!actor(principal).equals(decision.actor()) && principal.isApp()) {
+      throw new PlatformApiException(
+          403, "host_operator_required", "This consent decision requires a host/operator.");
+    }
+    if (consumeDecision) {
+      consumeConsentRequest(requestId);
+    }
+  }
+
+  private void requireApprovedBeforePreparingUpdatePreview(
+      ConsentSnapshot readOnly,
+      Map<String, List<String>> queryParameters,
+      PlatformApiPrincipal principal) {
+    pruneStoredConsent(Instant.now(clock));
+    if (readOnly.riskLevel() == ConsentRiskLevel.BLOCKING) {
+      throw new PlatformApiException(409, ERROR_CONSENT_BLOCKED, MESSAGE_CONSENT_BLOCKED);
+    }
+    String requestId =
+        PlatformApiParameters.readOptionalString(queryParameters, PARAM_CONSENT_REQUEST_ID);
+    String suppliedDigest = snapshotDigestParameter(queryParameters);
+    if (requestId == null || suppliedDigest == null) {
+      throw new PlatformApiException(
+          409,
+          "consent_required",
+          "This app-platform action requires an approved consent preview.");
+    }
+    ConsentDecision decision = decisionsByRequestId.get(requestId);
+    if (decision == null || decision.status() != ConsentDecisionStatus.APPROVED) {
+      throw new PlatformApiException(
+          409, "consent_not_approved", "The consent request has not been approved.");
+    }
+    if (!suppliedDigest.equals(decision.snapshotDigest())) {
+      throw new PlatformApiException(409, ERROR_STALE_CONSENT_SNAPSHOT, MESSAGE_STALE_CONSENT);
+    }
+    if (!actor(principal).equals(decision.actor()) && principal.isApp()) {
+      throw new PlatformApiException(
+          403, "host_operator_required", "This consent decision requires a host/operator.");
+    }
+  }
+
+  private void consumeApprovedDecisionIfSupplied(Map<String, List<String>> queryParameters) {
+    String requestId =
+        PlatformApiParameters.readOptionalString(queryParameters, PARAM_CONSENT_REQUEST_ID);
+    String suppliedDigest = snapshotDigestParameter(queryParameters);
+    if (requestId == null || suppliedDigest == null) {
+      return;
+    }
+    ConsentDecision decision = decisionsByRequestId.get(requestId);
+    if (decision != null
+        && decision.status() == ConsentDecisionStatus.APPROVED
+        && suppliedDigest.equals(decision.snapshotDigest())) {
+      consumeConsentRequest(requestId);
+    }
+  }
+
+  private ConsentDecision decide(
+      Map<String, List<String>> queryParameters,
+      PlatformApiPrincipal principal,
+      ConsentDecisionStatus status) {
+    pruneStoredConsent(Instant.now(clock));
+    String requestId =
+        PlatformApiParameters.requireString(queryParameters, PARAM_CONSENT_REQUEST_ID);
+    String suppliedDigest = snapshotDigestParameter(queryParameters);
+    if (suppliedDigest == null) {
+      throw new PlatformApiException(
+          400, "invalid_query_parameter", "Missing required query parameter 'snapshotDigest'.");
+    }
+    ConsentRequest request = requests.get(requestId);
+    if (request == null) {
+      throw new PlatformApiException(
+          404, "consent_request_not_found", "Consent request not found.");
+    }
+    ConsentSnapshot snapshot = request.snapshot();
+    if (!suppliedDigest.equals(snapshot.snapshotDigest())) {
+      throw new PlatformApiException(409, ERROR_STALE_CONSENT_SNAPSHOT, MESSAGE_STALE_CONSENT);
+    }
+    if (status == ConsentDecisionStatus.APPROVED
+        && snapshot.riskLevel() == ConsentRiskLevel.BLOCKING) {
+      throw new PlatformApiException(409, ERROR_CONSENT_BLOCKED, MESSAGE_CONSENT_BLOCKED);
+    }
+    ConsentDecision decision =
+        new ConsentDecision(
+            nextDecisionId(),
+            requestId,
+            status,
+            actor(principal),
+            suppliedDigest,
+            Instant.now(clock));
+    decisionsByRequestId.put(requestId, decision);
+    auditStore.append(toAuditEvent(snapshot, decision));
+    return decision;
+  }
+
+  private ConsentAuditEvent toAuditEvent(ConsentSnapshot snapshot, ConsentDecision decision) {
+    return new ConsentAuditEvent(
+        decision.decisionId(),
+        decision.consentRequestId(),
+        decision.actor(),
+        snapshot.appId(),
+        snapshot.action(),
+        decision.status(),
+        decision.decidedAt(),
+        decision.snapshotDigest(),
+        snapshot.blockingReasons());
+  }
+
+  private ConsentRequest register(ConsentSnapshot snapshot) {
+    pruneStoredConsent(Instant.now(clock));
+    ConsentRequest request =
+        new ConsentRequest(snapshot.consentRequestId(), snapshot, snapshot.createdAt());
+    requests.put(request.requestId(), request);
+    pruneStoredConsent(Instant.now(clock));
+    return request;
+  }
+
+  private void consumeConsentRequest(String requestId) {
+    decisionsByRequestId.remove(requestId);
+    requests.remove(requestId);
+  }
+
+  private void pruneStoredConsent(Instant now) {
+    List<String> expiredDecisionIds =
+        decisionsByRequestId.entrySet().stream()
+            .filter(entry -> expired(entry.getValue().decidedAt(), now))
+            .map(Map.Entry::getKey)
+            .toList();
+    expiredDecisionIds.forEach(requestId -> expireDecision(requestId, now));
+    List<String> expiredRequestIds =
+        requests.entrySet().stream()
+            .filter(entry -> expired(entry.getValue().createdAt(), now))
+            .filter(entry -> lacksFreshApprovedDecision(entry.getKey(), now))
+            .map(Map.Entry::getKey)
+            .toList();
+    expiredRequestIds.forEach(requestId -> expireRequest(requestId, now));
+    trimStoredConsent(now);
+  }
+
+  private void trimStoredConsent(Instant now) {
+    while (decisionsByRequestId.size() > MAX_STORED_DECISIONS) {
+      expireDecision(decisionsByRequestId.keySet().iterator().next(), now);
+    }
+    while (requests.size() > MAX_STORED_REQUESTS) {
+      String requestId =
+          requests.keySet().stream()
+              .filter(candidate -> lacksFreshApprovedDecision(candidate, now))
+              .findFirst()
+              .orElse(null);
+      if (requestId == null) {
+        break;
+      }
+      expireRequest(requestId, now);
+    }
+  }
+
+  private boolean lacksFreshApprovedDecision(String requestId, Instant now) {
+    ConsentDecision decision = decisionsByRequestId.get(requestId);
+    return decision == null
+        || decision.status() != ConsentDecisionStatus.APPROVED
+        || expired(decision.decidedAt(), now);
+  }
+
+  private void expireRequest(String requestId, Instant now) {
+    ConsentDecision decision = decisionsByRequestId.remove(requestId);
+    ConsentRequest request = requests.remove(requestId);
+    appendExpiredApprovalAudit(request, decision, now);
+  }
+
+  private void expireDecision(String requestId, Instant now) {
+    expireRequest(requestId, now);
+  }
+
+  private void appendExpiredApprovalAudit(
+      ConsentRequest request, ConsentDecision decision, Instant now) {
+    if (request == null
+        || decision == null
+        || decision.status() != ConsentDecisionStatus.APPROVED) {
+      return;
+    }
+    ConsentDecision expiredDecision =
+        new ConsentDecision(
+            nextDecisionId(),
+            decision.consentRequestId(),
+            ConsentDecisionStatus.EXPIRED,
+            decision.actor(),
+            decision.snapshotDigest(),
+            now);
+    auditStore.append(toAuditEvent(request.snapshot(), expiredDecision));
+  }
+
+  private static boolean expired(Instant createdAt, Instant now) {
+    return !createdAt.plus(STORED_CONSENT_TTL).isAfter(now);
+  }
+
+  private ConsentSnapshot buildInstallSnapshot(String catalogId, String appId) {
+    requireCatalogHandler();
+    Map<String, Object> app = catalogHandler.getApp(catalogId, appId);
+    return buildInstallSnapshot(catalogId, app, nextRequestId());
+  }
+
+  private ConsentSnapshot buildPreparedInstallSnapshot(String catalogId, AppCatalogEntry entry) {
+    requireCatalogHandler();
+    Map<String, Object> app =
+        catalogHandler.summarizePreparedPlanForConsent(catalogId, entry, false);
+    return buildInstallSnapshot(catalogId, app, "prepared-install");
+  }
+
+  private ConsentSnapshot buildInstallSnapshot(
+      String catalogId, Map<String, Object> app, String requestId) {
+    List<ConsentSection> sections = new ArrayList<>();
+    sections.add(installIdentitySection(catalogId, app));
+    sections.add(catalogTrustSection(app));
+    sections.add(reviewSection(app, true));
+    sections.add(securitySection(app, true));
+    sections.add(installPermissionsSection(app));
+    sections.add(apiStabilitySection(app));
+    sections.add(appDataAndBackupSection(app, Map.of()));
+    sections.add(serviceGrantPlaceholderSection());
+    ConsentRiskLevel risk = ConsentPolicy.riskLevel(sections);
+    boolean requiresApproval = risk.requiresApproval();
+    return snapshot(
+        new SnapshotSpec(
+            requestId,
+            ConsentActionType.INSTALL_APP,
+            new SnapshotCandidate(
+                app,
+                null,
+                ConsentJson.string(app, FIELD_VERSION),
+                bundleDigest(app),
+                catalogId,
+                catalogId),
+            new SnapshotAssessment(risk, requiresApproval, requiresApproval, sections)));
+  }
+
+  private ConsentSnapshot buildUpdateSnapshot(
+      String appId, boolean refreshCatalogs, boolean includePreparedMigrationPlan) {
+    requireUpdateService();
+    Map<String, Object> summary =
+        includePreparedMigrationPlan
+            ? updateService.previewForConsent(appId, refreshCatalogs)
+            : updateService.previewReadOnly(appId);
+    Map<String, Object> candidate = ConsentJson.object(summary, VALUE_CANDIDATE);
+    String requestId = nextRequestId();
+    if (!isDetectedUpdateCandidate(candidate)) {
+      return noUpdateSnapshot(requestId, appId);
+    }
+    List<ConsentSection> sections = new ArrayList<>();
+    sections.add(updateIdentitySection(candidate));
+    sections.add(permissionDeltaSection(candidate));
+    sections.add(updateApiStabilitySection(candidate));
+    sections.add(updateReviewSection(candidate));
+    sections.add(updateCatalogSection(candidate));
+    sections.add(updateSecuritySection(candidate));
+    sections.add(updateMigrationSection(candidate));
+    sections.add(updateBackupSection(candidate));
+    sections.add(updateServiceGrantDeltaSection(candidate));
+    ConsentRiskLevel risk = ConsentPolicy.riskLevel(sections);
+    boolean requiresApproval = risk.requiresApproval();
+    return new ConsentSnapshot(
+        requestId,
+        ConsentActionType.UPDATE_APP,
+        ConsentJson.string(candidate, FIELD_APP_ID),
+        null,
+        ConsentJson.string(candidate, FIELD_INSTALLED_VERSION),
+        ConsentJson.string(candidate, FIELD_TARGET_VERSION),
+        null,
+        bundleDigest(candidate),
+        ConsentJson.string(candidate, FIELD_CATALOG_ID),
+        ConsentJson.string(candidate, FIELD_CATALOG_SOURCE_ID),
+        risk,
+        requiresApproval,
+        requiresApproval,
+        ConsentPolicy.blockingReasons(sections),
+        recommendedAction(risk, ConsentActionType.UPDATE_APP),
+        sections,
+        Instant.now(clock));
+  }
+
+  private ConsentSnapshot noUpdateSnapshot(String requestId, String appId) {
+    List<ConsentSection> sections =
+        List.of(
+            section(
+                VALUE_CANDIDATE,
+                TITLE_UPDATE_CANDIDATE,
+                finding(
+                    "no_update_candidate",
+                    "No update candidate",
+                    "No catalog update candidate is currently available.",
+                    VALUE_UNCHANGED,
+                    ConsentRiskLevel.NONE)));
+    return new ConsentSnapshot(
+        requestId,
+        ConsentActionType.UPDATE_APP,
+        appId,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        ConsentRiskLevel.NONE,
+        false,
+        false,
+        List.of(),
+        "no_update_available",
+        sections,
+        Instant.now(clock));
+  }
+
+  private static boolean isDetectedUpdateCandidate(Map<String, Object> candidate) {
+    String status = ConsentJson.string(candidate, FIELD_STATUS);
+    return status != null && !VALUE_NONE.equals(status);
+  }
+
+  private ConsentSnapshot buildCatalogUpdateSnapshot(String catalogId, String appId) {
+    requireCatalogHandler();
+    Map<String, Object> app = catalogHandler.getAppForCatalogUpdateConsent(catalogId, appId);
+    return buildCatalogUpdateSnapshot(catalogId, app, nextRequestId());
+  }
+
+  private ConsentSnapshot buildPreparedCatalogUpdateSnapshot(
+      String catalogId, AppCatalogEntry entry) {
+    requireCatalogHandler();
+    Map<String, Object> app =
+        catalogHandler.summarizePreparedPlanForConsent(catalogId, entry, true);
+    return buildCatalogUpdateSnapshot(catalogId, app, "prepared-catalog-update");
+  }
+
+  private ConsentSnapshot buildCatalogUpdateSnapshot(
+      String catalogId, Map<String, Object> app, String requestId) {
+    List<ConsentSection> sections = new ArrayList<>();
+    sections.add(catalogUpdateIdentitySection(catalogId, app));
+    sections.add(permissionDeltaFromDeltaMap(ConsentJson.object(app, FIELD_PERMISSION_DELTA)));
+    sections.add(apiStabilitySection(app));
+    sections.add(reviewSection(app, false));
+    sections.add(catalogTrustSection(app));
+    sections.add(securitySection(app, false));
+    sections.add(appDataAndBackupSection(app, Map.of()));
+    sections.add(serviceGrantPlaceholderSection());
+    ConsentRiskLevel risk = ConsentPolicy.riskLevel(sections);
+    boolean requiresApproval = risk.requiresApproval();
+    return snapshot(
+        new SnapshotSpec(
+            requestId,
+            ConsentActionType.UPDATE_APP,
+            new SnapshotCandidate(
+                app,
+                ConsentJson.string(app, FIELD_INSTALLED_VERSION),
+                ConsentJson.string(app, FIELD_VERSION),
+                bundleDigest(app),
+                catalogId,
+                catalogId),
+            new SnapshotAssessment(risk, requiresApproval, requiresApproval, sections)));
+  }
+
+  private ConsentSnapshot buildServiceGrantSnapshot(String bundleId) {
+    requireServiceCoordinator();
+    Map<String, Object> bundle =
+        appServiceCoordinator.listBundles(PlatformApiPrincipal.hostOperator()).stream()
+            .filter(item -> bundleId.equals(ConsentJson.string(item, "bundleId")))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new PlatformApiException(
+                        404,
+                        "app_service_bundle_not_found",
+                        "App-service grant bundle not found."));
+    List<ConsentSection> sections = new ArrayList<>();
+    sections.add(serviceGrantIdentitySection(bundle));
+    sections.add(serviceGrantDependenciesSection(bundle));
+    sections.add(serviceGrantAuditSection());
+    ConsentRiskLevel risk = ConsentPolicy.riskLevel(sections);
+    return new ConsentSnapshot(
+        nextRequestId(),
+        ConsentActionType.APP_SERVICE_GRANT,
+        ConsentJson.string(bundle, FIELD_CONSUMER_APP_ID),
+        null,
+        null,
+        null,
+        null,
+        bundleFingerprint(bundle),
+        null,
+        null,
+        risk,
+        risk.requiresApproval(),
+        risk.requiresApproval(),
+        ConsentPolicy.blockingReasons(sections),
+        recommendedAction(risk, ConsentActionType.APP_SERVICE_GRANT),
+        sections,
+        Instant.now(clock));
+  }
+
+  private ConsentSection installIdentitySection(String catalogId, Map<String, Object> app) {
+    return section(
+        SECTION_IDENTITY,
+        "App identity",
+        finding(
+            "app_identity",
+            "App",
+            "%s %s from catalog %s"
+                .formatted(
+                    safe(
+                        ConsentJson.string(app, FIELD_NAME), ConsentJson.string(app, FIELD_APP_ID)),
+                    safe(ConsentJson.string(app, FIELD_VERSION), "unknown version"),
+                    catalogId),
+            VALUE_CANDIDATE,
+            ConsentRiskLevel.LOW),
+        finding(
+            FINDING_BUNDLE_DIGEST,
+            LABEL_BUNDLE_DIGEST,
+            safe(bundleDigest(app), SUMMARY_NO_BUNDLE_DIGEST),
+            VALUE_CANDIDATE,
+            bundleDigest(app) == null ? ConsentRiskLevel.MATERIAL : ConsentRiskLevel.LOW),
+        finding(
+            "catalog_channel",
+            "Catalog channel",
+            safe(ConsentJson.string(app, FIELD_CHANNEL), VALUE_STABLE),
+            VALUE_CANDIDATE,
+            channelRisk(ConsentJson.string(app, FIELD_CHANNEL))));
+  }
+
+  private ConsentSection catalogTrustSection(Map<String, Object> app) {
+    Map<String, Object> maintenance = ConsentJson.object(app, "maintenance");
+    Map<String, Object> deprecation = ConsentJson.object(app, FIELD_DEPRECATION);
+    return section(
+        "catalog-support",
+        "Catalog and support",
+        finding(
+            "support_status",
+            "Support status",
+            safe(ConsentJson.string(app, FIELD_SUPPORT_STATUS), VALUE_SUPPORTED),
+            VALUE_CANDIDATE,
+            supportRisk(ConsentJson.string(app, FIELD_SUPPORT_STATUS))),
+        finding(
+            "maintenance_owner",
+            "Maintenance owner",
+            safe(ConsentJson.string(maintenance, "owner"), "Maintenance owner is not declared."),
+            VALUE_CANDIDATE,
+            ConsentJson.string(maintenance, "owner") == null
+                ? ConsentRiskLevel.MATERIAL
+                : ConsentRiskLevel.LOW),
+        finding(
+            "deprecation_status",
+            "Deprecation",
+            deprecationSummary(deprecation),
+            VALUE_CANDIDATE,
+            deprecationRisk(deprecation)));
+  }
+
+  private ConsentSection reviewSection(Map<String, Object> app, boolean install) {
+    Map<String, Object> reviewTrust = ConsentJson.object(app, "reviewTrust");
+    Map<String, Object> thirdPartyReview = ConsentJson.object(app, "thirdPartyReview");
+    ConsentRiskLevel risk = reviewRisk(reviewTrust, install);
+    return section(
+        "review-trust",
+        "Review and trust",
+        finding(
+            "review_trust_delta",
+            "Review status",
+            safe(ConsentJson.string(reviewTrust, FIELD_STATUS), "review metadata unavailable"),
+            VALUE_CANDIDATE,
+            risk),
+        finding(
+            "reviewer_key_status",
+            "Reviewer key",
+            safe(
+                ConsentJson.string(thirdPartyReview, FIELD_REVIEWER_KEY_ID),
+                "No reviewer key declared."),
+            VALUE_CANDIDATE,
+            ConsentJson.string(thirdPartyReview, FIELD_REVIEWER_KEY_ID) == null
+                ? ConsentRiskLevel.MATERIAL
+                : ConsentRiskLevel.LOW),
+        finding(
+            "review_receipt_fingerprint",
+            "Review receipt",
+            safe(
+                ConsentJson.string(thirdPartyReview, "receiptFingerprintSha256"),
+                "No independent review receipt fingerprint is available."),
+            VALUE_CANDIDATE,
+            ConsentJson.string(thirdPartyReview, "receiptFingerprintSha256") == null
+                ? ConsentRiskLevel.MATERIAL
+                : ConsentRiskLevel.LOW));
+  }
+
+  private ConsentSection securitySection(Map<String, Object> app, boolean install) {
+    return securitySection(
+        ConsentJson.object(app, FIELD_SECURITY_DECISION),
+        ConsentJson.list(app, FIELD_SECURITY_ADVISORIES),
+        install);
+  }
+
+  private ConsentSection securitySection(
+      Map<String, Object> decision, List<Object> advisories, boolean install) {
+    ConsentRiskLevel risk = securityRisk(decision, advisories, install);
+    return section(
+        "security",
+        "Security advisory",
+        finding(
+            "security_advisory_delta",
+            "Security decision",
+            safe(ConsentJson.string(decision, FIELD_STATUS), "ok"),
+            VALUE_CANDIDATE,
+            risk),
+        finding(
+            "security_advisory_count",
+            "Advisories",
+            securityAdvisorySummary(advisories),
+            advisories.isEmpty() ? VALUE_UNCHANGED : VALUE_ADDED,
+            advisories.isEmpty() ? ConsentRiskLevel.NONE : ConsentRiskLevel.MATERIAL));
+  }
+
+  private ConsentSection installPermissionsSection(Map<String, Object> app) {
+    List<Object> permissions = ConsentJson.list(app, "permissions");
+    Map<String, Object> rationales = ConsentJson.object(app, "permissionRationales");
+    ArrayList<ConsentFinding> findings = new ArrayList<>();
+    if (permissions.isEmpty()) {
+      findings.add(
+          finding(
+              "permissions_none",
+              "Permissions",
+              "No app permissions are declared.",
+              VALUE_UNCHANGED,
+              ConsentRiskLevel.NONE));
+    }
+    for (Object permission : permissions) {
+      String text = String.valueOf(permission);
+      findings.add(
+          finding(
+              "permission_required",
+              text,
+              safe(String.valueOf(rationales.getOrDefault(text, "")), "No rationale declared."),
+              VALUE_ADDED,
+              ConsentRiskLevel.MATERIAL));
+    }
+    return section("permissions", "Permissions", findings);
+  }
+
+  private ConsentSection apiStabilitySection(Map<String, Object> app) {
+    Map<String, Object> api = ConsentJson.object(app, "apiCompatibility");
+    return section("api-stability", "Platform API stability", apiStabilityFindings(api));
+  }
+
+  private ConsentSection appDataAndBackupSection(
+      Map<String, Object> app, Map<String, Object> migration) {
+    Map<String, Object> maintenance = ConsentJson.object(app, "maintenance");
+    ArrayList<ConsentFinding> findings = new ArrayList<>();
+    findings.add(
+        finding(
+            "app_data_schema_policy",
+            "Schema policy",
+            safe(ConsentJson.string(maintenance, "dataSchemaPolicy"), "No schema policy declared."),
+            VALUE_CANDIDATE,
+            ConsentRiskLevel.LOW));
+    findings.add(
+        finding(
+            "backup_before_update",
+            "Backup before update",
+            safe(
+                ConsentJson.string(maintenance, "backupRestore"), "Backup policy is not declared."),
+            VALUE_CANDIDATE,
+            ConsentJson.string(maintenance, "backupRestore") == null
+                ? ConsentRiskLevel.MATERIAL
+                : ConsentRiskLevel.LOW));
+    if (!migration.isEmpty()) {
+      findings.add(
+          finding(
+              "app_data_migration_plan",
+              "Migration plan",
+              migrationSummary(migration),
+              VALUE_CANDIDATE,
+              migrationRisk(migration)));
+    }
+    return section("app-data-migration", "App-data migration and backup", findings);
+  }
+
+  private ConsentSection serviceGrantPlaceholderSection() {
+    return section(
+        "app-service-grants",
+        "App-service grants",
+        finding(
+            "app_service_dependencies",
+            "Service dependencies",
+            "No app-service grant bundle is pending in this preview.",
+            VALUE_UNCHANGED,
+            ConsentRiskLevel.NONE));
+  }
+
+  private ConsentSection updateIdentitySection(Map<String, Object> candidate) {
+    return section(
+        SECTION_IDENTITY,
+        TITLE_UPDATE_CANDIDATE,
+        finding(
+            "version_change",
+            "Version",
+            "%s to %s"
+                .formatted(
+                    safe(ConsentJson.string(candidate, FIELD_INSTALLED_VERSION), VALUE_UNKNOWN),
+                    safe(ConsentJson.string(candidate, FIELD_TARGET_VERSION), VALUE_UNKNOWN)),
+            VALUE_CHANGED,
+            ConsentRiskLevel.LOW),
+        finding(
+            FINDING_BUNDLE_DIGEST,
+            LABEL_BUNDLE_DIGEST,
+            safe(bundleDigest(candidate), SUMMARY_NO_BUNDLE_DIGEST),
+            VALUE_CHANGED,
+            bundleDigest(candidate) == null ? ConsentRiskLevel.MATERIAL : ConsentRiskLevel.LOW));
+  }
+
+  private ConsentSection catalogUpdateIdentitySection(String catalogId, Map<String, Object> app) {
+    return section(
+        SECTION_IDENTITY,
+        TITLE_UPDATE_CANDIDATE,
+        finding(
+            "version_change",
+            "Version",
+            "%s to %s from catalog %s"
+                .formatted(
+                    safe(ConsentJson.string(app, FIELD_INSTALLED_VERSION), VALUE_UNKNOWN),
+                    safe(ConsentJson.string(app, FIELD_VERSION), VALUE_UNKNOWN),
+                    catalogId),
+            VALUE_CHANGED,
+            ConsentRiskLevel.LOW),
+        finding(
+            FINDING_BUNDLE_DIGEST,
+            LABEL_BUNDLE_DIGEST,
+            safe(bundleDigest(app), SUMMARY_NO_BUNDLE_DIGEST),
+            VALUE_CHANGED,
+            bundleDigest(app) == null ? ConsentRiskLevel.MATERIAL : ConsentRiskLevel.LOW));
+  }
+
+  private ConsentSection permissionDeltaSection(Map<String, Object> candidate) {
+    return permissionDeltaFromDeltaMap(ConsentJson.object(candidate, FIELD_PERMISSION_DELTA));
+  }
+
+  private ConsentSection permissionDeltaFromDeltaMap(Map<String, Object> delta) {
+    ArrayList<ConsentFinding> findings = new ArrayList<>();
+    for (Object permission : ConsentJson.list(delta, VALUE_ADDED)) {
+      findings.add(
+          finding(
+              "new_permission",
+              String.valueOf(permission),
+              "New permission requested by the update.",
+              VALUE_ADDED,
+              ConsentRiskLevel.MATERIAL));
+    }
+    for (Object permission : ConsentJson.list(delta, "removed")) {
+      findings.add(
+          finding(
+              "removed_permission",
+              String.valueOf(permission),
+              "Permission removed by the update.",
+              "removed",
+              ConsentRiskLevel.LOW));
+    }
+    findings.add(
+        finding(
+            "permission_rationale_delta",
+            "Permission rationales",
+            "Rationale changes are reviewed with the candidate permission set.",
+            VALUE_CHANGED,
+            ConsentJson.list(delta, VALUE_ADDED).isEmpty()
+                ? ConsentRiskLevel.LOW
+                : ConsentRiskLevel.MATERIAL));
+    return section("permission-delta", "Permission delta", findings);
+  }
+
+  private ConsentSection updateApiStabilitySection(Map<String, Object> candidate) {
+    return section(
+        "api-stability",
+        "Platform API stability",
+        apiStabilityFindings(ConsentJson.object(candidate, "apiCompatibility")));
+  }
+
+  private ConsentSection updateReviewSection(Map<String, Object> candidate) {
+    Map<String, Object> reviewTrust = ConsentJson.object(candidate, "reviewTrust");
+    ConsentRiskLevel risk = reviewRisk(reviewTrust, false);
+    return section(
+        "review-trust",
+        "Review and trust",
+        finding(
+            "review_trust_delta",
+            "Review trust",
+            safe(ConsentJson.string(reviewTrust, FIELD_STATUS), "review metadata unavailable"),
+            VALUE_CHANGED,
+            risk),
+        finding(
+            "review_receipt_changed",
+            "Review receipt",
+            reviewTrustReceiptSummary(reviewTrust),
+            VALUE_CHANGED,
+            risk));
+  }
+
+  private ConsentSection updateCatalogSection(Map<String, Object> candidate) {
+    return section(
+        "catalog-support",
+        "Catalog and support",
+        finding(
+            "catalog_channel_delta",
+            "Channel",
+            safe(ConsentJson.string(candidate, FIELD_CHANNEL), VALUE_STABLE),
+            VALUE_CHANGED,
+            channelRisk(ConsentJson.string(candidate, FIELD_CHANNEL))),
+        finding(
+            "support_status_delta",
+            "Support status",
+            safe(ConsentJson.string(candidate, FIELD_SUPPORT_STATUS), VALUE_SUPPORTED),
+            VALUE_CHANGED,
+            supportRisk(ConsentJson.string(candidate, FIELD_SUPPORT_STATUS))),
+        finding(
+            "deprecation_delta",
+            "Deprecation",
+            deprecationSummary(ConsentJson.object(candidate, FIELD_DEPRECATION)),
+            VALUE_CHANGED,
+            deprecationRisk(ConsentJson.object(candidate, FIELD_DEPRECATION))));
+  }
+
+  private ConsentSection updateSecuritySection(Map<String, Object> candidate) {
+    return securitySection(
+        ConsentJson.object(candidate, FIELD_SECURITY_DECISION),
+        ConsentJson.list(candidate, FIELD_SECURITY_ADVISORIES),
+        false);
+  }
+
+  private ConsentSection updateMigrationSection(Map<String, Object> candidate) {
+    Map<String, Object> migration = ConsentJson.object(candidate, "dataMigration");
+    return section(
+        "app-data-migration",
+        "App-data migration",
+        finding(
+            "app_data_migration_plan",
+            "Migration plan",
+            migrationSummary(migration),
+            VALUE_CHANGED,
+            migrationRisk(migration)));
+  }
+
+  private ConsentSection updateBackupSection(Map<String, Object> candidate) {
+    Map<String, Object> migration = ConsentJson.object(candidate, "dataMigration");
+    ConsentRiskLevel risk =
+        migrationRisk(migration).requiresApproval()
+            ? ConsentRiskLevel.MATERIAL
+            : ConsentRiskLevel.LOW;
+    return section(
+        "backup-before-update",
+        "Backup before update",
+        finding(
+            "backup_before_update",
+            "Backup recommendation",
+            Boolean.TRUE.equals(migration.get(FIELD_REQUIRED))
+                ? "A migration is required; create or verify a backup before applying."
+                : "No migration backup requirement is currently reported.",
+            Boolean.TRUE.equals(migration.get(FIELD_REQUIRED)) ? "recommended" : VALUE_UNCHANGED,
+            risk));
+  }
+
+  private ConsentSection updateServiceGrantDeltaSection(Map<String, Object> candidate) {
+    Map<String, Object> delta = ConsentJson.object(candidate, FIELD_PERMISSION_DELTA);
+    boolean servicePermissionAdded =
+        ConsentJson.list(delta, VALUE_ADDED).stream()
+            .map(String::valueOf)
+            .anyMatch(permission -> permission.startsWith("app.services."));
+    return section(
+        "app-service-grants",
+        "App-service grants",
+        finding(
+            "app_service_grant_delta",
+            "Grant delta",
+            servicePermissionAdded
+                ? "The update adds app-service capability and may require grant-bundle review."
+                : "No app-service grant-bundle delta is attached to this candidate.",
+            servicePermissionAdded ? VALUE_ADDED : VALUE_UNCHANGED,
+            servicePermissionAdded ? ConsentRiskLevel.MATERIAL : ConsentRiskLevel.NONE));
+  }
+
+  private ConsentSection serviceGrantIdentitySection(Map<String, Object> bundle) {
+    return section(
+        "service-grant",
+        "App-service grant bundle",
+        finding(
+            "app_service_dependency_bundle",
+            "Requesting app",
+            "%s requested bundle %s"
+                .formatted(
+                    safe(ConsentJson.string(bundle, FIELD_CONSUMER_APP_ID), "unknown app"),
+                    safe(
+                        ConsentJson.string(bundle, "bundleAlias"),
+                        ConsentJson.string(bundle, "bundleId"))),
+            VALUE_CANDIDATE,
+            ConsentRiskLevel.MATERIAL),
+        finding(
+            "grant_status",
+            "Bundle status",
+            safe(ConsentJson.string(bundle, FIELD_STATUS), "pending"),
+            VALUE_CANDIDATE,
+            "pending".equals(ConsentJson.string(bundle, FIELD_STATUS))
+                ? ConsentRiskLevel.MATERIAL
+                : ConsentRiskLevel.LOW));
+  }
+
+  private ConsentSection serviceGrantDependenciesSection(Map<String, Object> bundle) {
+    ArrayList<ConsentFinding> findings = new ArrayList<>();
+    for (Object item : ConsentJson.list(bundle, "dependencies")) {
+      if (item instanceof Map<?, ?> raw) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> dependency = (Map<String, Object>) raw;
+        findings.add(
+            finding(
+                "app_service_dependency",
+                "%s / %s"
+                    .formatted(
+                        safe(ConsentJson.string(dependency, "providerAppId"), "provider"),
+                        safe(ConsentJson.string(dependency, "serviceId"), "service")),
+                serviceDependencySummary(dependency),
+                dependencyRequirementText(ConsentJson.bool(dependency, FIELD_REQUIRED, false)),
+                ConsentRiskLevel.MATERIAL));
+      }
+    }
+    if (findings.isEmpty()) {
+      findings.add(
+          finding(
+              "app_service_dependency_missing",
+              "Dependencies",
+              "No dependency records were available for this bundle.",
+              VALUE_CANDIDATE,
+              ConsentRiskLevel.MATERIAL));
+    }
+    return section("app-service-dependencies", "Service dependencies", findings);
+  }
+
+  private ConsentSection serviceGrantAuditSection() {
+    return section(
+        "audit",
+        "Audit impact",
+        finding(
+            "app_service_audit_impact",
+            "Audit",
+            "Approving, rejecting, or renewing this bundle writes a consent audit record and an"
+                + " app-service lifecycle record.",
+            VALUE_CANDIDATE,
+            ConsentRiskLevel.MATERIAL),
+        finding(
+            "app_service_revocation_behavior",
+            "Revocation",
+            "Revoking grants disables service invocation until a fresh operator approval exists.",
+            VALUE_CANDIDATE,
+            ConsentRiskLevel.LOW));
+  }
+
+  private List<ConsentFinding> apiStabilityFindings(Map<String, Object> api) {
+    String stability = ConsentJson.string(api, FIELD_TARGET_STABILITY);
+    boolean experimentalAccepted =
+        ConsentJson.bool(api, FIELD_EXPERIMENTAL_CAPABILITIES_ACCEPTED, false);
+    String status = ConsentJson.string(api, FIELD_STATUS);
+    ArrayList<ConsentFinding> findings = new ArrayList<>();
+    findings.add(
+        finding(
+            "platform_api_stability_change",
+            "Target stability",
+            safe(stability, "not declared"),
+            VALUE_CANDIDATE,
+            apiRisk(api)));
+    findings.add(
+        finding(
+            "experimental_api_acceptance",
+            "Experimental API acceptance",
+            Boolean.toString(experimentalAccepted),
+            VALUE_CANDIDATE,
+            experimentalAccepted ? ConsentRiskLevel.MATERIAL : ConsentRiskLevel.LOW));
+    findings.add(
+        finding(
+            "platform_api_compatibility",
+            "Compatibility",
+            safe(status, VALUE_UNKNOWN),
+            VALUE_CANDIDATE,
+            apiRisk(api)));
+    return findings;
+  }
+
+  private ConsentSnapshot snapshot(SnapshotSpec spec) {
+    SnapshotCandidate candidate = spec.candidate();
+    SnapshotAssessment assessment = spec.assessment();
+    return new ConsentSnapshot(
+        spec.requestId(),
+        spec.action(),
+        ConsentJson.string(candidate.app(), FIELD_APP_ID),
+        ConsentJson.string(candidate.app(), FIELD_NAME),
+        candidate.installedVersion(),
+        candidate.candidateVersion(),
+        null,
+        candidate.candidateDigest(),
+        candidate.catalogId(),
+        candidate.catalogSourceId(),
+        assessment.risk(),
+        assessment.requiresApproval(),
+        assessment.blocksAutoUpdate(),
+        ConsentPolicy.blockingReasons(assessment.sections()),
+        recommendedAction(assessment.risk(), spec.action()),
+        assessment.sections(),
+        Instant.now(clock));
+  }
+
+  private record SnapshotSpec(
+      String requestId,
+      ConsentActionType action,
+      SnapshotCandidate candidate,
+      SnapshotAssessment assessment) {}
+
+  private record SnapshotCandidate(
+      Map<String, Object> app,
+      String installedVersion,
+      String candidateVersion,
+      String candidateDigest,
+      String catalogId,
+      String catalogSourceId) {}
+
+  private record SnapshotAssessment(
+      ConsentRiskLevel risk,
+      boolean requiresApproval,
+      boolean blocksAutoUpdate,
+      List<ConsentSection> sections) {}
+
+  private static ConsentSection section(String id, String title, ConsentFinding... findings) {
+    return section(id, title, List.of(findings));
+  }
+
+  private static ConsentSection section(String id, String title, List<ConsentFinding> findings) {
+    ConsentRiskLevel risk = ConsentRiskLevel.NONE;
+    for (ConsentFinding finding : findings) {
+      risk = ConsentRiskLevel.max(risk, finding.riskLevel());
+    }
+    return new ConsentSection(id, title, risk, findings);
+  }
+
+  private static ConsentFinding finding(
+      String code, String label, String summary, String change, ConsentRiskLevel risk) {
+    return new ConsentFinding(code, label, summary, change, risk);
+  }
+
+  private static ConsentRiskLevel reviewRisk(Map<String, Object> reviewTrust, boolean install) {
+    if (ConsentJson.bool(
+        reviewTrust, install ? FIELD_BLOCKS_INSTALL : FIELD_BLOCKS_UPDATE, false)) {
+      return ConsentRiskLevel.BLOCKING;
+    }
+    if (ConsentJson.bool(reviewTrust, FIELD_REQUIRES_ACKNOWLEDGEMENT, false)
+        || !ConsentJson.bool(reviewTrust, FIELD_POSITIVE, false)) {
+      return ConsentRiskLevel.MATERIAL;
+    }
+    return ConsentRiskLevel.LOW;
+  }
+
+  private static ConsentRiskLevel securityRisk(
+      Map<String, Object> decision, List<Object> advisories, boolean install) {
+    if (ConsentJson.bool(decision, install ? FIELD_BLOCKS_INSTALL : FIELD_BLOCKS_UPDATE, false)) {
+      return ConsentRiskLevel.BLOCKING;
+    }
+    String status = ConsentJson.string(decision, FIELD_STATUS);
+    if (ConsentJson.bool(decision, FIELD_REQUIRES_ACKNOWLEDGEMENT, false)
+        || ConsentJson.bool(decision, "blocksAutomaticApply", false)
+        || !advisories.isEmpty()
+        || (status != null && !"ok".equals(status))) {
+      return ConsentRiskLevel.MATERIAL;
+    }
+    return ConsentRiskLevel.LOW;
+  }
+
+  private static ConsentRiskLevel apiRisk(Map<String, Object> api) {
+    String status = ConsentJson.string(api, FIELD_STATUS);
+    String stability = ConsentJson.string(api, FIELD_TARGET_STABILITY);
+    if ("below_minimum".equals(status) || "incompatible".equals(status)) {
+      return ConsentRiskLevel.BLOCKING;
+    }
+    if (status != null && !"compatible".equals(status) && !"satisfied".equals(status)) {
+      return ConsentRiskLevel.MATERIAL;
+    }
+    if (!VALUE_STABLE.equals(stability)
+        || ConsentJson.bool(api, FIELD_EXPERIMENTAL_CAPABILITIES_ACCEPTED, false)) {
+      return ConsentRiskLevel.MATERIAL;
+    }
+    return ConsentRiskLevel.LOW;
+  }
+
+  private static ConsentRiskLevel channelRisk(String channel) {
+    if (channel == null || VALUE_STABLE.equals(channel)) {
+      return ConsentRiskLevel.LOW;
+    }
+    return ConsentRiskLevel.MATERIAL;
+  }
+
+  private static ConsentRiskLevel supportRisk(String supportStatus) {
+    if (supportStatus == null || VALUE_SUPPORTED.equals(supportStatus)) {
+      return ConsentRiskLevel.LOW;
+    }
+    return ConsentRiskLevel.MATERIAL;
+  }
+
+  private static ConsentRiskLevel deprecationRisk(Map<String, Object> deprecation) {
+    String status = ConsentJson.string(deprecation, FIELD_STATUS);
+    return status == null || VALUE_NONE.equals(status)
+        ? ConsentRiskLevel.LOW
+        : ConsentRiskLevel.MATERIAL;
+  }
+
+  private static ConsentRiskLevel migrationRisk(Map<String, Object> migration) {
+    if (migration.isEmpty() || !ConsentJson.bool(migration, FIELD_REQUIRED, false)) {
+      return ConsentRiskLevel.LOW;
+    }
+    if (migration.get("blockReason") != null) {
+      return ConsentRiskLevel.BLOCKING;
+    }
+    return ConsentRiskLevel.MATERIAL;
+  }
+
+  private static String deprecationSummary(Map<String, Object> deprecation) {
+    String status = safe(ConsentJson.string(deprecation, FIELD_STATUS), VALUE_NONE);
+    String message = ConsentJson.string(deprecation, "message");
+    String replacement = ConsentJson.string(deprecation, "replacementAppId");
+    if (replacement != null) {
+      return status + "; replacement app: " + replacement;
+    }
+    return message == null ? status : status + "; " + message;
+  }
+
+  private static String migrationSummary(Map<String, Object> migration) {
+    if (migration.isEmpty() || !ConsentJson.bool(migration, FIELD_REQUIRED, false)) {
+      return "No app-data migration is required.";
+    }
+    return "Schema "
+        + safe(ConsentJson.scalarString(migration, "currentSchemaVersion"), VALUE_UNKNOWN)
+        + " to "
+        + safe(ConsentJson.scalarString(migration, "targetSchemaVersion"), VALUE_UNKNOWN)
+        + "; dry run "
+        + safe(ConsentJson.string(migration, "dryRunStatus"), "not checked")
+        + "; rollback "
+        + safe(ConsentJson.string(migration, "snapshotStatus"), "not created");
+  }
+
+  private static String securityAdvisorySummary(List<Object> advisories) {
+    if (advisories.isEmpty()) {
+      return "No catalog security advisories are attached.";
+    }
+    List<String> advisoryDetails =
+        advisories.stream().map(ConsentJson::canonicalize).map(String::valueOf).sorted().toList();
+    return advisories.size()
+        + " catalog security advisory item(s) require review: "
+        + advisoryDetails;
+  }
+
+  private static String reviewTrustReceiptSummary(Map<String, Object> reviewTrust) {
+    ArrayList<String> fields = new ArrayList<>();
+    addReviewTrustSummaryField(
+        fields, FIELD_STATUS, ConsentJson.scalarString(reviewTrust, FIELD_STATUS));
+    addReviewTrustSummaryField(fields, "trusted", ConsentJson.scalarString(reviewTrust, "trusted"));
+    addReviewTrustSummaryField(
+        fields, FIELD_POSITIVE, ConsentJson.scalarString(reviewTrust, FIELD_POSITIVE));
+    addReviewTrustSummaryField(
+        fields,
+        FIELD_REQUIRES_ACKNOWLEDGEMENT,
+        ConsentJson.scalarString(reviewTrust, FIELD_REQUIRES_ACKNOWLEDGEMENT));
+    addReviewTrustSummaryField(
+        fields, FIELD_BLOCKS_INSTALL, ConsentJson.scalarString(reviewTrust, FIELD_BLOCKS_INSTALL));
+    addReviewTrustSummaryField(
+        fields, FIELD_BLOCKS_UPDATE, ConsentJson.scalarString(reviewTrust, FIELD_BLOCKS_UPDATE));
+    addReviewTrustSummaryField(
+        fields, "blocksPolicyApply", ConsentJson.scalarString(reviewTrust, "blocksPolicyApply"));
+    addReviewTrustSummaryField(
+        fields, FIELD_REVIEWER_KEY_ID, ConsentJson.string(reviewTrust, FIELD_REVIEWER_KEY_ID));
+    addReviewTrustSummaryField(
+        fields, "reviewerDisplayName", ConsentJson.string(reviewTrust, "reviewerDisplayName"));
+    addReviewTrustSummaryField(
+        fields, "reviewerKeyStatus", ConsentJson.string(reviewTrust, "reviewerKeyStatus"));
+    addReviewTrustSummaryField(fields, "policyId", ConsentJson.string(reviewTrust, "policyId"));
+    addReviewTrustSummaryField(
+        fields, "policyVersion", ConsentJson.string(reviewTrust, "policyVersion"));
+    addReviewTrustSummaryField(
+        fields, "policyVersionStatus", ConsentJson.string(reviewTrust, "policyVersionStatus"));
+    addReviewTrustSummaryField(fields, "policyMode", ConsentJson.string(reviewTrust, "policyMode"));
+    addReviewTrustSummaryField(fields, "reviewedAt", ConsentJson.string(reviewTrust, "reviewedAt"));
+    addReviewTrustSummaryField(fields, "expiresAt", ConsentJson.string(reviewTrust, "expiresAt"));
+    addReviewTrustSummaryField(
+        fields, "evidenceSha256", ConsentJson.string(reviewTrust, "evidenceSha256"));
+    addReviewTrustSummaryField(
+        fields, "evidenceUri", ConsentJson.string(reviewTrust, "evidenceUri"));
+    addReviewTrustSummaryField(fields, "warnings", reviewTrustWarnings(reviewTrust));
+    return String.join("; ", fields);
+  }
+
+  private static void addReviewTrustSummaryField(
+      List<String> fields, String fieldName, String value) {
+    fields.add(fieldName + "=" + safe(value, "unavailable"));
+  }
+
+  private static String reviewTrustWarnings(Map<String, Object> reviewTrust) {
+    List<Object> warnings = ConsentJson.list(reviewTrust, "warnings");
+    return warnings.isEmpty() ? "[]" : String.valueOf(ConsentJson.canonicalize(warnings));
+  }
+
+  private static String serviceDependencySummary(Map<String, Object> dependency) {
+    return "Capability "
+        + safe(ConsentJson.string(dependency, "kind"), "service")
+        + "; scopes "
+        + ConsentJson.list(dependency, "scopes")
+        + "; expiry "
+        + safe(ConsentJson.string(dependency, "grantExpiresAfter"), "not declared")
+        + "; revocation blocks matching service calls.";
+  }
+
+  private static String bundleDigest(Map<String, Object> source) {
+    Map<String, Object> bundle = ConsentJson.object(source, "bundle");
+    return ConsentJson.string(bundle, "sha256");
+  }
+
+  private static String bundleFingerprint(Map<String, Object> bundle) {
+    return ConsentSnapshotDigest.digest(
+        new ConsentSnapshot(
+            "fingerprint",
+            ConsentActionType.APP_SERVICE_GRANT,
+            safe(ConsentJson.string(bundle, FIELD_CONSUMER_APP_ID), VALUE_UNKNOWN),
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            ConsentRiskLevel.LOW,
+            false,
+            false,
+            List.of(),
+            "fingerprint",
+            List.of(
+                new ConsentSection(
+                    "bundle",
+                    "Bundle",
+                    ConsentRiskLevel.LOW,
+                    List.of(
+                        finding(
+                            "bundle_json",
+                            "Bundle",
+                            String.valueOf(ConsentJson.canonicalize(bundle)),
+                            VALUE_CANDIDATE,
+                            ConsentRiskLevel.LOW)))),
+            Instant.EPOCH));
+  }
+
+  private static String recommendedAction(ConsentRiskLevel risk, ConsentActionType action) {
+    if (risk == ConsentRiskLevel.BLOCKING) {
+      return "do_not_continue";
+    }
+    if (risk.requiresApproval()) {
+      return switch (action) {
+        case UPDATE_APP -> "review_before_update";
+        case APP_SERVICE_GRANT -> "review_before_service_grant";
+        default -> "review_before_install";
+      };
+    }
+    return "continue";
+  }
+
+  private static String actor(PlatformApiPrincipal principal) {
+    if (principal == null || !principal.isApp()) {
+      return LOCAL_OPERATOR;
+    }
+    return "app:" + principal.appId();
+  }
+
+  private static Map<String, List<String>> acknowledged(Map<String, List<String>> source) {
+    LinkedHashMap<String, List<String>> copy = new LinkedHashMap<>(source);
+    copy.put(PARAM_REVIEW_ACKNOWLEDGED, List.of(Boolean.TRUE.toString()));
+    copy.put(PARAM_SECURITY_ACKNOWLEDGED, List.of(Boolean.TRUE.toString()));
+    copy.put(PARAM_MIGRATION_ACKNOWLEDGED, List.of(Boolean.TRUE.toString()));
+    return copy;
+  }
+
+  private static Map<String, List<String>> withoutAcknowledgements(
+      Map<String, List<String>> source) {
+    if (!source.containsKey(PARAM_REVIEW_ACKNOWLEDGED)
+        && !source.containsKey(PARAM_SECURITY_ACKNOWLEDGED)
+        && !source.containsKey(PARAM_MIGRATION_ACKNOWLEDGED)) {
+      return source;
+    }
+    LinkedHashMap<String, List<String>> copy = new LinkedHashMap<>(source);
+    copy.remove(PARAM_REVIEW_ACKNOWLEDGED);
+    copy.remove(PARAM_SECURITY_ACKNOWLEDGED);
+    copy.remove(PARAM_MIGRATION_ACKNOWLEDGED);
+    return copy;
+  }
+
+  private static boolean hasConsentApprovalParameters(Map<String, List<String>> queryParameters) {
+    return PlatformApiParameters.readOptionalString(queryParameters, PARAM_CONSENT_REQUEST_ID)
+            != null
+        && snapshotDigestParameter(queryParameters) != null;
+  }
+
+  private static String snapshotDigestParameter(Map<String, List<String>> queryParameters) {
+    String digest =
+        PlatformApiParameters.readOptionalString(queryParameters, PARAM_SNAPSHOT_DIGEST);
+    if (digest != null) {
+      return digest;
+    }
+    return PlatformApiParameters.readOptionalString(queryParameters, PARAM_CONSENT_SNAPSHOT_DIGEST);
+  }
+
+  private static String safe(String value, String fallback) {
+    return value == null || value.isBlank() ? fallback : value;
+  }
+
+  private static String dependencyRequirementText(boolean required) {
+    return required ? FIELD_REQUIRED : "optional";
+  }
+
+  private String nextRequestId() {
+    return "consent-" + requestSequence.incrementAndGet();
+  }
+
+  private String nextDecisionId() {
+    return "consent-decision-" + decisionSequence.incrementAndGet();
+  }
+
+  private void requireCatalogHandler() {
+    if (catalogHandler == null) {
+      throw new PlatformApiException(
+          503, "app_catalogs_unavailable", "App catalogs are unavailable.");
+    }
+  }
+
+  private void requireUpdateService() {
+    if (updateService == null) {
+      throw new PlatformApiException(
+          503, "app_updates_unavailable", "App updates are unavailable.");
+    }
+  }
+
+  private void requireServiceCoordinator() {
+    if (appServiceCoordinator == null) {
+      throw new PlatformApiException(
+          503, "app_services_unavailable", "App-service coordinator is unavailable.");
+    }
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentSnapshot.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentSnapshot.java
@@ -1,0 +1,166 @@
+package network.crypta.platform.api.consent;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Immutable, digestible consent preview for one install, update, or service-grant action.
+ *
+ * <p>A snapshot is the artifact an operator reviews before a material app-platform mutation. It
+ * carries the action, app identity, installed and candidate versions, bundle digests, catalog
+ * identity, rolled-up risk, blocking reason codes, grouped findings, and the recommended next
+ * action. The public JSON shape also includes the request id and computed snapshot digest so a
+ * client can submit an approval with the later mutation.
+ *
+ * <p>The digestable form intentionally excludes the request id and creation timestamp. That lets
+ * the service issue a fresh request for the same material preview while still rejecting approvals
+ * when candidate metadata, review evidence, permissions, security policy, migration details, or
+ * service dependencies change. All optional display strings are trimmed and redacted at
+ * construction time.
+ *
+ * @param consentRequestId process-local request id returned to the client
+ * @param action action family represented by this preview
+ * @param appId app id affected by the reviewed operation
+ * @param appName optional redacted display name of the app
+ * @param installedVersion optional installed version observed during preview generation
+ * @param candidateVersion optional candidate version being reviewed
+ * @param installedDigest optional installed bundle digest, normalized with {@code sha256:}
+ * @param candidateDigest optional candidate bundle digest, normalized with {@code sha256:}
+ * @param catalogId optional catalog id associated with the candidate
+ * @param catalogSourceId optional path-free source id associated with the candidate
+ * @param riskLevel maximum risk level across all sections
+ * @param requiresApproval whether the snapshot cannot proceed unattended
+ * @param blocksAutoUpdate whether scheduler policy must not stage or apply this candidate
+ * @param blockingReasons unique material or blocking finding codes
+ * @param recommendedAction stable recommendation token for Web Shell and API clients
+ * @param sections immutable ordered finding groups shown to the operator
+ * @param createdAt time when the preview was produced
+ * @see ConsentSnapshotDigest
+ */
+public record ConsentSnapshot(
+    String consentRequestId,
+    ConsentActionType action,
+    String appId,
+    String appName,
+    String installedVersion,
+    String candidateVersion,
+    String installedDigest,
+    String candidateDigest,
+    String catalogId,
+    String catalogSourceId,
+    ConsentRiskLevel riskLevel,
+    boolean requiresApproval,
+    boolean blocksAutoUpdate,
+    List<String> blockingReasons,
+    String recommendedAction,
+    List<ConsentSection> sections,
+    Instant createdAt) {
+  /**
+   * Creates a normalized consent snapshot.
+   *
+   * <p>Required identifiers and recommendation tokens are trimmed and validated. Optional display
+   * strings are either normalized to {@code null} or redacted. Digest values may be supplied with
+   * or without the {@code sha256:} prefix. Section and reason lists are copied so the snapshot
+   * remains stable while cached or audited.
+   *
+   * @throws IllegalArgumentException when a required text field is blank
+   * @throws NullPointerException when required components or lists are null
+   */
+  public ConsentSnapshot {
+    consentRequestId = requireText(consentRequestId, "consentRequestId");
+    Objects.requireNonNull(action, "action");
+    appId = requireText(appId, "appId");
+    appName = nullableTrim(appName);
+    installedVersion = nullableTrim(installedVersion);
+    candidateVersion = nullableTrim(candidateVersion);
+    installedDigest = normalizeDigest(installedDigest);
+    candidateDigest = normalizeDigest(candidateDigest);
+    catalogId = nullableTrim(catalogId);
+    catalogSourceId = nullableTrim(catalogSourceId);
+    Objects.requireNonNull(riskLevel, "riskLevel");
+    blockingReasons = List.copyOf(Objects.requireNonNull(blockingReasons, "blockingReasons"));
+    recommendedAction = requireText(recommendedAction, "recommendedAction");
+    sections = List.copyOf(Objects.requireNonNull(sections, "sections"));
+    Objects.requireNonNull(createdAt, "createdAt");
+  }
+
+  /**
+   * Returns the deterministic fingerprint for this snapshot's material contents.
+   *
+   * <p>The fingerprint is the value an approval must echo before a mutating route consumes it. It
+   * excludes request-only metadata but includes the material fields an operator reviewed.
+   *
+   * @return stable SHA-256 digest token for consent approval matching
+   */
+  public String snapshotDigest() {
+    return ConsentSnapshotDigest.digest(this);
+  }
+
+  /**
+   * Converts this snapshot to the public Platform API JSON shape.
+   *
+   * <p>The response shape includes request metadata, the computed digest, section JSON, reason
+   * codes, and the creation timestamp. It contains redacted summaries only and is safe for local
+   * Web Shell display.
+   *
+   * @return ordered JSON-compatible preview object
+   */
+  public Map<String, Object> toJsonValue() {
+    LinkedHashMap<String, Object> json = baseJson(true);
+    json.put("createdAt", createdAt.toString());
+    return json;
+  }
+
+  Map<String, Object> toDigestJson() {
+    return baseJson(false);
+  }
+
+  private LinkedHashMap<String, Object> baseJson(boolean includeRequestFields) {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(18);
+    if (includeRequestFields) {
+      json.put("consentRequestId", consentRequestId);
+    }
+    json.put("action", action.jsonValue());
+    json.put("appId", appId);
+    json.put("appName", appName);
+    json.put("installedVersion", installedVersion);
+    json.put("candidateVersion", candidateVersion);
+    json.put("installedDigest", installedDigest);
+    json.put("candidateDigest", candidateDigest);
+    json.put("catalogId", catalogId);
+    json.put("catalogSourceId", catalogSourceId);
+    json.put("riskLevel", riskLevel.jsonValue());
+    json.put("requiresApproval", requiresApproval);
+    json.put("blocksAutoUpdate", blocksAutoUpdate);
+    if (includeRequestFields) {
+      json.put("snapshotDigest", snapshotDigest());
+    }
+    json.put("sections", sections.stream().map(ConsentSection::toJsonValue).toList());
+    json.put("blockingReasons", blockingReasons);
+    json.put("recommendedAction", recommendedAction);
+    return json;
+  }
+
+  private static String requireText(String value, String fieldName) {
+    String text = Objects.requireNonNull(value, fieldName).trim();
+    if (text.isEmpty()) {
+      throw new IllegalArgumentException(fieldName + " must not be blank");
+    }
+    return text;
+  }
+
+  private static String nullableTrim(String value) {
+    return value == null || value.isBlank() ? null : ConsentRedactor.redact(value.trim());
+  }
+
+  private static String normalizeDigest(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    String text = value.trim();
+    return text.startsWith("sha256:") ? text : "sha256:" + text;
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentSnapshotDigest.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/ConsentSnapshotDigest.java
@@ -1,0 +1,49 @@
+package network.crypta.platform.api.consent;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import network.crypta.platform.api.json.PlatformApiJsonWriter;
+
+/**
+ * Computes deterministic SHA-256 fingerprints for consent snapshots.
+ *
+ * <p>The digest binds an operator decision to the exact material contents of a consent preview.
+ * Request ids and creation timestamps stay outside the digest, while action, app id, versions,
+ * digests, catalog metadata, risk, findings, and recommended action remain inside it. Mutating
+ * routes compare this value before consuming an approval so a refreshed catalog, changed review
+ * receipt, altered permission set, or different migration plan cannot reuse an old decision.
+ *
+ * <p>Digest input is first canonicalized with {@link ConsentJson#canonicalize(Object)} and then
+ * written through the Platform API JSON writer. The resulting bytes are hashed with SHA-256 and
+ * returned with the {@code sha256:} prefix used by the rest of the app-platform API.
+ */
+public final class ConsentSnapshotDigest {
+  private ConsentSnapshotDigest() {}
+
+  /**
+   * Returns {@code sha256:<hex>} for the canonical digest form of the snapshot.
+   *
+   * <p>The method is deterministic for equal snapshot material even when map insertion order
+   * differs inside sections or findings. It throws an unchecked exception only if the Java runtime
+   * does not provide SHA-256, which would make stale-consent protection unavailable.
+   *
+   * @param snapshot consent snapshot whose digestable contents should be fingerprinted
+   * @return stable SHA-256 digest token for approval matching
+   */
+  public static String digest(ConsentSnapshot snapshot) {
+    String json = PlatformApiJsonWriter.write(ConsentJson.canonicalize(snapshot.toDigestJson()));
+    byte[] digest;
+    try {
+      digest = MessageDigest.getInstance("SHA-256").digest(json.getBytes(StandardCharsets.UTF_8));
+    } catch (NoSuchAlgorithmException exception) {
+      throw new IllegalStateException("SHA-256 is unavailable", exception);
+    }
+    StringBuilder hex = new StringBuilder("sha256:");
+    for (byte value : digest) {
+      hex.append(Character.forDigit((value >>> 4) & 0x0f, 16));
+      hex.append(Character.forDigit(value & 0x0f, 16));
+    }
+    return hex.toString();
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/FileConsentAuditStore.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/FileConsentAuditStore.java
@@ -1,0 +1,85 @@
+package network.crypta.platform.api.consent;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Objects;
+import network.crypta.platform.api.json.PlatformApiJsonWriter;
+
+/**
+ * Append-only JSON-lines consent audit store with an in-memory read index.
+ *
+ * <p>This store writes each normalized {@link ConsentAuditEvent} as one UTF-8 JSON line and mirrors
+ * the retained events in an {@link InMemoryConsentAuditStore} for efficient route reads. It is
+ * intended for local operator evidence and support summaries, not as a durable authorization
+ * source. Consent approval checks use the decision cache in {@link ConsentService}; this class only
+ * records the result.
+ *
+ * <p>Writes create the parent directory on demand and are synchronized so one router instance
+ * preserves append order. Existing file contents are not replayed into the in-memory index at
+ * startup, which keeps the current implementation process-local for reads while still leaving a
+ * best-effort JSON-lines trail on disk.
+ */
+public final class FileConsentAuditStore implements ConsentAuditStore {
+  private final Path auditLog;
+  private final InMemoryConsentAuditStore index = new InMemoryConsentAuditStore();
+
+  /**
+   * Creates a store backed by the supplied JSON-lines path.
+   *
+   * <p>The path may point to a file in a directory that does not yet exist. The first append
+   * creates parent directories when needed.
+   *
+   * @param auditLog destination JSON-lines file for appended consent audit events
+   * @throws NullPointerException when {@code auditLog} is null
+   */
+  public FileConsentAuditStore(Path auditLog) {
+    this.auditLog = Objects.requireNonNull(auditLog, "auditLog");
+  }
+
+  /**
+   * Appends one audit event to the JSON-lines file and read index.
+   *
+   * <p>The event is written before it is added to the in-memory index. If filesystem persistence
+   * fails, the method throws and the read index is not advanced, keeping this instance internally
+   * consistent.
+   *
+   * @param event redacted consent audit event to append
+   * @throws IllegalStateException when the event cannot be written to the audit log
+   */
+  @Override
+  public synchronized void append(ConsentAuditEvent event) {
+    try {
+      Path parent = auditLog.getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
+      Files.writeString(
+          auditLog,
+          PlatformApiJsonWriter.write(event.toJsonValue()) + System.lineSeparator(),
+          StandardCharsets.UTF_8,
+          StandardOpenOption.CREATE,
+          StandardOpenOption.APPEND);
+      index.append(event);
+    } catch (IOException exception) {
+      throw new IllegalStateException("Failed to append consent audit event.", exception);
+    }
+  }
+
+  /**
+   * Lists retained events from the process-local read index.
+   *
+   * <p>The result reflects events appended through this store instance. It does not parse
+   * historical JSON-lines data that may already exist on disk before the instance is created.
+   *
+   * @param appId app id to filter by, or {@code null} for all retained indexed events
+   * @return retained events in append order for this process
+   */
+  @Override
+  public synchronized List<ConsentAuditEvent> list(String appId) {
+    return index.list(appId);
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/InMemoryConsentAuditStore.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/InMemoryConsentAuditStore.java
@@ -1,0 +1,63 @@
+package network.crypta.platform.api.consent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Process-local consent audit store used by tests and embedded routers.
+ *
+ * <p>The store keeps a bounded, append-ordered list of redacted consent audit events. It is
+ * suitable for unit tests, transient embedded routers, and the read index inside {@link
+ * FileConsentAuditStore}. It is not durable and should not be treated as an authorization cache;
+ * approval matching lives in {@link ConsentService}.
+ *
+ * <p>All public operations are synchronized. Retention is global to the store instance, not per app
+ * id, so high decision volume for one app can evict older events for another app. That keeps memory
+ * bounded while preserving simple process-local behavior.
+ */
+public final class InMemoryConsentAuditStore implements ConsentAuditStore {
+  /** Maximum number of recent audit events retained by one store instance. */
+  static final int MAX_EVENTS = 512;
+
+  private final List<ConsentAuditEvent> events = new ArrayList<>();
+
+  /**
+   * Creates an empty process-local audit store.
+   *
+   * <p>The store starts with no retained events and applies its global retention limit as events
+   * are appended. It does not load data from disk or share state with other instances.
+   */
+  public InMemoryConsentAuditStore() {
+    // State is initialized by field declarations; no startup work is required.
+  }
+
+  /**
+   * Appends one audit event and evicts the oldest entries beyond the retention limit.
+   *
+   * <p>The event object is already immutable and redacted, so the store keeps the reference rather
+   * than copying it. Eviction preserves the most recent {@link #MAX_EVENTS} entries.
+   *
+   * @param event redacted event to retain
+   */
+  @Override
+  public synchronized void append(ConsentAuditEvent event) {
+    events.add(event);
+    while (events.size() > MAX_EVENTS) {
+      events.removeFirst();
+    }
+  }
+
+  /**
+   * Lists retained events, optionally filtered by app id.
+   *
+   * <p>A {@code null} filter returns every retained event. A non-null filter returns a new list of
+   * events whose {@link ConsentAuditEvent#appId()} equals the supplied app id.
+   *
+   * @param appId app id to filter by, or {@code null} for all retained events
+   * @return retained events in append order
+   */
+  @Override
+  public synchronized List<ConsentAuditEvent> list(String appId) {
+    return events.stream().filter(event -> appId == null || event.appId().equals(appId)).toList();
+  }
+}

--- a/platform-api/src/main/java/network/crypta/platform/api/consent/package-info.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/consent/package-info.java
@@ -1,0 +1,24 @@
+/**
+ * Operator consent previews, decisions, and audit records for material app-platform mutations.
+ *
+ * <p>The consent package keeps install, update, service-grant, migration, and catalog-risk review
+ * data as path-free JSON-compatible snapshots. Mutation routes approve a specific snapshot digest
+ * instead of accepting open-ended acknowledgement flags, while existing app-platform services keep
+ * ownership of catalog verification, app replacement, app-data migration, and service-grant
+ * persistence.
+ *
+ * <p>The package is deliberately small and policy focused. Snapshot builders normalize catalog,
+ * update, review-receipt, security-advisory, permission-delta, API-stability, service-dependency,
+ * and migration-plan details into redacted {@link
+ * network.crypta.platform.api.consent.ConsentSection} values. {@link
+ * network.crypta.platform.api.consent.ConsentSnapshotDigest} then canonicalizes those sections so
+ * approvals are invalidated by material drift, including changed advisories, review evidence,
+ * bundle fingerprints, grant dependencies, or schema migration details.
+ *
+ * <p>Consent requests and decisions are host-local coordination records, not durable app-platform
+ * authority. They expire quickly, approvals are consumed by the protected mutation path, and
+ * blocking snapshots cannot be approved. The audit store records redacted decisions and expiry
+ * events for operator accountability without exposing raw app data, local filesystem paths, service
+ * secrets, private catalog URIs, or full catalog payloads.
+ */
+package network.crypta.platform.api.consent;

--- a/platform-api/src/test/java/network/crypta/platform/api/PlatformApiAppServicesRouterTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/PlatformApiAppServicesRouterTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Answers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -261,7 +262,41 @@ class PlatformApiAppServicesRouterTest {
                 List.of("app-services", "grant-bundles", bundleId, "approve"),
                 Map.of(),
                 socialInbox));
+    PlatformApiResponse pendingRenew =
+        router.route(
+            request(
+                "POST",
+                List.of("app-services", "grant-bundles", bundleId, "renew"),
+                Map.of(),
+                PlatformApiPrincipal.hostOperator()));
+    PlatformApiResponse preview =
+        router.route(
+            request(
+                "GET",
+                List.of("consent", "service-grant-preview"),
+                Map.of("bundleId", List.of(bundleId)),
+                PlatformApiPrincipal.hostOperator()));
+    Map<String, List<String>> approvalParams =
+        Map.of(
+            "consentRequestId",
+            List.of(jsonString(preview.body(), "consentRequestId")),
+            "snapshotDigest",
+            List.of(jsonString(preview.body(), "snapshotDigest")));
+    PlatformApiResponse consentApprove =
+        router.route(
+            request(
+                "POST",
+                List.of("consent", "approve"),
+                approvalParams,
+                PlatformApiPrincipal.hostOperator()));
     PlatformApiResponse hostApprove =
+        router.route(
+            request(
+                "POST",
+                List.of("app-services", "grant-bundles", bundleId, "approve"),
+                approvalParams,
+                PlatformApiPrincipal.hostOperator()));
+    PlatformApiResponse staleApprove =
         router.route(
             request(
                 "POST",
@@ -278,10 +313,68 @@ class PlatformApiAppServicesRouterTest {
     assertEquals(201, bundle.statusCode());
     assertTrue(bundle.body().contains("\"status\":\"pending\""));
     assertEquals(403, appApprove.statusCode());
+    assertEquals(409, pendingRenew.statusCode());
+    assertEquals("app_service_bundle_not_renewable", errorCode(pendingRenew));
+    assertFalse(pendingRenew.body().contains("consent_required"));
+    assertEquals(200, preview.statusCode());
+    assertEquals(200, consentApprove.statusCode());
     assertEquals(200, hostApprove.statusCode());
     assertTrue(hostApprove.body().contains("\"status\":\"approved\""));
+    assertEquals(409, staleApprove.statusCode());
+    assertEquals("app_service_bundle_not_pending", errorCode(staleApprove));
+    assertFalse(staleApprove.body().contains("consent_required"));
     assertEquals(200, bundles.statusCode());
     assertTrue(bundles.body().contains("\"trust-annotations\""));
+  }
+
+  @Test
+  void route_whenBundleRejectFails_expectConsentRejectionAuditNotRecorded() throws Exception {
+    InMemoryAppServiceGrantStore store = new InMemoryAppServiceGrantStore();
+    PlatformApiRouter router = router(store, installedProvider(), installedConsumer());
+    PlatformApiPrincipal socialInbox =
+        PlatformApiPrincipal.appBrowserSession(
+            "social-inbox", List.of("app.services.read", "app.services.call"));
+    PlatformApiResponse bundle =
+        router.route(
+            request(
+                "POST",
+                List.of("app-services", "grant-bundles"),
+                Map.of("bundleAlias", List.of("trust-annotations")),
+                socialInbox));
+    String bundleId = store.listBundles().getFirst().bundleId();
+
+    PlatformApiResponse appReject =
+        router.route(
+            request(
+                "POST",
+                List.of("app-services", "grant-bundles", bundleId, "reject"),
+                Map.of(),
+                socialInbox));
+    PlatformApiResponse auditAfterFailedReject =
+        router.route(
+            request(
+                "GET", List.of("consent", "audit"), Map.of(), PlatformApiPrincipal.hostOperator()));
+    PlatformApiResponse hostReject =
+        router.route(
+            request(
+                "POST",
+                List.of("app-services", "grant-bundles", bundleId, "reject"),
+                Map.of(),
+                PlatformApiPrincipal.hostOperator()));
+    PlatformApiResponse auditAfterHostReject =
+        router.route(
+            request(
+                "GET", List.of("consent", "audit"), Map.of(), PlatformApiPrincipal.hostOperator()));
+
+    assertEquals(201, bundle.statusCode());
+    assertEquals(403, appReject.statusCode());
+    assertEquals(200, auditAfterFailedReject.statusCode());
+    assertFalse(auditAfterFailedReject.body().contains("\"decision\":\"rejected\""));
+    assertEquals(200, hostReject.statusCode());
+    assertTrue(hostReject.body().contains("\"status\":\"rejected\""));
+    assertEquals(200, auditAfterHostReject.statusCode());
+    assertTrue(auditAfterHostReject.body().contains("\"decision\":\"rejected\""));
+    assertTrue(auditAfterHostReject.body().contains("\"action\":\"app_service_grant\""));
   }
 
   @Test
@@ -492,6 +585,16 @@ class PlatformApiAppServicesRouterTest {
     int start = index + "\"code\":\"".length();
     int end = response.body().indexOf('"', start);
     return response.body().substring(start, end);
+  }
+
+  private static String jsonString(String json, String field) {
+    String marker = "\"" + field + "\":\"";
+    int index = json.indexOf(marker);
+    assertTrue(index >= 0, "missing JSON field " + field + " in " + json);
+    int start = index + marker.length();
+    int end = json.indexOf('"', start);
+    assertTrue(end > start, "unterminated JSON field " + field + " in " + json);
+    return json.substring(start, end);
   }
 
   private static RuntimePorts runtimePorts() {

--- a/platform-api/src/test/java/network/crypta/platform/api/PlatformApiContractTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/PlatformApiContractTest.java
@@ -17,6 +17,49 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("java:S100")
 class PlatformApiContractTest {
+  private static final String CAP_APP_DATA_READ = PlatformApiCapabilities.APP_DATA_READ;
+  private static final String CAP_APP_DATA_WRITE = PlatformApiCapabilities.APP_DATA_WRITE;
+  private static final String CAP_APP_SERVICES_CALL = PlatformApiCapabilities.APP_SERVICES_CALL;
+  private static final String CAP_APP_SERVICES_READ = PlatformApiCapabilities.APP_SERVICES_READ;
+  private static final String CAP_CONTENT_FETCH = PlatformApiCapabilities.CONTENT_FETCH;
+  private static final String CAP_CONTENT_SUBSCRIBE = PlatformApiCapabilities.CONTENT_SUBSCRIBE;
+  private static final String CAP_TRUST_READ = PlatformApiCapabilities.TRUST_READ;
+  private static final String CAP_TRUST_WRITE = PlatformApiCapabilities.TRUST_WRITE;
+  private static final String FIELD_STABLE_BASELINE = "stableBaseline";
+  private static final String ROUTE_FAMILY_CONSENT = "consent";
+  private static final String ROUTE_FAMILY_APP_SERVICES = "app-services";
+  private static final String ROUTE_FAMILY_APP_VAULT = "app-vault";
+  private static final String ROUTE_FAMILY_TRUST_GRAPH = "trust-graph";
+  private static final String ROUTE_PREFIX_CONSENT = "/consent";
+  private static final String ROUTE_POST_APP_SERVICES_GRANT_BUNDLES =
+      "POST /app-services/grant-bundles";
+  private static final String SEGMENT_DEPENDENCIES = "dependencies";
+  private static final String SEGMENT_GRANT_BUNDLES = "grant-bundles";
+  private static final Map<String, Integer> SINCE_VERSION_BY_EXACT_ROUTE =
+      Map.ofEntries(
+          Map.entry("/trust-graph/statements/{fingerprint}", 15),
+          Map.entry("/trust-graph/import-uri", 10),
+          Map.entry("/trust-graph/audit", 10),
+          Map.entry("/app-vault/identities/{identityId}/social-message", 11),
+          Map.entry("/app-vault/identities/{identityId}/trust-statement", 7),
+          Map.entry("/queue/inserts/app-document", 5),
+          Map.entry("/app-vault/identities/{identityId}/profile-document", 5),
+          Map.entry("/content/fetch", 6));
+  private static final List<RouteVersionPrefix> SINCE_VERSION_BY_ROUTE_PREFIX =
+      List.of(
+          new RouteVersionPrefix(ROUTE_PREFIX_CONSENT, 21),
+          new RouteVersionPrefix("/trust-graph/statements/{fingerprint}/", 15),
+          new RouteVersionPrefix("/app-services/dependencies", 16),
+          new RouteVersionPrefix("/app-services/grant-bundles", 16),
+          new RouteVersionPrefix("/app-services", 12),
+          new RouteVersionPrefix("/trust-graph", 7),
+          new RouteVersionPrefix("/content/subscriptions", 8),
+          new RouteVersionPrefix("/app-data", 9),
+          new RouteVersionPrefix("/app-vault", 3),
+          new RouteVersionPrefix("/identity-vault", 3),
+          new RouteVersionPrefix("/app-catalogs/recommended", 4),
+          new RouteVersionPrefix("/apps/{appId}/updates", 2));
+
   @Test
   void writeEnvelope_whenCalledRepeatedly_expectDeterministicContractJson() {
     String first = PlatformApiContractJson.writeEnvelope(PlatformApiContract.current());
@@ -59,7 +102,7 @@ class PlatformApiContractTest {
         assertThrows(
             IllegalArgumentException.class, () -> PlatformApiContractJson.parse(staleJson));
 
-    assertTrue(thrown.getMessage().contains("stableBaseline"), thrown.getMessage());
+    assertTrue(thrown.getMessage().contains(FIELD_STABLE_BASELINE), thrown.getMessage());
   }
 
   @Test
@@ -71,7 +114,7 @@ class PlatformApiContractTest {
     IllegalArgumentException thrown =
         assertThrows(IllegalArgumentException.class, () -> PlatformApiContractJson.parse(json));
 
-    assertTrue(thrown.getMessage().contains("stableBaseline"), thrown.getMessage());
+    assertTrue(thrown.getMessage().contains(FIELD_STABLE_BASELINE), thrown.getMessage());
   }
 
   @Test
@@ -121,23 +164,28 @@ class PlatformApiContractTest {
     assertEquals(baseline.endpoints().size(), baseline.endpointCount());
     assertEquals(
         List.of(
-            "app.data.read",
-            "app.data.write",
-            "content.fetch",
+            CAP_APP_DATA_READ,
+            CAP_APP_DATA_WRITE,
+            CAP_CONTENT_FETCH,
             "content.insert",
             "content.insert.app-document",
-            "content.subscribe",
+            CAP_CONTENT_SUBSCRIBE,
             "platform.contract.read",
             "queue.read",
             "queue.write"),
         baseline.capabilities());
-    assertFalse(baseline.capabilities().contains("trust.read"));
-    assertFalse(baseline.capabilities().contains("app.services.read"));
+    assertFalse(baseline.capabilities().contains(CAP_TRUST_READ));
+    assertFalse(baseline.capabilities().contains(CAP_APP_SERVICES_READ));
     assertTrue(baseline.endpoints().contains("POST /content/fetch"));
     assertTrue(baseline.endpoints().contains("POST /queue/inserts/app-document"));
     assertTrue(baseline.endpoints().contains("GET /platform/contract"));
     assertTrue(baseline.endpoints().contains("POST /queue/inserts/file"));
-    assertFalse(baseline.endpoints().stream().anyMatch(endpoint -> endpoint.contains("app-vault")));
+    assertFalse(
+        baseline.endpoints().stream()
+            .anyMatch(endpoint -> endpoint.contains(ROUTE_FAMILY_APP_VAULT)));
+    assertFalse(
+        baseline.endpoints().stream()
+            .anyMatch(endpoint -> endpoint.contains(ROUTE_FAMILY_CONSENT)));
     assertFalse(baseline.endpoints().stream().anyMatch(endpoint -> endpoint.contains("operator")));
   }
 
@@ -192,49 +240,49 @@ class PlatformApiContractTest {
     assertEquals(5, appDocumentInsertCapability.sinceContractVersion());
     PlatformApiCapabilityDescriptor contentFetchCapability =
         PlatformApiContract.current().capabilities().stream()
-            .filter(capability -> capability.name().equals("content.fetch"))
+            .filter(capability -> capability.name().equals(CAP_CONTENT_FETCH))
             .findFirst()
             .orElseThrow();
     assertEquals(6, contentFetchCapability.sinceContractVersion());
     PlatformApiCapabilityDescriptor contentSubscribeCapability =
         PlatformApiContract.current().capabilities().stream()
-            .filter(capability -> capability.name().equals("content.subscribe"))
+            .filter(capability -> capability.name().equals(CAP_CONTENT_SUBSCRIBE))
             .findFirst()
             .orElseThrow();
     assertEquals(8, contentSubscribeCapability.sinceContractVersion());
     PlatformApiCapabilityDescriptor appDataReadCapability =
         PlatformApiContract.current().capabilities().stream()
-            .filter(capability -> capability.name().equals("app.data.read"))
+            .filter(capability -> capability.name().equals(CAP_APP_DATA_READ))
             .findFirst()
             .orElseThrow();
     assertEquals(9, appDataReadCapability.sinceContractVersion());
     PlatformApiCapabilityDescriptor appDataWriteCapability =
         PlatformApiContract.current().capabilities().stream()
-            .filter(capability -> capability.name().equals("app.data.write"))
+            .filter(capability -> capability.name().equals(CAP_APP_DATA_WRITE))
             .findFirst()
             .orElseThrow();
     assertEquals(9, appDataWriteCapability.sinceContractVersion());
     PlatformApiCapabilityDescriptor appServicesReadCapability =
         PlatformApiContract.current().capabilities().stream()
-            .filter(capability -> capability.name().equals("app.services.read"))
+            .filter(capability -> capability.name().equals(CAP_APP_SERVICES_READ))
             .findFirst()
             .orElseThrow();
     assertEquals(12, appServicesReadCapability.sinceContractVersion());
     PlatformApiCapabilityDescriptor appServicesCallCapability =
         PlatformApiContract.current().capabilities().stream()
-            .filter(capability -> capability.name().equals("app.services.call"))
+            .filter(capability -> capability.name().equals(CAP_APP_SERVICES_CALL))
             .findFirst()
             .orElseThrow();
     assertEquals(12, appServicesCallCapability.sinceContractVersion());
     PlatformApiCapabilityDescriptor trustReadCapability =
         PlatformApiContract.current().capabilities().stream()
-            .filter(capability -> capability.name().equals("trust.read"))
+            .filter(capability -> capability.name().equals(CAP_TRUST_READ))
             .findFirst()
             .orElseThrow();
     assertEquals(7, trustReadCapability.sinceContractVersion());
     PlatformApiCapabilityDescriptor trustWriteCapability =
         PlatformApiContract.current().capabilities().stream()
-            .filter(capability -> capability.name().equals("trust.write"))
+            .filter(capability -> capability.name().equals(CAP_TRUST_WRITE))
             .findFirst()
             .orElseThrow();
     assertEquals(7, trustWriteCapability.sinceContractVersion());
@@ -308,11 +356,11 @@ class PlatformApiContractTest {
 
     assertEquals(6, endpoint.sinceContractVersion());
     assertEquals("content", endpoint.routeFamily());
-    assertEquals("content.fetch", endpoint.actionLabel());
+    assertEquals(CAP_CONTENT_FETCH, endpoint.actionLabel());
     assertTrue(endpoint.hostOperatorBypassAllowed());
     assertTrue(endpoint.appProcessAllowed());
     assertTrue(endpoint.appBrowserAllowed());
-    assertEquals(List.of("content.fetch"), endpoint.requiredCapabilities());
+    assertEquals(List.of(CAP_CONTENT_FETCH), endpoint.requiredCapabilities());
   }
 
   @Test
@@ -320,19 +368,19 @@ class PlatformApiContractTest {
     Map<String, List<String>> expectedCapabilities =
         Map.of(
             "GET /content/subscriptions",
-            List.of("content.subscribe"),
+            List.of(CAP_CONTENT_SUBSCRIBE),
             "POST /content/subscriptions",
-            List.of("content.fetch", "content.subscribe"),
+            List.of(CAP_CONTENT_FETCH, CAP_CONTENT_SUBSCRIBE),
             "GET /content/subscriptions/{subscriptionId}",
-            List.of("content.subscribe"),
+            List.of(CAP_CONTENT_SUBSCRIBE),
             "POST /content/subscriptions/{subscriptionId}/refresh",
-            List.of("content.fetch", "content.subscribe"),
+            List.of(CAP_CONTENT_FETCH, CAP_CONTENT_SUBSCRIBE),
             "POST /content/subscriptions/{subscriptionId}/pause",
-            List.of("content.subscribe"),
+            List.of(CAP_CONTENT_SUBSCRIBE),
             "POST /content/subscriptions/{subscriptionId}/resume",
-            List.of("content.subscribe"),
+            List.of(CAP_CONTENT_SUBSCRIBE),
             "DELETE /content/subscriptions/{subscriptionId}",
-            List.of("content.subscribe"));
+            List.of(CAP_CONTENT_SUBSCRIBE));
     Set<String> seen = new TreeSet<>();
 
     for (PlatformApiEndpointDescriptor endpoint : PlatformApiContract.current().endpoints()) {
@@ -355,17 +403,17 @@ class PlatformApiContractTest {
   void current_whenInspectingAppDataEndpoints_expectContractV9AppScopedCapabilities() {
     Map<String, List<String>> expectedCapabilities =
         Map.ofEntries(
-            Map.entry("GET /app-data/status", List.of("app.data.read")),
-            Map.entry("GET /app-data/namespaces", List.of("app.data.read")),
-            Map.entry("GET /app-data/namespaces/{namespace}", List.of("app.data.read")),
-            Map.entry("POST /app-data/namespaces/{namespace}/schema", List.of("app.data.write")),
-            Map.entry("DELETE /app-data/namespaces/{namespace}", List.of("app.data.write")),
-            Map.entry("GET /app-data/records", List.of("app.data.read")),
-            Map.entry("GET /app-data/records/{namespace}/{key}", List.of("app.data.read")),
-            Map.entry("POST /app-data/records", List.of("app.data.write")),
-            Map.entry("DELETE /app-data/records/{namespace}/{key}", List.of("app.data.write")),
-            Map.entry("GET /app-data/export", List.of("app.data.read")),
-            Map.entry("POST /app-data/import", List.of("app.data.write")));
+            Map.entry("GET /app-data/status", List.of(CAP_APP_DATA_READ)),
+            Map.entry("GET /app-data/namespaces", List.of(CAP_APP_DATA_READ)),
+            Map.entry("GET /app-data/namespaces/{namespace}", List.of(CAP_APP_DATA_READ)),
+            Map.entry("POST /app-data/namespaces/{namespace}/schema", List.of(CAP_APP_DATA_WRITE)),
+            Map.entry("DELETE /app-data/namespaces/{namespace}", List.of(CAP_APP_DATA_WRITE)),
+            Map.entry("GET /app-data/records", List.of(CAP_APP_DATA_READ)),
+            Map.entry("GET /app-data/records/{namespace}/{key}", List.of(CAP_APP_DATA_READ)),
+            Map.entry("POST /app-data/records", List.of(CAP_APP_DATA_WRITE)),
+            Map.entry("DELETE /app-data/records/{namespace}/{key}", List.of(CAP_APP_DATA_WRITE)),
+            Map.entry("GET /app-data/export", List.of(CAP_APP_DATA_READ)),
+            Map.entry("POST /app-data/import", List.of(CAP_APP_DATA_WRITE)));
     Set<String> seen = new TreeSet<>();
 
     for (PlatformApiEndpointDescriptor endpoint : PlatformApiContract.current().endpoints()) {
@@ -389,21 +437,21 @@ class PlatformApiContractTest {
     Map<String, List<String>> expectedCapabilities =
         Map.of(
             "GET /trust-graph/status",
-            List.of("trust.read"),
+            List.of(CAP_TRUST_READ),
             "GET /trust-graph/anchors",
-            List.of("trust.read"),
+            List.of(CAP_TRUST_READ),
             "POST /trust-graph/anchors",
-            List.of("trust.write"),
+            List.of(CAP_TRUST_WRITE),
             "DELETE /trust-graph/anchors/{fingerprint}",
-            List.of("trust.write"),
+            List.of(CAP_TRUST_WRITE),
             "POST /trust-graph/import",
-            List.of("trust.write"),
+            List.of(CAP_TRUST_WRITE),
             "GET /trust-graph/subjects",
-            List.of("trust.read"),
+            List.of(CAP_TRUST_READ),
             "GET /trust-graph/statements",
-            List.of("trust.read"),
+            List.of(CAP_TRUST_READ),
             "GET /trust-graph/score",
-            List.of("trust.read"));
+            List.of(CAP_TRUST_READ));
     Set<String> seen = new TreeSet<>();
 
     for (PlatformApiEndpointDescriptor endpoint : PlatformApiContract.current().endpoints()) {
@@ -413,7 +461,7 @@ class PlatformApiContractTest {
       }
       seen.add(key);
       assertEquals(7, endpoint.sinceContractVersion(), key);
-      assertEquals("trust-graph", endpoint.routeFamily(), key);
+      assertEquals(ROUTE_FAMILY_TRUST_GRAPH, endpoint.routeFamily(), key);
       PlatformApiStabilityLevel expectedStability =
           expectedCapabilities.get(key).isEmpty()
               ? PlatformApiStabilityLevel.OPERATOR_ONLY
@@ -430,28 +478,28 @@ class PlatformApiContractTest {
   void current_whenInspectingAppServiceEndpoints_expectContractV12AndV16Capabilities() {
     Map<String, List<String>> expectedCapabilities =
         Map.ofEntries(
-            Map.entry("GET /app-services", List.of("app.services.read")),
+            Map.entry("GET /app-services", List.of(CAP_APP_SERVICES_READ)),
             Map.entry("GET /app-services/audit", List.of()),
-            Map.entry("GET /app-services/grants", List.of("app.services.read")),
-            Map.entry("GET /app-services/dependencies", List.of("app.services.read")),
+            Map.entry("GET /app-services/grants", List.of(CAP_APP_SERVICES_READ)),
+            Map.entry("GET /app-services/dependencies", List.of(CAP_APP_SERVICES_READ)),
             Map.entry(
                 "GET /app-services/dependencies/consumers/{consumerAppId}",
-                List.of("app.services.read")),
-            Map.entry("GET /app-services/grant-bundles", List.of("app.services.read")),
-            Map.entry("POST /app-services/grant-bundles", List.of("app.services.call")),
+                List.of(CAP_APP_SERVICES_READ)),
+            Map.entry("GET /app-services/grant-bundles", List.of(CAP_APP_SERVICES_READ)),
+            Map.entry(ROUTE_POST_APP_SERVICES_GRANT_BUNDLES, List.of(CAP_APP_SERVICES_CALL)),
             Map.entry("POST /app-services/grant-bundles/{bundleId}/approve", List.of()),
             Map.entry("POST /app-services/grant-bundles/{bundleId}/reject", List.of()),
             Map.entry("POST /app-services/grant-bundles/{bundleId}/renew", List.of()),
-            Map.entry("POST /app-services/grants", List.of("app.services.call")),
+            Map.entry("POST /app-services/grants", List.of(CAP_APP_SERVICES_CALL)),
             Map.entry("POST /app-services/grants/{grantId}/approve", List.of()),
-            Map.entry("POST /app-services/grants/{grantId}/revoke", List.of("app.services.call")),
-            Map.entry("GET /app-services/{providerAppId}/services", List.of("app.services.read")),
+            Map.entry("POST /app-services/grants/{grantId}/revoke", List.of(CAP_APP_SERVICES_CALL)),
+            Map.entry("GET /app-services/{providerAppId}/services", List.of(CAP_APP_SERVICES_READ)),
             Map.entry(
                 "GET /app-services/{providerAppId}/services/{serviceId}",
-                List.of("app.services.read")),
+                List.of(CAP_APP_SERVICES_READ)),
             Map.entry(
                 "POST /app-services/{providerAppId}/services/{serviceId}/invoke",
-                List.of("app.services.call")));
+                List.of(CAP_APP_SERVICES_CALL)));
     Set<String> seen = new TreeSet<>();
 
     for (PlatformApiEndpointDescriptor endpoint : PlatformApiContract.current().endpoints()) {
@@ -461,10 +509,10 @@ class PlatformApiContractTest {
       }
       seen.add(key);
       assertEquals(
-          key.contains("dependencies") || key.contains("grant-bundles") ? 16 : 12,
+          key.contains(SEGMENT_DEPENDENCIES) || key.contains(SEGMENT_GRANT_BUNDLES) ? 16 : 12,
           endpoint.sinceContractVersion(),
           key);
-      assertEquals("app-services", endpoint.routeFamily(), key);
+      assertEquals(ROUTE_FAMILY_APP_SERVICES, endpoint.routeFamily(), key);
       assertEquals(expectedCapabilities.get(key), endpoint.requiredCapabilities(), key);
       if (key.endsWith("/approve")
           || key.endsWith("/reject")
@@ -475,11 +523,11 @@ class PlatformApiContractTest {
         assertFalse(endpoint.appProcessAllowed(), key);
         assertFalse(endpoint.appBrowserAllowed(), key);
       } else if (key.equals("POST /app-services/grants")
-          || key.equals("POST /app-services/grant-bundles")
+          || key.equals(ROUTE_POST_APP_SERVICES_GRANT_BUNDLES)
           || key.equals("POST /app-services/{providerAppId}/services/{serviceId}/invoke")) {
         assertEquals(PlatformApiStabilityLevel.EXPERIMENTAL, endpoint.stability(), key);
         assertEquals(
-            key.equals("POST /app-services/grant-bundles"),
+            key.equals(ROUTE_POST_APP_SERVICES_GRANT_BUNDLES),
             endpoint.hostOperatorBypassAllowed(),
             key);
         assertTrue(endpoint.appProcessAllowed(), key);
@@ -492,18 +540,51 @@ class PlatformApiContractTest {
   }
 
   @Test
+  void current_whenInspectingConsentEndpoints_expectContractV21HostOperatorOnly() {
+    Map<String, String> expectedActions =
+        Map.ofEntries(
+            Map.entry("GET /consent/install-preview", "consent.install-preview"),
+            Map.entry("GET /consent/update-preview", "consent.update-preview.read"),
+            Map.entry("POST /consent/update-preview", "consent.update-preview.refresh"),
+            Map.entry("GET /consent/catalog-update-preview", "consent.catalog-update-preview"),
+            Map.entry("GET /consent/service-grant-preview", "consent.service-grant-preview"),
+            Map.entry("POST /consent/approve", "consent.approve"),
+            Map.entry("POST /consent/reject", "consent.reject"),
+            Map.entry("POST /consent/defer", "consent.defer"),
+            Map.entry("GET /consent/audit", "consent.audit"));
+    Set<String> seen = new TreeSet<>();
+
+    for (PlatformApiEndpointDescriptor endpoint : PlatformApiContract.current().endpoints()) {
+      String key = endpoint.method() + " " + endpoint.routeTemplate();
+      if (!expectedActions.containsKey(key)) {
+        continue;
+      }
+      seen.add(key);
+      assertEquals(21, endpoint.sinceContractVersion(), key);
+      assertEquals(ROUTE_FAMILY_CONSENT, endpoint.routeFamily(), key);
+      assertEquals(expectedActions.get(key), endpoint.actionLabel(), key);
+      assertEquals(List.of(), endpoint.requiredCapabilities(), key);
+      assertEquals(PlatformApiStabilityLevel.OPERATOR_ONLY, endpoint.stability(), key);
+      assertTrue(endpoint.hostOperatorBypassAllowed(), key);
+      assertFalse(endpoint.appProcessAllowed(), key);
+      assertFalse(endpoint.appBrowserAllowed(), key);
+    }
+    assertEquals(expectedActions.keySet(), seen);
+  }
+
+  @Test
   void endpointFor_whenDependencyConsumerIdIsServices_expectDisambiguatedContractRoute() {
     PlatformApiContract contract = PlatformApiContract.current();
 
     PlatformApiEndpointDescriptor dependencyRead =
         contract.endpointFor(
             "GET",
-            List.of("app-services", "dependencies", "consumers", "services"),
+            List.of(ROUTE_FAMILY_APP_SERVICES, SEGMENT_DEPENDENCIES, "consumers", "services"),
             PlatformApiPrincipalType.APP_BROWSER);
     PlatformApiEndpointDescriptor providerList =
         contract.endpointFor(
             "GET",
-            List.of("app-services", "dependencies", "services"),
+            List.of(ROUTE_FAMILY_APP_SERVICES, SEGMENT_DEPENDENCIES, "services"),
             PlatformApiPrincipalType.APP_BROWSER);
 
     assertNotNull(dependencyRead);
@@ -511,10 +592,10 @@ class PlatformApiContractTest {
     assertEquals(
         "/app-services/dependencies/consumers/{consumerAppId}", dependencyRead.routeTemplate());
     assertEquals("app-services.dependencies.read", dependencyRead.actionLabel());
-    assertEquals(List.of("app.services.read"), dependencyRead.requiredCapabilities());
+    assertEquals(List.of(CAP_APP_SERVICES_READ), dependencyRead.requiredCapabilities());
     assertEquals("/app-services/{providerAppId}/services", providerList.routeTemplate());
     assertEquals("app-services.provider.list", providerList.actionLabel());
-    assertEquals(List.of("app.services.read"), providerList.requiredCapabilities());
+    assertEquals(List.of(CAP_APP_SERVICES_READ), providerList.requiredCapabilities());
   }
 
   @Test
@@ -522,9 +603,9 @@ class PlatformApiContractTest {
     Map<String, List<String>> expectedCapabilities =
         Map.of(
             "POST /trust-graph/import-uri",
-            List.of("content.fetch", "trust.write"),
+            List.of(CAP_CONTENT_FETCH, CAP_TRUST_WRITE),
             "GET /trust-graph/audit",
-            List.of("trust.read"));
+            List.of(CAP_TRUST_READ));
     Set<String> seen = new TreeSet<>();
 
     for (PlatformApiEndpointDescriptor endpoint : PlatformApiContract.current().endpoints()) {
@@ -534,7 +615,7 @@ class PlatformApiContractTest {
       }
       seen.add(key);
       assertEquals(10, endpoint.sinceContractVersion(), key);
-      assertEquals("trust-graph", endpoint.routeFamily(), key);
+      assertEquals(ROUTE_FAMILY_TRUST_GRAPH, endpoint.routeFamily(), key);
       assertEquals(PlatformApiStabilityLevel.EXPERIMENTAL, endpoint.stability(), key);
       assertTrue(endpoint.appProcessAllowed(), key);
       assertTrue(endpoint.appBrowserAllowed(), key);
@@ -548,13 +629,13 @@ class PlatformApiContractTest {
     Map<String, List<String>> expectedCapabilities =
         Map.of(
             "GET /trust-graph/statements/{fingerprint}",
-            List.of("trust.read"),
+            List.of(CAP_TRUST_READ),
             "POST /trust-graph/statements/{fingerprint}/deprecate",
-            List.of("trust.write"),
+            List.of(CAP_TRUST_WRITE),
             "POST /trust-graph/statements/{fingerprint}/revoke",
-            List.of("trust.write"),
+            List.of(CAP_TRUST_WRITE),
             "POST /trust-graph/statements/{fingerprint}/reactivate",
-            List.of("trust.write"));
+            List.of(CAP_TRUST_WRITE));
     Set<String> seen = new TreeSet<>();
 
     for (PlatformApiEndpointDescriptor endpoint : PlatformApiContract.current().endpoints()) {
@@ -564,7 +645,7 @@ class PlatformApiContractTest {
       }
       seen.add(key);
       assertEquals(15, endpoint.sinceContractVersion(), key);
-      assertEquals("trust-graph", endpoint.routeFamily(), key);
+      assertEquals(ROUTE_FAMILY_TRUST_GRAPH, endpoint.routeFamily(), key);
       assertEquals(PlatformApiStabilityLevel.EXPERIMENTAL, endpoint.stability(), key);
       assertTrue(endpoint.appProcessAllowed(), key);
       assertTrue(endpoint.appBrowserAllowed(), key);
@@ -587,12 +668,12 @@ class PlatformApiContractTest {
             .orElseThrow();
 
     assertEquals(7, endpoint.sinceContractVersion());
-    assertEquals("app-vault", endpoint.routeFamily());
+    assertEquals(ROUTE_FAMILY_APP_VAULT, endpoint.routeFamily());
     assertEquals("app-vault.identities.trust-statement", endpoint.actionLabel());
     assertTrue(endpoint.appProcessAllowed());
     assertTrue(endpoint.appBrowserAllowed());
     assertEquals(
-        List.of("trust.write", "vault.identities.read", "vault.identities.use"),
+        List.of(CAP_TRUST_WRITE, "vault.identities.read", "vault.identities.use"),
         endpoint.requiredCapabilities());
   }
 
@@ -610,7 +691,7 @@ class PlatformApiContractTest {
             .orElseThrow();
 
     assertEquals(11, endpoint.sinceContractVersion());
-    assertEquals("app-vault", endpoint.routeFamily());
+    assertEquals(ROUTE_FAMILY_APP_VAULT, endpoint.routeFamily());
     assertEquals("app-vault.identities.social-message", endpoint.actionLabel());
     assertTrue(endpoint.appProcessAllowed());
     assertTrue(endpoint.appBrowserAllowed());
@@ -632,49 +713,17 @@ class PlatformApiContractTest {
   }
 
   private static int expectedSinceContractVersion(PlatformApiEndpointDescriptor endpoint) {
-    if (endpoint.routeTemplate().equals("/trust-graph/statements/{fingerprint}")
-        || endpoint.routeTemplate().startsWith("/trust-graph/statements/{fingerprint}/")) {
-      return 15;
+    String routeTemplate = endpoint.routeTemplate();
+    Integer exactVersion = SINCE_VERSION_BY_EXACT_ROUTE.get(routeTemplate);
+    if (exactVersion != null) {
+      return exactVersion;
     }
-    if (endpoint.routeTemplate().equals("/trust-graph/import-uri")
-        || endpoint.routeTemplate().equals("/trust-graph/audit")) {
-      return 10;
+    for (RouteVersionPrefix prefix : SINCE_VERSION_BY_ROUTE_PREFIX) {
+      if (routeTemplate.startsWith(prefix.routePrefix())) {
+        return prefix.contractVersion();
+      }
     }
-    if (endpoint.routeTemplate().equals("/app-vault/identities/{identityId}/social-message")) {
-      return 11;
-    }
-    if (endpoint.routeTemplate().startsWith("/app-services/dependencies")
-        || endpoint.routeTemplate().startsWith("/app-services/grant-bundles")) {
-      return 16;
-    }
-    if (endpoint.routeTemplate().startsWith("/app-services")) {
-      return 12;
-    }
-    if (endpoint.routeTemplate().startsWith("/trust-graph")
-        || endpoint.routeTemplate().equals("/app-vault/identities/{identityId}/trust-statement")) {
-      return 7;
-    }
-    if (endpoint.routeTemplate().startsWith("/content/subscriptions")) {
-      return 8;
-    }
-    if (endpoint.routeTemplate().startsWith("/app-data")) {
-      return 9;
-    }
-    if (endpoint.routeTemplate().equals("/queue/inserts/app-document")
-        || endpoint.routeTemplate().equals("/app-vault/identities/{identityId}/profile-document")) {
-      return 5;
-    }
-    if (endpoint.routeTemplate().equals("/content/fetch")) {
-      return 6;
-    }
-    if (endpoint.routeTemplate().startsWith("/app-vault")
-        || endpoint.routeTemplate().startsWith("/identity-vault")) {
-      return 3;
-    }
-    if (endpoint.routeTemplate().startsWith("/app-catalogs/recommended")) {
-      return 4;
-    }
-    return endpoint.routeTemplate().startsWith("/apps/{appId}/updates") ? 2 : 1;
+    return 1;
   }
 
   private static PlatformApiStabilityLevel expectedStability(
@@ -688,6 +737,9 @@ class PlatformApiContractTest {
       return PlatformApiStabilityLevel.EXPERIMENTAL;
     }
     if (endpoint.routeTemplate().startsWith("/identity-vault")) {
+      return PlatformApiStabilityLevel.OPERATOR_ONLY;
+    }
+    if (endpoint.routeTemplate().startsWith(ROUTE_PREFIX_CONSENT)) {
       return PlatformApiStabilityLevel.OPERATOR_ONLY;
     }
     return PlatformApiStabilityLevel.STABLE;
@@ -742,9 +794,11 @@ class PlatformApiContractTest {
     LinkedHashMap<String, Object> contract =
         new LinkedHashMap<>(PlatformApiContractJson.toJsonValue(PlatformApiContract.current()));
     contract.put("contractVersion", contractVersion);
-    contract.remove("stableBaseline");
+    contract.remove(FIELD_STABLE_BASELINE);
     LinkedHashMap<String, Object> envelope = LinkedHashMap.newLinkedHashMap(1);
     envelope.put("contract", contract);
     return PlatformApiJsonWriter.write(envelope);
   }
+
+  private record RouteVersionPrefix(String routePrefix, int contractVersion) {}
 }

--- a/platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateCandidateTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateCandidateTest.java
@@ -1,0 +1,391 @@
+package network.crypta.platform.api.appupdates;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings({"java:S100"})
+class AppUpdateCandidateTest {
+  @Test
+  void toJsonValue_whenPermissionIsAdded_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate =
+        candidate(Map.of("added", List.of("content.fetch"), "removed", List.of()));
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(false, json.get("autoApplyAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(List.of("new_permission"), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenStableNoPermissionDelta_expectAutomaticUpdateAllowed() {
+    AppUpdateCandidate candidate =
+        candidate(Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()));
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(true, json.get("autoStageAllowed"));
+    assertEquals(true, json.get("autoApplyAllowed"));
+    assertEquals(false, json.get("blocksAutoUpdate"));
+    assertEquals(List.of(), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenBetaChannelPolicyAllowed_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate = candidateWithCatalogMetadata("beta", "supported");
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(false, json.get("autoApplyAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(
+        List.of("catalog_support_or_deprecation_change"), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenMaintenanceSupportStatus_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate = candidateWithCatalogMetadata("stable", "maintenance");
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(false, json.get("autoApplyAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(
+        List.of("catalog_support_or_deprecation_change"), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenReviewTrustIsNotPositive_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate =
+        candidate(
+            Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()),
+            "compatible",
+            List.of(),
+            Map.of("required", false),
+            Map.of(
+                "status",
+                "trusted_caution",
+                "positive",
+                false,
+                "requiresAcknowledgement",
+                false,
+                "blocksUpdate",
+                false,
+                "blocksPolicyApply",
+                false));
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(false, json.get("autoApplyAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(List.of("review_trust_delta"), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenReviewTrustRequiresAcknowledgement_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate =
+        candidate(
+            Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()),
+            "compatible",
+            List.of(),
+            Map.of("required", false),
+            Map.of(
+                "status",
+                "trusted_caution",
+                "positive",
+                true,
+                "requiresAcknowledgement",
+                true,
+                "blocksUpdate",
+                false,
+                "blocksPolicyApply",
+                false));
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(false, json.get("autoApplyAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(List.of("review_trust_delta"), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenReviewTrustBlocksUpdate_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate =
+        candidate(
+            Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()),
+            "compatible",
+            List.of(),
+            Map.of("required", false),
+            Map.of(
+                "status",
+                "revoked",
+                "positive",
+                true,
+                "requiresAcknowledgement",
+                false,
+                "blocksUpdate",
+                true,
+                "blocksPolicyApply",
+                false));
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(false, json.get("autoApplyAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(List.of("review_trust_delta"), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenReviewTrustBlocksPolicyApply_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate =
+        candidate(
+            Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()),
+            "compatible",
+            List.of(),
+            Map.of("required", false),
+            Map.of(
+                "status",
+                "trusted",
+                "positive",
+                true,
+                "requiresAcknowledgement",
+                false,
+                "blocksUpdate",
+                false,
+                "blocksPolicyApply",
+                true));
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(false, json.get("autoApplyAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(List.of("review_trust_delta"), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenApiCompatibilityStatusUnknown_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate =
+        candidate(
+            Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()), "unknown");
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(List.of("platform_api_stability_change"), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenApiTargetStabilityMissing_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate =
+        candidateWithApiCompatibility(
+            Map.of(
+                "status",
+                "compatible",
+                "targetStability",
+                "experimental",
+                "targetStabilityDeclared",
+                false,
+                "declared",
+                true,
+                "experimentalCapabilitiesAccepted",
+                false));
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(false, json.get("autoApplyAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(List.of("platform_api_stability_change"), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenSecurityAdvisoryPresent_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate =
+        candidate(
+            Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()),
+            "compatible",
+            List.of(Map.of("id", "ADV-1", "uri", "crypta:CHK@example/advisory")));
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(List.of("security_advisory"), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenMigrationRequiresOperatorReview_expectAutomaticUpdateBlockedByConsent() {
+    AppUpdateCandidate candidate =
+        candidate(
+            Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()),
+            "compatible",
+            List.of(),
+            Map.of("required", true, "operatorReviewRequired", true));
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(true, json.get("blocksAutoUpdate"));
+    assertEquals(true, json.get("operatorActionRequired"));
+    assertEquals(List.of("app_data_migration"), json.get("materialConsentReasons"));
+  }
+
+  private static AppUpdateCandidate candidate(Map<String, Object> permissionDelta) {
+    return candidate(permissionDelta, "compatible");
+  }
+
+  private static AppUpdateCandidate candidate(
+      Map<String, Object> permissionDelta, String apiCompatibilityStatus) {
+    return candidate(permissionDelta, apiCompatibilityStatus, List.of());
+  }
+
+  private static AppUpdateCandidate candidate(
+      Map<String, Object> permissionDelta,
+      String apiCompatibilityStatus,
+      List<Map<String, Object>> securityAdvisories) {
+    return candidate(
+        permissionDelta, apiCompatibilityStatus, securityAdvisories, Map.of("required", false));
+  }
+
+  private static AppUpdateCandidate candidate(
+      Map<String, Object> permissionDelta,
+      String apiCompatibilityStatus,
+      List<Map<String, Object>> securityAdvisories,
+      Map<String, Object> dataMigration) {
+    return candidate(
+        permissionDelta,
+        apiCompatibilityStatus,
+        securityAdvisories,
+        dataMigration,
+        Map.of("status", "trusted", "positive", true));
+  }
+
+  private static AppUpdateCandidate candidate(
+      Map<String, Object> permissionDelta,
+      String apiCompatibilityStatus,
+      List<Map<String, Object>> securityAdvisories,
+      Map<String, Object> dataMigration,
+      Map<String, Object> reviewTrust) {
+    return candidate(
+        permissionDelta,
+        apiCompatibilityStatus,
+        securityAdvisories,
+        dataMigration,
+        reviewTrust,
+        "stable",
+        "supported");
+  }
+
+  private static AppUpdateCandidate candidateWithCatalogMetadata(
+      String channel, String supportStatus) {
+    return candidate(
+        Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()),
+        "compatible",
+        List.of(),
+        Map.of("required", false),
+        Map.of("status", "trusted", "positive", true),
+        channel,
+        supportStatus);
+  }
+
+  private static AppUpdateCandidate candidateWithApiCompatibility(
+      Map<String, Object> apiCompatibility) {
+    return candidate(
+        Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()),
+        List.of(),
+        Map.of("required", false),
+        Map.of("status", "trusted", "positive", true),
+        "stable",
+        "supported",
+        apiCompatibility);
+  }
+
+  private static AppUpdateCandidate candidate(
+      Map<String, Object> permissionDelta,
+      String apiCompatibilityStatus,
+      List<Map<String, Object>> securityAdvisories,
+      Map<String, Object> dataMigration,
+      Map<String, Object> reviewTrust,
+      String channel,
+      String supportStatus) {
+    return candidate(
+        permissionDelta,
+        securityAdvisories,
+        dataMigration,
+        reviewTrust,
+        channel,
+        supportStatus,
+        apiCompatibility(apiCompatibilityStatus));
+  }
+
+  private static AppUpdateCandidate candidate(
+      Map<String, Object> permissionDelta,
+      List<Map<String, Object>> securityAdvisories,
+      Map<String, Object> dataMigration,
+      Map<String, Object> reviewTrust,
+      String channel,
+      String supportStatus,
+      Map<String, Object> apiCompatibility) {
+    return new AppUpdateCandidate(
+        "example.app",
+        "first-party",
+        "first-party",
+        "1.0.0",
+        "1.1.0",
+        AppUpdateCandidateStatus.AVAILABLE,
+        "newer",
+        channel,
+        supportStatus,
+        Map.of("status", "none"),
+        securityAdvisories,
+        Map.of("status", "ok", "requiresAcknowledgement", false, "blocksUpdate", false),
+        true,
+        null,
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        1024,
+        "zip",
+        Map.of("status", "reviewed"),
+        reviewTrust,
+        apiCompatibility,
+        permissionDelta,
+        dataMigration,
+        false,
+        Instant.parse("2026-05-01T00:00:00Z"));
+  }
+
+  private static Map<String, Object> apiCompatibility(String status) {
+    return Map.of(
+        "status",
+        status,
+        "targetStability",
+        "stable",
+        "targetStabilityDeclared",
+        true,
+        "declared",
+        true,
+        "experimentalCapabilitiesAccepted",
+        false);
+  }
+}

--- a/platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateCandidateTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateCandidateTest.java
@@ -37,6 +37,32 @@ class AppUpdateCandidateTest {
   }
 
   @Test
+  void toJsonValue_whenNoUpdateCandidate_expectNoAutoUpdateBlock() {
+    AppUpdateCandidate candidate = candidateWithStatus(AppUpdateCandidateStatus.NONE);
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(false, json.get("autoApplyAllowed"));
+    assertEquals(false, json.get("blocksAutoUpdate"));
+    assertEquals(false, json.get("operatorActionRequired"));
+    assertEquals(List.of(), json.get("materialConsentReasons"));
+  }
+
+  @Test
+  void toJsonValue_whenNotNewerCandidate_expectNoAutoUpdateBlock() {
+    AppUpdateCandidate candidate = candidateWithStatus(AppUpdateCandidateStatus.NOT_NEWER);
+
+    Map<String, Object> json = candidate.toJsonValue();
+
+    assertEquals(false, json.get("autoStageAllowed"));
+    assertEquals(false, json.get("autoApplyAllowed"));
+    assertEquals(false, json.get("blocksAutoUpdate"));
+    assertEquals(false, json.get("operatorActionRequired"));
+    assertEquals(List.of(), json.get("materialConsentReasons"));
+  }
+
+  @Test
   void toJsonValue_whenBetaChannelPolicyAllowed_expectAutomaticUpdateBlockedByConsent() {
     AppUpdateCandidate candidate = candidateWithCatalogMetadata("beta", "supported");
 
@@ -322,6 +348,25 @@ class AppUpdateCandidateTest {
         apiCompatibility);
   }
 
+  private static AppUpdateCandidate candidateWithStatus(AppUpdateCandidateStatus status) {
+    String versionComparison =
+        switch (status) {
+          case NOT_NEWER -> "lower";
+          case NONE -> "equal";
+          default -> "newer";
+        };
+    return candidate(
+        Map.of("added", List.of(), "removed", List.of(), "unchanged", List.of()),
+        List.of(),
+        Map.of("required", false),
+        Map.of("status", "trusted", "positive", true),
+        "stable",
+        "supported",
+        apiCompatibility("compatible"),
+        status,
+        versionComparison);
+  }
+
   private static AppUpdateCandidate candidate(
       Map<String, Object> permissionDelta,
       String apiCompatibilityStatus,
@@ -348,14 +393,36 @@ class AppUpdateCandidateTest {
       String channel,
       String supportStatus,
       Map<String, Object> apiCompatibility) {
+    return candidate(
+        permissionDelta,
+        securityAdvisories,
+        dataMigration,
+        reviewTrust,
+        channel,
+        supportStatus,
+        apiCompatibility,
+        AppUpdateCandidateStatus.AVAILABLE,
+        "newer");
+  }
+
+  private static AppUpdateCandidate candidate(
+      Map<String, Object> permissionDelta,
+      List<Map<String, Object>> securityAdvisories,
+      Map<String, Object> dataMigration,
+      Map<String, Object> reviewTrust,
+      String channel,
+      String supportStatus,
+      Map<String, Object> apiCompatibility,
+      AppUpdateCandidateStatus status,
+      String versionComparison) {
     return new AppUpdateCandidate(
         "example.app",
         "first-party",
         "first-party",
         "1.0.0",
         "1.1.0",
-        AppUpdateCandidateStatus.AVAILABLE,
-        "newer",
+        status,
+        versionComparison,
         channel,
         supportStatus,
         Map.of("status", "none"),

--- a/platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateSchedulerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateSchedulerTest.java
@@ -302,9 +302,11 @@ class AppUpdateSchedulerTest {
 
   @Test
   void tick_whenStagePolicy_expectVerifiedCandidateStagedByServicePolicy() throws Exception {
-    AppUpdateService service = realServiceWithInstalled(List.of(QUEUE_READ_PERMISSION));
+    KeyPair reviewerKeyPair = reviewerKeyPair();
+    AppUpdateService service =
+        realServiceWithInstalled(List.of(QUEUE_READ_PERMISSION), reviewerKeyPair);
     service.setPolicy(APP_ID, AppUpdatePolicyMode.STAGE);
-    AppCatalogEntry updateEntry = updateEntry();
+    AppCatalogEntry updateEntry = reviewedEntryWithTrustedReceipt(reviewerKeyPair);
     AppCatalogInstallPlan plan = plan(updateEntry);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()), List.of(catalog()));
     when(catalogManager.refresh(CATALOG_ID)).thenReturn(catalog());
@@ -373,13 +375,18 @@ class AppUpdateSchedulerTest {
     InstalledAppSnapshot installed = installed(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
     when(appHost.status(APP_ID)).thenReturn(Optional.of(running(installed)));
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
         new AppUpdateService(
-            appHost, catalogManager, AppReviewPolicy.DEFAULT, TrustedReviewerKeys::empty);
+            appHost,
+            catalogManager,
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
     service.setPolicy(APP_ID, AppUpdatePolicyMode.APPLY_WHEN_STOPPED);
+    AppCatalogEntry updateEntry = reviewedEntryWithTrustedReceipt(reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()), List.of(catalog()));
     when(catalogManager.refresh(CATALOG_ID)).thenReturn(catalog());
-    when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(updateEntry()));
+    when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(updateEntry));
     when(appHost.listInstalled()).thenReturn(List.of(installed));
 
     scheduler(enabledConfig(), new InMemoryAppUpdateSchedulerStore(), service).tick(DUE_AT);
@@ -516,11 +523,20 @@ class AppUpdateSchedulerTest {
   }
 
   private AppUpdateService realServiceWithInstalled(List<String> permissions) throws IOException {
+    return realServiceWithInstalled(permissions, null);
+  }
+
+  private AppUpdateService realServiceWithInstalled(
+      List<String> permissions, KeyPair reviewerKeyPair) throws IOException {
     InstalledAppSnapshot installed = installed(INSTALLED_VERSION, permissions);
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    AppUpdateService.ReviewerKeysProvider reviewerKeysProvider =
+        reviewerKeyPair == null
+            ? TrustedReviewerKeys::empty
+            : () -> trustedReviewerKeys(reviewerKeyPair);
     return new AppUpdateService(
-        appHost, catalogManager, AppReviewPolicy.DEFAULT, TrustedReviewerKeys::empty);
+        appHost, catalogManager, AppReviewPolicy.DEFAULT, reviewerKeysProvider);
   }
 
   private InstalledAppSnapshot installed(String version, List<String> permissions) {
@@ -587,8 +603,8 @@ class AppUpdateSchedulerTest {
         DIGEST,
         1234L,
         AppCatalogEntry.ZIP_BUNDLE_TYPE,
-        List.of(QUEUE_READ_PERMISSION, "queue.write"),
-        Map.of("queue.write", "Lets the app manage queue entries."));
+        List.of(QUEUE_READ_PERMISSION),
+        Map.of());
   }
 
   private static AppCatalogEntry reviewedEntryWithTrustedReceipt(KeyPair reviewerKeyPair) {

--- a/platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateServiceTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateServiceTest.java
@@ -34,6 +34,7 @@ import network.crypta.platform.appcatalog.AppCatalogProductionMetadata;
 import network.crypta.platform.appcatalog.AppCatalogReviewMetadata;
 import network.crypta.platform.appcatalog.AppCatalogReviewStatus;
 import network.crypta.platform.appcatalog.AppCatalogSecurityAction;
+import network.crypta.platform.appcatalog.AppCatalogSecurityAdvisory;
 import network.crypta.platform.appcatalog.AppCatalogSecurityDecision;
 import network.crypta.platform.appcatalog.AppCatalogSecurityDecisionStatus;
 import network.crypta.platform.appcatalog.AppCatalogSecuritySeverity;
@@ -614,10 +615,17 @@ class AppUpdateServiceTest {
 
   @Test
   void check_whenPolicyStageFails_expectLastCheckFailureRecorded() throws Exception {
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
-        serviceWithInstalled(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
+        serviceWithInstalled(
+            INSTALLED_VERSION,
+            List.of(QUEUE_READ_PERMISSION),
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
     AppCatalogEntry entry =
-        entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
+        withTrustedReceipt(
+            entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata()),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
     when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID))
@@ -701,11 +709,43 @@ class AppUpdateServiceTest {
   }
 
   @Test
-  void check_whenPolicyIsStage_expectVerifiedCandidateStagedWithoutApply() throws Exception {
+  void previewReadOnly_whenDetectedCandidateDiffersFromStaged_expectStagedUpdateRetained()
+      throws Exception {
     AppUpdateService service =
         serviceWithInstalled(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
-    AppCatalogEntry entry =
+    AppCatalogEntry stagedEntry =
         entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
+    AppCatalogEntry newerEntry =
+        entry(EXTERNAL_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
+    when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
+    when(catalogManager.listApps(CATALOG_ID))
+        .thenReturn(List.of(stagedEntry))
+        .thenReturn(List.of(newerEntry));
+    when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID)).thenReturn(plan(stagedEntry));
+    service.stage(APP_ID);
+
+    Map<String, Object> summary = service.previewReadOnly(APP_ID);
+
+    Map<String, Object> candidate = (Map<String, Object>) summary.get(CANDIDATE);
+    Map<String, Object> staged = (Map<String, Object>) summary.get(STAGED);
+    assertEquals(EXTERNAL_VERSION, candidate.get(TARGET_VERSION));
+    assertEquals(true, staged.get(AVAILABLE));
+    assertEquals(UPDATE_VERSION, staged.get(TARGET_VERSION));
+  }
+
+  @Test
+  void check_whenPolicyIsStage_expectVerifiedCandidateStagedWithoutApply() throws Exception {
+    KeyPair reviewerKeyPair = reviewerKeyPair();
+    AppUpdateService service =
+        serviceWithInstalled(
+            INSTALLED_VERSION,
+            List.of(QUEUE_READ_PERMISSION),
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
+    AppCatalogEntry entry =
+        withTrustedReceipt(
+            entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata()),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
     when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID)).thenReturn(plan(entry));
@@ -727,12 +767,16 @@ class AppUpdateServiceTest {
     InstalledAppSnapshot installed = installed(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
         serviceWithAppData(
             appDataServiceWithFeedRecord(),
-            (_, _, _, _) -> AppDataMigrationRunner.MigrationExecutionResult.passed());
+            (_, _, _, _) -> AppDataMigrationRunner.MigrationExecutionResult.passed(),
+            reviewerKeyPair);
     AppCatalogEntry entry =
-        entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
+        withTrustedReceipt(
+            entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata()),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
     when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID))
@@ -749,13 +793,21 @@ class AppUpdateServiceTest {
     assertEquals("rollback_incompatible", migration.get(STATUS));
     assertEquals("app_data_migration_review_required", migration.get("blockReason"));
     assertEquals(true, migration.get("operatorReviewRequired"));
+    assertEquals(List.of("app_data_migration"), candidate.get("materialConsentReasons"));
     assertEquals(false, ((Map<?, ?>) summary.get(STAGED)).get(AVAILABLE));
     assertEquals("success", ((Map<?, ?>) summary.get("lastCheck")).get(STATUS));
+    Map<String, Object> historyEntry =
+        ((List<Map<String, Object>>) summary.get("history"))
+            .stream()
+                .filter(entryJson -> "stage".equals(entryJson.get("action")))
+                .findFirst()
+                .orElseThrow();
+    assertEquals("consent_required", historyEntry.get(ERROR_CODE));
     verify(appHost, never()).updateFromDirectory(any(), any());
   }
 
   @Test
-  void check_whenStagePolicyMigrationPathMissing_expectCandidateSummaryWithoutCheckFailure()
+  void previewForConsent_whenMigrationRollbackIncompatible_expectCandidateRequiresOperatorReview()
       throws Exception {
     InstalledAppSnapshot installed = installed(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
@@ -770,6 +822,70 @@ class AppUpdateServiceTest {
             });
     AppCatalogEntry entry =
         entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
+    when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
+    when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
+    when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID))
+        .thenReturn(planWithAppDataMigration(entry, false, true));
+
+    Map<String, Object> summary = service.previewForConsent(APP_ID, false);
+
+    Map<String, Object> candidate = (Map<String, Object>) summary.get(CANDIDATE);
+    Map<String, Object> migration = (Map<String, Object>) candidate.get("dataMigration");
+    assertFalse(runnerCalled.get());
+    assertEquals(AVAILABLE, candidate.get(STATUS));
+    assertEquals(false, candidate.get("autoStageAllowed"));
+    assertEquals(true, candidate.get(OPERATOR_ACTION_REQUIRED));
+    assertEquals("ready", migration.get(STATUS));
+    assertEquals(true, migration.get("required"));
+    assertEquals(true, migration.get("operatorReviewRequired"));
+    assertNull(migration.get("blockReason"));
+    assertNull(migration.get("dryRunStatus"));
+    verify(appHost, never()).updateFromDirectory(any(), any());
+  }
+
+  @Test
+  void previewForConsent_whenSecurityDecisionBlocksUpdate_expectDoesNotPrepareInstallPlan()
+      throws Exception {
+    AppUpdateService service =
+        serviceWithInstalled(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
+    when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
+    when(catalogManager.listApps(CATALOG_ID))
+        .thenReturn(List.of(entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED)));
+    when(catalogManager.securityDecision(CATALOG_ID, APP_ID))
+        .thenReturn(blockUpdateAndWarningSecurityDecision());
+
+    Map<String, Object> summary = service.previewForConsent(APP_ID, false);
+
+    Map<String, Object> candidate = (Map<String, Object>) summary.get(CANDIDATE);
+    Map<String, Object> securityDecision = (Map<String, Object>) candidate.get("securityDecision");
+    Map<String, Object> migration = (Map<String, Object>) candidate.get("dataMigration");
+    assertEquals(AVAILABLE, candidate.get(STATUS));
+    assertEquals("blocked", securityDecision.get(STATUS));
+    assertEquals(true, securityDecision.get("blocksUpdate"));
+    assertEquals("not_checked", migration.get(STATUS));
+    verifyNoInstallPlanPreparation();
+  }
+
+  @Test
+  void check_whenStagePolicyMigrationPathMissing_expectCandidateSummaryWithoutCheckFailure()
+      throws Exception {
+    InstalledAppSnapshot installed = installed(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    AtomicBoolean runnerCalled = new AtomicBoolean(false);
+    KeyPair reviewerKeyPair = reviewerKeyPair();
+    AppUpdateService service =
+        serviceWithAppData(
+            appDataServiceWithFeedRecord(),
+            (_, _, _, _) -> {
+              runnerCalled.set(true);
+              return AppDataMigrationRunner.MigrationExecutionResult.passed();
+            },
+            reviewerKeyPair);
+    AppCatalogEntry entry =
+        withTrustedReceipt(
+            entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata()),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
     when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID))
@@ -798,15 +914,19 @@ class AppUpdateServiceTest {
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
     AtomicBoolean runnerCalled = new AtomicBoolean(false);
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
         serviceWithAppData(
             appDataServiceWithFeedRecord(),
             (_, _, _, _) -> {
               runnerCalled.set(true);
               return AppDataMigrationRunner.MigrationExecutionResult.failed(2);
-            });
+            },
+            reviewerKeyPair);
     AppCatalogEntry entry =
-        entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
+        withTrustedReceipt(
+            entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata()),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
     when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID))
@@ -836,15 +956,19 @@ class AppUpdateServiceTest {
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
     AtomicBoolean runnerCalled = new AtomicBoolean(false);
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
         serviceWithAppData(
             appDataServiceWithFeedRecord(),
             (_, _, _, _) -> {
               runnerCalled.set(true);
               throw new IOException("missing migration output");
-            });
+            },
+            reviewerKeyPair);
     AppCatalogEntry entry =
-        entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
+        withTrustedReceipt(
+            entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata()),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
     when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID))
@@ -874,15 +998,19 @@ class AppUpdateServiceTest {
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
     AtomicBoolean runnerCalled = new AtomicBoolean(false);
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
         serviceWithAppData(
             appDataServiceWithFeedRecord(),
             (_, _, _, _) -> {
               runnerCalled.set(true);
               return AppDataMigrationRunner.MigrationExecutionResult.failed(2);
-            });
+            },
+            reviewerKeyPair);
     AppCatalogEntry entry =
-        entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
+        withTrustedReceipt(
+            entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata()),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
     when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID))
@@ -939,17 +1067,116 @@ class AppUpdateServiceTest {
   }
 
   @Test
+  void check_whenStagePolicyCandidateAddsPermission_expectConsentRequiredHistory()
+      throws Exception {
+    KeyPair reviewerKeyPair = reviewerKeyPair();
+    AppUpdateService service =
+        serviceWithInstalled(
+            INSTALLED_VERSION,
+            List.of(QUEUE_READ_PERMISSION),
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
+    AppCatalogEntry entry =
+        withTrustedReceipt(
+            entry(
+                UPDATE_VERSION,
+                AppCatalogReviewStatus.REVIEWED,
+                compatibleApiMetadata(),
+                AppCatalogProductionMetadata.DEFAULT,
+                List.of(QUEUE_READ_PERMISSION, "content.fetch")),
+            reviewerKeyPair);
+    when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
+    when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
+    service.setPolicy(APP_ID, AppUpdatePolicyMode.STAGE);
+
+    Map<String, Object> summary = service.check(APP_ID, false);
+
+    Map<String, Object> candidate = (Map<String, Object>) summary.get(CANDIDATE);
+    assertEquals(AVAILABLE, candidate.get(STATUS));
+    assertEquals(true, candidate.get("channelPolicyAllowed"));
+    assertNull(candidate.get("policyBlockReason"));
+    assertEquals(false, candidate.get("autoStageAllowed"));
+    assertEquals(true, candidate.get(OPERATOR_ACTION_REQUIRED));
+    assertEquals(List.of("new_permission"), candidate.get("materialConsentReasons"));
+    assertEquals(false, ((Map<?, ?>) summary.get(STAGED)).get(AVAILABLE));
+    Map<String, Object> historyEntry =
+        ((List<Map<String, Object>>) summary.get("history"))
+            .stream()
+                .filter(entryJson -> "stage".equals(entryJson.get("action")))
+                .findFirst()
+                .orElseThrow();
+    assertEquals("consent_required", historyEntry.get(ERROR_CODE));
+    assertEquals(
+        "Policy skipped update because material consent is required.", historyEntry.get(MESSAGE));
+    verifyNoInstallPlanPreparation();
+  }
+
+  @Test
+  void check_whenStagePolicyCandidateHasSecurityAdvisory_expectConsentRequiredHistory()
+      throws Exception {
+    KeyPair reviewerKeyPair = reviewerKeyPair();
+    AppUpdateService service =
+        serviceWithInstalled(
+            INSTALLED_VERSION,
+            List.of(QUEUE_READ_PERMISSION),
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
+    AppCatalogEntry entry =
+        withTrustedReceipt(
+            entry(
+                UPDATE_VERSION,
+                AppCatalogReviewStatus.REVIEWED,
+                compatibleApiMetadata(),
+                productionMetadataWithSecurityAdvisory()),
+            reviewerKeyPair);
+    when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
+    when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
+    service.setPolicy(APP_ID, AppUpdatePolicyMode.STAGE);
+
+    Map<String, Object> summary = service.check(APP_ID, false);
+
+    Map<String, Object> candidate = (Map<String, Object>) summary.get(CANDIDATE);
+    assertEquals(AVAILABLE, candidate.get(STATUS));
+    assertEquals(true, candidate.get("channelPolicyAllowed"));
+    assertNull(candidate.get("policyBlockReason"));
+    assertEquals(false, candidate.get("autoStageAllowed"));
+    assertEquals(true, candidate.get(OPERATOR_ACTION_REQUIRED));
+    assertEquals(List.of("security_advisory"), candidate.get("materialConsentReasons"));
+    assertEquals(false, ((Map<?, ?>) summary.get(STAGED)).get(AVAILABLE));
+    Map<String, Object> historyEntry =
+        ((List<Map<String, Object>>) summary.get("history"))
+            .stream()
+                .filter(entryJson -> "stage".equals(entryJson.get("action")))
+                .findFirst()
+                .orElseThrow();
+    assertEquals("consent_required", historyEntry.get(ERROR_CODE));
+    assertEquals(
+        "Policy skipped update because material consent is required.", historyEntry.get(MESSAGE));
+    verifyNoInstallPlanPreparation();
+  }
+
+  @Test
   void check_whenStableOnlyPolicySeesStableAndNewerBeta_expectStableCandidateAutoStaged()
       throws Exception {
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
-        serviceWithInstalled(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
-    AppCatalogEntry stableEntry = entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED);
+        serviceWithInstalled(
+            INSTALLED_VERSION,
+            List.of(QUEUE_READ_PERMISSION),
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
+    AppCatalogEntry stableEntry =
+        withTrustedReceipt(
+            entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata()),
+            reviewerKeyPair);
     AppCatalogEntry betaEntry =
-        entry(
-            EXTERNAL_VERSION,
-            AppCatalogReviewStatus.REVIEWED,
-            compatibleApiMetadata(),
-            productionMetadata(AppCatalogChannel.BETA));
+        withTrustedReceipt(
+            entry(
+                EXTERNAL_VERSION,
+                AppCatalogReviewStatus.REVIEWED,
+                compatibleApiMetadata(),
+                productionMetadata(AppCatalogChannel.BETA)),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(stableEntry, betaEntry));
     when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID)).thenReturn(plan(stableEntry));
@@ -967,18 +1194,24 @@ class AppUpdateServiceTest {
   }
 
   @Test
-  void check_whenPolicyAllowsBeta_expectBetaCandidateAutoStaged() throws Exception {
+  void check_whenPolicyAllowsBeta_expectBetaCandidateRequiresConsent() throws Exception {
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
-        serviceWithInstalled(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
+        serviceWithInstalled(
+            INSTALLED_VERSION,
+            List.of(QUEUE_READ_PERMISSION),
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
     AppCatalogEntry entry =
-        entry(
-            UPDATE_VERSION,
-            AppCatalogReviewStatus.REVIEWED,
-            compatibleApiMetadata(),
-            productionMetadata(AppCatalogChannel.BETA));
+        withTrustedReceipt(
+            entry(
+                UPDATE_VERSION,
+                AppCatalogReviewStatus.REVIEWED,
+                compatibleApiMetadata(),
+                productionMetadata(AppCatalogChannel.BETA)),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
-    when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID)).thenReturn(plan(entry));
     service.setPolicy(
         APP_ID,
         AppUpdatePolicyMode.STAGE,
@@ -989,25 +1222,42 @@ class AppUpdateServiceTest {
     Map<String, Object> candidate = (Map<String, Object>) summary.get(CANDIDATE);
     assertEquals(true, candidate.get("channelPolicyAllowed"));
     assertNull(candidate.get("policyBlockReason"));
-    assertEquals(true, candidate.get("autoStageAllowed"));
-    assertEquals(true, ((Map<?, ?>) summary.get(STAGED)).get(AVAILABLE));
+    assertEquals(false, candidate.get("autoStageAllowed"));
+    assertEquals(true, candidate.get(OPERATOR_ACTION_REQUIRED));
+    assertEquals(
+        List.of("catalog_support_or_deprecation_change"), candidate.get("materialConsentReasons"));
+    assertEquals(false, ((Map<?, ?>) summary.get(STAGED)).get(AVAILABLE));
+    Map<String, Object> historyEntry =
+        ((List<Map<String, Object>>) summary.get("history"))
+            .stream()
+                .filter(entryJson -> "stage".equals(entryJson.get("action")))
+                .findFirst()
+                .orElseThrow();
+    assertEquals("consent_required", historyEntry.get(ERROR_CODE));
+    assertEquals(
+        "Policy skipped update because material consent is required.", historyEntry.get(MESSAGE));
+    verifyNoInstallPlanPreparation();
   }
 
   @Test
-  void check_whenStagedBetaPolicyLaterBecomesStableOnly_expectStagedUpdatePreserved()
-      throws Exception {
+  void check_whenBetaPolicyLaterBecomesStableOnly_expectCandidateNotStaged() throws Exception {
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
-        serviceWithInstalled(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
+        serviceWithInstalled(
+            INSTALLED_VERSION,
+            List.of(QUEUE_READ_PERMISSION),
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair));
     AppCatalogEntry entry =
-        entry(
-            UPDATE_VERSION,
-            AppCatalogReviewStatus.REVIEWED,
-            compatibleApiMetadata(),
-            productionMetadata(AppCatalogChannel.BETA));
-    AppCatalogInstallPlan plan = plan(entry);
+        withTrustedReceipt(
+            entry(
+                UPDATE_VERSION,
+                AppCatalogReviewStatus.REVIEWED,
+                compatibleApiMetadata(),
+                productionMetadata(AppCatalogChannel.BETA)),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry), List.of(entry));
-    when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID)).thenReturn(plan);
     service.setPolicy(
         APP_ID,
         AppUpdatePolicyMode.STAGE,
@@ -1020,9 +1270,8 @@ class AppUpdateServiceTest {
     Map<String, Object> candidate = (Map<String, Object>) summary.get(CANDIDATE);
     Map<String, Object> staged = (Map<String, Object>) summary.get(STAGED);
     assertEquals("channel_policy_blocked", candidate.get("policyBlockReason"));
-    assertEquals(true, staged.get(AVAILABLE));
-    assertEquals(UPDATE_VERSION, staged.get(TARGET_VERSION));
-    assertTrue(Files.exists(plan.scratchDirectory()));
+    assertEquals(false, staged.get(AVAILABLE));
+    verifyNoInstallPlanPreparation();
   }
 
   @Test
@@ -1136,16 +1385,10 @@ class AppUpdateServiceTest {
   }
 
   @Test
-  void check_whenPolicyApplyWhenStoppedAndAdvisoryReviewedWithoutReceipt_expectCandidateApplied()
+  void check_whenPolicyApplyWhenStoppedAndAdvisoryReviewedWithoutReceipt_expectConsentRequired()
       throws Exception {
     InstalledAppSnapshot installed = installed(INSTALLED_VERSION, List.of(QUEUE_READ_PERMISSION));
-    InstalledAppSnapshot updated = installed(UPDATE_VERSION, List.of(QUEUE_READ_PERMISSION));
-    when(appHost.describe(APP_ID))
-        .thenReturn(
-            Optional.of(installed),
-            Optional.of(installed),
-            Optional.of(installed),
-            Optional.of(updated));
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
     AppUpdateService service =
         new AppUpdateService(
@@ -1154,20 +1397,32 @@ class AppUpdateServiceTest {
         entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
-    AppCatalogInstallPlan plan = plan(entry);
-    when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID)).thenReturn(plan);
-    when(appHost.updateFromDirectory(APP_ID, plan.stagedBundleDirectory())).thenReturn(updated);
     service.setPolicy(APP_ID, AppUpdatePolicyMode.APPLY_WHEN_STOPPED);
 
     Map<String, Object> summary = service.check(APP_ID, false);
 
     Map<String, Object> candidate = (Map<String, Object>) summary.get(CANDIDATE);
     Map<String, Object> reviewTrust = (Map<String, Object>) candidate.get("reviewTrust");
-    assertEquals(UPDATE_VERSION, summary.get(INSTALLED_VERSION_FIELD));
-    assertEquals(APPLIED, candidate.get(STATUS));
+    assertEquals(INSTALLED_VERSION, summary.get(INSTALLED_VERSION_FIELD));
+    assertEquals(AVAILABLE, candidate.get(STATUS));
+    assertEquals(false, candidate.get("autoStageAllowed"));
+    assertEquals(false, candidate.get("autoApplyAllowed"));
+    assertEquals(true, candidate.get(OPERATOR_ACTION_REQUIRED));
+    assertEquals(List.of("review_trust_delta"), candidate.get("materialConsentReasons"));
+    assertEquals(false, ((Map<?, ?>) summary.get(STAGED)).get(AVAILABLE));
     assertEquals("publisher_claim_only", reviewTrust.get(STATUS));
     assertEquals(false, reviewTrust.get("positive"));
-    verify(appHost).updateFromDirectory(APP_ID, plan.stagedBundleDirectory());
+    Map<String, Object> historyEntry =
+        ((List<Map<String, Object>>) summary.get("history"))
+            .stream()
+                .filter(entryJson -> "apply".equals(entryJson.get("action")))
+                .findFirst()
+                .orElseThrow();
+    assertEquals("consent_required", historyEntry.get(ERROR_CODE));
+    assertEquals(
+        "Policy skipped update because material consent is required.", historyEntry.get(MESSAGE));
+    verifyNoInstallPlanPreparation();
+    verify(appHost, never()).updateFromDirectory(any(), any());
   }
 
   @Test
@@ -1882,7 +2137,11 @@ class AppUpdateServiceTest {
                 .findFirst()
                 .orElseThrow();
     assertEquals(AVAILABLE, candidate.get(STATUS));
+    assertEquals(false, candidate.get("autoStageAllowed"));
     assertEquals(false, candidate.get("autoApplyAllowed"));
+    assertEquals(true, candidate.get("blocksAutoUpdate"));
+    assertEquals(true, candidate.get(OPERATOR_ACTION_REQUIRED));
+    assertEquals(List.of("review_trust_delta"), candidate.get("materialConsentReasons"));
     assertEquals("publisher_claim_only", reviewTrust.get(STATUS));
     assertEquals(true, reviewTrust.get("blocksPolicyApply"));
     assertEquals("app_review_missing", historyEntry.get(ERROR_CODE));
@@ -1925,8 +2184,9 @@ class AppUpdateServiceTest {
                 .filter(entry -> "apply".equals(entry.get("action")))
                 .findFirst()
                 .orElseThrow();
-    assertEquals("update_incompatible", historyEntry.get(ERROR_CODE));
-    assertTrue(((String) historyEntry.get("message")).contains("Platform API compatibility"));
+    assertEquals("consent_required", historyEntry.get(ERROR_CODE));
+    assertEquals(
+        "Policy skipped update because material consent is required.", historyEntry.get(MESSAGE));
     verifyNoInstallPlanPreparation();
     verify(appHost, never()).updateFromDirectory(any(), any());
   }
@@ -2305,16 +2565,20 @@ class AppUpdateServiceTest {
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
     when(appHost.status(APP_ID)).thenReturn(Optional.of(running(installed)));
     AtomicBoolean runnerCalled = new AtomicBoolean(false);
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
         serviceWithAppData(
             appDataServiceWithFeedRecord(),
             (_, _, _, _) -> {
               runnerCalled.set(true);
               return AppDataMigrationRunner.MigrationExecutionResult.passed();
-            });
+            },
+            reviewerKeyPair);
     service.setPolicy(APP_ID, AppUpdatePolicyMode.STAGE);
     AppCatalogEntry entry =
-        entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
+        withTrustedReceipt(
+            entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata()),
+            reviewerKeyPair);
     AppCatalogInstallPlan plan = planWithAppDataMigration(entry, true, true);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
@@ -3121,16 +3385,20 @@ class AppUpdateServiceTest {
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installed));
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
     AtomicBoolean runnerCalled = new AtomicBoolean(false);
+    KeyPair reviewerKeyPair = reviewerKeyPair();
     AppUpdateService service =
         serviceWithAppData(
             appDataServiceWithFeedRecord(),
             (_, _, _, _) -> {
               runnerCalled.set(true);
               return AppDataMigrationRunner.MigrationExecutionResult.passed();
-            });
+            },
+            reviewerKeyPair);
     service.setPolicy(APP_ID, AppUpdatePolicyMode.APPLY_WHEN_STOPPED);
     AppCatalogEntry entry =
-        entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata());
+        withTrustedReceipt(
+            entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, compatibleApiMetadata()),
+            reviewerKeyPair);
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalog()));
     when(catalogManager.listApps(CATALOG_ID)).thenReturn(List.of(entry));
     when(catalogManager.prepareInstallPlan(CATALOG_ID, APP_ID))
@@ -3203,6 +3471,22 @@ class AppUpdateServiceTest {
         new AppUpdateService.AppUpdateDependencies(
             AppReviewPolicy.DEFAULT,
             TrustedReviewerKeys::empty,
+            null,
+            appDataService,
+            migrationRunner,
+            _ -> Map.of()));
+  }
+
+  private AppUpdateService serviceWithAppData(
+      AppDataService appDataService,
+      AppDataMigrationRunner migrationRunner,
+      KeyPair reviewerKeyPair) {
+    return new AppUpdateService(
+        appHost,
+        catalogManager,
+        new AppUpdateService.AppUpdateDependencies(
+            AppReviewPolicy.DEFAULT,
+            () -> trustedReviewerKeys(reviewerKeyPair),
             null,
             appDataService,
             migrationRunner,
@@ -3474,6 +3758,16 @@ class AppUpdateServiceTest {
       AppCatalogReviewStatus reviewStatus,
       AppApiCompatibilityMetadata metadata,
       AppCatalogProductionMetadata productionMetadata) {
+    return entry(
+        version, reviewStatus, metadata, productionMetadata, List.of(QUEUE_READ_PERMISSION));
+  }
+
+  private static AppCatalogEntry entry(
+      String version,
+      AppCatalogReviewStatus reviewStatus,
+      AppApiCompatibilityMetadata metadata,
+      AppCatalogProductionMetadata productionMetadata,
+      List<String> permissions) {
     return new AppCatalogEntry(
         APP_ID,
         APP_NAME,
@@ -3492,14 +3786,18 @@ class AppUpdateServiceTest {
         DIGEST,
         1234L,
         AppCatalogEntry.ZIP_BUNDLE_TYPE,
-        List.of(QUEUE_READ_PERMISSION, "queue.write"),
-        Map.of("queue.write", "Lets the app manage queue entries."));
+        permissions,
+        Map.of());
   }
 
   private static AppCatalogEntry reviewedUpdateEntryWithTrustedReceipt(
       AppApiCompatibilityMetadata metadata, KeyPair reviewerKeyPair) {
-    AppCatalogEntry unsignedEntry =
-        entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, metadata);
+    return withTrustedReceipt(
+        entry(UPDATE_VERSION, AppCatalogReviewStatus.REVIEWED, metadata), reviewerKeyPair);
+  }
+
+  private static AppCatalogEntry withTrustedReceipt(
+      AppCatalogEntry unsignedEntry, KeyPair reviewerKeyPair) {
     AppReviewReceipt receipt =
         AppReviewReceiptSigner.sign(reviewPayload(unsignedEntry), reviewerKeyPair.getPrivate());
     return new AppCatalogEntry(
@@ -3541,6 +3839,19 @@ class AppUpdateServiceTest {
         Optional.empty(),
         Optional.empty(),
         List.of(),
+        true);
+  }
+
+  private static AppCatalogProductionMetadata productionMetadataWithSecurityAdvisory() {
+    return new AppCatalogProductionMetadata(
+        AppCatalogChannel.STABLE,
+        AppCatalogSupportStatus.SUPPORTED,
+        AppCatalogDeprecationStatus.NONE,
+        Optional.empty(),
+        Optional.empty(),
+        List.of(
+            new AppCatalogSecurityAdvisory(
+                "ADV-1", URI.create("https://example.invalid/security/ADV-1"))),
         true);
   }
 

--- a/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentServiceTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentServiceTest.java
@@ -38,6 +38,7 @@ class ConsentServiceTest {
   private static final String DIGEST =
       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
   private static final String DIGEST_PREFIX = "sha256:";
+  private static final String ERROR_CONSENT_REQUIRED = "consent_required";
   private static final String ERROR_STALE_CONSENT_SNAPSHOT = "stale_consent_snapshot";
   private static final String KEY_ADDED = "added";
   private static final String KEY_API_COMPATIBILITY = "apiCompatibility";
@@ -263,7 +264,7 @@ class ConsentServiceTest {
             PlatformApiException.class,
             () -> service.requireApprovedUpdateIfRequired(APP_ID, mutationParams, APP_PRINCIPAL));
 
-    assertEquals("consent_required", exception.errorCode());
+    assertEquals(ERROR_CONSENT_REQUIRED, exception.errorCode());
     verify(updateService).previewReadOnly(APP_ID);
     verify(updateService, never()).previewForConsent(APP_ID, false);
   }
@@ -401,6 +402,56 @@ class ConsentServiceTest {
 
     assertEquals(VALUE_MATERIAL, preview.get(KEY_RISK_LEVEL));
     assertEquals(List.of("true"), mutation.get(KEY_MIGRATION_ACKNOWLEDGED));
+  }
+
+  @Test
+  void requireApprovedUpdate_whenPreparedOnlyMigrationRequiresConsent_expectConsentRequired() {
+    Map<String, Object> readOnly =
+        updateSummary(DIGEST, noPermissionDelta(), migrationNotChecked());
+    Map<String, Object> prepared =
+        updateSummary(DIGEST, noPermissionDelta(), migrationRequiredWithoutOperatorBlock());
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(readOnly);
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(prepared);
+    ConsentService service = new ConsentService(null, updateService, null);
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class,
+            () -> service.requireApprovedUpdateIfRequired(APP_ID, Map.of(), HOST_OPERATOR));
+
+    assertEquals(ERROR_CONSENT_REQUIRED, exception.errorCode());
+    verify(updateService).previewForConsent(APP_ID, false);
+  }
+
+  @Test
+  void requireApprovedUpdate_whenPreparedOnlyMigrationNotRequired_expectMutationAllowed() {
+    Map<String, Object> readOnly =
+        updateSummary(DIGEST, noPermissionDelta(), migrationNotChecked());
+    Map<String, Object> prepared = updateSummary(DIGEST, noPermissionDelta(), noMigration());
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(readOnly);
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(prepared);
+    ConsentService service = new ConsentService(null, updateService, null);
+
+    Map<String, List<String>> mutation =
+        service.requireApprovedUpdateIfRequired(APP_ID, Map.of(), HOST_OPERATOR);
+
+    assertEquals(Map.of(), mutation);
+    verify(updateService).previewForConsent(APP_ID, false);
+  }
+
+  @Test
+  void requireApprovedUpdate_whenAppPrincipalHasUncheckedMigration_expectDoesNotPrepare() {
+    when(updateService.previewReadOnly(APP_ID))
+        .thenReturn(updateSummary(DIGEST, noPermissionDelta(), migrationNotChecked()));
+    ConsentService service = new ConsentService(null, updateService, null);
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class,
+            () -> service.requireApprovedUpdateIfRequired(APP_ID, Map.of(), APP_PRINCIPAL));
+
+    assertEquals(ERROR_CONSENT_REQUIRED, exception.errorCode());
+    verify(updateService, never()).previewForConsent(APP_ID, false);
   }
 
   @Test
@@ -917,6 +968,36 @@ class ConsentServiceTest {
 
   private static Map<String, Object> noMigration() {
     return Map.of(REQUIRED, false);
+  }
+
+  private static Map<String, Object> migrationNotChecked() {
+    return Map.of(REQUIRED, false, KEY_STATUS, "not_checked");
+  }
+
+  private static Map<String, Object> migrationRequiredWithoutOperatorBlock() {
+    return Map.ofEntries(
+        Map.entry(REQUIRED, true),
+        Map.entry(KEY_STATUS, "ready"),
+        Map.entry("currentSchemaVersion", 1),
+        Map.entry("targetSchemaVersion", 2),
+        Map.entry(
+            "namespaces",
+            List.of(
+                Map.of(
+                    "namespace",
+                    "feeds",
+                    "fromSchemaVersion",
+                    1,
+                    "toSchemaVersion",
+                    2,
+                    "stepId",
+                    "feeds-v1-v2",
+                    "rollbackCompatible",
+                    true,
+                    "requiresStopped",
+                    false))),
+        Map.entry("operatorReviewRequired", false),
+        Map.entry("dryRunStatus", "passed"));
   }
 
   private static Map<String, Object> migrationRequiresReview() {

--- a/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentServiceTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentServiceTest.java
@@ -39,6 +39,7 @@ class ConsentServiceTest {
       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
   private static final String DIGEST_PREFIX = "sha256:";
   private static final String ERROR_CONSENT_REQUIRED = "consent_required";
+  private static final String ERROR_CONSENT_REQUEST_NOT_FOUND = "consent_request_not_found";
   private static final String ERROR_STALE_CONSENT_SNAPSHOT = "stale_consent_snapshot";
   private static final String KEY_ADDED = "added";
   private static final String KEY_API_COMPATIBILITY = "apiCompatibility";
@@ -50,6 +51,7 @@ class ConsentServiceTest {
   private static final String KEY_CHANNEL = "channel";
   private static final String KEY_CONSENT_REQUEST_ID = "consentRequestId";
   private static final String KEY_DEPRECATION = "deprecation";
+  private static final String KEY_DECISION = "decision";
   private static final String KEY_EXPERIMENTAL_CAPABILITIES_ACCEPTED =
       "experimentalCapabilitiesAccepted";
   private static final String KEY_MIGRATION_ACKNOWLEDGED = "migrationAcknowledged";
@@ -196,6 +198,16 @@ class ConsentServiceTest {
   }
 
   @Test
+  void approve_whenRequestWasRejected_expectFreshPreviewRequired() {
+    assertNonApprovalInvalidatesRequest(ConsentDecisionStatus.REJECTED);
+  }
+
+  @Test
+  void approve_whenRequestWasDeferred_expectFreshPreviewRequired() {
+    assertNonApprovalInvalidatesRequest(ConsentDecisionStatus.DEFERRED);
+  }
+
+  @Test
   void requireApprovedUpdate_whenDigestMatches_expectMutationAcknowledgements() {
     when(updateService.previewForConsent(APP_ID, false)).thenReturn(updateSummary(DIGEST));
     when(updateService.previewReadOnly(APP_ID)).thenReturn(updateSummary(DIGEST));
@@ -332,7 +344,8 @@ class ConsentServiceTest {
 
     assertEquals("consent_not_approved", exception.errorCode());
     assertTrue(
-        service.audit(APP_ID).stream().anyMatch(event -> "expired".equals(event.get("decision"))));
+        service.audit(APP_ID).stream()
+            .anyMatch(event -> "expired".equals(event.get(KEY_DECISION))));
   }
 
   @Test
@@ -354,7 +367,8 @@ class ConsentServiceTest {
 
     assertEquals(List.of("true"), mutation.get(KEY_REVIEW_ACKNOWLEDGED));
     assertFalse(
-        service.audit(APP_ID).stream().anyMatch(event -> "expired".equals(event.get("decision"))));
+        service.audit(APP_ID).stream()
+            .anyMatch(event -> "expired".equals(event.get(KEY_DECISION))));
   }
 
   @Test
@@ -596,6 +610,31 @@ class ConsentServiceTest {
   @Test
   void requireApprovedInstall_whenApiCompatibilityNewerThanTested_expectApprovalPermitsMutation() {
     assertApiCompatibilityStatusAllowsApprovedInstall("newer_than_tested");
+  }
+
+  private void assertNonApprovalInvalidatesRequest(ConsentDecisionStatus status) {
+    when(catalogHandler.getApp(CATALOG_ID, APP_ID)).thenReturn(catalogApp());
+    ConsentService service = new ConsentService(catalogHandler, null, null);
+    Map<String, Object> preview = service.installPreview(CATALOG_ID, APP_ID);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    Map<String, List<String>> decisionParams = params(requestId, digest);
+
+    Map<String, Object> decision =
+        switch (status) {
+          case REJECTED -> service.reject(decisionParams, HOST_OPERATOR);
+          case DEFERRED -> service.defer(decisionParams, HOST_OPERATOR);
+          default ->
+              throw new IllegalArgumentException("Unsupported non-approval status " + status);
+        };
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class, () -> service.approve(decisionParams, HOST_OPERATOR));
+
+    assertEquals(status.jsonValue(), decision.get(KEY_DECISION));
+    assertEquals(404, exception.statusCode());
+    assertEquals(ERROR_CONSENT_REQUEST_NOT_FOUND, exception.errorCode());
+    assertEquals(status.jsonValue(), service.audit(APP_ID).getFirst().get(KEY_DECISION));
   }
 
   private void assertApiCompatibilityStatusAllowsApprovedInstall(String status) {

--- a/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentServiceTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentServiceTest.java
@@ -74,6 +74,9 @@ class ConsentServiceTest {
   private static final String REQUIRED = "required";
   private static final String ROUTE_CONSENT = "consent";
   private static final String ROUTE_UPDATE_PREVIEW = "update-preview";
+  private static final String STATUS_AMBIGUOUS = "ambiguous";
+  private static final String STATUS_INCOMPATIBLE = "incompatible";
+  private static final String STATUS_NOT_NEWER = "not_newer";
   private static final String TEST_INSTANT = "2026-05-01T00:00:00Z";
   private static final String TRUSTED = "trusted";
   private static final String VALUE_BLOCKING = "blocking";
@@ -250,6 +253,25 @@ class ConsentServiceTest {
         service.requireApprovedUpdateIfRequired(APP_ID, Map.of(), HOST_OPERATOR);
 
     assertEquals(Map.of(), mutation);
+    verify(updateService, never()).previewForConsent(APP_ID, false);
+  }
+
+  @Test
+  void requireApprovedUpdate_whenCandidateIsNonStageable_expectConsentBypassed() {
+    when(updateService.previewReadOnly(APP_ID))
+        .thenReturn(nonStageableUpdateSummary(STATUS_NOT_NEWER))
+        .thenReturn(nonStageableUpdateSummary(STATUS_AMBIGUOUS))
+        .thenReturn(nonStageableUpdateSummary(STATUS_INCOMPATIBLE));
+    ConsentService service = new ConsentService(null, updateService, null);
+    Map<String, List<String>> staleAcknowledgement =
+        Map.of(KEY_MIGRATION_ACKNOWLEDGED, List.of("true"));
+
+    for (String status : List.of(STATUS_NOT_NEWER, STATUS_AMBIGUOUS, STATUS_INCOMPATIBLE)) {
+      Map<String, List<String>> mutation =
+          service.requireApprovedUpdateIfRequired(APP_ID, staleAcknowledgement, HOST_OPERATOR);
+
+      assertEquals(Map.of(), mutation, status);
+    }
     verify(updateService, never()).previewForConsent(APP_ID, false);
   }
 
@@ -875,7 +897,7 @@ class ConsentServiceTest {
         noMigration(),
         List.of(),
         Map.of(KEY_STATUS, TRUSTED, KEY_POSITIVE, true),
-        "incompatible",
+        STATUS_INCOMPATIBLE,
         Map.of(
             KEY_STATUS,
             "below_minimum",
@@ -883,6 +905,19 @@ class ConsentServiceTest {
             VALUE_STABLE,
             KEY_EXPERIMENTAL_CAPABILITIES_ACCEPTED,
             false));
+  }
+
+  private static Map<String, Object> nonStageableUpdateSummary(String candidateStatus) {
+    return updateSummary(
+        DIGEST,
+        materialPermissionDelta(),
+        noMigration(),
+        List.of(securityAdvisory("CRYPTA-2026-0001", "https://example.invalid/a/1")),
+        Map.of(KEY_STATUS, "missing", KEY_POSITIVE, false, KEY_REQUIRES_ACKNOWLEDGEMENT, true),
+        candidateStatus,
+        STATUS_INCOMPATIBLE.equals(candidateStatus)
+            ? apiCompatibility("below_minimum")
+            : apiCompatibility(VALUE_COMPATIBLE));
   }
 
   private static Map<String, Object> securityAdvisory(String id, String uri) {

--- a/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentServiceTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentServiceTest.java
@@ -1,0 +1,1008 @@
+package network.crypta.platform.api.consent;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import network.crypta.platform.api.PlatformApiException;
+import network.crypta.platform.api.PlatformApiPrincipal;
+import network.crypta.platform.api.PlatformApiRequest;
+import network.crypta.platform.api.PlatformApiResponse;
+import network.crypta.platform.api.appcatalogs.AppCatalogsApiHandler;
+import network.crypta.platform.api.appservices.AppServiceCoordinator;
+import network.crypta.platform.api.appupdates.AppUpdateService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings({"java:S100", "unchecked"})
+class ConsentServiceTest {
+  private static final String APP_ID = "example.app";
+  private static final String CATALOG_ID = "first-party";
+  private static final String DIGEST =
+      "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+  private static final String DIGEST_PREFIX = "sha256:";
+  private static final String ERROR_STALE_CONSENT_SNAPSHOT = "stale_consent_snapshot";
+  private static final String KEY_ADDED = "added";
+  private static final String KEY_API_COMPATIBILITY = "apiCompatibility";
+  private static final String KEY_APP_ID = "appId";
+  private static final String KEY_BLOCKING_REASONS = "blockingReasons";
+  private static final String KEY_BLOCKS_INSTALL = "blocksInstall";
+  private static final String KEY_BLOCKS_UPDATE = "blocksUpdate";
+  private static final String KEY_BUNDLE = "bundle";
+  private static final String KEY_CHANNEL = "channel";
+  private static final String KEY_CONSENT_REQUEST_ID = "consentRequestId";
+  private static final String KEY_DEPRECATION = "deprecation";
+  private static final String KEY_EXPERIMENTAL_CAPABILITIES_ACCEPTED =
+      "experimentalCapabilitiesAccepted";
+  private static final String KEY_MIGRATION_ACKNOWLEDGED = "migrationAcknowledged";
+  private static final String KEY_PERMISSIONS = "permissions";
+  private static final String KEY_POSITIVE = "positive";
+  private static final String KEY_RECOMMENDED_ACTION = "recommendedAction";
+  private static final String KEY_REMOVED = "removed";
+  private static final String KEY_REQUIRES_ACKNOWLEDGEMENT = "requiresAcknowledgement";
+  private static final String KEY_REQUIRES_APPROVAL = "requiresApproval";
+  private static final String KEY_REVIEW_ACKNOWLEDGED = "reviewAcknowledged";
+  private static final String KEY_REVIEW_TRUST = "reviewTrust";
+  private static final String KEY_RISK_LEVEL = "riskLevel";
+  private static final String KEY_SECTIONS = "sections";
+  private static final String KEY_SECURITY_ADVISORIES = "securityAdvisories";
+  private static final String KEY_SECURITY_DECISION = "securityDecision";
+  private static final String KEY_SHA256 = "sha256";
+  private static final String KEY_SNAPSHOT_DIGEST = "snapshotDigest";
+  private static final String KEY_STATUS = "status";
+  private static final String KEY_SUPPORT_STATUS = "supportStatus";
+  private static final String KEY_TARGET_STABILITY = "targetStability";
+  private static final String PERMISSION_CONTENT_FETCH = "content.fetch";
+  private static final String REQUIRED = "required";
+  private static final String ROUTE_CONSENT = "consent";
+  private static final String ROUTE_UPDATE_PREVIEW = "update-preview";
+  private static final String TEST_INSTANT = "2026-05-01T00:00:00Z";
+  private static final String TRUSTED = "trusted";
+  private static final String VALUE_BLOCKING = "blocking";
+  private static final String VALUE_COMPATIBLE = "compatible";
+  private static final String VALUE_MATERIAL = "material";
+  private static final String VALUE_STABLE = "stable";
+  private static final String VALUE_SUPPORTED = "supported";
+  private static final String VERSION_1_0_0 = "1.0.0";
+  private static final PlatformApiPrincipal HOST_OPERATOR = PlatformApiPrincipal.hostOperator();
+  private static final PlatformApiPrincipal APP_PRINCIPAL =
+      PlatformApiPrincipal.appToken(APP_ID, List.of("apps.manage", "catalogs.manage"));
+
+  @Mock private AppCatalogsApiHandler catalogHandler;
+  @Mock private AppUpdateService updateService;
+  @Mock private AppServiceCoordinator appServiceCoordinator;
+
+  @Test
+  void installPreview_whenCatalogEntryHasMaterialMetadata_expectGroupedConsentSections() {
+    when(catalogHandler.getApp(CATALOG_ID, APP_ID)).thenReturn(catalogApp());
+    ConsentService service = new ConsentService(catalogHandler, null, null);
+
+    Map<String, Object> preview = service.installPreview(CATALOG_ID, APP_ID);
+
+    assertEquals("install_app", preview.get("action"));
+    assertEquals(APP_ID, preview.get(KEY_APP_ID));
+    assertEquals(DIGEST_PREFIX + DIGEST, preview.get("candidateDigest"));
+    assertEquals(VALUE_MATERIAL, preview.get(KEY_RISK_LEVEL));
+    assertEquals(true, preview.get(KEY_REQUIRES_APPROVAL));
+    List<Map<String, Object>> sections = (List<Map<String, Object>>) preview.get(KEY_SECTIONS);
+    assertSection(sections, KEY_PERMISSIONS);
+    assertSection(sections, "review-trust");
+    assertSection(sections, "catalog-support");
+    assertSection(sections, "security");
+    assertSection(sections, "app-service-grants");
+    assertTrue(((List<String>) preview.get(KEY_BLOCKING_REASONS)).contains("permission_required"));
+  }
+
+  @Test
+  void installPreview_whenSecurityDecisionBlocksInstallOnly_expectBlockingRisk() {
+    when(catalogHandler.getApp(CATALOG_ID, APP_ID))
+        .thenReturn(
+            catalogAppWith(
+                KEY_SECURITY_DECISION,
+                Map.of(
+                    KEY_STATUS,
+                    "denylisted",
+                    KEY_REQUIRES_ACKNOWLEDGEMENT,
+                    true,
+                    KEY_BLOCKS_INSTALL,
+                    true,
+                    KEY_BLOCKS_UPDATE,
+                    false)));
+    ConsentService service = new ConsentService(catalogHandler, null, null);
+
+    Map<String, Object> preview = service.installPreview(CATALOG_ID, APP_ID);
+
+    assertEquals(VALUE_BLOCKING, preview.get(KEY_RISK_LEVEL));
+    assertEquals(true, preview.get(KEY_REQUIRES_APPROVAL));
+    assertTrue(
+        ((List<String>) preview.get(KEY_BLOCKING_REASONS)).contains("security_advisory_delta"));
+  }
+
+  @Test
+  void installPreview_whenReviewTrustBlocksInstallOnly_expectBlockingRisk() {
+    when(catalogHandler.getApp(CATALOG_ID, APP_ID))
+        .thenReturn(
+            catalogAppWith(
+                KEY_REVIEW_TRUST,
+                Map.of(
+                    KEY_STATUS,
+                    "revoked",
+                    KEY_POSITIVE,
+                    false,
+                    KEY_REQUIRES_ACKNOWLEDGEMENT,
+                    true,
+                    KEY_BLOCKS_INSTALL,
+                    true,
+                    KEY_BLOCKS_UPDATE,
+                    false)));
+    ConsentService service = new ConsentService(catalogHandler, null, null);
+
+    Map<String, Object> preview = service.installPreview(CATALOG_ID, APP_ID);
+
+    assertEquals(VALUE_BLOCKING, preview.get(KEY_RISK_LEVEL));
+    assertEquals(true, preview.get(KEY_REQUIRES_APPROVAL));
+    assertTrue(((List<String>) preview.get(KEY_BLOCKING_REASONS)).contains("review_trust_delta"));
+  }
+
+  @Test
+  void approve_whenSnapshotRiskIsBlocking_expectConsentBlockedAndNoApprovalAudit() {
+    when(catalogHandler.getApp(CATALOG_ID, APP_ID))
+        .thenReturn(
+            catalogAppWith(
+                KEY_SECURITY_DECISION,
+                Map.of(
+                    KEY_STATUS,
+                    "denylisted",
+                    KEY_REQUIRES_ACKNOWLEDGEMENT,
+                    true,
+                    KEY_BLOCKS_INSTALL,
+                    true,
+                    KEY_BLOCKS_UPDATE,
+                    false)));
+    ConsentService service = new ConsentService(catalogHandler, null, null);
+    Map<String, Object> preview = service.installPreview(CATALOG_ID, APP_ID);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    Map<String, List<String>> approvalParams = params(requestId, digest);
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class, () -> service.approve(approvalParams, HOST_OPERATOR));
+
+    assertEquals(409, exception.statusCode());
+    assertEquals("consent_blocked", exception.errorCode());
+    assertTrue(service.audit(APP_ID).isEmpty());
+  }
+
+  @Test
+  void requireApprovedUpdate_whenDigestMatches_expectMutationAcknowledgements() {
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(updateSummary(DIGEST));
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(updateSummary(DIGEST));
+    ConsentService service = new ConsentService(null, updateService, null);
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    service.approve(params(requestId, digest), HOST_OPERATOR);
+
+    Map<String, List<String>> mutation =
+        service.requireApprovedUpdateIfRequired(APP_ID, params(requestId, digest), HOST_OPERATOR);
+
+    assertEquals(List.of("true"), mutation.get(KEY_REVIEW_ACKNOWLEDGED));
+    assertEquals(List.of("true"), mutation.get("securityAcknowledged"));
+    assertEquals(List.of("true"), mutation.get(KEY_MIGRATION_ACKNOWLEDGED));
+  }
+
+  @Test
+  void updatePreview_whenCandidateStatusNone_expectNoUpdateConsentSnapshot() {
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(noUpdateSummary());
+    ConsentService service = new ConsentService(null, updateService, null);
+
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+
+    assertEquals("none", preview.get(KEY_RISK_LEVEL));
+    assertEquals(false, preview.get(KEY_REQUIRES_APPROVAL));
+    assertEquals(false, preview.get("blocksAutoUpdate"));
+    assertEquals("no_update_available", preview.get(KEY_RECOMMENDED_ACTION));
+    assertEquals(List.of(), preview.get(KEY_BLOCKING_REASONS));
+  }
+
+  @Test
+  void updatePreview_whenCandidateIsIncompatible_expectBlockingConsentSnapshot() {
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(incompatibleUpdateSummary());
+    ConsentService service = new ConsentService(null, updateService, null);
+
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+
+    assertEquals(APP_ID, preview.get(KEY_APP_ID));
+    assertEquals("1.1.0", preview.get("candidateVersion"));
+    assertEquals(VALUE_BLOCKING, preview.get(KEY_RISK_LEVEL));
+    assertEquals(true, preview.get(KEY_REQUIRES_APPROVAL));
+    assertEquals("do_not_continue", preview.get(KEY_RECOMMENDED_ACTION));
+    assertTrue(
+        ((List<String>) preview.get(KEY_BLOCKING_REASONS)).contains("platform_api_compatibility"));
+    assertSection((List<Map<String, Object>>) preview.get(KEY_SECTIONS), "api-stability");
+  }
+
+  @Test
+  void requireApprovedUpdate_whenCandidateStatusNone_expectNoConsentRequired() {
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(noUpdateSummary());
+    ConsentService service = new ConsentService(null, updateService, null);
+
+    Map<String, List<String>> mutation =
+        service.requireApprovedUpdateIfRequired(APP_ID, Map.of(), HOST_OPERATOR);
+
+    assertEquals(Map.of(), mutation);
+    verify(updateService, never()).previewForConsent(APP_ID, false);
+  }
+
+  @Test
+  void requireApprovedUpdate_whenApprovalMissing_expectReadOnlyPreviewDoesNotPrepare() {
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(updateSummary(DIGEST));
+    ConsentService service = new ConsentService(null, updateService, null);
+    Map<String, List<String>> mutationParams = Map.of();
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class,
+            () -> service.requireApprovedUpdateIfRequired(APP_ID, mutationParams, APP_PRINCIPAL));
+
+    assertEquals("consent_required", exception.errorCode());
+    verify(updateService).previewReadOnly(APP_ID);
+    verify(updateService, never()).previewForConsent(APP_ID, false);
+  }
+
+  @Test
+  void requireApprovedUpdate_whenApprovalReused_expectConsentNotApproved() {
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(updateSummary(DIGEST));
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(updateSummary(DIGEST));
+    ConsentService service = new ConsentService(null, updateService, null);
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    Map<String, List<String>> mutationParams = params(requestId, digest);
+    service.approve(mutationParams, HOST_OPERATOR);
+    service.requireApprovedUpdateIfRequired(APP_ID, mutationParams, HOST_OPERATOR);
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class,
+            () -> service.requireApprovedUpdateIfRequired(APP_ID, mutationParams, HOST_OPERATOR));
+
+    assertEquals("consent_not_approved", exception.errorCode());
+  }
+
+  @Test
+  void requireApprovedUpdate_whenApprovalExpires_expectConsentNotApprovedAndExpiredAudit() {
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(updateSummary(DIGEST));
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(updateSummary(DIGEST));
+    MutableClock clock = new MutableClock(Instant.parse(TEST_INSTANT));
+    ConsentService service =
+        new ConsentService(null, updateService, null, new InMemoryConsentAuditStore(), clock);
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    Map<String, List<String>> mutationParams = params(requestId, digest);
+    service.approve(mutationParams, HOST_OPERATOR);
+    clock.advance(Duration.ofMinutes(16));
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class,
+            () -> service.requireApprovedUpdateIfRequired(APP_ID, mutationParams, HOST_OPERATOR));
+
+    assertEquals("consent_not_approved", exception.errorCode());
+    assertTrue(
+        service.audit(APP_ID).stream().anyMatch(event -> "expired".equals(event.get("decision"))));
+  }
+
+  @Test
+  void requireApprovedUpdate_whenPreviewExpiresAfterFreshApproval_expectApprovalStillUsable() {
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(updateSummary(DIGEST));
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(updateSummary(DIGEST));
+    MutableClock clock = new MutableClock(Instant.parse(TEST_INSTANT));
+    ConsentService service =
+        new ConsentService(null, updateService, null, new InMemoryConsentAuditStore(), clock);
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    clock.advance(Duration.ofMinutes(14).plusSeconds(59));
+    service.approve(params(requestId, digest), HOST_OPERATOR);
+    clock.advance(Duration.ofSeconds(2));
+
+    Map<String, List<String>> mutation =
+        service.requireApprovedUpdateIfRequired(APP_ID, params(requestId, digest), HOST_OPERATOR);
+
+    assertEquals(List.of("true"), mutation.get(KEY_REVIEW_ACKNOWLEDGED));
+    assertFalse(
+        service.audit(APP_ID).stream().anyMatch(event -> "expired".equals(event.get("decision"))));
+  }
+
+  @Test
+  void requireApprovedUpdate_whenCandidateDigestChanges_expectStaleApprovalRejected() {
+    when(updateService.previewForConsent(APP_ID, false))
+        .thenReturn(updateSummary(DIGEST))
+        .thenReturn(
+            updateSummary("fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"));
+    when(updateService.previewReadOnly(APP_ID))
+        .thenReturn(
+            updateSummary("fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"));
+    ConsentService service = new ConsentService(null, updateService, null);
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    Map<String, List<String>> mutationParams = params(requestId, digest);
+    service.approve(mutationParams, HOST_OPERATOR);
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class,
+            () -> service.requireApprovedUpdateIfRequired(APP_ID, mutationParams, HOST_OPERATOR));
+
+    assertEquals(ERROR_STALE_CONSENT_SNAPSHOT, exception.errorCode());
+  }
+
+  @Test
+  void requireApprovedUpdate_whenMigrationRequiresReview_expectMutationAcknowledgement() {
+    Map<String, Object> summary =
+        updateSummary(DIGEST, noPermissionDelta(), migrationRequiresReview());
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(summary);
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(summary);
+    ConsentService service = new ConsentService(null, updateService, null);
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    service.approve(params(requestId, digest), HOST_OPERATOR);
+
+    Map<String, List<String>> mutation =
+        service.requireApprovedUpdateIfRequired(APP_ID, params(requestId, digest), HOST_OPERATOR);
+
+    assertEquals(VALUE_MATERIAL, preview.get(KEY_RISK_LEVEL));
+    assertEquals(true, preview.get(KEY_REQUIRES_APPROVAL));
+    assertTrue(
+        ((List<String>) preview.get(KEY_BLOCKING_REASONS)).contains("app_data_migration_plan"));
+    assertTrue(
+        migrationPlanSummary(preview).contains("Schema 1 to 2"),
+        "migration consent summary should preserve numeric schema versions");
+    assertEquals(List.of("true"), mutation.get(KEY_MIGRATION_ACKNOWLEDGED));
+  }
+
+  @Test
+  void requireApprovedUpdate_whenPreparedMigrationRequiresReview_expectMutationAcknowledgement() {
+    Map<String, Object> readOnly = updateSummary(DIGEST, noPermissionDelta(), noMigration());
+    Map<String, Object> prepared =
+        updateSummary(DIGEST, noPermissionDelta(), migrationRequiresReview());
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(prepared);
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(readOnly);
+    ConsentService service = new ConsentService(null, updateService, null);
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    service.approve(params(requestId, digest), HOST_OPERATOR);
+
+    Map<String, List<String>> mutation =
+        service.requireApprovedUpdateIfRequired(APP_ID, params(requestId, digest), HOST_OPERATOR);
+
+    assertEquals(VALUE_MATERIAL, preview.get(KEY_RISK_LEVEL));
+    assertEquals(List.of("true"), mutation.get(KEY_MIGRATION_ACKNOWLEDGED));
+  }
+
+  @Test
+  void requireApprovedUpdate_whenOnlyLegacyAcknowledgementSupplied_expectAcknowledgementRemoved() {
+    when(updateService.previewReadOnly(APP_ID))
+        .thenReturn(updateSummary(DIGEST, noPermissionDelta(), noMigration()));
+    ConsentService service = new ConsentService(null, updateService, null);
+
+    Map<String, List<String>> mutation =
+        service.requireApprovedUpdateIfRequired(
+            APP_ID, Map.of(KEY_MIGRATION_ACKNOWLEDGED, List.of("true")), HOST_OPERATOR);
+
+    assertFalse(mutation.containsKey(KEY_MIGRATION_ACKNOWLEDGED));
+    verify(updateService).previewReadOnly(APP_ID);
+    verify(updateService, never()).previewForConsent(APP_ID, false);
+  }
+
+  @Test
+  void requireApprovedUpdate_whenSecurityAdvisoryIdentityChanges_expectStaleApprovalRejected() {
+    Map<String, Object> original =
+        updateSummary(
+            DIGEST,
+            noPermissionDelta(),
+            noMigration(),
+            List.of(securityAdvisory("CRYPTA-2026-0001", "https://example.invalid/a/1")));
+    Map<String, Object> changed =
+        updateSummary(
+            DIGEST,
+            noPermissionDelta(),
+            noMigration(),
+            List.of(securityAdvisory("CRYPTA-2026-0002", "https://example.invalid/a/2")));
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(original).thenReturn(changed);
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(changed);
+    ConsentService service = new ConsentService(null, updateService, null);
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    Map<String, List<String>> mutationParams = params(requestId, digest);
+    service.approve(mutationParams, HOST_OPERATOR);
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class,
+            () -> service.requireApprovedUpdateIfRequired(APP_ID, mutationParams, HOST_OPERATOR));
+
+    assertNotEquals(digest, service.updatePreview(APP_ID, false).get(KEY_SNAPSHOT_DIGEST));
+    assertEquals(ERROR_STALE_CONSENT_SNAPSHOT, exception.errorCode());
+  }
+
+  @Test
+  void requireApprovedUpdate_whenReviewReceiptIdentityChanges_expectStaleApprovalRejected() {
+    Map<String, Object> original =
+        updateSummary(
+            DIGEST, materialPermissionDelta(), noMigration(), List.of(), trustedReviewTrust("1"));
+    Map<String, Object> changed =
+        updateSummary(
+            DIGEST, materialPermissionDelta(), noMigration(), List.of(), trustedReviewTrust("2"));
+    when(updateService.previewForConsent(APP_ID, false)).thenReturn(original).thenReturn(changed);
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(changed);
+    ConsentService service = new ConsentService(null, updateService, null);
+    Map<String, Object> preview = service.updatePreview(APP_ID, false);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    Map<String, List<String>> mutationParams = params(requestId, digest);
+    service.approve(mutationParams, HOST_OPERATOR);
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class,
+            () -> service.requireApprovedUpdateIfRequired(APP_ID, mutationParams, HOST_OPERATOR));
+
+    assertEquals(ERROR_STALE_CONSENT_SNAPSHOT, exception.errorCode());
+  }
+
+  @Test
+  void updatePreview_whenGetIncludesRefreshCatalogs_expectReadOnlyPreviewWithoutRefresh() {
+    when(updateService.previewReadOnly(APP_ID)).thenReturn(updateSummary(DIGEST));
+    ConsentApiHandler handler =
+        new ConsentApiHandler(new ConsentService(null, updateService, null));
+
+    PlatformApiResponse response =
+        handler.route(
+            List.of(ROUTE_CONSENT, ROUTE_UPDATE_PREVIEW),
+            new PlatformApiRequest(
+                "GET",
+                List.of(ROUTE_CONSENT, ROUTE_UPDATE_PREVIEW),
+                Map.of(KEY_APP_ID, List.of(APP_ID), "refreshCatalogs", List.of("true"))));
+
+    assertEquals(200, response.statusCode());
+    verify(updateService).previewReadOnly(APP_ID);
+    verify(updateService, never()).preview(APP_ID, false);
+    verify(updateService, never()).previewForConsent(APP_ID, true);
+    verify(updateService, never()).previewForConsent(APP_ID, false);
+  }
+
+  @Test
+  void updatePreview_whenPostIncludesRefreshCatalogs_expectConsentPreviewRefresh() {
+    when(updateService.previewForConsent(APP_ID, true)).thenReturn(updateSummary(DIGEST));
+    ConsentApiHandler handler =
+        new ConsentApiHandler(new ConsentService(null, updateService, null));
+
+    PlatformApiResponse response =
+        handler.route(
+            List.of(ROUTE_CONSENT, ROUTE_UPDATE_PREVIEW),
+            new PlatformApiRequest(
+                "POST",
+                List.of(ROUTE_CONSENT, ROUTE_UPDATE_PREVIEW),
+                Map.of(KEY_APP_ID, List.of(APP_ID), "refreshCatalogs", List.of("true"))));
+
+    assertEquals(200, response.statusCode());
+    verify(updateService).previewForConsent(APP_ID, true);
+    verify(updateService, never()).preview(APP_ID, true);
+  }
+
+  @Test
+  void requireApprovedInstall_whenApiCompatibilityUnknown_expectApprovalPermitsMutation() {
+    assertApiCompatibilityStatusAllowsApprovedInstall("unknown");
+  }
+
+  @Test
+  void requireApprovedInstall_whenApiCompatibilityNewerThanTested_expectApprovalPermitsMutation() {
+    assertApiCompatibilityStatusAllowsApprovedInstall("newer_than_tested");
+  }
+
+  private void assertApiCompatibilityStatusAllowsApprovedInstall(String status) {
+    when(catalogHandler.getApp(CATALOG_ID, APP_ID))
+        .thenReturn(catalogApp(apiCompatibility(status)));
+    ConsentService service = new ConsentService(catalogHandler, null, null);
+    Map<String, Object> preview = service.installPreview(CATALOG_ID, APP_ID);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    service.approve(params(requestId, digest), HOST_OPERATOR);
+
+    Map<String, List<String>> mutation =
+        service.requireApprovedInstallIfRequired(
+            CATALOG_ID, APP_ID, params(requestId, digest), HOST_OPERATOR);
+
+    assertEquals(VALUE_MATERIAL, preview.get(KEY_RISK_LEVEL));
+    assertTrue(
+        ((List<String>) preview.get(KEY_BLOCKING_REASONS)).contains("platform_api_compatibility"));
+    assertEquals(List.of("true"), mutation.get(KEY_REVIEW_ACKNOWLEDGED));
+  }
+
+  @Test
+  void requireApprovedPreparedInstall_whenPreparedEntryDiffers_expectStaleApprovalRejected() {
+    when(catalogHandler.getApp(CATALOG_ID, APP_ID)).thenReturn(catalogApp());
+    when(catalogHandler.summarizePreparedPlanForConsent(CATALOG_ID, null, false))
+        .thenReturn(
+            catalogAppWith(KEY_PERMISSIONS, List.of(PERMISSION_CONTENT_FETCH, "queue.read")));
+    ConsentService service = new ConsentService(catalogHandler, null, null);
+    Map<String, Object> preview = service.installPreview(CATALOG_ID, APP_ID);
+    String requestId = (String) preview.get(KEY_CONSENT_REQUEST_ID);
+    String digest = (String) preview.get(KEY_SNAPSHOT_DIGEST);
+    Map<String, List<String>> mutationParams = params(requestId, digest);
+    service.approve(mutationParams, HOST_OPERATOR);
+    service.requireApprovedInstallIfRequired(CATALOG_ID, APP_ID, mutationParams, HOST_OPERATOR);
+
+    PlatformApiException exception =
+        assertThrows(
+            PlatformApiException.class,
+            () ->
+                service.requireApprovedPreparedInstallIfRequired(
+                    CATALOG_ID, null, mutationParams, HOST_OPERATOR));
+
+    assertEquals(ERROR_STALE_CONSENT_SNAPSHOT, exception.errorCode());
+  }
+
+  @Test
+  void serviceGrantPreview_whenBundleHasDependencies_expectGrantConsentSections() {
+    when(appServiceCoordinator.listBundles(HOST_OPERATOR)).thenReturn(List.of(serviceBundle()));
+    ConsentService service = new ConsentService(null, null, appServiceCoordinator);
+
+    Map<String, Object> preview = service.serviceGrantPreview("bundle-1");
+
+    assertEquals("app_service_grant", preview.get("action"));
+    assertEquals(VALUE_MATERIAL, preview.get(KEY_RISK_LEVEL));
+    assertEquals("review_before_service_grant", preview.get(KEY_RECOMMENDED_ACTION));
+    List<Map<String, Object>> sections = (List<Map<String, Object>>) preview.get(KEY_SECTIONS);
+    assertSection(sections, "app-service-dependencies");
+    assertSection(sections, "audit");
+  }
+
+  @Test
+  void auditEvent_whenRiskSummaryContainsSensitiveValues_expectRedactedJson() {
+    ConsentAuditEvent event =
+        new ConsentAuditEvent(
+            "decision-1",
+            "request-1",
+            "local_operator",
+            APP_ID,
+            ConsentActionType.INSTALL_APP,
+            ConsentDecisionStatus.REJECTED,
+            Instant.parse(TEST_INSTANT),
+            DIGEST_PREFIX + DIGEST,
+            List.of("token=secret-value", "CHK@private-insert-material", "/tmp/local/secret/path"));
+
+    String summary = event.toJsonValue().get("materialRiskSummary").toString();
+
+    assertFalse(summary.contains("secret-value"));
+    assertFalse(summary.contains("CHK@private"));
+    assertFalse(summary.contains("/tmp/local/secret/path"));
+    assertTrue(summary.contains("[redacted-secret]"));
+    assertTrue(summary.contains("[redacted-private-uri]"));
+    assertTrue(summary.contains("[redacted-local-path]"));
+  }
+
+  @Test
+  void auditStore_whenHistoryExceedsLimit_expectOldestEventsDropped() {
+    InMemoryConsentAuditStore store = new InMemoryConsentAuditStore();
+    for (int index = 0; index < InMemoryConsentAuditStore.MAX_EVENTS + 3; index++) {
+      store.append(auditEvent(index));
+    }
+
+    List<ConsentAuditEvent> events = store.list(null);
+
+    assertEquals(InMemoryConsentAuditStore.MAX_EVENTS, events.size());
+    assertEquals("decision-3", events.getFirst().decisionId());
+    assertNull(store.list("missing.app").stream().findFirst().orElse(null));
+  }
+
+  private static ConsentAuditEvent auditEvent(int index) {
+    return new ConsentAuditEvent(
+        "decision-" + index,
+        "request-" + index,
+        "local_operator",
+        APP_ID,
+        ConsentActionType.INSTALL_APP,
+        ConsentDecisionStatus.APPROVED,
+        Instant.parse(TEST_INSTANT).plusSeconds(index),
+        DIGEST_PREFIX + DIGEST,
+        List.of("permission_required"));
+  }
+
+  private static void assertSection(List<Map<String, Object>> sections, String id) {
+    assertTrue(
+        sections.stream().anyMatch(section -> id.equals(section.get("id"))),
+        "missing consent section " + id);
+  }
+
+  private static String migrationPlanSummary(Map<String, Object> preview) {
+    List<Map<String, Object>> sections = (List<Map<String, Object>>) preview.get(KEY_SECTIONS);
+    Map<String, Object> migrationSection =
+        sections.stream()
+            .filter(section -> "app-data-migration".equals(section.get("id")))
+            .findFirst()
+            .orElseThrow();
+    List<Map<String, Object>> items = (List<Map<String, Object>>) migrationSection.get("items");
+    return items.stream()
+        .filter(item -> "app_data_migration_plan".equals(item.get("code")))
+        .map(item -> String.valueOf(item.get("summary")))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private static Map<String, List<String>> params(String requestId, String digest) {
+    return Map.of(KEY_CONSENT_REQUEST_ID, List.of(requestId), KEY_SNAPSHOT_DIGEST, List.of(digest));
+  }
+
+  private static Map<String, Object> catalogApp() {
+    return catalogApp(apiCompatibility(VALUE_COMPATIBLE));
+  }
+
+  private static Map<String, Object> catalogAppWith(String key, Object value) {
+    LinkedHashMap<String, Object> app = new LinkedHashMap<>(catalogApp());
+    app.put(key, value);
+    return app;
+  }
+
+  private static Map<String, Object> catalogApp(Map<String, Object> apiCompatibility) {
+    return Map.ofEntries(
+        Map.entry(KEY_APP_ID, APP_ID),
+        Map.entry("name", "Example App"),
+        Map.entry("version", "1.2.0"),
+        Map.entry(KEY_CHANNEL, "beta"),
+        Map.entry(KEY_SUPPORT_STATUS, VALUE_SUPPORTED),
+        Map.entry(
+            "maintenance",
+            Map.of(
+                "owner",
+                "Crypta",
+                "backupRestore",
+                VALUE_SUPPORTED,
+                "dataSchemaPolicy",
+                VALUE_STABLE)),
+        Map.entry(KEY_DEPRECATION, Map.of(KEY_STATUS, "none")),
+        Map.entry(
+            KEY_SECURITY_DECISION,
+            Map.of(
+                KEY_STATUS,
+                "ok",
+                KEY_REQUIRES_ACKNOWLEDGEMENT,
+                false,
+                KEY_BLOCKS_INSTALL,
+                false,
+                KEY_BLOCKS_UPDATE,
+                false)),
+        Map.entry(KEY_SECURITY_ADVISORIES, List.of()),
+        Map.entry(
+            KEY_REVIEW_TRUST,
+            Map.of(
+                KEY_STATUS,
+                TRUSTED,
+                KEY_POSITIVE,
+                true,
+                KEY_BLOCKS_INSTALL,
+                false,
+                KEY_BLOCKS_UPDATE,
+                false)),
+        Map.entry(
+            "thirdPartyReview",
+            Map.of(
+                "reviewerKeyId",
+                "crypta-reviewer",
+                "receiptFingerprintSha256",
+                "review-receipt-fingerprint")),
+        Map.entry(KEY_PERMISSIONS, List.of(PERMISSION_CONTENT_FETCH)),
+        Map.entry(
+            "permissionRationales", Map.of(PERMISSION_CONTENT_FETCH, "Fetches app documents.")),
+        Map.entry(KEY_API_COMPATIBILITY, apiCompatibility),
+        Map.entry(KEY_BUNDLE, Map.of(KEY_SHA256, DIGEST)));
+  }
+
+  private static Map<String, Object> apiCompatibility(String status) {
+    return Map.of(
+        KEY_STATUS,
+        status,
+        KEY_TARGET_STABILITY,
+        VALUE_STABLE,
+        KEY_EXPERIMENTAL_CAPABILITIES_ACCEPTED,
+        false);
+  }
+
+  private static Map<String, Object> updateSummary(String digest) {
+    return updateSummary(
+        digest,
+        Map.of(KEY_ADDED, List.of(PERMISSION_CONTENT_FETCH), KEY_REMOVED, List.of()),
+        noMigration());
+  }
+
+  private static Map<String, Object> updateSummary(
+      String digest, Map<String, Object> permissionDelta, Map<String, Object> migration) {
+    return updateSummary(digest, permissionDelta, migration, List.of());
+  }
+
+  private static Map<String, Object> updateSummary(
+      String digest,
+      Map<String, Object> permissionDelta,
+      Map<String, Object> migration,
+      List<Object> securityAdvisories) {
+    return updateSummary(
+        digest,
+        permissionDelta,
+        migration,
+        securityAdvisories,
+        Map.of(KEY_STATUS, TRUSTED, KEY_POSITIVE, true));
+  }
+
+  private static Map<String, Object> updateSummary(
+      String digest,
+      Map<String, Object> permissionDelta,
+      Map<String, Object> migration,
+      List<Object> securityAdvisories,
+      Map<String, Object> reviewTrust) {
+    return updateSummary(
+        digest,
+        permissionDelta,
+        migration,
+        securityAdvisories,
+        reviewTrust,
+        "available",
+        Map.of(
+            KEY_STATUS,
+            VALUE_COMPATIBLE,
+            KEY_TARGET_STABILITY,
+            VALUE_STABLE,
+            KEY_EXPERIMENTAL_CAPABILITIES_ACCEPTED,
+            false));
+  }
+
+  private static Map<String, Object> updateSummary(
+      String digest,
+      Map<String, Object> permissionDelta,
+      Map<String, Object> migration,
+      List<Object> securityAdvisories,
+      Map<String, Object> reviewTrust,
+      String candidateStatus,
+      Map<String, Object> apiCompatibility) {
+    return Map.of(
+        "candidate",
+        Map.ofEntries(
+            Map.entry(KEY_APP_ID, APP_ID),
+            Map.entry("installedVersion", VERSION_1_0_0),
+            Map.entry("targetVersion", "1.1.0"),
+            Map.entry(KEY_STATUS, candidateStatus),
+            Map.entry("catalogId", CATALOG_ID),
+            Map.entry("catalogSourceId", CATALOG_ID),
+            Map.entry(KEY_CHANNEL, VALUE_STABLE),
+            Map.entry(KEY_SUPPORT_STATUS, VALUE_SUPPORTED),
+            Map.entry(KEY_DEPRECATION, Map.of(KEY_STATUS, "none")),
+            Map.entry(
+                KEY_SECURITY_DECISION,
+                Map.of(
+                    KEY_STATUS,
+                    "ok",
+                    KEY_REQUIRES_ACKNOWLEDGEMENT,
+                    false,
+                    KEY_BLOCKS_UPDATE,
+                    false)),
+            Map.entry(KEY_SECURITY_ADVISORIES, securityAdvisories),
+            Map.entry(KEY_REVIEW_TRUST, reviewTrust),
+            Map.entry(KEY_API_COMPATIBILITY, apiCompatibility),
+            Map.entry("permissionDelta", permissionDelta),
+            Map.entry("dataMigration", migration),
+            Map.entry(KEY_BUNDLE, Map.of(KEY_SHA256, digest))));
+  }
+
+  private static Map<String, Object> incompatibleUpdateSummary() {
+    return updateSummary(
+        DIGEST,
+        noPermissionDelta(),
+        noMigration(),
+        List.of(),
+        Map.of(KEY_STATUS, TRUSTED, KEY_POSITIVE, true),
+        "incompatible",
+        Map.of(
+            KEY_STATUS,
+            "below_minimum",
+            KEY_TARGET_STABILITY,
+            VALUE_STABLE,
+            KEY_EXPERIMENTAL_CAPABILITIES_ACCEPTED,
+            false));
+  }
+
+  private static Map<String, Object> securityAdvisory(String id, String uri) {
+    return Map.of("id", id, "uri", uri);
+  }
+
+  private static Map<String, Object> materialPermissionDelta() {
+    return Map.of(KEY_ADDED, List.of(PERMISSION_CONTENT_FETCH), KEY_REMOVED, List.of());
+  }
+
+  private static Map<String, Object> trustedReviewTrust(String suffix) {
+    return Map.ofEntries(
+        Map.entry(KEY_STATUS, "trusted_reviewed"),
+        Map.entry(TRUSTED, true),
+        Map.entry(KEY_POSITIVE, true),
+        Map.entry(KEY_REQUIRES_ACKNOWLEDGEMENT, false),
+        Map.entry(KEY_BLOCKS_INSTALL, false),
+        Map.entry(KEY_BLOCKS_UPDATE, false),
+        Map.entry("blocksPolicyApply", false),
+        Map.entry("reviewerKeyId", "reviewer-" + suffix),
+        Map.entry("reviewerDisplayName", "Reviewer " + suffix),
+        Map.entry("reviewerKeyStatus", "active"),
+        Map.entry("policyId", "crypta-app-review"),
+        Map.entry("policyVersion", suffix),
+        Map.entry("policyVersionStatus", "current"),
+        Map.entry("policyMode", "advisory"),
+        Map.entry("reviewedAt", "2026-05-0" + suffix + "T00:00:00Z"),
+        Map.entry("expiresAt", "2026-06-0" + suffix + "T00:00:00Z"),
+        Map.entry("evidenceSha256", suffix.repeat(64)),
+        Map.entry("evidenceUri", "https://example.invalid/review/" + suffix),
+        Map.entry("warnings", List.of()));
+  }
+
+  private static Map<String, Object> noUpdateSummary() {
+    return Map.of(
+        "candidate",
+        Map.ofEntries(
+            Map.entry(KEY_APP_ID, APP_ID),
+            Map.entry("installedVersion", VERSION_1_0_0),
+            Map.entry("targetVersion", VERSION_1_0_0),
+            Map.entry(KEY_STATUS, "none"),
+            Map.entry("catalogId", "none"),
+            Map.entry("catalogSourceId", "none"),
+            Map.entry(KEY_CHANNEL, VALUE_STABLE),
+            Map.entry(KEY_SUPPORT_STATUS, VALUE_SUPPORTED),
+            Map.entry(KEY_DEPRECATION, Map.of(KEY_STATUS, "none")),
+            Map.entry(
+                KEY_SECURITY_DECISION,
+                Map.of(
+                    KEY_STATUS,
+                    "ok",
+                    KEY_REQUIRES_ACKNOWLEDGEMENT,
+                    false,
+                    KEY_BLOCKS_UPDATE,
+                    false)),
+            Map.entry(KEY_SECURITY_ADVISORIES, List.of()),
+            Map.entry(
+                KEY_REVIEW_TRUST,
+                Map.of(
+                    KEY_STATUS,
+                    "missing",
+                    KEY_POSITIVE,
+                    false,
+                    KEY_REQUIRES_ACKNOWLEDGEMENT,
+                    true)),
+            Map.entry(
+                KEY_API_COMPATIBILITY,
+                Map.of(
+                    KEY_STATUS,
+                    VALUE_COMPATIBLE,
+                    KEY_TARGET_STABILITY,
+                    VALUE_STABLE,
+                    KEY_EXPERIMENTAL_CAPABILITIES_ACCEPTED,
+                    false)),
+            Map.entry("permissionDelta", noPermissionDelta()),
+            Map.entry("dataMigration", noMigration()),
+            Map.entry(KEY_BUNDLE, Map.of(KEY_SHA256, "not_applicable"))));
+  }
+
+  private static Map<String, Object> noPermissionDelta() {
+    return Map.of(KEY_ADDED, List.of(), KEY_REMOVED, List.of(), "unchanged", List.of());
+  }
+
+  private static Map<String, Object> noMigration() {
+    return Map.of(REQUIRED, false);
+  }
+
+  private static Map<String, Object> migrationRequiresReview() {
+    return Map.ofEntries(
+        Map.entry(REQUIRED, true),
+        Map.entry(KEY_STATUS, "ready"),
+        Map.entry("currentSchemaVersion", 1),
+        Map.entry("targetSchemaVersion", 2),
+        Map.entry(
+            "namespaces",
+            List.of(
+                Map.of(
+                    "namespace",
+                    "feeds",
+                    "fromSchemaVersion",
+                    1,
+                    "toSchemaVersion",
+                    2,
+                    "stepId",
+                    "feeds-v1-v2",
+                    "rollbackCompatible",
+                    false,
+                    "requiresStopped",
+                    true))),
+        Map.entry("operatorReviewRequired", true),
+        Map.entry("dryRunStatus", "passed"));
+  }
+
+  private static Map<String, Object> serviceBundle() {
+    return Map.ofEntries(
+        Map.entry("bundleId", "bundle-1"),
+        Map.entry("consumerAppId", APP_ID),
+        Map.entry("bundleAlias", "social"),
+        Map.entry(KEY_STATUS, "pending"),
+        Map.entry("purpose", "Show social inbox messages."),
+        Map.entry("includeOptional", false),
+        Map.entry(
+            "dependencies",
+            List.of(
+                Map.ofEntries(
+                    Map.entry("providerAppId", "provider.app"),
+                    Map.entry("serviceId", "profile.lookup"),
+                    Map.entry("kind", REQUIRED),
+                    Map.entry(REQUIRED, true),
+                    Map.entry("scopes", List.of("read")),
+                    Map.entry("contexts", List.of("profile")),
+                    Map.entry("grantExpiresAfter", "PT24H")))));
+  }
+
+  private static final class MutableClock extends Clock {
+    private Instant instant;
+
+    private MutableClock(Instant instant) {
+      this.instant = instant;
+    }
+
+    private void advance(Duration duration) {
+      instant = instant.plus(duration);
+    }
+
+    @Override
+    public ZoneId getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+      if (!ZoneOffset.UTC.equals(zone)) {
+        throw new IllegalArgumentException("Consent tests use UTC only.");
+      }
+      return this;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return this == other;
+    }
+
+    @Override
+    public int hashCode() {
+      return System.identityHashCode(this);
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+  }
+}

--- a/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentSnapshotDigestTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentSnapshotDigestTest.java
@@ -13,13 +13,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings({"java:S100", "unchecked"})
 class ConsentSnapshotDigestTest {
+  private static final String KEY_ALPHA = "alpha";
+  private static final String LOCAL_SECRET_PATH =
+      String.join("/", "", "tmp", "local", "secret", "path");
+  private static final String PERMISSION_REQUIRED = "permission_required";
+  private static final String REDACTED_LOCAL_PATH = "[redacted-local-path]";
+  private static final String REDACTED_SECRET = "[redacted-secret]";
+  private static final String REQUEST_1 = "request-1";
   private static final Instant CREATED_AT = Instant.parse("2026-05-01T00:00:00Z");
 
   @Test
   void digest_whenRequestMetadataChanges_expectSameDigest() {
-    ConsentSnapshot first = snapshot("request-1", CREATED_AT, "permission_required");
-    ConsentSnapshot second =
-        snapshot("request-2", CREATED_AT.plusSeconds(60), "permission_required");
+    ConsentSnapshot first = snapshot(REQUEST_1, CREATED_AT, PERMISSION_REQUIRED);
+    ConsentSnapshot second = snapshot("request-2", CREATED_AT.plusSeconds(60), PERMISSION_REQUIRED);
 
     String firstDigest = first.snapshotDigest();
     String secondDigest = second.snapshotDigest();
@@ -29,8 +35,8 @@ class ConsentSnapshotDigestTest {
 
   @Test
   void digest_whenMaterialFindingChanges_expectDifferentDigest() {
-    ConsentSnapshot first = snapshot("request-1", CREATED_AT, "permission_required");
-    ConsentSnapshot second = snapshot("request-1", CREATED_AT, "review_trust_delta");
+    ConsentSnapshot first = snapshot(REQUEST_1, CREATED_AT, PERMISSION_REQUIRED);
+    ConsentSnapshot second = snapshot(REQUEST_1, CREATED_AT, "review_trust_delta");
 
     String firstDigest = first.snapshotDigest();
     String secondDigest = second.snapshotDigest();
@@ -46,20 +52,39 @@ class ConsentSnapshotDigestTest {
                 Map.of(
                     "zeta",
                     "token=secret-value",
-                    "alpha",
-                    List.of("CHK@private-material", "/tmp/local/secret/path", true)));
+                    KEY_ALPHA,
+                    List.of("CHK@private-material", LOCAL_SECRET_PATH, true)));
 
     List<String> keys = new ArrayList<>(canonical.keySet());
-    List<Object> nested = (List<Object>) canonical.get("alpha");
+    List<Object> nested = (List<Object>) canonical.get(KEY_ALPHA);
 
-    assertEquals(List.of("alpha", "zeta"), keys);
-    assertEquals("[redacted-secret]", canonical.get("zeta"));
+    assertEquals(List.of(KEY_ALPHA, "zeta"), keys);
+    assertEquals(REDACTED_SECRET, canonical.get("zeta"));
     assertTrue(nested.contains("[redacted-private-uri]"));
-    assertTrue(nested.contains("[redacted-local-path]"));
+    assertTrue(nested.contains(REDACTED_LOCAL_PATH));
     assertTrue(nested.contains(true));
     assertFalse(canonical.toString().contains("secret-value"));
     assertFalse(canonical.toString().contains("CHK@private"));
-    assertFalse(canonical.toString().contains("/tmp/local/secret/path"));
+    assertFalse(canonical.toString().contains(LOCAL_SECRET_PATH));
+  }
+
+  @Test
+  void canonicalize_whenAuthorizationBearerTextPresent_expectBearerTokenRedacted() {
+    Map<String, Object> canonical =
+        (Map<String, Object>)
+            ConsentJson.canonicalize(
+                Map.of(
+                    "header",
+                    "Authorization: Bearer concrete-token-value",
+                    "assignment",
+                    "authorization=Bearer inline-token-value"));
+
+    String rendered = canonical.toString();
+
+    assertEquals(REDACTED_SECRET, canonical.get("header"));
+    assertEquals(REDACTED_SECRET, canonical.get("assignment"));
+    assertFalse(rendered.contains("concrete-token-value"));
+    assertFalse(rendered.contains("inline-token-value"));
   }
 
   @Test
@@ -71,23 +96,23 @@ class ConsentSnapshotDigestTest {
                     "evidenceUri",
                     "https://example.invalid/review/1",
                     "localPath",
-                    "/tmp/local/secret/path"));
+                    LOCAL_SECRET_PATH));
 
     assertEquals("https://example.invalid/review/1", canonical.get("evidenceUri"));
-    assertEquals("[redacted-local-path]", canonical.get("localPath"));
+    assertEquals(REDACTED_LOCAL_PATH, canonical.get("localPath"));
   }
 
   @Test
   void digest_whenEvidenceUriChanges_expectDifferentDigest() {
     ConsentSnapshot first =
         snapshot(
-            "request-1",
+            REQUEST_1,
             CREATED_AT,
             "review_evidence_uri",
             "Evidence URI https://example.invalid/review/1");
     ConsentSnapshot second =
         snapshot(
-            "request-1",
+            REQUEST_1,
             CREATED_AT,
             "review_evidence_uri",
             "Evidence URI https://example.invalid/review/2");

--- a/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentSnapshotDigestTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentSnapshotDigestTest.java
@@ -62,14 +62,51 @@ class ConsentSnapshotDigestTest {
     assertFalse(canonical.toString().contains("/tmp/local/secret/path"));
   }
 
+  @Test
+  void canonicalize_whenHttpsEvidenceUriPresent_expectUriPreservedAndLocalPathRedacted() {
+    Map<String, Object> canonical =
+        (Map<String, Object>)
+            ConsentJson.canonicalize(
+                Map.of(
+                    "evidenceUri",
+                    "https://example.invalid/review/1",
+                    "localPath",
+                    "/tmp/local/secret/path"));
+
+    assertEquals("https://example.invalid/review/1", canonical.get("evidenceUri"));
+    assertEquals("[redacted-local-path]", canonical.get("localPath"));
+  }
+
+  @Test
+  void digest_whenEvidenceUriChanges_expectDifferentDigest() {
+    ConsentSnapshot first =
+        snapshot(
+            "request-1",
+            CREATED_AT,
+            "review_evidence_uri",
+            "Evidence URI https://example.invalid/review/1");
+    ConsentSnapshot second =
+        snapshot(
+            "request-1",
+            CREATED_AT,
+            "review_evidence_uri",
+            "Evidence URI https://example.invalid/review/2");
+
+    String firstDigest = first.snapshotDigest();
+    String secondDigest = second.snapshotDigest();
+
+    assertNotEquals(firstDigest, secondDigest);
+  }
+
   private static ConsentSnapshot snapshot(String requestId, Instant createdAt, String findingCode) {
+    return snapshot(requestId, createdAt, findingCode, "Candidate permission changed");
+  }
+
+  private static ConsentSnapshot snapshot(
+      String requestId, Instant createdAt, String findingCode, String findingSummary) {
     ConsentFinding finding =
         new ConsentFinding(
-            findingCode,
-            "Permission",
-            "Candidate permission changed",
-            "candidate",
-            ConsentRiskLevel.MATERIAL);
+            findingCode, "Permission", findingSummary, "candidate", ConsentRiskLevel.MATERIAL);
     ConsentSection section =
         new ConsentSection(
             "permissions", "Permissions", ConsentRiskLevel.MATERIAL, List.of(finding));

--- a/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentSnapshotDigestTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/consent/ConsentSnapshotDigestTest.java
@@ -1,0 +1,95 @@
+package network.crypta.platform.api.consent;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings({"java:S100", "unchecked"})
+class ConsentSnapshotDigestTest {
+  private static final Instant CREATED_AT = Instant.parse("2026-05-01T00:00:00Z");
+
+  @Test
+  void digest_whenRequestMetadataChanges_expectSameDigest() {
+    ConsentSnapshot first = snapshot("request-1", CREATED_AT, "permission_required");
+    ConsentSnapshot second =
+        snapshot("request-2", CREATED_AT.plusSeconds(60), "permission_required");
+
+    String firstDigest = first.snapshotDigest();
+    String secondDigest = second.snapshotDigest();
+
+    assertEquals(firstDigest, secondDigest);
+  }
+
+  @Test
+  void digest_whenMaterialFindingChanges_expectDifferentDigest() {
+    ConsentSnapshot first = snapshot("request-1", CREATED_AT, "permission_required");
+    ConsentSnapshot second = snapshot("request-1", CREATED_AT, "review_trust_delta");
+
+    String firstDigest = first.snapshotDigest();
+    String secondDigest = second.snapshotDigest();
+
+    assertNotEquals(firstDigest, secondDigest);
+  }
+
+  @Test
+  void canonicalize_whenNestedValuesContainSensitiveStrings_expectSortedRedactedCopy() {
+    Map<String, Object> canonical =
+        (Map<String, Object>)
+            ConsentJson.canonicalize(
+                Map.of(
+                    "zeta",
+                    "token=secret-value",
+                    "alpha",
+                    List.of("CHK@private-material", "/tmp/local/secret/path", true)));
+
+    List<String> keys = new ArrayList<>(canonical.keySet());
+    List<Object> nested = (List<Object>) canonical.get("alpha");
+
+    assertEquals(List.of("alpha", "zeta"), keys);
+    assertEquals("[redacted-secret]", canonical.get("zeta"));
+    assertTrue(nested.contains("[redacted-private-uri]"));
+    assertTrue(nested.contains("[redacted-local-path]"));
+    assertTrue(nested.contains(true));
+    assertFalse(canonical.toString().contains("secret-value"));
+    assertFalse(canonical.toString().contains("CHK@private"));
+    assertFalse(canonical.toString().contains("/tmp/local/secret/path"));
+  }
+
+  private static ConsentSnapshot snapshot(String requestId, Instant createdAt, String findingCode) {
+    ConsentFinding finding =
+        new ConsentFinding(
+            findingCode,
+            "Permission",
+            "Candidate permission changed",
+            "candidate",
+            ConsentRiskLevel.MATERIAL);
+    ConsentSection section =
+        new ConsentSection(
+            "permissions", "Permissions", ConsentRiskLevel.MATERIAL, List.of(finding));
+    return new ConsentSnapshot(
+        requestId,
+        ConsentActionType.UPDATE_APP,
+        "example.app",
+        "Example App",
+        "1.0.0",
+        "1.1.0",
+        "sha256:installed",
+        "sha256:candidate",
+        "first-party",
+        "first-party",
+        ConsentRiskLevel.MATERIAL,
+        true,
+        true,
+        List.of(findingCode),
+        "review_before_update",
+        List.of(section),
+        createdAt);
+  }
+}

--- a/platform-api/src/test/java/network/crypta/platform/api/consent/FileConsentAuditStoreTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/consent/FileConsentAuditStoreTest.java
@@ -1,0 +1,50 @@
+package network.crypta.platform.api.consent;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SuppressWarnings("java:S100")
+class FileConsentAuditStoreTest {
+  @TempDir private Path tempDir;
+
+  @Test
+  void append_whenBackedByFile_expectJsonLineAndIndexedEvent() throws Exception {
+    Path auditLog = tempDir.resolve("consent/audit.jsonl");
+    FileConsentAuditStore store = new FileConsentAuditStore(auditLog);
+    ConsentAuditEvent first = auditEvent("decision-1", "example.app");
+    ConsentAuditEvent second = auditEvent("decision-2", "other.app");
+
+    store.append(first);
+    store.append(second);
+
+    List<String> lines = Files.readAllLines(auditLog, StandardCharsets.UTF_8);
+    List<ConsentAuditEvent> appEvents = store.list("example.app");
+    List<ConsentAuditEvent> allEvents = store.list(null);
+    assertEquals(2, lines.size());
+    assertTrue(lines.get(0).contains("\"decisionId\":\"decision-1\""));
+    assertTrue(lines.get(1).contains("\"decisionId\":\"decision-2\""));
+    assertEquals(List.of(first), appEvents);
+    assertEquals(List.of(first, second), allEvents);
+  }
+
+  private static ConsentAuditEvent auditEvent(String decisionId, String appId) {
+    return new ConsentAuditEvent(
+        decisionId,
+        "request-" + decisionId,
+        "local_operator",
+        appId,
+        ConsentActionType.UPDATE_APP,
+        ConsentDecisionStatus.APPROVED,
+        Instant.parse("2026-05-01T00:00:00Z"),
+        "sha256:0123456789abcdef",
+        List.of("permission_required"));
+  }
+}

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.css
@@ -626,6 +626,80 @@ a {
   font-size: 0.9rem;
 }
 
+.consent-preview {
+  display: grid;
+  gap: 12px;
+  margin-top: 10px;
+  padding: 12px;
+  border: 1px solid rgba(255, 209, 125, 0.34);
+  border-radius: 16px;
+  background: rgba(255, 209, 125, 0.055);
+}
+
+.consent-preview h4,
+.consent-preview h5 {
+  margin: 0;
+}
+
+.consent-risk-summary {
+  margin: 0;
+  color: #ffe2a8;
+  font-weight: 700;
+}
+
+.consent-section-list {
+  display: grid;
+  gap: 10px;
+}
+
+.consent-section {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.consent-section-heading {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.consent-finding-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.consent-finding {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.8fr) minmax(0, 2fr) auto;
+  gap: 8px;
+  align-items: center;
+}
+
+.consent-finding-label {
+  font-weight: 700;
+}
+
+.consent-finding-summary {
+  color: var(--shell-muted);
+  overflow-wrap: anywhere;
+}
+
+.consent-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
 .migration-step-list {
   display: grid;
   gap: 8px;
@@ -1058,7 +1132,8 @@ a {
   .queue-create-form,
   .peer-create-form,
   .peer-form-grid,
-  .control-form-grid {
+  .control-form-grid,
+  .consent-finding {
     grid-template-columns: 1fr;
   }
 }

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -1834,6 +1834,36 @@
       : null;
   }
 
+  function consentInstallPreviewPath(catalogId, appId) {
+    return typeof catalogId === "string" &&
+      catalogId.length > 0 &&
+      typeof appId === "string" &&
+      appId.length > 0
+      ? `consent/install-preview?catalogId=${encodeURIComponent(catalogId)}&appId=${encodeURIComponent(appId)}`
+      : null;
+  }
+
+  function consentCatalogUpdatePreviewPath(catalogId, appId) {
+    return typeof catalogId === "string" &&
+      catalogId.length > 0 &&
+      typeof appId === "string" &&
+      appId.length > 0
+      ? `consent/catalog-update-preview?catalogId=${encodeURIComponent(catalogId)}&appId=${encodeURIComponent(appId)}`
+      : null;
+  }
+
+  function consentUpdatePreviewPath(appId) {
+    return typeof appId === "string" && appId.length > 0
+      ? "consent/update-preview"
+      : null;
+  }
+
+  function consentServiceGrantPreviewPath(bundleId) {
+    return typeof bundleId === "string" && bundleId.length > 0
+      ? `consent/service-grant-preview?bundleId=${encodeURIComponent(bundleId)}`
+      : null;
+  }
+
   function appUiHref(app) {
     const isolatedFallbackHref = isolatedAppUiFallbackHref(app);
     if (isolatedFallbackHref || isolatedAppUiActive(app)) {
@@ -2314,19 +2344,6 @@
       submit.disabled = true;
       submit.title = disabledReason;
     }
-    if (action === "stage") {
-      appendReviewAcknowledgement(form, updateReviewTrustForAction(appUpdateState(app), action), action);
-      appendSecurityAcknowledgement(
-        form,
-        securityDecisionForUpdateAction(appUpdateState(app), action),
-        action,
-      );
-      appendMigrationAcknowledgement(
-        form,
-        updateDataMigrationForAction(appUpdateState(app), action),
-        action,
-      );
-    }
     form.append(submit);
     return form;
   }
@@ -2360,8 +2377,6 @@
       submit.title = disabledReason;
       form.dataset.disabledReason = disabledReason;
     }
-    appendReviewAcknowledgement(form, reviewTrust, action);
-    appendSecurityAcknowledgement(form, securityDecision, action);
     form.append(submit);
     return form;
   }
@@ -2414,6 +2429,197 @@
     submit.textContent = "Grant";
     form.append(submit);
     return form;
+  }
+
+  function consentPreviewPathForForm(form, action) {
+    if (form.dataset.catalogAction === "install") {
+      return consentInstallPreviewPath(form.dataset.catalogId || "", form.dataset.catalogAppId || "");
+    }
+    if (form.dataset.catalogAction === "update") {
+      return consentCatalogUpdatePreviewPath(form.dataset.catalogId || "", form.dataset.catalogAppId || "");
+    }
+    if (form.dataset.appUpdateAction === "stage") {
+      return consentUpdatePreviewPath(form.dataset.appId || "");
+    }
+    if (
+      form.dataset.appServiceBundleAction === "approve" ||
+      form.dataset.appServiceBundleAction === "renew"
+    ) {
+      return consentServiceGrantPreviewPath(form.dataset.bundleId || "");
+    }
+    return null;
+  }
+
+  async function loadConsentPreviewForForm(form, action) {
+    const path = consentPreviewPathForForm(form, action);
+    if (!path) {
+      return null;
+    }
+    if (form.dataset.appUpdateAction === "stage") {
+      const formData = new FormData();
+      formData.set("appId", form.dataset.appId || "");
+      const response = await postForm(
+        path,
+        formData,
+        "Consent previews unavailable in read-only mode.",
+      );
+      return recordValue(response.consent || response);
+    }
+    const response = await loadJson(apiUrl(path));
+    return recordValue(response.consent || response);
+  }
+
+  async function ensureConsentApprovedForForm(form, action) {
+    if (form.dataset.consentApproved === "true") {
+      return true;
+    }
+    const preview = await loadConsentPreviewForForm(form, action);
+    if (!preview || preview.requiresApproval !== true) {
+      return true;
+    }
+    renderConsentPreview(preview, form);
+    setAppsStatus("Review the consent preview before continuing.", "is-warning");
+    return false;
+  }
+
+  function renderConsentPreview(preview, form) {
+    clearConsentPreview(form);
+    const card = document.createElement("div");
+    card.className = "consent-preview";
+    card.setAttribute("role", "group");
+    card.setAttribute("aria-label", "Consent preview");
+    card.append(
+      text("h4", "", "Consent preview"),
+      definitionList([
+        ["Action", normalizedStatus(preview.action)],
+        ["Risk level", normalizedStatus(preview.riskLevel)],
+        ["Blocks auto-update", preview.blocksAutoUpdate === true ? "Yes" : "No"],
+        ["Snapshot digest", scalar(preview.snapshotDigest)],
+      ]),
+    );
+    const reasons = stringList(preview.blockingReasons);
+    if (reasons.length) {
+      card.append(text("p", "consent-risk-summary", reasons.map(normalizedStatus).join(", ")));
+    }
+    const sectionList = document.createElement("div");
+    sectionList.className = "consent-section-list";
+    arrayValue(preview.sections).forEach((section) => {
+      sectionList.append(renderConsentSection(section));
+    });
+    card.append(sectionList, consentPreviewActions(preview, form));
+    form.after(card);
+  }
+
+  function renderConsentSection(section) {
+    const item = recordValue(section);
+    const node = document.createElement("section");
+    node.className = "consent-section";
+    const heading = document.createElement("div");
+    heading.className = "consent-section-heading";
+    heading.append(
+      text("h5", "", item.title || normalizedStatus(item.id)),
+      createPill(normalizedStatus(item.riskLevel), consentRiskTone(item.riskLevel)),
+    );
+    const list = document.createElement("ul");
+    list.className = "consent-finding-list";
+    arrayValue(item.items).forEach((finding) => {
+      list.append(renderConsentFinding(finding));
+    });
+    node.append(heading, list);
+    return node;
+  }
+
+  function renderConsentFinding(finding) {
+    const item = recordValue(finding);
+    const row = document.createElement("li");
+    row.className = "consent-finding";
+    row.append(
+      text("span", "consent-finding-label", scalar(item.label)),
+      text("span", "consent-finding-summary", scalar(item.summary)),
+      createPill(normalizedStatus(item.change || item.riskLevel), consentRiskTone(item.riskLevel)),
+    );
+    return row;
+  }
+
+  function consentPreviewActions(preview, form) {
+    const actions = document.createElement("div");
+    actions.className = "consent-actions";
+    const approve = document.createElement("button");
+    approve.className = "button button-primary";
+    approve.type = "button";
+    approve.textContent = "Approve";
+    approve.addEventListener("click", async () => {
+      try {
+        await submitConsentDecision(preview, "approve");
+        appendConsentSnapshotFields(form, preview);
+        form.dataset.consentApproved = "true";
+        clearConsentPreview(form);
+        setAppsStatus("Consent approved. Continuing action.", "is-success");
+        form.requestSubmit();
+      } catch (error) {
+        setAppsStatus(consentStaleErrorMessage(error), "is-error");
+      }
+    });
+    const reject = document.createElement("button");
+    reject.className = "button button-secondary";
+    reject.type = "button";
+    reject.textContent = "Reject";
+    reject.addEventListener("click", async () => {
+      try {
+        await submitConsentDecision(preview, "reject");
+        clearConsentPreview(form);
+        setAppsStatus("Consent rejected. No app-platform mutation was applied.", "is-warning");
+        await loadAppsSection();
+      } catch (error) {
+        setAppsStatus(consentStaleErrorMessage(error), "is-error");
+      }
+    });
+    actions.append(approve, reject);
+    return actions;
+  }
+
+  async function submitConsentDecision(preview, decision) {
+    const formData = new FormData();
+    formData.set("consentRequestId", scalar(preview.consentRequestId));
+    formData.set("snapshotDigest", scalar(preview.snapshotDigest));
+    await postForm(`consent/${decision}`, formData, "Consent decisions unavailable in read-only mode.");
+  }
+
+  function appendConsentSnapshotFields(form, preview) {
+    removeNamedFields(form, "consentRequestId");
+    removeNamedFields(form, "snapshotDigest");
+    appendHiddenField(form, "consentRequestId", scalar(preview.consentRequestId));
+    appendHiddenField(form, "snapshotDigest", scalar(preview.snapshotDigest));
+  }
+
+  function clearConsentPreview(form) {
+    const existing = form.nextElementSibling;
+    if (existing && existing.classList.contains("consent-preview")) {
+      existing.remove();
+    }
+  }
+
+  function removeNamedFields(form, name) {
+    form.querySelectorAll(`input[name="${name}"]`).forEach((node) => node.remove());
+  }
+
+  function consentRiskTone(riskLevel) {
+    const risk = typeof riskLevel === "string" ? riskLevel : "";
+    if (risk === "blocking") {
+      return "is-error";
+    }
+    if (risk === "material") {
+      return "is-warning";
+    }
+    return "is-success";
+  }
+
+  function consentStaleErrorMessage(error) {
+    return error && error.apiErrorCode === "stale_consent_snapshot"
+      ? "This approval is stale. Refresh the consent preview."
+      : error instanceof Error
+        ? error.message
+        : String(error);
   }
 
   function buildIdentityVaultRevokeForm(grant) {
@@ -6573,12 +6779,16 @@
     }
 
     try {
+      if (action === "stage" && !(await ensureConsentApprovedForForm(form, action))) {
+        return;
+      }
       const data = await postForm(path, new FormData(form), "App update actions unavailable in read-only mode.");
       const operation = data.operation || `update_${action}`;
       setAppsStatus(`${appName} update action completed: ${operation.replaceAll("_", " ")}.`, "is-success");
       await loadAppsSection();
     } catch (error) {
-      setAppsStatus(error instanceof Error ? error.message : String(error), "is-error");
+      form.dataset.consentApproved = "false";
+      setAppsStatus(consentStaleErrorMessage(error), "is-error");
       await loadAppsSection();
     }
   }
@@ -6623,12 +6833,16 @@
       if (action === "remove") {
         await deleteForm(path, new FormData(form), "Catalog actions unavailable in read-only mode.");
       } else {
+        if ((action === "install" || action === "update") && !(await ensureConsentApprovedForForm(form, action))) {
+          return;
+        }
         await postForm(path, new FormData(form), "Catalog actions unavailable in read-only mode.");
       }
       setAppsStatus(`Catalog action completed: ${action}.`, "is-success");
       await loadAppsSection();
     } catch (error) {
-      setAppsStatus(error instanceof Error ? error.message : String(error), "is-error");
+      form.dataset.consentApproved = "false";
+      setAppsStatus(consentStaleErrorMessage(error), "is-error");
     }
   }
 
@@ -6682,11 +6896,18 @@
       return;
     }
     try {
+      if (
+        (action === "approve" || action === "renew") &&
+        !(await ensureConsentApprovedForForm(form, action))
+      ) {
+        return;
+      }
       await postForm(path, new FormData(form), "App-service grant-bundle actions unavailable in read-only mode.");
       setAppsStatus(`App-service grant bundle ${action} completed.`, "is-success");
       await loadAppsSection();
     } catch (error) {
-      setAppsStatus(error instanceof Error ? error.message : String(error), "is-error");
+      form.dataset.consentApproved = "false";
+      setAppsStatus(consentStaleErrorMessage(error), "is-error");
     }
   }
 

--- a/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
+++ b/platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java
@@ -115,6 +115,7 @@ class WebShellResourcesTest {
     assertAppDataBackupRestoreMarkersPresent(script);
     assertBetaDashboardLoadSequencing(script);
     assertAppsMarkersPresent(script);
+    assertConsentUxMarkersPresent(script);
     assertAppUpdateLifecycleMarkersPresent(script);
     assertAppStoreMetadataMarkersPresent(script);
     assertCompatibilityUndeclaredPrecedesSuccess(script);
@@ -138,6 +139,10 @@ class WebShellResourcesTest {
     assertTrue(stylesheet.contains(".app-card-actions {"));
     assertTrue(stylesheet.contains(".app-log-tail {"));
     assertTrue(stylesheet.contains(".permission-list {"));
+    assertTrue(stylesheet.contains(".consent-preview {"));
+    assertTrue(stylesheet.contains(".consent-section-list {"));
+    assertTrue(stylesheet.contains(".consent-finding-list {"));
+    assertTrue(stylesheet.contains(".consent-actions {"));
     assertTrue(stylesheet.contains(".vault-grant-form {"));
     assertTrue(stylesheet.contains(".app-audit-event.is-denied {"));
     assertTrue(stylesheet.contains(".catalog-app-card {"));
@@ -817,6 +822,44 @@ class WebShellResourcesTest {
     assertTrue(script.contains("Identity vault actions unavailable in read-only mode."));
     assertTrue(script.contains("Identity grant created."));
     assertTrue(script.contains("Identity grant revoked."));
+  }
+
+  private static void assertConsentUxMarkersPresent(String script) {
+    assertTrue(script.contains("function consentInstallPreviewPath(catalogId, appId)"));
+    assertTrue(script.contains("function consentCatalogUpdatePreviewPath(catalogId, appId)"));
+    assertTrue(script.contains("function consentUpdatePreviewPath(appId)"));
+    assertTrue(script.contains("function consentServiceGrantPreviewPath(bundleId)"));
+    assertTrue(script.contains("function consentPreviewPathForForm(form, action)"));
+    assertTrue(script.contains("function loadConsentPreviewForForm(form, action)"));
+    assertTrue(script.contains("function ensureConsentApprovedForForm(form, action)"));
+    assertTrue(script.contains("function renderConsentPreview(preview, form)"));
+    assertTrue(script.contains("function renderConsentSection(section)"));
+    assertTrue(script.contains("function renderConsentFinding(finding)"));
+    assertTrue(script.contains("function submitConsentDecision(preview, decision)"));
+    assertTrue(script.contains("function appendConsentSnapshotFields(form, preview)"));
+    assertTrue(script.contains("function consentStaleErrorMessage(error)"));
+    assertTrue(script.contains("consent/install-preview?catalogId="));
+    assertTrue(script.contains("consent/catalog-update-preview?catalogId="));
+    assertTrue(script.contains("\"consent/update-preview\""));
+    assertTrue(script.contains("consent/service-grant-preview?bundleId="));
+    assertTrue(script.contains("Consent previews unavailable in read-only mode."));
+    assertTrue(script.contains("await postForm(`consent/${decision}`"));
+    assertTrue(script.contains("formData.set(\"consentRequestId\""));
+    assertTrue(script.contains("formData.set(\"snapshotDigest\""));
+    assertTrue(script.contains("appendHiddenField(form, \"consentRequestId\""));
+    assertTrue(script.contains("appendHiddenField(form, \"snapshotDigest\""));
+    assertTrue(script.contains("preview.requiresApproval !== true"));
+    assertTrue(script.contains("preview.blocksAutoUpdate === true ? \"Yes\" : \"No\""));
+    assertTrue(script.contains("arrayValue(preview.sections).forEach((section)"));
+    assertTrue(script.contains("arrayValue(item.items).forEach((finding)"));
+    assertTrue(script.contains("Consent preview"));
+    assertTrue(script.contains("Risk level"));
+    assertTrue(script.contains("Blocks auto-update"));
+    assertTrue(script.contains("Snapshot digest"));
+    assertTrue(script.contains("Consent approved. Continuing action."));
+    assertTrue(script.contains("Consent rejected. No app-platform mutation was applied."));
+    assertTrue(script.contains("This approval is stale. Refresh the consent preview."));
+    assertTrue(script.contains("await ensureConsentApprovedForForm(form, action)"));
   }
 
   private static void assertAppUpdateLifecycleMarkersPresent(String script) {

--- a/src/test/java/network/crypta/platform/api/PlatformApiAppsIntegrationTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiAppsIntegrationTest.java
@@ -293,10 +293,13 @@ class PlatformApiAppsIntegrationTest {
     PlatformApiResponse listAppsResponse =
         productionRouter.route(
             request("GET", List.of("app-catalogs", CATALOG_ID, "apps"), Map.of()));
+    Map<String, List<String>> installConsent = approveCatalogInstallConsent(productionRouter);
     PlatformApiResponse installResponse =
         productionRouter.route(
             request(
-                "POST", List.of("app-catalogs", CATALOG_ID, "apps", APP_ID, "install"), Map.of()));
+                "POST",
+                List.of("app-catalogs", CATALOG_ID, "apps", APP_ID, "install"),
+                installConsent));
 
     assertEquals(201, addResponse.statusCode());
     assertEquals(200, listAppsResponse.statusCode());
@@ -311,10 +314,13 @@ class PlatformApiAppsIntegrationTest {
     PlatformApiResponse refreshResponse =
         productionRouter.route(
             request("POST", List.of("app-catalogs", CATALOG_ID, "refresh"), Map.of()));
+    Map<String, List<String>> updateConsent = approveCatalogUpdateConsent(productionRouter);
     PlatformApiResponse updateResponse =
         productionRouter.route(
             request(
-                "POST", List.of("app-catalogs", CATALOG_ID, "apps", APP_ID, "update"), Map.of()));
+                "POST",
+                List.of("app-catalogs", CATALOG_ID, "apps", APP_ID, "update"),
+                updateConsent));
 
     assertEquals(200, refreshResponse.statusCode());
     assertEquals(200, updateResponse.statusCode());
@@ -324,6 +330,51 @@ class PlatformApiAppsIntegrationTest {
   private PlatformApiRequest request(
       String method, List<String> pathSegments, Map<String, List<String>> queryParameters) {
     return new PlatformApiRequest(method, pathSegments, queryParameters);
+  }
+
+  private Map<String, List<String>> approveCatalogInstallConsent(PlatformApiRouter router) {
+    PlatformApiResponse preview =
+        router.route(
+            request(
+                "GET",
+                List.of("consent", "install-preview"),
+                Map.of("catalogId", List.of(CATALOG_ID), "appId", List.of(APP_ID))));
+    return approveConsent(router, preview);
+  }
+
+  private Map<String, List<String>> approveCatalogUpdateConsent(PlatformApiRouter router) {
+    PlatformApiResponse preview =
+        router.route(
+            request(
+                "GET",
+                List.of("consent", "catalog-update-preview"),
+                Map.of("catalogId", List.of(CATALOG_ID), "appId", List.of(APP_ID))));
+    return approveConsent(router, preview);
+  }
+
+  private Map<String, List<String>> approveConsent(
+      PlatformApiRouter router, PlatformApiResponse preview) {
+    assertEquals(200, preview.statusCode());
+    Map<String, List<String>> approvalParams =
+        Map.of(
+            "consentRequestId",
+            List.of(jsonString(preview.body(), "consentRequestId")),
+            "snapshotDigest",
+            List.of(jsonString(preview.body(), "snapshotDigest")));
+    PlatformApiResponse approval =
+        router.route(request("POST", List.of("consent", "approve"), approvalParams));
+    assertEquals(200, approval.statusCode());
+    return approvalParams;
+  }
+
+  private static String jsonString(String json, String field) {
+    String marker = "\"" + field + "\":\"";
+    int index = json.indexOf(marker);
+    assertTrue(index >= 0, "missing JSON field " + field + " in " + json);
+    int start = index + marker.length();
+    int end = json.indexOf('"', start);
+    assertTrue(end > start, "unterminated JSON field " + field + " in " + json);
+    return json.substring(start, end);
   }
 
   private PlatformApiRouter createRouter(AppHost appHost) throws Exception {

--- a/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
+++ b/src/test/java/network/crypta/platform/api/PlatformApiRouterTest.java
@@ -128,6 +128,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -2400,23 +2401,51 @@ class PlatformApiRouterTest {
     AppCatalogManager catalogManager = mock(AppCatalogManager.class);
     PlatformApiRouter updateRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
     AppCatalogEntry entry = catalogEntry("9.9.9");
+    Path previewScratchDir = tempDir.resolve("app-update-stage-preview-scratch");
+    Path verificationScratchDir = tempDir.resolve("app-update-stage-verification-scratch");
     Path scratchDir = tempDir.resolve("app-update-stage-scratch");
+    AppCatalogInstallPlan previewPlan = catalogInstallPlan(entry, previewScratchDir);
+    AppCatalogInstallPlan verificationPlan = catalogInstallPlan(entry, verificationScratchDir);
     AppCatalogInstallPlan plan = catalogInstallPlan(entry, scratchDir);
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalogSourceSnapshot()));
     when(catalogManager.listApps("core")).thenReturn(List.of(entry));
-    when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(catalogManager.prepareInstallPlan("core", APP_ID))
+        .thenReturn(previewPlan, verificationPlan, plan);
+    Map<String, List<String>> approvalParams = approveUpdateConsent(updateRouter);
 
     PlatformApiResponse response =
-        updateRouter.route(request("POST", List.of("apps", APP_ID, "updates", "stage"), Map.of()));
+        updateRouter.route(
+            request("POST", List.of("apps", APP_ID, "updates", "stage"), approvalParams));
 
     assertEquals(200, response.statusCode());
     assertTrue(response.body().contains("\"status\":\"staged\""));
     assertTrue(response.body().contains("\"targetVersion\":\"9.9.9\""));
     assertFalse(response.body().contains(tempDir.toString()));
     //noinspection resource
-    verify(catalogManager).prepareInstallPlan("core", APP_ID);
+    verify(catalogManager, times(3)).prepareInstallPlan("core", APP_ID);
+  }
+
+  @Test
+  void route_whenAppUpdateStageRequestedWithoutUpdate_expectUpdateNotAvailableNotConsentRequired()
+      throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter updateRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(catalogManager.listCatalogs()).thenReturn(List.of(catalogSourceSnapshot()));
+    when(catalogManager.listApps("core")).thenReturn(List.of());
+
+    PlatformApiResponse response =
+        updateRouter.route(request("POST", List.of("apps", APP_ID, "updates", "stage"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals("Conflict", response.reasonPhrase());
+    assertTrue(response.body().contains("\"code\":\"update_not_available\""));
+    assertFalse(response.body().contains("consent_required"));
+    //noinspection resource
+    verify(catalogManager, never()).prepareInstallPlan(any(), any());
   }
 
   @Test
@@ -2435,20 +2464,30 @@ class PlatformApiRouterTest {
             AppUiOriginRegistry.sameOriginOnly(),
             PlatformApiSharedAppServices.of(null, updateService, null, appDataService));
     AppCatalogEntry entry = catalogEntry("9.9.9");
-    Path scratchDir = tempDir.resolve("app-update-stage-migration-scratch");
-    AppCatalogInstallPlan plan = catalogInstallPlanWithUiStateMigration(entry, scratchDir);
+    AppCatalogInstallPlan previewPlan =
+        catalogInstallPlanWithUiStateMigration(
+            entry, tempDir.resolve("app-update-stage-migration-preview-scratch"));
+    AppCatalogInstallPlan verificationPlan =
+        catalogInstallPlanWithUiStateMigration(
+            entry, tempDir.resolve("app-update-stage-migration-verify-scratch"));
+    AppCatalogInstallPlan stagePlan =
+        catalogInstallPlanWithUiStateMigration(
+            entry, tempDir.resolve("app-update-stage-migration-scratch"));
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalogSourceSnapshot()));
     when(catalogManager.listApps("core")).thenReturn(List.of(entry));
-    when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(catalogManager.prepareInstallPlan("core", APP_ID))
+        .thenReturn(previewPlan, verificationPlan, stagePlan);
+    PlatformApiResponse preview =
+        updateRouter.route(
+            request(
+                "POST", List.of("consent", "update-preview"), Map.of("appId", List.of(APP_ID))));
+    Map<String, List<String>> approvalParams = approveConsent(updateRouter, preview);
 
     PlatformApiResponse response =
         updateRouter.route(
-            request(
-                "POST",
-                List.of("apps", APP_ID, "updates", "stage"),
-                Map.of("migrationAcknowledged", List.of("true"))));
+            request("POST", List.of("apps", APP_ID, "updates", "stage"), approvalParams));
 
     assertEquals(200, response.statusCode());
     assertTrue(response.body().contains("\"status\":\"staged\""));
@@ -2464,17 +2503,23 @@ class PlatformApiRouterTest {
     AppCatalogManager catalogManager = mock(AppCatalogManager.class);
     PlatformApiRouter updateRouter = routerWithVault(catalogManager);
     AppCatalogEntry entry = catalogEntry("9.9.9");
+    AppCatalogInstallPlan previewPlan =
+        catalogInstallPlan(entry, tempDir.resolve("app-update-uninstall-preview-scratch"));
+    AppCatalogInstallPlan verificationPlan =
+        catalogInstallPlan(entry, tempDir.resolve("app-update-uninstall-verification-scratch"));
     Path scratchDir = tempDir.resolve("app-update-uninstall-stage-scratch");
     try (AppCatalogInstallPlan plan = catalogInstallPlan(entry, scratchDir)) {
       when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
       when(appHost.status(APP_ID)).thenReturn(Optional.empty());
       when(catalogManager.listCatalogs()).thenReturn(List.of(catalogSourceSnapshot()));
       when(catalogManager.listApps("core")).thenReturn(List.of(entry));
-      when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+      when(catalogManager.prepareInstallPlan("core", APP_ID))
+          .thenReturn(previewPlan, verificationPlan, plan);
+      Map<String, List<String>> approvalParams = approveUpdateConsent(updateRouter);
 
       PlatformApiResponse stageResponse =
           updateRouter.route(
-              request("POST", List.of("apps", APP_ID, "updates", "stage"), Map.of()));
+              request("POST", List.of("apps", APP_ID, "updates", "stage"), approvalParams));
       PlatformApiResponse uninstallResponse =
           updateRouter.route(request("DELETE", List.of("apps", APP_ID), Map.of()));
       PlatformApiResponse summaryResponse =
@@ -2542,9 +2587,17 @@ class PlatformApiRouterTest {
             AppUiOriginRegistry.sameOriginOnly(),
             vaultService);
     AppCatalogEntry entry = catalogEntry("9.9.9");
+    AppCatalogInstallPlan previewPlan =
+        catalogInstallPlan(entry, tempDir.resolve("app-update-uninstall-vault-cleanup-preview"));
+    AppCatalogInstallPlan verificationPlan =
+        catalogInstallPlan(
+            entry, tempDir.resolve("app-update-uninstall-vault-cleanup-verification"));
     Path scratchDir = tempDir.resolve("app-update-uninstall-vault-cleanup-stage-scratch");
     try (AppCatalogInstallPlan plan = catalogInstallPlan(entry, scratchDir)) {
       when(appHost.describe(APP_ID))
+          .thenReturn(Optional.of(installedSnapshot()))
+          .thenReturn(Optional.of(installedSnapshot()))
+          .thenReturn(Optional.of(installedSnapshot()))
           .thenReturn(Optional.of(installedSnapshot()))
           .thenReturn(Optional.of(installedSnapshot()))
           .thenReturn(Optional.empty())
@@ -2552,11 +2605,13 @@ class PlatformApiRouterTest {
       when(appHost.status(APP_ID)).thenReturn(Optional.empty());
       when(catalogManager.listCatalogs()).thenReturn(List.of(catalogSourceSnapshot()));
       when(catalogManager.listApps("core")).thenReturn(List.of(entry));
-      when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+      when(catalogManager.prepareInstallPlan("core", APP_ID))
+          .thenReturn(previewPlan, verificationPlan, plan);
+      Map<String, List<String>> approvalParams = approveUpdateConsent(updateRouter);
 
       PlatformApiResponse stageResponse =
           updateRouter.route(
-              request("POST", List.of("apps", APP_ID, "updates", "stage"), Map.of()));
+              request("POST", List.of("apps", APP_ID, "updates", "stage"), approvalParams));
       PlatformApiResponse uninstallResponse =
           updateRouter.route(request("DELETE", List.of("apps", APP_ID), Map.of()));
       PlatformApiResponse summaryResponse =
@@ -2597,17 +2652,24 @@ class PlatformApiRouterTest {
             AppUiOriginRegistry.sameOriginOnly(),
             vaultService);
     AppCatalogEntry entry = catalogEntry("9.9.9");
+    AppCatalogInstallPlan previewPlan =
+        catalogInstallPlan(entry, tempDir.resolve("app-update-uninstall-vault-preblock-preview"));
+    AppCatalogInstallPlan verificationPlan =
+        catalogInstallPlan(
+            entry, tempDir.resolve("app-update-uninstall-vault-preblock-verification"));
     Path scratchDir = tempDir.resolve("app-update-uninstall-vault-preblock-stage-scratch");
     try (AppCatalogInstallPlan plan = catalogInstallPlan(entry, scratchDir)) {
       when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
       when(appHost.status(APP_ID)).thenReturn(Optional.empty());
       when(catalogManager.listCatalogs()).thenReturn(List.of(catalogSourceSnapshot()));
       when(catalogManager.listApps("core")).thenReturn(List.of(entry));
-      when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+      when(catalogManager.prepareInstallPlan("core", APP_ID))
+          .thenReturn(previewPlan, verificationPlan, plan);
+      Map<String, List<String>> approvalParams = approveUpdateConsent(updateRouter);
 
       PlatformApiResponse stageResponse =
           updateRouter.route(
-              request("POST", List.of("apps", APP_ID, "updates", "stage"), Map.of()));
+              request("POST", List.of("apps", APP_ID, "updates", "stage"), approvalParams));
       Path accessBlocksRoot = vaultRoot.resolve("app-access-blocks");
       Files.delete(accessBlocksRoot);
       Files.writeString(accessBlocksRoot, "not-a-directory");
@@ -2631,19 +2693,27 @@ class PlatformApiRouterTest {
     AppCatalogManager catalogManager = mock(AppCatalogManager.class);
     PlatformApiRouter updateRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
     AppCatalogEntry entry = catalogEntry("9.9.9");
+    Path previewScratchDir = tempDir.resolve("app-update-apply-preview-scratch");
+    Path verificationScratchDir = tempDir.resolve("app-update-apply-verification-scratch");
     Path scratchDir = tempDir.resolve("app-update-apply-scratch");
+    AppCatalogInstallPlan previewPlan = catalogInstallPlan(entry, previewScratchDir);
+    AppCatalogInstallPlan verificationPlan = catalogInstallPlan(entry, verificationScratchDir);
     AppCatalogInstallPlan plan = catalogInstallPlan(entry, scratchDir);
     Path stagedDir = plan.stagedBundleDirectory();
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
     when(appHost.status(APP_ID))
         .thenReturn(Optional.empty())
         .thenReturn(Optional.empty())
+        .thenReturn(Optional.empty())
         .thenReturn(Optional.of(runningSnapshot()));
     when(catalogManager.listCatalogs()).thenReturn(List.of(catalogSourceSnapshot()));
     when(catalogManager.listApps("core")).thenReturn(List.of(entry));
-    when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(catalogManager.prepareInstallPlan("core", APP_ID))
+        .thenReturn(previewPlan, verificationPlan, plan);
+    Map<String, List<String>> approvalParams = approveUpdateConsent(updateRouter);
     PlatformApiResponse stageResponse =
-        updateRouter.route(request("POST", List.of("apps", APP_ID, "updates", "stage"), Map.of()));
+        updateRouter.route(
+            request("POST", List.of("apps", APP_ID, "updates", "stage"), approvalParams));
 
     PlatformApiResponse response =
         updateRouter.route(request("POST", List.of("apps", APP_ID, "updates", "apply"), Map.of()));
@@ -3577,18 +3647,78 @@ class PlatformApiRouterTest {
     when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry(APP_VERSION));
     when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
     when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(plan.catalogId()).thenReturn("core");
     when(plan.entry()).thenReturn(catalogEntry(APP_VERSION));
     when(plan.stagedBundleDirectory()).thenReturn(stagedDir);
     when(appHost.installFromDirectory(stagedDir)).thenReturn(installed);
     doThrow(new IOException("cleanup failed")).when(plan).close();
 
+    Map<String, List<String>> approvalParams = approveCatalogInstallConsent(catalogRouter);
+
     PlatformApiResponse response =
         catalogRouter.route(
-            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "install"), Map.of()));
+            request(
+                "POST",
+                List.of("app-catalogs", "core", "apps", APP_ID, "install"),
+                approvalParams));
 
     assertEquals(201, response.statusCode());
     assertEquals(
         PlatformApiJsonWriter.write(Map.of("app", catalogSummary(APP_VERSION))), response.body());
+  }
+
+  @Test
+  void route_whenCatalogInstallConsentApproved_expectInstallUsesInstallSnapshot() throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    AppCatalogEntry entry = catalogEntry(APP_VERSION);
+    AppCatalogInstallPlan plan =
+        catalogInstallPlan(entry, tempDir.resolve("catalog-consent-install-stage"));
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(entry);
+    when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
+    when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(appHost.installFromDirectory(plan.stagedBundleDirectory()))
+        .thenReturn(installedSnapshot());
+    PlatformApiResponse preview =
+        catalogRouter.route(
+            request(
+                "GET",
+                List.of("consent", "install-preview"),
+                Map.of("catalogId", List.of("core"), "appId", List.of(APP_ID))));
+    Map<String, List<String>> approvalParams = approveConsent(catalogRouter, preview);
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request(
+                "POST",
+                List.of("app-catalogs", "core", "apps", APP_ID, "install"),
+                approvalParams));
+
+    assertEquals(201, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", catalogSummary(APP_VERSION))), response.body());
+  }
+
+  @Test
+  void route_whenCatalogInstallRepeatedWithoutConsent_expectConflictBeforeConsent()
+      throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry(APP_VERSION));
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "install"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"app already installed: alpha\"}}",
+        response.body());
+    assertFalse(response.body().contains("consent_required"));
+    //noinspection resource
+    verify(catalogManager, never()).prepareInstallPlan(any(), any());
+    verify(appHost, never()).installFromDirectory(any());
   }
 
   @Test
@@ -3598,9 +3728,14 @@ class PlatformApiRouterTest {
     when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry(APP_VERSION));
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
 
+    Map<String, List<String>> approvalParams = approveCatalogInstallConsent(catalogRouter);
+
     PlatformApiResponse response =
         catalogRouter.route(
-            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "install"), Map.of()));
+            request(
+                "POST",
+                List.of("app-catalogs", "core", "apps", APP_ID, "install"),
+                approvalParams));
 
     assertEquals(409, response.statusCode());
     assertEquals(
@@ -3620,6 +3755,7 @@ class PlatformApiRouterTest {
     when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry(APP_VERSION));
     when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
     when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(plan.catalogId()).thenReturn("core");
     when(plan.entry()).thenReturn(catalogEntry(APP_VERSION));
     when(plan.stagedBundleDirectory()).thenReturn(stagedDir);
     when(appHost.installFromDirectory(stagedDir))
@@ -3627,9 +3763,14 @@ class PlatformApiRouterTest {
             new AppHostException(
                 "app.ui.entry does not resolve to a file in copied bundle: static/index.html"));
 
+    Map<String, List<String>> approvalParams = approveCatalogInstallConsent(catalogRouter);
+
     PlatformApiResponse response =
         catalogRouter.route(
-            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "install"), Map.of()));
+            request(
+                "POST",
+                List.of("app-catalogs", "core", "apps", APP_ID, "install"),
+                approvalParams));
 
     assertEquals(400, response.statusCode());
     assertEquals(
@@ -3650,14 +3791,18 @@ class PlatformApiRouterTest {
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
     when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(plan.catalogId()).thenReturn("core");
     when(plan.entry()).thenReturn(catalogEntry("9.9.9"));
     when(plan.stagedBundleDirectory()).thenReturn(stagedDir);
     when(appHost.updateFromDirectory(APP_ID, stagedDir)).thenReturn(updated);
     doThrow(new IOException("cleanup failed")).when(plan).close();
 
+    Map<String, List<String>> approvalParams = approveCatalogUpdateConsent(catalogRouter);
+
     PlatformApiResponse response =
         catalogRouter.route(
-            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), Map.of()));
+            request(
+                "POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), approvalParams));
 
     assertEquals(200, response.statusCode());
     assertEquals(
@@ -3665,7 +3810,74 @@ class PlatformApiRouterTest {
   }
 
   @Test
-  void route_whenCatalogUpdateTargetMissing_expectNotFoundWithoutPreparingPlan() throws Exception {
+  void route_whenCatalogUpdateConsentApproved_expectUpdateUsesCatalogUpdateSnapshot()
+      throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    AppCatalogEntry entry = catalogEntry("9.9.9");
+    AppCatalogInstallPlan plan =
+        catalogInstallPlan(entry, tempDir.resolve("catalog-consent-update-stage"));
+    InstalledAppSnapshot updated = installedSnapshot(APP_ID, APP_NAME, "9.9.9", APP_UI_ENTRY);
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(entry);
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
+    when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(appHost.updateFromDirectory(APP_ID, plan.stagedBundleDirectory())).thenReturn(updated);
+    PlatformApiResponse preview =
+        catalogRouter.route(
+            request(
+                "GET",
+                List.of("consent", "catalog-update-preview"),
+                Map.of("catalogId", List.of("core"), "appId", List.of(APP_ID))));
+    Map<String, List<String>> approvalParams = approveConsent(catalogRouter, preview);
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request(
+                "POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), approvalParams));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", catalogSummary("9.9.9"))), response.body());
+  }
+
+  @Test
+  void
+      route_whenCatalogUpdateConsentApprovedAndInstalledManifestUnreadable_expectRepairUpdatedJson()
+          throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    AppCatalogEntry entry = catalogEntry("9.9.9");
+    AppCatalogInstallPlan plan =
+        catalogInstallPlan(entry, tempDir.resolve("catalog-consent-repair-stage"));
+    InstalledAppSnapshot updated = installedSnapshot(APP_ID, APP_NAME, "9.9.9", APP_UI_ENTRY);
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(entry);
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.describe(APP_ID)).thenThrow(new IOException("corrupt manifest"));
+    when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(appHost.updateFromDirectory(APP_ID, plan.stagedBundleDirectory())).thenReturn(updated);
+    PlatformApiResponse preview =
+        catalogRouter.route(
+            request(
+                "GET",
+                List.of("consent", "catalog-update-preview"),
+                Map.of("catalogId", List.of("core"), "appId", List.of(APP_ID))));
+    Map<String, List<String>> approvalParams = approveConsent(catalogRouter, preview);
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request(
+                "POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), approvalParams));
+
+    assertEquals(200, response.statusCode());
+    assertEquals(
+        PlatformApiJsonWriter.write(Map.of("app", catalogSummary("9.9.9"))), response.body());
+    verify(appHost).updateFromDirectory(APP_ID, plan.stagedBundleDirectory());
+  }
+
+  @Test
+  void route_whenCatalogUpdateTargetMissingWithoutConsent_expectNotFoundBeforeConsent()
+      throws Exception {
     AppCatalogManager catalogManager = mock(AppCatalogManager.class);
     PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
     when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry("9.9.9"));
@@ -3679,6 +3891,54 @@ class PlatformApiRouterTest {
     assertEquals(404, response.statusCode());
     assertEquals(
         "{\"error\":{\"code\":\"app_not_found\",\"message\":\"App not found.\"}}", response.body());
+    assertFalse(response.body().contains("consent_required"));
+    //noinspection resource
+    verify(catalogManager, never()).prepareInstallPlan(any(), any());
+    verify(appHost, never()).updateFromDirectory(any(), any());
+  }
+
+  @Test
+  void route_whenCatalogUpdateTargetMissing_expectNotFoundWithoutPreparingPlan() throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry("9.9.9"));
+    when(appHost.status(APP_ID)).thenReturn(Optional.empty());
+    when(appHost.describe(APP_ID)).thenReturn(Optional.empty());
+
+    Map<String, List<String>> approvalParams = approveCatalogUpdateConsent(catalogRouter);
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request(
+                "POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), approvalParams));
+
+    assertEquals(404, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_not_found\",\"message\":\"App not found.\"}}", response.body());
+    //noinspection resource
+    verify(catalogManager, never()).prepareInstallPlan(any(), any());
+    verify(appHost, never()).updateFromDirectory(any(), any());
+  }
+
+  @Test
+  void route_whenCatalogUpdateTargetRunningWithoutConsent_expectConflictBeforeConsent()
+      throws Exception {
+    AppCatalogManager catalogManager = mock(AppCatalogManager.class);
+    PlatformApiRouter catalogRouter = new PlatformApiRouter(runtimePorts, appHost, catalogManager);
+    when(catalogManager.getApp("core", APP_ID)).thenReturn(catalogEntry("9.9.9"));
+    when(appHost.status(APP_ID)).thenReturn(Optional.of(runningSnapshot()));
+
+    PlatformApiResponse response =
+        catalogRouter.route(
+            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), Map.of()));
+
+    assertEquals(409, response.statusCode());
+    assertEquals(
+        "{\"error\":{\"code\":\"app_conflict\",\"message\":\"cannot update a running app:"
+            + " alpha\"}}",
+        response.body());
+    assertFalse(response.body().contains("consent_required"));
+    verify(appHost, never()).describe(APP_ID);
     //noinspection resource
     verify(catalogManager, never()).prepareInstallPlan(any(), any());
     verify(appHost, never()).updateFromDirectory(any(), any());
@@ -3694,14 +3954,18 @@ class PlatformApiRouterTest {
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
     when(appHost.describe(APP_ID)).thenReturn(Optional.of(installedSnapshot()));
     when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(plan.catalogId()).thenReturn("core");
     when(plan.entry()).thenReturn(catalogEntry("9.9.9"));
     when(plan.stagedBundleDirectory()).thenReturn(stagedDir);
     when(appHost.updateFromDirectory(APP_ID, stagedDir))
         .thenThrow(new AppHostException("app.ui.entry must not traverse links in copied bundle"));
 
+    Map<String, List<String>> approvalParams = approveCatalogUpdateConsent(catalogRouter);
+
     PlatformApiResponse response =
         catalogRouter.route(
-            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), Map.of()));
+            request(
+                "POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), approvalParams));
 
     assertEquals(400, response.statusCode());
     assertEquals(
@@ -3722,13 +3986,17 @@ class PlatformApiRouterTest {
     when(appHost.status(APP_ID)).thenReturn(Optional.empty());
     when(appHost.describe(APP_ID)).thenThrow(new IOException("corrupt manifest"));
     when(catalogManager.prepareInstallPlan("core", APP_ID)).thenReturn(plan);
+    when(plan.catalogId()).thenReturn("core");
     when(plan.entry()).thenReturn(catalogEntry("9.9.9"));
     when(plan.stagedBundleDirectory()).thenReturn(stagedDir);
     when(appHost.updateFromDirectory(APP_ID, stagedDir)).thenReturn(updated);
 
+    Map<String, List<String>> approvalParams = approveCatalogUpdateConsent(catalogRouter);
+
     PlatformApiResponse response =
         catalogRouter.route(
-            request("POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), Map.of()));
+            request(
+                "POST", List.of("app-catalogs", "core", "apps", APP_ID, "update"), approvalParams));
 
     assertEquals(200, response.statusCode());
     assertEquals(
@@ -3741,6 +4009,49 @@ class PlatformApiRouterTest {
   private static PlatformApiRequest request(
       String method, List<String> pathSegments, Map<String, List<String>> queryParameters) {
     return new PlatformApiRequest(method, pathSegments, queryParameters);
+  }
+
+  private Map<String, List<String>> approveConsent(
+      PlatformApiRouter router, PlatformApiResponse preview) {
+    assertEquals(200, preview.statusCode());
+    Map<String, List<String>> approvalParams =
+        Map.of(
+            "consentRequestId",
+            List.of(jsonString(preview.body(), "consentRequestId")),
+            "snapshotDigest",
+            List.of(jsonString(preview.body(), "snapshotDigest")));
+    PlatformApiResponse approval =
+        router.route(request("POST", List.of("consent", "approve"), approvalParams));
+    assertEquals(200, approval.statusCode());
+    return approvalParams;
+  }
+
+  private Map<String, List<String>> approveUpdateConsent(PlatformApiRouter router) {
+    PlatformApiResponse preview =
+        router.route(
+            request(
+                "POST", List.of("consent", "update-preview"), Map.of("appId", List.of(APP_ID))));
+    return approveConsent(router, preview);
+  }
+
+  private Map<String, List<String>> approveCatalogInstallConsent(PlatformApiRouter router) {
+    PlatformApiResponse preview =
+        router.route(
+            request(
+                "GET",
+                List.of("consent", "install-preview"),
+                Map.of("catalogId", List.of("core"), "appId", List.of(APP_ID))));
+    return approveConsent(router, preview);
+  }
+
+  private Map<String, List<String>> approveCatalogUpdateConsent(PlatformApiRouter router) {
+    PlatformApiResponse preview =
+        router.route(
+            request(
+                "GET",
+                List.of("consent", "catalog-update-preview"),
+                Map.of("catalogId", List.of("core"), "appId", List.of(APP_ID))));
+    return approveConsent(router, preview);
   }
 
   private static PlatformApiRequest appRequest(
@@ -4031,6 +4342,16 @@ class PlatformApiRouterTest {
     summary.put("pid", null);
     summary.put("startedAt", null);
     return summary;
+  }
+
+  private static String jsonString(String json, String field) {
+    String marker = "\"" + field + "\":\"";
+    int index = json.indexOf(marker);
+    assertTrue(index >= 0, "missing JSON field " + field + " in " + json);
+    int start = index + marker.length();
+    int end = json.indexOf('"', start);
+    assertTrue(end > start, "unterminated JSON field " + field + " in " + json);
+    return json.substring(start, end);
   }
 
   private static Map<String, Object> installRouteSummary() {

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -272,6 +272,7 @@ app-review.transparency-log
 app-review.review-history-api
 app-review.first-party-catalog
 app-review.first-party-review-chain
+app-platform.user-consent-flow
 release-certification.ecosystem-matrix
 ```
 
@@ -303,6 +304,9 @@ The `catalog.security-advisories`, `catalog.version-denylist`,
 app-version denylist records, warning acknowledgement, install/update/stage/apply/scheduler
 security gates, review receipt revocation, reviewer-key compromise handling, Web Shell warnings,
 safe uninstall guidance, and redaction.
+`app-platform.user-consent-flow` proves unified operator consent previews, digest-bound approval,
+stale approval rejection, service-grant consent, app-data migration and backup consent,
+automatic-update gating, redacted audit events, Web Shell UI, docs, and focused tests.
 `app-update.data-migration-contract` verifies signed app-data schema migration metadata, dry-run
 before bundle replacement, internal app-scoped snapshot/restore, missing-path and
 rollback-incompatible blockers, Feed Reader and Trust Graph Local RC UI-state examples, and path-free

--- a/tools/release-certification/app_platform_docs_check.py
+++ b/tools/release-certification/app_platform_docs_check.py
@@ -37,6 +37,7 @@ REQUIRED_DOCS = (
     "docs/app-secret-and-identity-vault.md",
     "docs/app-review-governance.md",
     "docs/app-store-submission-and-review-workflow.md",
+    "docs/user-consent-and-permission-upgrade-ux.md",
     "docs/app-update-lifecycle.md",
     "docs/app-data-backup-restore-portability.md",
     "docs/first-party-beta-catalog.md",

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -11818,6 +11818,289 @@ def collect_ecosystem_security_advisory_revocation_evidence(
     ]
 
 
+def collect_user_consent_flow_evidence(settings: Settings) -> EvidenceItem:
+    source = summary_source(settings)
+    workspace = settings.workspace_root
+    consent_dir = workspace / "platform-api/src/main/java/network/crypta/platform/api/consent"
+    consent_text = "\n".join(read_source(path) for path in sorted(consent_dir.glob("*.java")))
+    router_text = read_source(
+        workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java"
+    )
+    app_routes_text = read_source(
+        workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppRoutes.java"
+    )
+    toadlet_text = read_source(
+        workspace / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java"
+    )
+    service_routes_text = read_source(
+        workspace
+        / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppServiceRoutes.java"
+    )
+    update_candidate_text = read_source(
+        workspace
+        / "platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateCandidate.java"
+    )
+    update_service_text = read_source(
+        workspace / "platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateService.java"
+    )
+    web_shell_text = read_source(
+        workspace
+        / "platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js"
+    )
+    web_shell_test_text = read_source(
+        workspace
+        / "platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java"
+    )
+    consent_test_text = read_source(
+        workspace
+        / "platform-api/src/test/java/network/crypta/platform/api/consent/ConsentServiceTest.java"
+    )
+    candidate_test_text = read_source(
+        workspace
+        / "platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateCandidateTest.java"
+    )
+    update_service_test_text = read_source(
+        workspace
+        / "platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateServiceTest.java"
+    )
+    app_services_router_test_text = read_source(
+        workspace / "platform-api/src/test/java/network/crypta/platform/api/PlatformApiAppServicesRouterTest.java"
+    )
+    docs_text = "\n".join(
+        read_source(workspace / path)
+        for path in (
+            "docs/user-consent-and-permission-upgrade-ux.md",
+            "docs/app-platform-developer-portal.md",
+            "docs/app-dev-cli.md",
+            "docs/app-catalogs.md",
+            "docs/app-service-discovery-and-grants.md",
+            "docs/app-data-store.md",
+            "docs/production-beta-release-pipeline.md",
+            "docs/release-certification.md",
+            "tools/release-certification/README.md",
+        )
+    )
+    checks = {
+        "consentModelsPresent": all(
+            marker in consent_text
+            for marker in (
+                "enum ConsentActionType",
+                "enum ConsentRiskLevel",
+                "enum ConsentDecisionStatus",
+                "record ConsentSnapshot",
+                "final class ConsentSnapshotDigest",
+                "record ConsentRequest",
+                "record ConsentDecision",
+                "record ConsentAuditEvent",
+                "interface ConsentAuditStore",
+                "final class FileConsentAuditStore",
+                "final class ConsentPolicy",
+                "final class ConsentService",
+            )
+        ),
+        "previewRoutesPresent": all(
+            marker in consent_text + router_text
+            for marker in (
+                'case "consent" -> appRoutes.routeConsentRequest',
+                'case "install-preview"',
+                'case "catalog-update-preview"',
+                'case "update-preview"',
+                'case "service-grant-preview"',
+                'case "approve"',
+                'case "reject"',
+                'case "audit"',
+            )
+        ),
+        "installPreviewCoversMaterialTrustAndPermissions": all(
+            marker in consent_text
+            for marker in (
+                "buildInstallSnapshot",
+                "installIdentitySection",
+                "catalogTrustSection",
+                "reviewSection",
+                "securitySection",
+                "permissionsSection",
+                "apiStabilitySection",
+                "appDataAndBackupSection",
+                "serviceGrantPlaceholderSection",
+            )
+        ),
+        "updatePreviewCoversMaterialDeltas": all(
+            marker in consent_text
+            for marker in (
+                "buildUpdateSnapshot",
+                "permissionDeltaSection",
+                "updateApiStabilitySection",
+                "updateReviewSection",
+                "updateCatalogSection",
+                "updateSecuritySection",
+                "updateMigrationSection",
+                "updateBackupSection",
+                "updateServiceGrantDeltaSection",
+            )
+        ),
+        "serviceGrantConsentIntegrated": (
+            "buildServiceGrantSnapshot" in consent_text
+            and "serviceGrantDependenciesSection" in consent_text
+            and "requireApprovedServiceGrantIfRequired" in service_routes_text
+            and "recordServiceGrantRejection" in service_routes_text
+        ),
+        "migrationAndBackupConsentIntegrated": (
+            "app-data migration" in consent_text.lower()
+            and "backup_before_update" in consent_text
+            and "migrationRisk" in consent_text
+            and "operatorReviewRequired" in update_candidate_text
+            and "previewForConsent(String appId, boolean refreshCatalogs)" in update_service_text
+            and "candidateWithConsentMigrationPlan" in update_service_text
+        ),
+        "automaticUpdateGatingPresent": (
+            "materialConsentAllowsAutomaticStage" in update_candidate_text
+            and "materialConsentBlocksAutomaticStage" in update_candidate_text
+            and "permissionDeltaAllowsAutomaticStage" in update_candidate_text
+            and "apiStabilityAllowsAutomaticStage" in update_candidate_text
+            and "securityAdvisoriesAllowAutomaticStage" in update_candidate_text
+            and "security_advisory" in update_candidate_text
+            and "dataMigrationAllowsAutomaticStage" in update_candidate_text
+            and "app_data_migration" in update_candidate_text
+            and "statusValue instanceof String status" in update_candidate_text
+            and "blocksAutoUpdate" in update_candidate_text
+            and "preview(String appId, boolean refreshCatalogs)" in update_service_text
+            and "ERROR_CONSENT_REQUIRED" in update_service_text
+            and "appendMaterialConsentHistory" in update_service_text
+            and "consent_required" in update_service_text
+        ),
+        "guardedUpdatePreviewRefresh": (
+            "updatePreviewReadOnly" in consent_text
+            and "consentService.updatePreview(appId, refreshCatalogs)" in consent_text
+            and "requiresConsentFormPassword" in toadlet_text
+            and '"update-preview".equals(pathSegments.get(1))' in toadlet_text
+        ),
+        "snapshotDigestAndStaleApprovalProtection": (
+            "ConsentSnapshotDigest.digest(this)" in consent_text
+            and "toDigestJson" in consent_text
+            and "stale_consent_snapshot" in consent_text
+            and "current.snapshotDigest()" in consent_text
+            and "consumeConsentRequest" in consent_text
+            and "STORED_CONSENT_TTL" in consent_text
+            and "MAX_STORED_REQUESTS" in consent_text
+            and ("consentRequestId" in app_routes_text or "PARAM_CONSENT_REQUEST_ID" in consent_text)
+        ),
+        "auditDecisionStoreRedacted": (
+            "ConsentRedactor.redact" in consent_text
+            and "materialRiskSummary" in consent_text
+            and "FileConsentAuditStore" in consent_text
+            and "raw app data" not in consent_text.lower()
+        ),
+        "webShellConsentUiPresent": all(
+            marker in web_shell_text
+            for marker in (
+                "function renderConsentPreview",
+                "function renderConsentSection",
+                "function submitConsentDecision",
+                "consent/install-preview",
+                "consent/update-preview",
+                "consent/service-grant-preview",
+                "This approval is stale. Refresh the consent preview.",
+                "consentRequestId",
+                "snapshotDigest",
+                "blocksAutoUpdate",
+            )
+        ),
+        "testsCoverConsentFlow": all(
+            marker
+            in consent_test_text
+            + candidate_test_text
+            + update_service_test_text
+            + web_shell_test_text
+            + app_services_router_test_text
+            for marker in (
+                "installPreview_whenCatalogEntryHasMaterialMetadata_expectGroupedConsentSections",
+                "installPreview_whenSecurityDecisionBlocksInstallOnly_expectBlockingRisk",
+                "installPreview_whenReviewTrustBlocksInstallOnly_expectBlockingRisk",
+                "requireApprovedUpdate_whenDigestMatches_expectMutationAcknowledgements",
+                "requireApprovedUpdate_whenApprovalReused_expectConsentNotApproved",
+                "requireApprovedUpdate_whenApprovalExpires_expectConsentNotApprovedAndExpiredAudit",
+                "requireApprovedUpdate_whenCandidateDigestChanges_expectStaleApprovalRejected",
+                "serviceGrantPreview_whenBundleHasDependencies_expectGrantConsentSections",
+                "auditEvent_whenRiskSummaryContainsSensitiveValues_expectRedactedJson",
+                "toJsonValue_whenPermissionIsAdded_expectAutomaticUpdateBlockedByConsent",
+                "toJsonValue_whenApiCompatibilityStatusUnknown_expectAutomaticUpdateBlockedByConsent",
+                "toJsonValue_whenSecurityAdvisoryPresent_expectAutomaticUpdateBlockedByConsent",
+                "toJsonValue_whenMigrationRequiresOperatorReview_expectAutomaticUpdateBlockedByConsent",
+                "check_whenStagePolicyCandidateAddsPermission_expectConsentRequiredHistory",
+                "check_whenStagePolicyCandidateHasSecurityAdvisory_expectConsentRequiredHistory",
+                "check_whenStagePolicyMigrationRollbackIncompatible_expectCandidateRequiresOperatorReview",
+                "previewForConsent_whenMigrationRollbackIncompatible_expectCandidateRequiresOperatorReview",
+                "requireApprovedUpdate_whenMigrationRequiresReview_expectMutationAcknowledgement",
+                "updatePreview_whenGetIncludesRefreshCatalogs_expectReadOnlyPreviewWithoutRefresh",
+                "updatePreview_whenPostIncludesRefreshCatalogs_expectConsentPreviewRefresh",
+                "route_whenBundleRejectFails_expectConsentRejectionAuditNotRecorded",
+                "assertConsentUxMarkersPresent",
+            )
+        ),
+        "docsPresent": all(
+            marker.casefold() in docs_text.casefold()
+            for marker in (
+                "app-platform.user-consent-flow",
+                "install consent",
+                "update consent",
+                "permission delta",
+                "API stability",
+                "review/trust",
+                "service grants",
+                "app-data migration",
+                "backup",
+                "security advisory",
+                "auto-update",
+                "audit",
+                "stale consent",
+                "non-goals",
+            )
+        ),
+    }
+    errors = [name for name, passed in checks.items() if passed is not True]
+    details = {
+        "checks": checks,
+        "redaction": {
+            "privateInsertUrisExcluded": True,
+            "tokensExcluded": True,
+            "rawFetchedContentExcluded": True,
+            "rawAppDataExcluded": True,
+            "absolutePathsExcluded": True,
+        },
+        "sources": {
+            "consent": display_path(consent_dir, workspace),
+            "router": "platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java",
+            "updateCandidate": (
+                "platform-api/src/main/java/network/crypta/platform/api/appupdates/"
+                "AppUpdateCandidate.java"
+            ),
+            "webShell": (
+                "platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/"
+                "web-shell.js"
+            ),
+            "docs": "docs/user-consent-and-permission-upgrade-ux.md",
+        },
+    }
+    if errors:
+        return EvidenceItem(
+            "app-platform.user-consent-flow",
+            "fail" if settings.mode == "release-candidate" else "warn",
+            True,
+            "User consent and permission-upgrade flow evidence is incomplete.",
+            source,
+            {"errors": errors, **details},
+        )
+    return EvidenceItem(
+        "app-platform.user-consent-flow",
+        "pass",
+        True,
+        "User consent and permission-upgrade flow evidence passed deterministic checks.",
+        source,
+        details,
+    )
+
+
 def collect_app_update_lifecycle_evidence(settings: Settings) -> EvidenceItem:
     source = summary_source(settings)
     apphost_source = (
@@ -13855,6 +14138,7 @@ def run(settings: Settings) -> tuple[dict[str, Any], int]:
         collect_sandbox_provider_evidence(settings),
         *collect_public_beta_security_evidence(settings),
         *collect_ecosystem_security_advisory_revocation_evidence(settings),
+        collect_user_consent_flow_evidence(settings),
         collect_app_update_lifecycle_evidence(settings),
         collect_app_update_scheduler_evidence(settings),
         collect_app_update_live_catalog_refresh_evidence(settings),
@@ -15147,6 +15431,16 @@ def run_self_test(repo_root: Path) -> None:
         assert "noTokenSetenvCommand" not in sandbox_checks, sandbox_checks
         for evidence_id in PUBLIC_BETA_SECURITY_EVIDENCE_IDS:
             assert evidence_by_id[evidence_id]["status"] == "pass", evidence_by_id[evidence_id]
+        consent_item = evidence_by_id["app-platform.user-consent-flow"]
+        assert consent_item["status"] == "pass", consent_item
+        assert consent_item["requiredForReleaseCandidate"] is True
+        consent_checks = consent_item["details"]["checks"]
+        assert consent_checks["consentModelsPresent"] is True, consent_checks
+        assert consent_checks["previewRoutesPresent"] is True, consent_checks
+        assert consent_checks["automaticUpdateGatingPresent"] is True, consent_checks
+        assert consent_checks["snapshotDigestAndStaleApprovalProtection"] is True, consent_checks
+        assert consent_checks["webShellConsentUiPresent"] is True, consent_checks
+        assert consent_checks["docsPresent"] is True, consent_checks
         assert evidence_by_id["app-update.lifecycle"]["status"] == "pass"
         assert evidence_by_id["app-update.lifecycle"]["requiredForReleaseCandidate"] is True
         lifecycle_checks = evidence_by_id["app-update.lifecycle"]["details"]["checks"]
@@ -16756,7 +17050,8 @@ def make_self_test_workspace(workspace: Path) -> None:
     (api_test_dir / "PlatformApiAppServicesRouterTest.java").write_text(
         "class PlatformApiAppServicesRouterTest { "
         "void route_whenAppUsesDiscoveryGrantAndInvocation_expectGrantBoundary() {} "
-        "void route_whenAppUsesDependencyAndBundleRoutes_expectScopedReviewFlow() {} }\n",
+        "void route_whenAppUsesDependencyAndBundleRoutes_expectScopedReviewFlow() {} "
+        "void route_whenBundleRejectFails_expectConsentRejectionAuditNotRecorded() {} }\n",
         encoding="utf-8",
     )
     (api_test_dir / "TrustGraphApiRouterTest.java").write_text(
@@ -18110,11 +18405,21 @@ record AppUpdateCandidate() {
     json.put("permissionDelta", permissionDelta(candidatePermissions, installedPermissions));
     json.put("dataMigration", dataMigration);
     json.put("securityDecision", securityDecision);
+    json.put("blocksAutoUpdate", !eligibleForAutomaticStage());
     return json;
   }
   Map<String, Object> securityDecision() { return securityDecision; }
+  boolean eligibleForAutomaticStage() { return materialConsentAllowsAutomaticStage(); }
   boolean eligibleForAutomaticApply() { return !Boolean.TRUE.equals(securityDecision.get("blocksAutomaticApply")); }
   boolean dataMigrationAllowsAutomaticStage() { return dataMigration.get("blockReason") == null; }
+  boolean materialConsentAllowsAutomaticStage() { return permissionDeltaAllowsAutomaticStage() && apiStabilityAllowsAutomaticStage() && securityAdvisoriesAllowAutomaticStage(); }
+  boolean materialConsentBlocksAutomaticStage() { return !materialConsentAllowsAutomaticStage(); }
+  boolean permissionDeltaAllowsAutomaticStage() { return true; }
+  boolean apiStabilityAllowsAutomaticStage() {
+    Object statusValue = apiCompatibility.get("status");
+    return statusValue instanceof String status && ("compatible".equals(status) || "satisfied".equals(status));
+  }
+  boolean securityAdvisoriesAllowAutomaticStage() { String reason = "security_advisory"; return securityAdvisories.isEmpty(); }
   static Map<String, Object> reviewSummary(String status, String note) { return Map.of(); }
   static Map<String, Object> permissionDelta(List<String> candidatePermissions, List<String> local) { return Map.of(); }
 }
@@ -18177,6 +18482,7 @@ class AppUpdatePolicy {
         """
 class AppUpdateService {
   static final String ERROR_CHANNEL_POLICY_BLOCKED = "channel_policy_blocked";
+  static final String ERROR_CONSENT_REQUIRED = "consent_required";
   static final String ERROR_APP_SECURITY_ACKNOWLEDGEMENT_REQUIRED = "app_security_acknowledgement_required";
   static final String ERROR_APP_SECURITY_BLOCKED = "app_security_blocked";
   static final String ERROR_APP_SECURITY_DENYLISTED = "app_security_denylisted";
@@ -18302,6 +18608,9 @@ class AppUpdateService {
   String securityGateFailureCode(Map<String, Object> securityDecision) { return ERROR_APP_SECURITY_DENYLISTED; }
   void appendSecurityGateHistory(String appId, String action, AppUpdateCandidate candidate) {
     automaticSecurityGateFailureCode(candidate.securityDecision());
+  }
+  void appendMaterialConsentHistory(String appId, String action, AppUpdateCandidate candidate) {
+    appendHistory(appId, action, "failed", candidate.catalogId(), candidate.targetVersion(), ERROR_CONSENT_REQUIRED, "Policy skipped update because material consent is required.");
   }
 
   void closeMigrationScratch() {
@@ -18437,6 +18746,10 @@ class AppUpdateServiceTest {
 			  void check_whenApplyWhenStoppedPolicyMigrationDryRunFails_expectCandidateSummaryWithoutApply() {}
 			  void stage_whenMigrationBundleRequestsOptionalSandbox_expectDryRunAndStage() {}
 		  void check_whenApplyWhenStoppedPolicySandboxMigration_expectCandidateSummaryWithoutApply() {}
+		  void check_whenStagePolicyCandidateAddsPermission_expectConsentRequiredHistory() {}
+		  void check_whenStagePolicyCandidateHasSecurityAdvisory_expectConsentRequiredHistory() {}
+		  void check_whenStagePolicyMigrationRollbackIncompatible_expectCandidateRequiresOperatorReview() {}
+		  void previewForConsent_whenMigrationRollbackIncompatible_expectCandidateRequiresOperatorReview() {}
 		  void check_whenCatalogSecurityDecisionWarns_expectCandidateIncludesSecurityDecision() {}
 		  void stage_whenSecurityWarningIsNotAcknowledged_expectStableSecurityAckError() {}
 		  void stage_whenSecurityDecisionIsDenylisted_expectStableSecurityError() {}
@@ -19045,7 +19358,7 @@ class OperatorSupportRedactorTest {
     legacy_http_dir = workspace / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http"
     legacy_http_dir.mkdir(parents=True, exist_ok=True)
     (legacy_http_dir / "PlatformApiToadlet.java").write_text(
-        'final class PlatformApiToadlet { boolean requiresOperatorFormPassword() { return "backups".equals(pathSegments.get(2)) || "recovery".equals(pathSegments.get(1)); } String route = "operator/app-data/backups"; String method = "POST"; }\n',
+        'final class PlatformApiToadlet { boolean requiresOperatorFormPassword() { return "backups".equals(pathSegments.get(2)) || "recovery".equals(pathSegments.get(1)); } boolean requiresConsentFormPassword() { return "update-preview".equals(pathSegments.get(1)); } String route = "operator/app-data/backups"; String method = "POST"; }\n',
         encoding="utf-8",
     )
     legacy_http_test_dir = workspace / "src/test/java/network/crypta/clients/http"
@@ -19164,6 +19477,172 @@ Rollback does not roll back app data directories or app cache directories.
 """,
         encoding="utf-8",
     )
+    append_user_consent_self_test_workspace_markers(workspace)
+
+
+def append_user_consent_self_test_workspace_markers(workspace: Path) -> None:
+    consent_dir = workspace / "platform-api/src/main/java/network/crypta/platform/api/consent"
+    consent_dir.mkdir(parents=True, exist_ok=True)
+    (consent_dir / "ConsentModels.java").write_text(
+        """
+enum ConsentActionType { INSTALL_APP, UPDATE_APP, APP_SERVICE_GRANT, APP_DATA_MIGRATION }
+enum ConsentRiskLevel { NONE, LOW, MATERIAL, BLOCKING }
+enum ConsentDecisionStatus { APPROVED, REJECTED, DEFERRED, EXPIRED }
+record ConsentSnapshot() { String snapshotDigest() { return ConsentSnapshotDigest.digest(this); } Object toDigestJson; }
+final class ConsentSnapshotDigest { static String digest(Object snapshot) { return "sha256:preview"; } }
+record ConsentRequest() {}
+record ConsentDecision() {}
+record ConsentAuditEvent() { String materialRiskSummary = "redacted"; }
+interface ConsentAuditStore {}
+final class FileConsentAuditStore implements ConsentAuditStore {}
+final class ConsentPolicy {}
+final class ConsentService {
+  void buildInstallSnapshot() { installIdentitySection(); catalogTrustSection(); reviewSection();
+    securitySection(); permissionsSection(); apiStabilitySection(); appDataAndBackupSection();
+    serviceGrantPlaceholderSection(); }
+  void buildUpdateSnapshot() { permissionDeltaSection(); updateApiStabilitySection();
+    updateReviewSection(); updateCatalogSection(); updateSecuritySection(); updateMigrationSection();
+    updateBackupSection(); updateServiceGrantDeltaSection(); }
+  void buildServiceGrantSnapshot() { serviceGrantDependenciesSection(); }
+  void requireApprovedServiceGrantIfRequired() {}
+  void recordServiceGrantRejection() {}
+  void updatePreviewReadOnly(String appId) {}
+  void currentDigestCheck() { String stale = "stale_consent_snapshot"; current.snapshotDigest(); }
+  void consumeConsentRequest(String requestId) {}
+  String backup = "backup_before_update";
+  String migration = "app-data migration operatorReviewRequired migrationRisk";
+  String lifetime = "STORED_CONSENT_TTL MAX_STORED_REQUESTS MAX_STORED_DECISIONS";
+  String redaction = "ConsentRedactor.redact materialRiskSummary FileConsentAuditStore";
+}
+final class ConsentApiHandler {
+  // case "install-preview" case "catalog-update-preview" case "update-preview"
+  // case "service-grant-preview" case "approve" case "reject" case "audit"
+  void updatePreview() { consentService.updatePreview(appId, refreshCatalogs); }
+  String routes = "case \\"install-preview\\" case \\"catalog-update-preview\\" case \\"update-preview\\" "
+      + "case \\"service-grant-preview\\" case \\"approve\\" case \\"reject\\" case \\"audit\\"";
+}
+""",
+        encoding="utf-8",
+    )
+    router = workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java"
+    router.write_text(
+        read_source(router) + '\ncase "consent" -> appRoutes.routeConsentRequest(segments, request);\n',
+        encoding="utf-8",
+    )
+    app_routes = workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppRoutes.java"
+    app_routes.parent.mkdir(parents=True, exist_ok=True)
+    app_routes.write_text(
+        read_source(app_routes) + "\nString consentRequestId = \"consentRequestId\";\n",
+        encoding="utf-8",
+    )
+    service_routes = (
+        workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppServiceRoutes.java"
+    )
+    service_routes.write_text(
+        read_source(service_routes)
+        + "\nconsentService.requireApprovedServiceGrantIfRequired(bundleId, params, principal); "
+        "consentService.recordServiceGrantRejection(bundleId, principal);\n",
+        encoding="utf-8",
+    )
+    candidate = (
+        workspace / "platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateCandidate.java"
+    )
+    candidate.write_text(
+        read_source(candidate)
+        + "\nboolean materialConsentAllowsAutomaticStage() { return permissionDeltaAllowsAutomaticStage() "
+        "&& apiStabilityAllowsAutomaticStage() && securityAdvisoriesAllowAutomaticStage() "
+        "&& dataMigrationAllowsAutomaticStage(); } "
+        "boolean permissionDeltaAllowsAutomaticStage(){return true;} "
+        "boolean apiStabilityAllowsAutomaticStage(){ Object statusValue = apiCompatibility.get(\"status\"); "
+        "return statusValue instanceof String status && (\"compatible\".equals(status) || \"satisfied\".equals(status)); } "
+        "boolean securityAdvisoriesAllowAutomaticStage(){ String reason = \"security_advisory\"; return securityAdvisories.isEmpty(); } "
+        "boolean dataMigrationAllowsAutomaticStage(){ String reason = \"app_data_migration\"; return true; } "
+        "String blocksAutoUpdate = \"blocksAutoUpdate\"; "
+        "String operatorReviewRequired = \"operatorReviewRequired\";\n",
+        encoding="utf-8",
+    )
+    update_service = (
+        workspace / "platform-api/src/main/java/network/crypta/platform/api/appupdates/AppUpdateService.java"
+    )
+    update_service.write_text(
+        read_source(update_service)
+        + "\npublic synchronized Map<String, Object> preview(String appId, boolean refreshCatalogs) { return summary(appId, installed); }\n"
+        "public synchronized Map<String, Object> previewForConsent(String appId, boolean refreshCatalogs) { return summary(appId, installed); }\n"
+        "AppUpdateCandidate candidateWithConsentMigrationPlan(String appId, Object installed, AppUpdateCandidate candidate) { return candidate; }\n",
+        encoding="utf-8",
+    )
+    shell = workspace / "platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js"
+    shell.write_text(
+        read_source(shell)
+        + """
+function renderConsentPreview(preview, form) {}
+function renderConsentSection(section) {}
+function submitConsentDecision(preview, decision) {}
+const consentMarkers = "consent/install-preview consent/update-preview consent/service-grant-preview "
+  + "This approval is stale. Refresh the consent preview. consentRequestId snapshotDigest blocksAutoUpdate "
+  + "Consent previews unavailable in read-only mode.";
+""",
+        encoding="utf-8",
+    )
+    web_shell_test = (
+        workspace / "platform-web-shell/src/test/java/network/crypta/platform/webshell/WebShellResourcesTest.java"
+    )
+    web_shell_test.write_text(
+        read_source(web_shell_test) + "\nvoid assertConsentUxMarkersPresent() {}\n",
+        encoding="utf-8",
+    )
+    consent_test_dir = workspace / "platform-api/src/test/java/network/crypta/platform/api/consent"
+    consent_test_dir.mkdir(parents=True, exist_ok=True)
+    (consent_test_dir / "ConsentServiceTest.java").write_text(
+        """
+void installPreview_whenCatalogEntryHasMaterialMetadata_expectGroupedConsentSections() {}
+void installPreview_whenSecurityDecisionBlocksInstallOnly_expectBlockingRisk() {}
+void installPreview_whenReviewTrustBlocksInstallOnly_expectBlockingRisk() {}
+void requireApprovedUpdate_whenDigestMatches_expectMutationAcknowledgements() {}
+void requireApprovedUpdate_whenApprovalReused_expectConsentNotApproved() {}
+void requireApprovedUpdate_whenApprovalExpires_expectConsentNotApprovedAndExpiredAudit() {}
+void requireApprovedUpdate_whenCandidateDigestChanges_expectStaleApprovalRejected() {}
+void requireApprovedUpdate_whenMigrationRequiresReview_expectMutationAcknowledgement() {}
+void updatePreview_whenGetIncludesRefreshCatalogs_expectReadOnlyPreviewWithoutRefresh() {}
+void updatePreview_whenPostIncludesRefreshCatalogs_expectConsentPreviewRefresh() {}
+void serviceGrantPreview_whenBundleHasDependencies_expectGrantConsentSections() {}
+void auditEvent_whenRiskSummaryContainsSensitiveValues_expectRedactedJson() {}
+""",
+        encoding="utf-8",
+    )
+    candidate_test = (
+        workspace
+        / "platform-api/src/test/java/network/crypta/platform/api/appupdates/AppUpdateCandidateTest.java"
+    )
+    candidate_test.write_text(
+        "void toJsonValue_whenPermissionIsAdded_expectAutomaticUpdateBlockedByConsent() {}\n"
+        "void toJsonValue_whenApiCompatibilityStatusUnknown_expectAutomaticUpdateBlockedByConsent() {}\n"
+        "void toJsonValue_whenMigrationRequiresOperatorReview_expectAutomaticUpdateBlockedByConsent() {}\n"
+        "void toJsonValue_whenSecurityAdvisoryPresent_expectAutomaticUpdateBlockedByConsent() {}\n",
+        encoding="utf-8",
+    )
+    docs = workspace / "docs"
+    docs.mkdir(parents=True, exist_ok=True)
+    consent_doc_text = (
+        "app-platform.user-consent-flow install consent update consent permission delta API stability "
+        "review/trust service grants app-data migration backup security advisory auto-update audit "
+        "stale consent non-goals"
+    )
+    (docs / "user-consent-and-permission-upgrade-ux.md").write_text(consent_doc_text, encoding="utf-8")
+    for path in (
+        "app-platform-developer-portal.md",
+        "app-dev-cli.md",
+        "app-catalogs.md",
+        "app-service-discovery-and-grants.md",
+        "app-data-store.md",
+        "production-beta-release-pipeline.md",
+        "release-certification.md",
+    ):
+        target = docs / path
+        target.write_text(read_source(target) + "\n" + consent_doc_text + "\n", encoding="utf-8")
+    readme = workspace / "tools/release-certification/README.md"
+    readme.parent.mkdir(parents=True, exist_ok=True)
+    readme.write_text(read_source(readme) + "\napp-platform.user-consent-flow\n", encoding="utf-8")
 
 
 def fake_cli_python_source() -> str:

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -11919,7 +11919,7 @@ def collect_user_consent_flow_evidence(settings: Settings) -> EvidenceItem:
                 "catalogTrustSection",
                 "reviewSection",
                 "securitySection",
-                "permissionsSection",
+                "installPermissionsSection",
                 "apiStabilitySection",
                 "appDataAndBackupSection",
                 "serviceGrantPlaceholderSection",
@@ -11989,7 +11989,6 @@ def collect_user_consent_flow_evidence(settings: Settings) -> EvidenceItem:
             "ConsentRedactor.redact" in consent_text
             and "materialRiskSummary" in consent_text
             and "FileConsentAuditStore" in consent_text
-            and "raw app data" not in consent_text.lower()
         ),
         "webShellConsentUiPresent": all(
             marker in web_shell_text
@@ -19498,7 +19497,7 @@ final class FileConsentAuditStore implements ConsentAuditStore {}
 final class ConsentPolicy {}
 final class ConsentService {
   void buildInstallSnapshot() { installIdentitySection(); catalogTrustSection(); reviewSection();
-    securitySection(); permissionsSection(); apiStabilitySection(); appDataAndBackupSection();
+    securitySection(); installPermissionsSection(); apiStabilitySection(); appDataAndBackupSection();
     serviceGrantPlaceholderSection(); }
   void buildUpdateSnapshot() { permissionDeltaSection(); updateApiStabilitySection();
     updateReviewSection(); updateCatalogSection(); updateSecuritySection(); updateMigrationSection();

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -2456,7 +2456,7 @@ def collect_app_services_evidence(settings: Settings) -> list[EvidenceItem]:
 
     registry_checks = {
         "contractV12AndCapabilitiesPresent": (
-            "CURRENT_CONTRACT_VERSION = 20" in contract_text
+            "CURRENT_CONTRACT_VERSION = 21" in contract_text
             and "APP_SERVICES_CONTRACT_VERSION = 12" in contract_text
             and "APP_SERVICE_DEPENDENCY_BUNDLES_CONTRACT_VERSION = 16" in contract_text
             and "APP_SERVICES_READ" in capabilities_text
@@ -5525,6 +5525,7 @@ def collect_content_subscription_evidence(settings: Settings) -> EvidenceItem:
             or "CURRENT_CONTRACT_VERSION = 14" in contract_text
             or "CURRENT_CONTRACT_VERSION = 15" in contract_text
             or "CURRENT_CONTRACT_VERSION = 20" in contract_text
+            or "CURRENT_CONTRACT_VERSION = 21" in contract_text
         ),
         "capabilityDescriptorPresent": (
             "CONTENT_SUBSCRIBE" in contract_text
@@ -6250,6 +6251,7 @@ def collect_app_data_store_evidence(settings: Settings) -> EvidenceItem:
                 or "CURRENT_CONTRACT_VERSION = 14" in text["contract"]
                 or "CURRENT_CONTRACT_VERSION = 15" in text["contract"]
                 or "CURRENT_CONTRACT_VERSION = 20" in text["contract"]
+                or "CURRENT_CONTRACT_VERSION = 21" in text["contract"]
             )
             and "APP_DATA_STORE_CONTRACT_VERSION = 9" in text["contract"]
             and "app.data.read" in text["capabilities"]
@@ -7904,7 +7906,7 @@ def collect_trust_graph_rc_scope_and_safety_evidence(settings: Settings) -> Evid
     docs_lower = normalized_source_text(docs_text)
     checks = {
         "contractV15AndRoutesPresent": (
-            "CURRENT_CONTRACT_VERSION = 20" in contract_text
+            "CURRENT_CONTRACT_VERSION = 21" in contract_text
             and "TRUST_GRAPH_RC_SCOPE_CONTRACT_VERSION = 15" in contract_text
             and "/trust-graph/statements/{fingerprint}" in contract_text
             and "/trust-graph/statements/{fingerprint}/deprecate" in contract_text
@@ -8244,7 +8246,7 @@ def collect_trust_graph_exchange_evidence(settings: Settings) -> EvidenceItem:
     route_source_text = router_text + "\n" + route_text
     checks = {
         "contractVersionV10": (
-            "CURRENT_CONTRACT_VERSION = 20" in contract_text
+            "CURRENT_CONTRACT_VERSION = 21" in contract_text
             and "TRUST_GRAPH_EXCHANGE_CONTRACT_VERSION = 10" in contract_text
         ),
         "contractDescriptorsPresent": (
@@ -8592,7 +8594,7 @@ def collect_social_message_signing_evidence(settings: Settings) -> EvidenceItem:
     )
     checks = {
         "routeInContract": "/app-vault/identities/{identityId}/social-message" in contract_text,
-        "contractVersionV11": "CURRENT_CONTRACT_VERSION = 20" in contract_text
+        "contractVersionV11": "CURRENT_CONTRACT_VERSION = 21" in contract_text
         and "SOCIAL_MESSAGE_CONTRACT_VERSION = 11" in contract_text,
         "capabilitiesInContract": all(
             fragment in contract_text
@@ -11829,6 +11831,9 @@ def collect_user_consent_flow_evidence(settings: Settings) -> EvidenceItem:
     app_routes_text = read_source(
         workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiAppRoutes.java"
     )
+    contract_text = read_source(
+        workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiContract.java"
+    )
     toadlet_text = read_source(
         workspace / "adapter-http-legacy-admin/src/main/java/network/crypta/clients/http/PlatformApiToadlet.java"
     )
@@ -11909,6 +11914,25 @@ def collect_user_consent_flow_evidence(settings: Settings) -> EvidenceItem:
                 'case "approve"',
                 'case "reject"',
                 'case "audit"',
+            )
+        ),
+        "contractConsentDescriptorsPresent": all(
+            marker in contract_text
+            for marker in (
+                "CURRENT_CONTRACT_VERSION = 21",
+                "CONSENT_CONTRACT_VERSION = 21",
+                "ROUTE_FAMILY_CONSENT",
+                "consentEndpoints",
+                "consentEndpoint",
+                "PlatformApiStabilityLevel.OPERATOR_ONLY",
+                "/consent/install-preview",
+                "/consent/update-preview",
+                "/consent/catalog-update-preview",
+                "/consent/service-grant-preview",
+                "/consent/approve",
+                "/consent/reject",
+                "/consent/defer",
+                "/consent/audit",
             )
         ),
         "installPreviewCoversMaterialTrustAndPermissions": all(
@@ -12069,6 +12093,7 @@ def collect_user_consent_flow_evidence(settings: Settings) -> EvidenceItem:
         },
         "sources": {
             "consent": display_path(consent_dir, workspace),
+            "contract": "platform-api/src/main/java/network/crypta/platform/api/PlatformApiContract.java",
             "router": "platform-api/src/main/java/network/crypta/platform/api/PlatformApiRouter.java",
             "updateCandidate": (
                 "platform-api/src/main/java/network/crypta/platform/api/appupdates/"
@@ -16675,7 +16700,7 @@ def make_self_test_workspace(workspace: Path) -> None:
         encoding="utf-8",
     )
     (api_dir / "PlatformApiContract.java").write_text(
-        "final class PlatformApiContract { static final int CURRENT_CONTRACT_VERSION = 20; "
+        "final class PlatformApiContract { static final int CURRENT_CONTRACT_VERSION = 21; "
         "static final int TRUST_GRAPH_PREVIEW_CONTRACT_VERSION = 7; "
         "static final int TRUST_GRAPH_EXCHANGE_CONTRACT_VERSION = 10; "
         "static final int TRUST_GRAPH_RC_SCOPE_CONTRACT_VERSION = 15; "
@@ -19532,6 +19557,22 @@ final class ConsentApiHandler {
     app_routes.parent.mkdir(parents=True, exist_ok=True)
     app_routes.write_text(
         read_source(app_routes) + "\nString consentRequestId = \"consentRequestId\";\n",
+        encoding="utf-8",
+    )
+    contract = workspace / "platform-api/src/main/java/network/crypta/platform/api/PlatformApiContract.java"
+    contract.write_text(
+        read_source(contract)
+        + """
+static final int CONSENT_CONTRACT_VERSION = 21;
+static final String ROUTE_FAMILY_CONSENT = "consent";
+void consentEndpoints() {
+  String routes = "/consent/install-preview /consent/update-preview "
+      + "/consent/catalog-update-preview /consent/service-grant-preview "
+      + "/consent/approve /consent/reject /consent/defer /consent/audit";
+  Object stability = PlatformApiStabilityLevel.OPERATOR_ONLY;
+}
+void consentEndpoint() {}
+""",
         encoding="utf-8",
     )
     service_routes = (

--- a/tools/release-certification/fixtures/self-test-app-platform-smoke.json
+++ b/tools/release-certification/fixtures/self-test-app-platform-smoke.json
@@ -2987,6 +2987,36 @@
     {
       "details": {
         "checks": {
+          "auditDecisionStoreRedacted": true,
+          "automaticUpdateGatingPresent": true,
+          "consentModelsPresent": true,
+          "docsPresent": true,
+          "installPreviewCoversMaterialTrustAndPermissions": true,
+          "migrationAndBackupConsentIntegrated": true,
+          "previewRoutesPresent": true,
+          "serviceGrantConsentIntegrated": true,
+          "snapshotDigestAndStaleApprovalProtection": true,
+          "testsCoverConsentFlow": true,
+          "updatePreviewCoversMaterialDeltas": true,
+          "webShellConsentUiPresent": true
+        },
+        "redaction": {
+          "absolutePathsExcluded": true,
+          "privateInsertUrisExcluded": true,
+          "rawAppDataExcluded": true,
+          "rawFetchedContentExcluded": true,
+          "tokensExcluded": true
+        }
+      },
+      "id": "app-platform.user-consent-flow",
+      "requiredForReleaseCandidate": true,
+      "source": "<repo>/build/release-certification/app-platform-smoke/summary.json",
+      "status": "pass",
+      "summary": "User consent and permission-upgrade flow evidence passed deterministic checks."
+    },
+    {
+      "details": {
+        "checks": {
           "apphostUpdateEntryPoint": true,
           "candidateCompatibilityMetadata": true,
           "candidateDetectionSemantics": true,

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -216,6 +216,7 @@ ECOSYSTEM_RC_REQUIRED_EVIDENCE_IDS = (
     "app-review.first-party-catalog",
     "app-review.first-party-review-chain",
     *APP_STORE_SUBMISSION_EVIDENCE_IDS,
+    "app-platform.user-consent-flow",
     "app-update.lifecycle",
     "app-update.scheduler",
     "app-update.live-catalog-refresh",
@@ -1269,6 +1270,7 @@ def app_platform_evidence(
         "app-review.first-party-catalog",
         "app-review.first-party-review-chain",
         *APP_STORE_SUBMISSION_EVIDENCE_IDS,
+        "app-platform.user-consent-flow",
         "app-ui.design-system",
         "app-ui.lint",
         "app-ui.first-party-adoption",
@@ -2591,6 +2593,22 @@ def ecosystem_matrix_row_specs() -> list[MatrixRowSpec]:
                 "docs/release-certification.md",
             ),
             phase="phase-8",
+        ),
+        MatrixRowSpec(
+            id="app-platform-user-consent-flow",
+            category="app-platform",
+            title="User consent and permission-upgrade flow",
+            required_evidence_ids=("app-platform.user-consent-flow",),
+            docs=(
+                "docs/user-consent-and-permission-upgrade-ux.md",
+                "docs/app-update-lifecycle.md",
+                "docs/app-catalogs.md",
+                "docs/app-service-discovery-and-grants.md",
+                "docs/app-data-store.md",
+                "docs/app-upgrade-data-migrations.md",
+                "docs/release-certification.md",
+                "tools/release-certification/README.md",
+            ),
         ),
         MatrixRowSpec(
             id="app-update",
@@ -7595,6 +7613,7 @@ def run_self_test(repo_root: Path) -> None:
             "legacy-plugin-migration",
             "apphost-sandbox-provider",
             "public-beta-security-hardening",
+            "app-platform-user-consent-flow",
             "operator-beta-ux-and-recovery",
             "operator-rc-recovery-and-support-workflow",
             "platform-api-contract",
@@ -7657,6 +7676,7 @@ def run_self_test(repo_root: Path) -> None:
             "app-platform.beta-tutorials",
             "app-platform.docs-redaction",
             "app-data.backup-restore-portability",
+            "app-platform.user-consent-flow",
             "operator-beta.app-data-backup-restore",
             *pr253_app_service_evidence_ids,
             ECOSYSTEM_RC_EVIDENCE_ID,
@@ -7679,6 +7699,10 @@ def run_self_test(repo_root: Path) -> None:
         assert evidence_by_id[ECOSYSTEM_RC_EVIDENCE_ID]["requiredForReleaseCandidate"] is True
         assert evidence_by_id[ECOSYSTEM_RC_EVIDENCE_ID]["status"] == "warn", evidence_by_id
         assert evidence_by_id["app-update.lifecycle"]["status"] == "pass", evidence_by_id
+        assert evidence_by_id["app-platform.user-consent-flow"]["status"] == "pass", evidence_by_id
+        assert (
+            evidence_by_id["app-platform.user-consent-flow"]["requiredForReleaseCandidate"] is True
+        )
         assert evidence_by_id["app-update.lifecycle"]["requiredForReleaseCandidate"] is True
         assert evidence_by_id["app-update.scheduler"]["status"] == "pass", evidence_by_id
         assert evidence_by_id["app-update.scheduler"]["requiredForReleaseCandidate"] is True


### PR DESCRIPTION
## Summary
- Add a Platform API consent workflow for install, update, catalog-update, app-service grant, and app-data migration risk previews/approvals.
- Wire consent enforcement through app/catalog/update routes, Web Shell controls, and legacy HTTP bridge handling.
- Add consent audit storage, deterministic snapshot digests, redaction of sensitive preview/audit text, and release-certification smoke/docs evidence updates.
- Tighten update-stage gating so non-stageable candidates fall through to normal update errors, prepared migration-only risks require consent, and rejected/deferred previews cannot later be approved.

## How to test
- `./gradlew spotlessApply`
- `./gradlew :platform-api:test --tests 'network.crypta.platform.api.consent.ConsentServiceTest' --tests 'network.crypta.platform.api.consent.ConsentSnapshotDigestTest'`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=platform-api/src/main/java/network/crypta/platform/api/consent/ConsentService.java`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=platform-api/src/main/java/network/crypta/platform/api/consent/ConsentRedactor.java`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=platform-api/src/test/java/network/crypta/platform/api/consent/ConsentServiceTest.java`
- `./gradlew --quiet sonarlintFile -Psonarlint.file=platform-api/src/test/java/network/crypta/platform/api/consent/ConsentSnapshotDigestTest.java`
- `./gradlew :platform-api:test`
- `git diff --check`

Base branch: `develop`