### PR TITLE
feat(release): Add production beta go/no-go dashboard

### DIFF
--- a/.agents/skills/cryptad-interop-performance-gates/SKILL.md
+++ b/.agents/skills/cryptad-interop-performance-gates/SKILL.md
@@ -86,14 +86,19 @@ build/release-certification/live-network-beta-smoke/live-network-beta-smoke-repo
   app-ecosystem release pipeline. It orchestrates Gradle build/install tasks, first-party app
   staging/signing/verification, signed catalog and review receipt generation, app-platform smoke,
   live-network beta smoke when required, network-scale soak, multi-node beta soak and upgrade
-  evidence, ecosystem RC certification, final artifact redaction, and public archive creation
-  under `build/production-beta-release/`.
+  evidence, ecosystem RC certification, final artifact redaction, the production beta go/no-go
+  dashboard, and public archive creation under `build/production-beta-release/`.
   `developer-dry-run` is CI-safe and non-release; `release-candidate` is strict but may use
   non-production signing labels; `production-beta` requires production signing, a complete
   in-pipeline Gradle build/stage/sign run, a public HTTPS artifact base URI, live-network evidence
   unless the explicit emergency skip is used, passing multi-node beta evidence, and a clean
   workspace before `promotionReady` can become true. Emergency build skips must leave
   `nonRelease=true` and fail the build-complete promotion gate.
+- `tools/release-certification/production_beta_go_no_go_dashboard.py` is the final release-manager
+  dashboard generator for production beta launch candidates. It consumes sanitized production beta,
+  release-certification, ecosystem matrix, app-platform, live-network, network-scale, multi-node,
+  security-response, and waiver inputs; emits JSON, Markdown, and a dashboard redaction report; and
+  decides only `go`, `no-go`, or `go-with-waivers`.
 - `tools/release-certification/app_platform_smoke.py` produces the app-platform summary consumed by
   the aggregator. It keeps `--self-test` offline and Python-only, including source/test evidence
   for the Platform API contract, Platform API 1.0 stable baseline, manifest/catalog target
@@ -147,6 +152,7 @@ python3 tools/release-certification/security_response_runbook.py verify
 python3 tools/release-certification/network_scale_soak.py --self-test
 python3 tools/release-certification/multi_node_beta_soak.py --self-test
 python3 tools/release-certification/live_network_beta_smoke.py --self-test
+python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test
 python3 tools/release-certification/production_beta_release.py --self-test
 tools/release-certification/run-release-certification.sh
 tools/release-certification/run-release-certification.sh --mode release-candidate --out-dir build/release-certification
@@ -219,7 +225,9 @@ tools/release-certification/run-production-beta-release.sh --mode developer-dry-
   `multi-node-beta.backup-restore`, `multi-node-beta.subscription-pressure`,
   `multi-node-beta.trust-graph-import`, `multi-node-beta.social-inbox-multi-source`,
   `multi-node-beta.support-bundle-drill`, `multi-node-beta.redaction`, and
-  `release-certification.ecosystem-matrix`.
+  `release-certification.ecosystem-matrix`, `production-beta.go-no-go-dashboard`,
+  `production-beta.go-no-go-decision`, `production-beta.waiver-validation`,
+  `production-beta.dashboard-redaction`, and `production-beta.launch-artifact-hygiene`.
 - Platform API stable-history checks compare the stable baseline name/counts/lists, stable endpoint
   required-capability sets, and stable endpoint app-process/app-browser access flags. In production
   history mode, missing previous baseline or endpoint metadata is a blocker; developer dry runs may
@@ -265,7 +273,7 @@ tools/release-certification/run-production-beta-release.sh --mode developer-dry-
 - `.github/workflows/production-beta-release.yml` runs the production beta pipeline in
   `developer-dry-run` for PR-safe checks, `release-candidate` for release refs/manual dispatch, and
   protected `production-beta` only when release secrets, live-node inputs, and a real artifact base
-  URI are available. Artifact uploads must stay gated on a passing production-beta redaction
-  summary.
+  URI are available. Artifact uploads and job-summary dashboard publication must stay gated on both
+  the production-beta redaction summary and `go-no-go-redaction-report.json` passing.
 - Release notes should mention interop, performance, or certification gate changes only when they
   affect release readiness, operator confidence, app/platform behavior, or packager workflows.

--- a/.agents/skills/cryptad-platform-apps/SKILL.md
+++ b/.agents/skills/cryptad-platform-apps/SKILL.md
@@ -368,6 +368,7 @@ python3 tools/release-certification/app_platform_smoke.py --self-test
 python3 tools/release-certification/network_scale_soak.py --self-test
 python3 tools/release-certification/multi_node_beta_soak.py --self-test
 python3 tools/release-certification/live_network_beta_smoke.py --self-test
+python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test
 ```
 
 When changing route contracts or bridge wiring, also run the relevant root router/toadlet tests
@@ -385,8 +386,9 @@ durable app data, app-data backup/restore, app-service
 dependencies/grant bundles, Trust Graph Local RC, Social Inbox RC, app-update
 lifecycle/scheduler/rollback, sandbox-provider evidence, operator beta dashboard/support-bundle
 behavior, production security response runbook/verifier behavior, live-network beta certification
-behavior, third-party developer beta docs/template/sample/submission evidence, reference
-content/profile/social/feed/trust apps, app platform beta docs evidence,
+behavior, production beta go/no-go dashboard behavior, third-party developer beta
+docs/template/sample/submission evidence, reference content/profile/social/feed/trust apps, app
+platform beta docs evidence,
 operator RC recovery/support behavior, or legacy-admin retirement evidence behavior, also run:
 
 ```bash
@@ -396,6 +398,7 @@ python3 tools/release-certification/app_platform_smoke.py --self-test
 python3 tools/release-certification/network_scale_soak.py --self-test
 python3 tools/release-certification/multi_node_beta_soak.py --self-test
 python3 tools/release-certification/live_network_beta_smoke.py --self-test
+python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test
 python3 tools/release-certification/production_beta_release.py --self-test
 tools/release-certification/run-release-certification.sh --mode pr --skip-gradle --skip-git-metadata
 ```

--- a/.agents/skills/cryptad-release-workflow/SKILL.md
+++ b/.agents/skills/cryptad-release-workflow/SKILL.md
@@ -40,8 +40,8 @@ Build: 2
   Publisher/Profile Publisher/Social Inbox RC/Feed Reader/Trust Graph Local RC reference-app
   evidence, app platform beta docs/program evidence, third-party developer beta evidence,
   multi-node beta soak and upgrade drill evidence, live USK catalog publication evidence,
-  production beta artifact redaction evidence and `production-security.response-runbook` when app
-  artifacts ship, app-update
+  production beta artifact redaction evidence, production beta go/no-go dashboard evidence, and
+  `production-security.response-runbook` when app artifacts ship, app-update
   lifecycle/scheduler/rollback and app-data migration contract evidence, `crypta-app` developer
   beta toolkit smoke, operator RC
   recovery/support evidence, legacy plugin freeze evidence, legacy-admin retirement/removal Wave
@@ -89,10 +89,12 @@ git checkout -b release/<build-number>
      --require-multi-node-soak \
      --require-sandbox-provider-tests
    ```
-   Preserve the JSON/Markdown summaries, redaction report, extracted `evidence/`, and
-   `dist/checksums.txt`. Any summary with `nonRelease=true`, `promotionReady=false`, failed
-   redaction, dirty workspace, fixture evidence, test signing, skipped production-beta build
-   stages, or an emergency live-network skip is not promotable.
+   Preserve the JSON/Markdown summaries, production redaction report, go/no-go dashboard JSON,
+   go/no-go dashboard Markdown, go/no-go redaction report, extracted `evidence/`, and
+   `dist/checksums.txt`. Any summary with `nonRelease=true`, `promotionReady=false`, `goNoGo`
+   decision `no-go`, failed production or dashboard redaction, dirty workspace, fixture evidence,
+   test signing, skipped production-beta build stages, or an emergency live-network skip is not
+   promotable.
 
 3) Stabilize on `release/<build-number>` (critical fixes only). Keep diffs minimal.
 

--- a/.github/workflows/production-beta-release.yml
+++ b/.github/workflows/production-beta-release.yml
@@ -181,8 +181,34 @@ jobs:
           echo "status=$status" >> "$GITHUB_OUTPUT"
           echo "Production beta redaction status: $status"
 
+      - name: Read go/no-go dashboard redaction status
+        id: go_no_go_redaction
+        if: always()
+        run: |
+          status="$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = Path("build/production-beta-release/reports/go-no-go-redaction-report.json")
+          try:
+              data = json.loads(report.read_text(encoding="utf-8"))
+              print(data.get("status") or "missing")
+          except Exception:
+              print("missing")
+          PY
+          )"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "Go/no-go dashboard redaction status: $status"
+
+      - name: Publish go/no-go dashboard summary
+        if: always() && steps.redaction.outputs.status == 'pass' && steps.go_no_go_redaction.outputs.status == 'pass'
+        run: |
+          if [[ -f build/production-beta-release/reports/go-no-go-dashboard.md ]]; then
+            cat build/production-beta-release/reports/go-no-go-dashboard.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload production beta dry-run artifacts
-        if: always() && steps.redaction.outputs.status == 'pass'
+        if: always() && steps.redaction.outputs.status == 'pass' && steps.go_no_go_redaction.outputs.status == 'pass'
         uses: actions/upload-artifact@v6
         with:
           name: production-beta-pipeline-${{ github.run_id }}-${{ github.run_attempt }}
@@ -313,8 +339,34 @@ jobs:
           echo "status=$status" >> "$GITHUB_OUTPUT"
           echo "Production beta redaction status: $status"
 
+      - name: Read go/no-go dashboard redaction status
+        id: go_no_go_redaction
+        if: always()
+        run: |
+          status="$(python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          report = Path("build/production-beta-release/reports/go-no-go-redaction-report.json")
+          try:
+              data = json.loads(report.read_text(encoding="utf-8"))
+              print(data.get("status") or "missing")
+          except Exception:
+              print("missing")
+          PY
+          )"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "Go/no-go dashboard redaction status: $status"
+
+      - name: Publish go/no-go dashboard summary
+        if: always() && steps.redaction.outputs.status == 'pass' && steps.go_no_go_redaction.outputs.status == 'pass'
+        run: |
+          if [[ -f build/production-beta-release/reports/go-no-go-dashboard.md ]]; then
+            cat build/production-beta-release/reports/go-no-go-dashboard.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Upload production beta artifacts
-        if: always() && steps.redaction.outputs.status == 'pass'
+        if: always() && steps.redaction.outputs.status == 'pass' && steps.go_no_go_redaction.outputs.status == 'pass'
         uses: actions/upload-artifact@v6
         with:
           name: production-beta-release-${{ github.run_id }}-${{ github.run_attempt }}

--- a/README.md
+++ b/README.md
@@ -604,8 +604,9 @@ maintenance policy metadata, freezes the Platform API 1.0 stable baseline, adds 
 third-party submission/review/catalog-candidate tooling, unifies user-consent upgrade UX, hardens
 Trust Graph Local RC and Social Inbox RC, finalizes the retained legacy admin surface, adds the
 production security response runbook, records multi-node beta soak and upgrade/rollback/backup
-drills, and documents the external third-party developer beta program with the stable-only
-`hello-stable` sample. These gates do not create a hosted public app store or introduce production
+drills, documents the external third-party developer beta program with the stable-only
+`hello-stable` sample, and adds the production beta go/no-go dashboard as the final launch
+decision artifact. These gates do not create a hosted public app store or introduce production
 signing material into local tests.
 
 Key docs:
@@ -626,6 +627,7 @@ Key docs:
 - [Signed app catalogs](docs/app-catalogs.md)
 - [First-party beta app catalog](docs/first-party-beta-catalog.md)
 - [Production beta release pipeline](docs/production-beta-release-pipeline.md)
+- [Production beta go/no-go dashboard](docs/production-beta-go-no-go-dashboard.md)
 - [Multi-node beta soak and upgrade drill](docs/multi-node-beta-soak-and-upgrade-drill.md)
 - [App-owned static UI](docs/app-owned-ui.md)
 - [App UI design system](docs/app-ui-design-system.md)
@@ -707,6 +709,7 @@ python3 tools/release-certification/release_certification.py --self-test
 python3 tools/release-certification/app_platform_smoke.py --self-test
 python3 tools/release-certification/network_scale_soak.py --self-test
 python3 tools/release-certification/multi_node_beta_soak.py --self-test
+python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test
 python3 tools/release-certification/production_beta_release.py --self-test
 ```
 
@@ -737,7 +740,7 @@ including `app-review.trusted-receipts`, `app-review.policy`,
 `app-services.web-shell`, `app-services.redaction`, `network-scale.*`, `multi-node-beta.*`,
 `third-party-developer.*`, app-vault capability/redaction evidence, historical comparison,
 ecosystem gates, structured waivers, optional live-node evidence, production beta promotion
-summaries, and redaction rules.
+summaries, the go/no-go dashboard, and redaction rules.
 
 ## Trust Graph Preview
 

--- a/docs/app-platform-beta-program.md
+++ b/docs/app-platform-beta-program.md
@@ -208,6 +208,7 @@ Use this runbook to decide whether the ecosystem beta is ready for a release can
    python3 tools/release-certification/app_platform_docs_check.py --self-test
    python3 tools/release-certification/app_platform_smoke.py --self-test
    python3 tools/release-certification/network_scale_soak.py --self-test
+   python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test
    ```
 
 3. Run release certification self-tests.
@@ -228,7 +229,8 @@ Use this runbook to decide whether the ecosystem beta is ready for a release can
    readiness. Use the command above with disposable fixture keys unless the release manager is
    intentionally publishing the candidate catalog.
 
-6. Inspect the release summary and report.
+6. Inspect the release summary and report. When the production beta wrapper runs, also inspect the
+   dashboard artifacts under `build/production-beta-release/reports/`.
 
    ```text
    build/release-certification/release-certification-summary.json
@@ -238,6 +240,9 @@ Use this runbook to decide whether the ecosystem beta is ready for a release can
    build/release-certification/app-platform-smoke/summary.json
    build/release-certification/app-platform-smoke/app-platform-smoke-report.md
    build/release-certification/network-scale-soak/summary.json
+   build/production-beta-release/reports/go-no-go-dashboard.json
+   build/production-beta-release/reports/go-no-go-dashboard.md
+   build/production-beta-release/reports/go-no-go-redaction-report.json
    ```
 
 7. Confirm the app-review governance evidence passes: review receipts, reviewer key lifecycle,

--- a/docs/app-platform-developer-portal.md
+++ b/docs/app-platform-developer-portal.md
@@ -169,6 +169,7 @@ Public beta readiness treats these workstreams as one ecosystem beta release sto
 | Operator recovery and support | [operator-rc-recovery-and-support-workflow.md](operator-rc-recovery-and-support-workflow.md), [operator-beta-dashboard.md](operator-beta-dashboard.md), [app-data-backup-restore-portability.md](app-data-backup-restore-portability.md), `operator-rc.*` evidence, `operator-beta.*` evidence, `operator-rc-recovery-and-support-workflow` and `operator-beta-ux-and-recovery` matrix rows |
 | Live-network beta certification | [release-certification.md](release-certification.md), `live-network-beta.*` evidence, `live-network-beta-certification` matrix row when explicitly required |
 | Ecosystem matrix | [release-certification.md](release-certification.md), `ecosystem certification matrix` |
+| Production beta go/no-go dashboard | [production-beta-go-no-go-dashboard.md](production-beta-go-no-go-dashboard.md), `production-beta.go-no-go-*` evidence, final `go`, `no-go`, or `go-with-waivers` launch decision |
 | Docs and beta program | This portal, [app-platform-beta-tutorials.md](app-platform-beta-tutorials.md), [app-platform-beta-known-limitations.md](app-platform-beta-known-limitations.md), [app-platform-beta-program.md](app-platform-beta-program.md) |
 
 Release candidates should run the normal build/test gates plus release certification:
@@ -180,14 +181,16 @@ python3 tools/release-certification/app_platform_smoke.py --self-test
 python3 tools/release-certification/network_scale_soak.py --self-test
 python3 tools/release-certification/multi_node_beta_soak.py --self-test
 python3 tools/release-certification/live_network_beta_smoke.py --self-test
+python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test
 tools/release-certification/run-release-certification.sh --mode release-candidate --out-dir build/release-certification
 ```
 
 The generated release summary, release report, app-platform smoke report, review transparency-log
 evidence, network-scale soak summary, legacy retirement evidence, optional live-network beta
-evidence, and ecosystem certification matrix are the closeout record. Live-network beta mode
-remains opt-in and should use only a localhost node with disposable fixtures unless the release
-manager is intentionally publishing the candidate first-party beta catalog.
+evidence, ecosystem certification matrix, and production beta go/no-go dashboard are the closeout
+record. Live-network beta mode remains opt-in and should use only a localhost node with disposable
+fixtures unless the release manager is intentionally publishing the candidate first-party beta
+catalog.
 
 ## Security entry points
 

--- a/docs/cryptad-release-workflow-and-runbook.md
+++ b/docs/cryptad-release-workflow-and-runbook.md
@@ -78,11 +78,18 @@ Treat these as release blockers, in order:
    `build/production-beta-release/reports/production-beta-summary.json`,
    `build/production-beta-release/reports/production-beta-summary.md`,
    `build/production-beta-release/reports/redaction-report.json`,
+   `build/production-beta-release/reports/go-no-go-dashboard.json`,
+   `build/production-beta-release/reports/go-no-go-dashboard.md`,
+   `build/production-beta-release/reports/go-no-go-redaction-report.json`,
    `build/production-beta-release/evidence/`, and
    `build/production-beta-release/dist/checksums.txt`. The public archive is
    `build/production-beta-release/dist/crypta-production-beta-<version>.tar.gz`. The workflow,
    modes, required secrets, artifact layout, cleanup guard, and rerun rules are documented in
    [production-beta-release-pipeline.md](production-beta-release-pipeline.md).
+   Read `go-no-go-dashboard.md` first. It is the release-manager launch surface that rolls the
+   production beta summary, ecosystem matrix, redaction report, waivers, live-network evidence, and
+   multi-node evidence into `go`, `no-go`, or `go-with-waivers`; drill into the detailed summaries
+   only after reviewing that decision.
    Confirm `production-security.response-runbook` passes in the production beta summary, and review
    the compact `multiNodeBetaSoak` and `developerBetaProgram` sections before promotion. Security
    releases or app ecosystem incident responses must also run
@@ -120,6 +127,9 @@ Treat these as release blockers, in order:
    network-scale soak, required live-network beta evidence, redaction, and waivers. Its scope and
    non-claims are documented in
    [ecosystem-rc-certification-gate.md](ecosystem-rc-certification-gate.md).
+   Production beta runs also surface this gate through
+   [production-beta-go-no-go-dashboard.md](production-beta-go-no-go-dashboard.md), which is the
+   final launch decision artifact for app-ecosystem production beta candidates.
    Confirm the `network-scale-soak-and-subscription-budget` row and
    `network-scale.rc-soak-summary` evidence are present. The wrapper generates a fresh simulated
    summary by default. Use `--network-scale-soak-summary <path>` or

--- a/docs/cryptad-release-workflow-and-runbook.md
+++ b/docs/cryptad-release-workflow-and-runbook.md
@@ -72,7 +72,7 @@ Treat these as release blockers, in order:
    A promotable `production-beta` run requires production signing inputs, a complete in-pipeline
    Gradle build/stage/sign run, a clean git workspace, a public HTTPS artifact base URI, required
    live-network beta evidence, required multi-node beta soak evidence, ecosystem RC certification,
-   and a passing final redaction scan.
+   a passing final artifact redaction scan, and a passing go/no-go dashboard redaction report.
    Signed catalog bundle URLs resolve under the published artifact root, for example
    `<base>/build/app-bundles/<app>-<version>.zip`. Preserve
    `build/production-beta-release/reports/production-beta-summary.json`,

--- a/docs/ecosystem-rc-certification-gate.md
+++ b/docs/ecosystem-rc-certification-gate.md
@@ -64,6 +64,12 @@ promote, resolve blockers, attach missing evidence, or record an approved waiver
 gap. A promoted release record should preserve the sanitized summary, report, matrix, history
 comparison, waiver records, and copied public artifacts.
 
+Production beta candidates surface this gate again in
+[production-beta-go-no-go-dashboard.md](production-beta-go-no-go-dashboard.md). The dashboard rolls
+the ecosystem RC gate, matrix blocker count, waiver usage, redaction status, live-network evidence,
+network-scale soak, and multi-node beta soak into the final `go`, `no-go`, or
+`go-with-waivers` launch decision.
+
 ## Network-scale soak evidence
 
 The release wrapper generates a fresh deterministic

--- a/docs/production-beta-go-no-go-dashboard.md
+++ b/docs/production-beta-go-no-go-dashboard.md
@@ -1,0 +1,189 @@
+# Production beta go/no-go dashboard
+
+This document explains how release managers generate and read the production beta go/no-go
+dashboard.
+
+## Scope
+
+The dashboard is a final review surface over existing sanitized release outputs. It consumes the
+production beta summary, release-certification summary, ecosystem matrix, app-platform smoke
+summary, live-network evidence when required, network-scale soak evidence, multi-node beta soak
+evidence, security response evidence, and optional waiver records.
+
+The dashboard does not sign artifacts, collect live-node evidence, approve third-party apps, or
+replace release certification. It records one release-manager decision:
+
+```text
+go
+no-go
+go-with-waivers
+```
+
+## Generate the dashboard
+
+The production beta pipeline writes the dashboard automatically under
+`build/production-beta-release/reports/`:
+
+```text
+reports/go-no-go-dashboard.json
+reports/go-no-go-dashboard.md
+reports/go-no-go-redaction-report.json
+```
+
+You can also generate it directly from existing redacted summaries:
+
+```bash
+python3 tools/release-certification/production_beta_go_no_go_dashboard.py build \
+  --workspace-root . \
+  --out-dir build/production-beta-go-no-go \
+  --production-beta-summary build/production-beta-release/reports/production-beta-summary.json \
+  --release-certification-summary build/release-certification/release-certification-summary.json \
+  --ecosystem-matrix build/release-certification/ecosystem-certification-matrix.json \
+  --app-platform-summary build/app-platform-smoke/summary.json \
+  --live-network-summary build/live-network-beta-smoke/summary.json \
+  --network-scale-soak-summary build/network-scale-soak/summary.json \
+  --multi-node-beta-soak-summary build/multi-node-beta-soak/summary.json \
+  --security-response-summary build/security-response-runbook/summary.json \
+  --waivers release/waivers.json \
+  --mode production-beta
+```
+
+Run the offline fixture tests with:
+
+```bash
+python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test
+```
+
+The self-test does not require Gradle, signing keys, network access, or a live node.
+
+## Required inputs
+
+Production beta mode fails closed when these critical inputs are missing or malformed:
+
+| Input | Purpose |
+| --- | --- |
+| `production-beta-summary.json` | Top-level pipeline status, promotion gates, signing profile, redaction status, and artifact references. |
+| `release-certification-summary.json` | Ecosystem RC decision, evidence ids, gates, history comparison, and waiver records. |
+| `ecosystem-certification-matrix.json` | Matrix rows, release blocker count, coverage, docs mapping, and redaction coverage. |
+| `app-platform-smoke/summary.json` | Platform API freeze, app signing, catalog/review, consent, legacy admin, third-party developer beta, and security response evidence. |
+| `live-network-beta-smoke/summary.json` | Required production beta live-network smoke evidence. |
+| `network-scale-soak/summary.json` | Network-scale budget, pressure, and redaction evidence. |
+| `multi-node-beta-soak/summary.json` | Multi-node soak, upgrade drill, scenario, and redaction evidence. |
+
+Developer dry-runs tolerate missing production-only inputs so PR and local runs remain CI-safe. A
+dry-run can complete successfully, but the dashboard still marks non-release artifacts as
+`no-go` for publication.
+
+## Decision states
+
+`go` means all required production beta gates pass, the production summary is promotion-ready,
+production signing is used, `nonRelease=false`, redaction passed, and there are no unwaived
+blockers.
+
+`go-with-waivers` means every remaining blocker is waivable and has a valid, scoped, approved, and
+unexpired waiver. The waiver remains visible in JSON and Markdown. Waived blockers are not hidden
+or converted to `pass`.
+
+`no-go` means at least one of these conditions exists:
+
+- unwaived blocker or critical finding;
+- missing critical production-beta input;
+- failed critical production gate;
+- invalid, expired, unknown-target, or out-of-scope waiver;
+- critical redaction finding;
+- unsafe artifact hygiene finding such as AppleDouble metadata, `.DS_Store`, or `__MACOSX`;
+- production beta mode using test-only or generated signing material;
+- production beta artifact marked `nonRelease=true`.
+
+## Waiver format
+
+The dashboard accepts a JSON waiver file:
+
+```json
+{
+  "schemaVersion": 1,
+  "releaseId": "crypta-production-beta-2026-06-24",
+  "waivers": [
+    {
+      "id": "waiver-live-network-lab-outage-001",
+      "evidenceId": "live.live-network-beta.content-fetch",
+      "severity": "blocker",
+      "scope": "production-beta",
+      "rationale": "Lab live node unavailable during the RC window.",
+      "approvedBy": "release-manager@example.invalid",
+      "owner": "release-engineering",
+      "createdAt": "2026-06-24T00:00:00Z",
+      "expiresAt": "2026-06-30T00:00:00Z",
+      "references": ["internal-ticket-1234"]
+    }
+  ]
+}
+```
+
+Each waiver must include `id`, `evidenceId`, `severity`, `scope`, `rationale`, `approvedBy`,
+`owner`, and `expiresAt`. `expiresAt` must be in the future at dashboard generation time. Scope is
+exact; `release-candidate-only` does not apply to production beta.
+
+Unknown evidence ids are rejected unless the waiver explicitly sets
+`externalRiskAccepted=true`. External risk waivers still need owner, approver, rationale, scope,
+and expiry.
+
+## Non-waivable findings
+
+These findings always produce `no-go`:
+
+- private insert URI, private key material, bearer token, app token, browser-session token, form
+  password, authorization header, CI secret value, raw fetched content, raw app data, raw backup
+  payload, or local absolute path in dashboard inputs or outputs;
+- AppleDouble `._*`, `.DS_Store`, `__MACOSX/`, secret-like filenames, key-store files, symlinks,
+  special files, invalid archives, or unsafe nested archive entries;
+- production beta using test-only signing material or generated test keys;
+- production beta output marked `nonRelease=true`;
+- malformed or expired waiver records.
+
+The scanner allows deterministic placeholders such as `<redacted-private-insert-uri>`,
+`<redacted-token>`, `<repo>`, `<workdir>`, `<home>`, and `<redacted-absolute-path>`.
+
+## Reading the Markdown dashboard
+
+Start with the topline:
+
+- Release ID;
+- mode;
+- decision;
+- promotion-ready boolean;
+- recommendation.
+
+Then review:
+
+- top blockers;
+- top warnings;
+- waivers used;
+- domain table;
+- redaction status;
+- required follow-ups;
+- redacted artifact references.
+
+The Markdown report only links or names redacted artifacts. It must not include raw JSON dumps,
+raw command output, local absolute paths, or secret-bearing values.
+
+## CI behavior
+
+The production beta GitHub Actions workflow writes the dashboard during both dry-run and protected
+production-beta jobs. The workflow appends the Markdown dashboard to the job summary only when the
+production beta redaction status is `pass`.
+
+Protected `production-beta` dispatches fail on `no-go`. A `go-with-waivers` decision is allowed
+only when the dashboard validates and records the waiver records that made the candidate
+launchable.
+
+## Release-manager workflow
+
+1. Generate the production beta pipeline outputs.
+2. Open `reports/go-no-go-dashboard.md`.
+3. If the decision is `no-go`, resolve the listed blockers and regenerate the dashboard.
+4. If the decision is `go-with-waivers`, confirm each waiver owner, approver, scope, expiry, and
+   release-record reference.
+5. Preserve the JSON dashboard, Markdown dashboard, redaction report, production beta summary,
+   release-certification summary, ecosystem matrix, evidence directory, checksums, and public
+   archive with the release candidate.

--- a/docs/production-beta-go-no-go-dashboard.md
+++ b/docs/production-beta-go-no-go-dashboard.md
@@ -171,7 +171,8 @@ raw command output, local absolute paths, or secret-bearing values.
 
 The production beta GitHub Actions workflow writes the dashboard during both dry-run and protected
 production-beta jobs. The workflow appends the Markdown dashboard to the job summary only when the
-production beta redaction status is `pass`.
+production beta redaction status is `pass` and the dashboard's own redaction report status is
+`pass`.
 
 Protected `production-beta` dispatches fail on `no-go`. A `go-with-waivers` decision is allowed
 only when the dashboard validates and records the waiver records that made the candidate

--- a/docs/production-beta-go-no-go-dashboard.md
+++ b/docs/production-beta-go-no-go-dashboard.md
@@ -124,6 +124,12 @@ Each waiver must include `id`, `evidenceId`, `severity`, `scope`, `rationale`, `
 `owner`, and `expiresAt`. `expiresAt` must be in the future at dashboard generation time. Scope is
 exact; `release-candidate-only` does not apply to production beta.
 
+The dashboard also accepts the existing release-certification structured waiver schema
+(`version`, `reason`, `status: approved`, `allowReleaseCandidate`) so a release-candidate pipeline
+can pass one waiver file through release certification and the final dashboard. When a record has
+no dashboard `scope`, `allowReleaseCandidate=true` maps to release-candidate scope only; it is not
+treated as a production-beta waiver.
+
 Unknown evidence ids are rejected unless the waiver explicitly sets
 `externalRiskAccepted=true`. External risk waivers still need owner, approver, rationale, scope,
 and expiry.

--- a/docs/production-beta-release-pipeline.md
+++ b/docs/production-beta-release-pipeline.md
@@ -321,6 +321,7 @@ python3 tools/release-certification/live_network_beta_smoke.py --self-test
 python3 tools/release-certification/network_scale_soak.py --self-test
 python3 tools/release-certification/multi_node_beta_soak.py --self-test
 python3 tools/release-certification/release_certification.py --self-test
+python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test
 tools/release-certification/run-release-certification.sh --mode release-candidate --out-dir build/release-certification
 ```
 
@@ -340,9 +341,11 @@ runs do not receive protected release artifact, live-node, form-password, catalo
 secrets; those are wired only for protected production-beta dispatches or manual release-candidate
 dispatches that explicitly require live-network evidence.
 
-The workflow uploads the full production beta artifact tree only when
-`reports/production-beta-summary.json` reports `redaction.status=pass`. Redaction failures keep the
-raw output on the runner and do not publish rejected artifacts through GitHub Actions.
+The workflow uploads the full production beta artifact tree only when both
+`reports/production-beta-summary.json` reports `redaction.status=pass` and
+`reports/go-no-go-redaction-report.json` reports `status=pass`. Redaction failures keep the raw
+output on the runner and do not publish rejected artifacts or the dashboard Markdown through
+GitHub Actions.
 
 ## Known limitations
 

--- a/docs/production-beta-release-pipeline.md
+++ b/docs/production-beta-release-pipeline.md
@@ -144,6 +144,9 @@ build/production-beta-release/
     production-beta-summary.json
     production-beta-summary.md
     redaction-report.json
+    go-no-go-dashboard.json
+    go-no-go-dashboard.md
+    go-no-go-redaction-report.json
   dist/
     crypta-production-beta-<version>.tar.gz
     checksums.txt
@@ -169,7 +172,33 @@ directories are kept outside the public artifact tree.
 | `multiNodeBetaSoak` | Compact status for multi-node soak and upgrade evidence, including mode, scenario statuses, blockers, warnings, promotion readiness, and the `evidence/multi-node-beta-soak.json` artifact path. |
 | `artifacts.firstPartyMaintenancePolicy` | Redacted copy of the checked-in first-party maintenance policy source used to generate signed catalog descriptors. |
 | `redaction` | Final artifact scanner result and findings. |
+| `goNoGo` | Compact pointer to the final production beta go/no-go decision, dashboard JSON, dashboard Markdown, redaction report, failed gate count, waiver count, and non-release state. |
 | `commands` | Redacted command metadata, exit codes, durations, and scrubbed output tails. |
+
+## Go/no-go dashboard
+
+The pipeline generates a final release-manager dashboard after `production-beta-summary.json` and
+before the public archive is created. The dashboard lives under `reports/`:
+
+```text
+reports/go-no-go-dashboard.json
+reports/go-no-go-dashboard.md
+reports/go-no-go-redaction-report.json
+```
+
+The dashboard consumes sanitized summaries and emits one decision:
+
+- `go`: production beta promotion is ready.
+- `go-with-waivers`: promotion is launchable only with the listed approved, scoped, unexpired
+  waivers preserved in the release record.
+- `no-go`: at least one unwaived blocker, invalid waiver, critical redaction finding, unsafe
+  artifact hygiene finding, test signing in production mode, or non-release production artifact
+  remains.
+
+Developer dry-runs can still exit successfully when command execution and redaction pass, but the
+dashboard marks `nonRelease=true` artifacts as `no-go` for publication. See
+[production-beta-go-no-go-dashboard.md](production-beta-go-no-go-dashboard.md) for the waiver schema,
+redaction rules, and release-manager review workflow.
 
 Production beta promotion includes `app-platform.user-consent-flow` evidence. That evidence proves
 that install/update previews, service-grant consent, migration and backup consent, automatic update
@@ -186,6 +215,7 @@ topology schema and local commands.
 
 `reports/production-beta-summary.md` is the human-readable companion. It lists failed gates, artifact
 paths, the security response summary, known limitations, and the production beta readiness decision.
+It also links the go/no-go dashboard artifacts.
 
 ## Third-party submission evidence
 

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -43,9 +43,12 @@ Production beta candidates use a separate wrapper around this release-candidate 
 `tools/release-certification/run-production-beta-release.sh`. That command builds and signs
 first-party app bundles, creates a signed first-party catalog, generates review receipts, runs the
 app-platform/live-network/soak/certification collectors, scans the final public artifact tree, and
-writes `reports/production-beta-summary.json`. See
+writes `reports/production-beta-summary.json` plus a production beta go/no-go dashboard. See
 [production-beta-release-pipeline.md](production-beta-release-pipeline.md) for the exact command,
 mode semantics, required secrets, artifact layout, failure classes, and rerun guidance.
+The go/no-go dashboard is a final review surface over the sanitized production beta and
+release-certification outputs; it does not replace this certification summary or the ecosystem
+matrix.
 
 ## Run locally
 
@@ -61,6 +64,7 @@ python3 tools/release-certification/app_platform_smoke.py --self-test
 python3 tools/release-certification/network_scale_soak.py --self-test
 python3 tools/release-certification/multi_node_beta_soak.py --self-test
 python3 tools/release-certification/live_network_beta_smoke.py --self-test
+python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test
 python3 tools/release-certification/production_beta_release.py --self-test
 ```
 
@@ -600,6 +604,11 @@ The aggregator writes `ecosystem-certification-matrix.json` and
 `ecosystem-certification-matrix.md` beside the summary and report. The matrix is the primary
 release-candidate checklist for the networked app layer. It does not replace the detailed evidence
 or ecosystem gates; it summarizes them into deterministic rows that answer:
+
+The production beta go/no-go dashboard consumes this matrix as an input and surfaces its blocker
+count, waiver ids, redaction coverage, and recommendations in one launch decision. Release
+managers should keep the matrix with the release record because it remains the detailed checklist
+behind the dashboard.
 
 | Field | Meaning |
 | --- | --- |

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -824,6 +824,9 @@ Structured waivers are merged with CLI `--waive` records and remain visible in t
 summary, and history comparison. Active waivers downgrade matching evidence or ecosystem gate
 blockers to `warn`; they do not erase the gate. Expired or malformed waivers do not apply.
 Malformed waiver files fail `release-candidate` mode and warn in `pr` or `nightly` mode.
+The production beta dashboard waiver schema is accepted here too: `schemaVersion` is treated like
+`version`, `rationale` is treated like `reason`, and `scope: release-candidate` or
+`scope: release-candidate-only` derives `allowReleaseCandidate=true`.
 
 ## Optional live-node evidence
 

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -355,6 +355,14 @@ Trust Graph statements, app tokens, private insert URIs, or local paths. `apphos
 optional stronger evidence because normal PR and scheduled CI must not require a live local node or
 operator form password.
 
+`production-beta.go-no-go-dashboard`, `production-beta.go-no-go-decision`,
+`production-beta.waiver-validation`, `production-beta.dashboard-redaction`, and
+`production-beta.launch-artifact-hygiene` are deterministic evidence for the final production beta
+launch dashboard. The self-test covers `go`, `no-go`, and `go-with-waivers`, malformed and expired
+waivers, redaction failures, production summary readiness, live-network waiver aliases, and
+test-only signing in production mode without requiring Gradle, signing keys, network access, or a
+live node.
+
 `app-catalog.first-party-beta` reports whether `CRYPTAD_FIRST_PARTY_CATALOG_SOURCE` and the trusted
 catalog key hints are configured in the certification environment, but it does not fetch a public
 Crypta catalog during normal tests. It uses source checks, documentation checks, and deterministic

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -18,6 +18,7 @@ python3 tools/release-certification/app_platform_smoke.py --self-test
 python3 tools/release-certification/network_scale_soak.py --self-test
 python3 tools/release-certification/multi_node_beta_soak.py --self-test
 python3 tools/release-certification/live_network_beta_smoke.py --self-test
+python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test
 python3 tools/release-certification/production_beta_release.py --self-test
 ```
 
@@ -70,8 +71,9 @@ tools/release-certification/run-production-beta-release.sh \
 
 The production beta command writes signed first-party app bundles, a signed first-party catalog,
 review receipts, extracted evidence, a redaction report, JSON/Markdown summaries, and a final
-`dist/crypta-production-beta-<version>.tar.gz` archive. `release-candidate` and `production-beta`
-runs require a real HTTPS artifact base URI through `--artifact-base-uri` or
+go/no-go dashboard under `reports/`, plus `dist/crypta-production-beta-<version>.tar.gz`.
+`release-candidate` and `production-beta` runs require a real HTTPS artifact base URI through
+`--artifact-base-uri` or
 `CRYPTAD_PRODUCTION_BETA_ARTIFACT_BASE_URI`; developer dry-runs may use the non-release fallback
 URI. Catalog bundle URLs are signed under the published layout root, for example
 `<base>/build/app-bundles/<app>-<version>.zip`. `--use-fixture-evidence` is accepted only for
@@ -157,6 +159,9 @@ evidence/
 reports/production-beta-summary.json
 reports/production-beta-summary.md
 reports/redaction-report.json
+reports/go-no-go-dashboard.json
+reports/go-no-go-dashboard.md
+reports/go-no-go-redaction-report.json
 dist/crypta-production-beta-<version>.tar.gz
 dist/checksums.txt
 ```
@@ -187,6 +192,10 @@ missing
 
 Each item contains `id`, `status`, `requiredForReleaseCandidate`, `summary`, `source`, and
 `details`.
+
+The production beta go/no-go dashboard emits `go`, `no-go`, or `go-with-waivers` from the sanitized
+pipeline summaries. Waiver rendering preserves ids, rationale, owner, approver, expiry, scope, and
+usage, but redaction findings and unsafe artifact hygiene findings are never downgraded by waivers.
 
 ## Required release-candidate evidence
 

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -612,6 +612,9 @@ emitted under `waiverRecords`. Active waivers downgrade matching evidence or eco
 blockers to `warn`; they do not remove the evidence, gate, or reason.
 Expired, unapproved, malformed, or release-candidate-disallowed waivers do not apply. A malformed
 waiver file fails `release-candidate` mode and warns in `pr` or `nightly` mode.
+The production beta go/no-go dashboard waiver schema is accepted by release certification too:
+`schemaVersion` is treated like `version`, `rationale` is treated like `reason`, and
+release-candidate scopes derive `allowReleaseCandidate=true`.
 Redaction findings are not waiver material. Raw secrets, private URIs, credentials, raw payloads,
 or local-path leaks keep the evidence, matrix row, and final ecosystem RC gate failing even when a
 waiver targets the same evidence id, row id, gate id, or issue id.

--- a/tools/release-certification/fixtures/go-no-go-artifact-gate-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-artifact-gate-waiver.json
@@ -1,0 +1,43 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "promotion": {
+        "failedGateCount": 1,
+        "gates": [
+          {
+            "id": "artifact.signed-first-party-bundles",
+            "source": "pipeline",
+            "status": "fail",
+            "summary": "Signed sidecars are missing for at least one first-party staged app."
+          }
+        ],
+        "promotionReady": true,
+        "status": "pass"
+      },
+      "promotionReady": true,
+      "status": "pass"
+    }
+  },
+  "mode": "production-beta",
+  "releaseId": "crypta-production-beta-269-artifact-gate-waiver",
+  "waivers": {
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-24T00:00:00Z",
+        "evidenceId": "artifact.signed-first-party-bundles",
+        "expiresAt": "2099-06-30T00:00:00Z",
+        "id": "waiver-signed-first-party-bundles-001",
+        "owner": "release-engineering",
+        "rationale": "Self-test waiver must not make missing signed app artifacts promotable.",
+        "references": [
+          "self-test"
+        ],
+        "scope": "production-beta",
+        "severity": "critical"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-critical-redaction.json
+++ b/tools/release-certification/fixtures/go-no-go-critical-redaction.json
@@ -1,0 +1,19 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "redaction": {
+        "findingCount": 1,
+        "findings": [
+          {
+            "kind": "private-insert-uri",
+            "path": "reports/unsafe-redaction-fixture.txt"
+          }
+        ],
+        "status": "fail"
+      }
+    }
+  },
+  "releaseId": "crypta-production-beta-269-critical-redaction",
+  "unsafeFixtureValue": "insert=USK@PRIVATE-INSERT/test"
+}

--- a/tools/release-certification/fixtures/go-no-go-expired-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-expired-waiver.json
@@ -1,0 +1,25 @@
+{
+  "extends": "go-no-go-with-waivers.json",
+  "generatedAt": "2026-06-24T00:00:00Z",
+  "releaseId": "crypta-production-beta-269-expired-waiver",
+  "waivers": {
+    "releaseId": "crypta-production-beta-269-expired-waiver",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-24T00:00:00Z",
+        "evidenceId": "live.live-network-beta.content-fetch",
+        "expiresAt": "2000-06-30T00:00:00Z",
+        "id": "waiver-live-network-lab-outage-expired",
+        "owner": "release-engineering",
+        "rationale": "Expired waiver fixture.",
+        "references": [
+          "internal-ticket-1234"
+        ],
+        "scope": "production-beta",
+        "severity": "blocker"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-live-evidence-waiver-alias.json
+++ b/tools/release-certification/fixtures/go-no-go-live-evidence-waiver-alias.json
@@ -1,0 +1,81 @@
+{
+  "extends": "go-no-go-with-waivers.json",
+  "inputs": {
+    "liveNetworkSummary": {
+      "enabled": true,
+      "evidence": [
+        {
+          "id": "live-network-beta.preflight",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live preflight passed."
+        },
+        {
+          "id": "live-network-beta.catalog-usk-fetch",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live catalog fetch passed."
+        },
+        {
+          "id": "live-network-beta.app-install-update-rollback",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live app install/update/rollback passed."
+        },
+        {
+          "id": "live-network-beta.content-fetch",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "fail",
+          "summary": "Live content fetch lab node was unavailable during the RC window."
+        },
+        {
+          "id": "live-network-beta.feed-subscription",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live feed subscription passed."
+        },
+        {
+          "id": "live-network-beta.profile-publish",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live profile publish passed."
+        },
+        {
+          "id": "live-network-beta.trust-statement-publish-import",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live trust statement publish/import passed."
+        },
+        {
+          "id": "live-network-beta.interop-perf-budget",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live interop/perf budget passed."
+        },
+        {
+          "id": "live-network-beta.redaction",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live redaction passed."
+        }
+      ],
+      "kind": "live-network-beta-smoke",
+      "mode": "release-candidate",
+      "redaction": {
+        "status": "pass"
+      },
+      "required": true,
+      "status": "fail"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-live-waiver-alias"
+}

--- a/tools/release-certification/fixtures/go-no-go-live-network-skip-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-live-network-skip-waiver.json
@@ -1,0 +1,43 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "promotion": {
+        "failedGateCount": 1,
+        "gates": [
+          {
+            "id": "live.production-beta-skip",
+            "source": "live-network-beta-smoke",
+            "status": "fail",
+            "summary": "Live-network beta evidence was skipped for a production-beta run."
+          }
+        ],
+        "promotionReady": false,
+        "status": "fail"
+      },
+      "promotionReady": false,
+      "status": "fail"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-live-network-skip-waiver",
+  "waivers": {
+    "releaseId": "crypta-production-beta-269-live-network-skip-waiver",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-20T00:00:00Z",
+        "evidenceId": "live.production-beta-skip",
+        "expiresAt": "2026-06-30T00:00:00Z",
+        "id": "waiver-live-network-production-beta-skip-001",
+        "owner": "release-engineering",
+        "rationale": "Fixture waiver that must not make skipped production live-network evidence launchable.",
+        "references": [
+          "fixture-pr-269-live-network-skip"
+        ],
+        "scope": "production-beta",
+        "severity": "blocker"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-malformed-ecosystem-matrix-count.json
+++ b/tools/release-certification/fixtures/go-no-go-malformed-ecosystem-matrix-count.json
@@ -1,0 +1,10 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "ecosystemMatrix": {
+      "releaseBlockerCount": "not-a-number",
+      "status": "pass"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-malformed-ecosystem-matrix-count"
+}

--- a/tools/release-certification/fixtures/go-no-go-malformed-non-release-status.json
+++ b/tools/release-certification/fixtures/go-no-go-malformed-non-release-status.json
@@ -1,0 +1,9 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "nonRelease": null
+    }
+  },
+  "releaseId": "crypta-production-beta-269-malformed-non-release-status"
+}

--- a/tools/release-certification/fixtures/go-no-go-missing-ecosystem-matrix-status.json
+++ b/tools/release-certification/fixtures/go-no-go-missing-ecosystem-matrix-status.json
@@ -1,0 +1,9 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "ecosystemMatrix": {
+      "status": "missing"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-missing-ecosystem-matrix-status"
+}

--- a/tools/release-certification/fixtures/go-no-go-multi-node-upgrade-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-multi-node-upgrade-waiver.json
@@ -1,0 +1,46 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "multiNodeBetaSoakSummary": {
+      "mode": "hybrid",
+      "promotionReady": true,
+      "redaction": {
+        "findings": [],
+        "status": "pass"
+      },
+      "scenarioStatuses": {
+        "app-install-update-rollback": "pass",
+        "backup-restore": "pass",
+        "catalog-channel-update": "pass",
+        "social-inbox-multi-source": "pass",
+        "subscription-pressure": "pass",
+        "support-bundle-drill": "pass",
+        "trust-graph-import": "pass",
+        "upgrade-from-previous-candidate": "fail"
+      },
+      "status": "pass"
+    }
+  },
+  "mode": "release-candidate",
+  "releaseId": "crypta-production-beta-269-multi-node-upgrade-waiver",
+  "waivers": {
+    "releaseId": "crypta-production-beta-269-multi-node-upgrade-waiver",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-24T00:00:00Z",
+        "evidenceId": "multi-node-beta.upgrade-drill",
+        "expiresAt": "2099-06-30T00:00:00Z",
+        "id": "waiver-multi-node-upgrade-drill-001",
+        "owner": "release-engineering",
+        "rationale": "Release manager accepted the multi-node upgrade-drill evidence gap for this release-candidate run.",
+        "references": [
+          "fixture-pr-269-multi-node-upgrade"
+        ],
+        "scope": "release-candidate",
+        "severity": "blocker"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-network-scale-redaction-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-network-scale-redaction-waiver.json
@@ -1,0 +1,44 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "networkScaleSoakSummary": {
+      "budgets": {
+        "concurrencyLeasesReleased": true,
+        "globalFetchBudgetEnforced": true,
+        "perAppFetchBudgetEnforced": true
+      },
+      "durationHoursSimulated": 24,
+      "mode": "simulated-rc-soak",
+      "redaction": {
+        "absolutePathsExcluded": true,
+        "privateInsertUrisExcluded": false,
+        "queueHtmlExcluded": true,
+        "rawFetchedContentExcluded": true,
+        "tokensExcluded": true
+      },
+      "status": "fail"
+    }
+  },
+  "mode": "release-candidate",
+  "releaseId": "crypta-production-beta-269-network-scale-redaction-waiver",
+  "waivers": {
+    "releaseId": "crypta-production-beta-269-network-scale-redaction-waiver",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-24T00:00:00Z",
+        "evidenceId": "network-scale.rc-soak-summary",
+        "expiresAt": "2099-06-30T00:00:00Z",
+        "id": "waiver-network-scale-status-001",
+        "owner": "release-engineering",
+        "rationale": "Fixture waiver for the generic network-scale status issue; redaction evidence must remain non-waivable.",
+        "references": [
+          "fixture-pr-269-network-scale-redaction"
+        ],
+        "scope": "release-candidate",
+        "severity": "blocker"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-no-go.json
+++ b/tools/release-certification/fixtures/go-no-go-no-go.json
@@ -1,0 +1,20 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "releaseCertificationSummary": {
+      "ecosystemGates": [
+        {
+          "id": "ecosystem.app-review-trust",
+          "releaseBlocker": true,
+          "status": "fail",
+          "summary": "App review trust evidence failed."
+        }
+      ],
+      "ecosystemRcPassed": false,
+      "promotionDecision": "FAIL",
+      "releaseCandidatePassed": false,
+      "status": "fail"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-no-go"
+}

--- a/tools/release-certification/fixtures/go-no-go-pass.json
+++ b/tools/release-certification/fixtures/go-no-go-pass.json
@@ -1,0 +1,529 @@
+{
+  "generatedAt": "1970-01-01T00:00:00Z",
+  "inputs": {
+    "appPlatformSummary": {
+      "evidence": [
+        {
+          "id": "app-platform.signed-bundles",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Signed first-party bundles passed."
+        },
+        {
+          "id": "catalog.smoke",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Catalog smoke passed."
+        },
+        {
+          "id": "catalog.production-channels",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Production channels passed."
+        },
+        {
+          "id": "app-review.trusted-receipts",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Trusted review receipts passed."
+        },
+        {
+          "id": "app-review.first-party-catalog",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "First-party catalog review chain passed."
+        },
+        {
+          "id": "app-review.first-party-review-chain",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "First-party review chain passed."
+        },
+        {
+          "id": "app-catalog.first-party-maintenance-policy",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Maintenance policy passed."
+        },
+        {
+          "id": "platform-api.contract",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Platform API contract passed."
+        },
+        {
+          "id": "platform-api.stable-baseline",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Stable baseline passed."
+        },
+        {
+          "id": "platform-api.stable-breaking-change-check",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Stable breaking-change check passed."
+        },
+        {
+          "id": "platform-api.manifest-target-stability",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Manifest target stability passed."
+        },
+        {
+          "id": "platform-api.first-party-stability-declarations",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "First-party stability declarations passed."
+        },
+        {
+          "id": "platform-api.stable-reference-docs",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Stable reference docs passed."
+        },
+        {
+          "id": "app-store.submission-package-schema",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Submission package schema passed."
+        },
+        {
+          "id": "app-store.submission-cli",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Submission CLI passed."
+        },
+        {
+          "id": "app-store.pre-review",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Pre-review passed."
+        },
+        {
+          "id": "app-store.review-decision-states",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Review decision states passed."
+        },
+        {
+          "id": "app-store.review-receipt-issued",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Review receipt issued evidence passed."
+        },
+        {
+          "id": "app-store.rejection-record",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Rejection record passed."
+        },
+        {
+          "id": "app-store.resubmission-link",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Resubmission link passed."
+        },
+        {
+          "id": "app-store.transparency-log",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Transparency log passed."
+        },
+        {
+          "id": "app-store.catalog-candidate",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Catalog candidate passed."
+        },
+        {
+          "id": "app-store.third-party-sample-flow",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Third-party sample flow passed."
+        },
+        {
+          "id": "app-store.redaction-clean",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "App-store redaction passed."
+        },
+        {
+          "id": "app-platform.user-consent-flow",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Consent and permission upgrade UX passed."
+        },
+        {
+          "id": "app-platform.trust-social-beta-hardening",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Trust/social hardening passed."
+        },
+        {
+          "id": "reference-app.trust-graph",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Trust Graph app passed."
+        },
+        {
+          "id": "reference-app.trust-graph-durable-exchange",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Trust Graph durable exchange passed."
+        },
+        {
+          "id": "reference-app.trust-graph-app-data-preview",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Trust Graph app-data preview passed."
+        },
+        {
+          "id": "reference-app.social-inbox",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Social Inbox passed."
+        },
+        {
+          "id": "reference-app.social-inbox-signed-message",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Social Inbox signed message passed."
+        },
+        {
+          "id": "reference-app.social-inbox-subscriptions",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Social Inbox subscriptions passed."
+        },
+        {
+          "id": "reference-app.social-inbox-app-data",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Social Inbox app data passed."
+        },
+        {
+          "id": "reference-app.social-inbox-trust-annotations",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Social Inbox trust annotations passed."
+        },
+        {
+          "id": "reference-app.social-inbox-rc-threading",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Social Inbox RC threading passed."
+        },
+        {
+          "id": "legacy-admin.removal-wave-5",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Legacy admin Wave 5 passed."
+        },
+        {
+          "id": "legacy-admin.final-admin-surface",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Legacy admin final surface passed."
+        },
+        {
+          "id": "legacy-admin.browse-retained",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Legacy browse retained evidence passed."
+        },
+        {
+          "id": "legacy-admin.emergency-fallback-retained",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Legacy emergency fallback evidence passed."
+        },
+        {
+          "id": "production-security.response-runbook",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Production security response runbook passed."
+        },
+        {
+          "id": "third-party-developer.beta-program",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Developer beta program passed."
+        },
+        {
+          "id": "third-party-developer.docs",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Developer beta docs passed."
+        },
+        {
+          "id": "third-party-developer.template",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Developer beta template passed."
+        },
+        {
+          "id": "third-party-developer.sample-app-flow",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Developer sample app flow passed."
+        },
+        {
+          "id": "third-party-developer.submission-checklist",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Developer submission checklist passed."
+        },
+        {
+          "id": "third-party-developer.compatibility-window",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Developer compatibility window passed."
+        },
+        {
+          "id": "third-party-developer.feedback-workflow",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Developer feedback workflow passed."
+        },
+        {
+          "id": "third-party-developer.plugin-author-migration",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Plugin author migration passed."
+        },
+        {
+          "id": "third-party-developer.redaction",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-app-platform",
+          "status": "pass",
+          "summary": "Developer beta redaction passed."
+        },
+        {
+          "id": "live-network-beta.preflight",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live preflight passed."
+        },
+        {
+          "id": "live-network-beta.catalog-usk-fetch",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live catalog fetch passed."
+        },
+        {
+          "id": "live-network-beta.app-install-update-rollback",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live app install/update/rollback passed."
+        },
+        {
+          "id": "live-network-beta.content-fetch",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live content fetch passed."
+        },
+        {
+          "id": "live-network-beta.feed-subscription",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live feed subscription passed."
+        },
+        {
+          "id": "live-network-beta.profile-publish",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live profile publish passed."
+        },
+        {
+          "id": "live-network-beta.trust-statement-publish-import",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live trust statement publish/import passed."
+        },
+        {
+          "id": "live-network-beta.interop-perf-budget",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live interop/perf budget passed."
+        },
+        {
+          "id": "live-network-beta.redaction",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "pass",
+          "summary": "Live redaction passed."
+        }
+      ],
+      "mode": "release-candidate",
+      "schemaVersion": 1,
+      "status": "pass",
+      "tool": "app-platform-smoke"
+    },
+    "ecosystemMatrix": {
+      "coverage": {
+        "docsCovered": true,
+        "ecosystemGatesCovered": true,
+        "firstPartyAppsCovered": true,
+        "redactionPassed": true,
+        "requiredEvidenceCovered": true
+      },
+      "releaseBlockerCount": 0,
+      "rows": [
+        {
+          "id": "production-beta-go-no-go-dashboard",
+          "releaseBlocker": false,
+          "status": "pass",
+          "title": "Production beta go/no-go dashboard"
+        }
+      ],
+      "status": "pass"
+    },
+    "liveNetworkSummary": {
+      "enabled": true,
+      "evidence": [],
+      "kind": "live-network-beta-smoke",
+      "mode": "release-candidate",
+      "redaction": {
+        "status": "pass"
+      },
+      "required": true,
+      "status": "pass"
+    },
+    "multiNodeBetaSoakSummary": {
+      "mode": "hybrid",
+      "promotionReady": true,
+      "redaction": {
+        "findings": [],
+        "status": "pass"
+      },
+      "scenarioStatuses": {
+        "app-install-update-rollback": "pass",
+        "backup-restore": "pass",
+        "catalog-channel-update": "pass",
+        "social-inbox-multi-source": "pass",
+        "subscription-pressure": "pass",
+        "support-bundle-drill": "pass",
+        "trust-graph-import": "pass",
+        "upgrade-from-previous-candidate": "pass"
+      },
+      "status": "pass"
+    },
+    "networkScaleSoakSummary": {
+      "budgets": {
+        "concurrencyLeasesReleased": true,
+        "globalFetchBudgetEnforced": true,
+        "perAppFetchBudgetEnforced": true
+      },
+      "durationHoursSimulated": 24,
+      "mode": "simulated-rc-soak",
+      "redaction": {
+        "absolutePathsExcluded": true,
+        "privateInsertUrisExcluded": true,
+        "queueHtmlExcluded": true,
+        "rawFetchedContentExcluded": true,
+        "tokensExcluded": true
+      },
+      "status": "success"
+    },
+    "productionBetaSummary": {
+      "artifacts": {
+        "checksums": "dist/checksums.txt",
+        "distArchive": "dist/crypta-production-beta-269.tar.gz",
+        "redactionReport": "reports/redaction-report.json"
+      },
+      "mode": "production-beta",
+      "nonRelease": false,
+      "promotion": {
+        "failedGateCount": 0,
+        "gates": [],
+        "promotionReady": true,
+        "status": "pass"
+      },
+      "promotionReady": true,
+      "redaction": {
+        "findingCount": 0,
+        "findings": [],
+        "status": "pass"
+      },
+      "schemaVersion": 1,
+      "signingProfile": {
+        "generatedTestKeys": false,
+        "kind": "production"
+      },
+      "status": "pass",
+      "tool": "production-beta-release",
+      "version": "269"
+    },
+    "releaseCertificationSummary": {
+      "ecosystemGates": [],
+      "ecosystemRcPassed": true,
+      "evidence": [],
+      "promotionDecision": "PASS",
+      "releaseCandidatePassed": true,
+      "status": "pass",
+      "waiverRecords": []
+    },
+    "securityResponseSummary": {
+      "status": "pass",
+      "tool": "security-response-runbook"
+    }
+  },
+  "mode": "production-beta",
+  "releaseId": "crypta-production-beta-269"
+}

--- a/tools/release-certification/fixtures/go-no-go-production-summary-not-ready.json
+++ b/tools/release-certification/fixtures/go-no-go-production-summary-not-ready.json
@@ -1,0 +1,16 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "promotion": {
+        "failedGateCount": 0,
+        "gates": [],
+        "promotionReady": false,
+        "status": "pass"
+      },
+      "promotionReady": false,
+      "status": "pass"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-summary-not-ready"
+}

--- a/tools/release-certification/fixtures/go-no-go-production-summary-not-ready.json
+++ b/tools/release-certification/fixtures/go-no-go-production-summary-not-ready.json
@@ -12,5 +12,25 @@
       "status": "pass"
     }
   },
-  "releaseId": "crypta-production-beta-269-summary-not-ready"
+  "releaseId": "crypta-production-beta-269-summary-not-ready",
+  "waivers": {
+    "releaseId": "crypta-production-beta-269-summary-not-ready",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-20T00:00:00Z",
+        "evidenceId": "production-beta.promotion-ready",
+        "expiresAt": "2026-06-30T00:00:00Z",
+        "id": "waiver-production-summary-not-ready-001",
+        "owner": "release-engineering",
+        "rationale": "Fixture waiver that must not make promotionReady=false launchable.",
+        "references": [
+          "fixture-pr-269-summary-not-ready"
+        ],
+        "scope": "production-beta",
+        "severity": "blocker"
+      }
+    ]
+  }
 }

--- a/tools/release-certification/fixtures/go-no-go-production-summary-skipped.json
+++ b/tools/release-certification/fixtures/go-no-go-production-summary-skipped.json
@@ -12,5 +12,25 @@
       "status": "skip"
     }
   },
-  "releaseId": "crypta-production-beta-269-summary-skipped"
+  "releaseId": "crypta-production-beta-269-summary-skipped",
+  "waivers": {
+    "releaseId": "crypta-production-beta-269-summary-skipped",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-20T00:00:00Z",
+        "evidenceId": "production-beta.summary",
+        "expiresAt": "2026-06-30T00:00:00Z",
+        "id": "waiver-production-summary-skipped-001",
+        "owner": "release-engineering",
+        "rationale": "Fixture waiver that must not make a skipped production summary launchable.",
+        "references": [
+          "fixture-pr-269-summary-skipped"
+        ],
+        "scope": "production-beta",
+        "severity": "blocker"
+      }
+    ]
+  }
 }

--- a/tools/release-certification/fixtures/go-no-go-production-summary-skipped.json
+++ b/tools/release-certification/fixtures/go-no-go-production-summary-skipped.json
@@ -1,0 +1,16 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "promotion": {
+        "failedGateCount": 0,
+        "gates": [],
+        "promotionReady": true,
+        "status": "pass"
+      },
+      "promotionReady": true,
+      "status": "skip"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-summary-skipped"
+}

--- a/tools/release-certification/fixtures/go-no-go-release-candidate-live-disabled.json
+++ b/tools/release-certification/fixtures/go-no-go-release-candidate-live-disabled.json
@@ -1,0 +1,25 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "liveNetworkSummary": {
+      "enabled": false,
+      "evidence": [],
+      "mode": "release-candidate",
+      "redaction": {
+        "status": "pass"
+      },
+      "required": false,
+      "status": "skip"
+    },
+    "productionBetaSummary": {
+      "mode": "release-candidate",
+      "nonRelease": true,
+      "signingProfile": {
+        "generatedTestKeys": true,
+        "kind": "test-fixture"
+      }
+    }
+  },
+  "mode": "release-candidate",
+  "releaseId": "crypta-production-beta-269-release-candidate-live-disabled"
+}

--- a/tools/release-certification/fixtures/go-no-go-release-cert-applied-waiver-expired.json
+++ b/tools/release-certification/fixtures/go-no-go-release-cert-applied-waiver-expired.json
@@ -1,0 +1,24 @@
+{
+  "extends": "go-no-go-release-cert-applied-waiver.json",
+  "generatedAt": "2026-06-24T00:00:00Z",
+  "inputs": {
+    "releaseCertificationSummary": {
+      "waiverRecords": [
+        {
+          "active": true,
+          "allowReleaseCandidate": true,
+          "appliesToReleaseCandidate": true,
+          "approvedBy": "release-manager@example.invalid",
+          "evidenceId": "release-certification.ecosystem-rc-gate",
+          "expiresAt": "2000-01-01T00:00:00Z",
+          "expired": false,
+          "id": "waiver-ecosystem-rc-gate-applied-001",
+          "reason": "Release certification accepted the ecosystem RC gate warning.",
+          "source": "release-certification",
+          "status": "approved"
+        }
+      ]
+    }
+  },
+  "releaseId": "crypta-production-beta-269-release-cert-applied-waiver-expired"
+}

--- a/tools/release-certification/fixtures/go-no-go-release-cert-applied-waiver-missing-record.json
+++ b/tools/release-certification/fixtures/go-no-go-release-cert-applied-waiver-missing-record.json
@@ -1,0 +1,9 @@
+{
+  "extends": "go-no-go-release-cert-applied-waiver.json",
+  "inputs": {
+    "releaseCertificationSummary": {
+      "waiverRecords": []
+    }
+  },
+  "releaseId": "crypta-production-beta-269-release-cert-applied-waiver-missing-record"
+}

--- a/tools/release-certification/fixtures/go-no-go-release-cert-applied-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-release-cert-applied-waiver.json
@@ -1,0 +1,39 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "releaseCertificationSummary": {
+      "evidence": [
+        {
+          "details": {
+            "waived": true,
+            "waiverId": "waiver-ecosystem-rc-gate-applied-001",
+            "waiverReason": "Release certification accepted the ecosystem RC gate warning.",
+            "waiverSource": "release-certification"
+          },
+          "id": "release-certification.ecosystem-rc-gate",
+          "requiredForReleaseCandidate": true,
+          "source": "release-certification",
+          "status": "warn",
+          "summary": "Ecosystem RC gate warning was waived during release certification."
+        }
+      ],
+      "waiverRecords": [
+        {
+          "active": true,
+          "allowReleaseCandidate": true,
+          "appliesToReleaseCandidate": true,
+          "approvedBy": "release-manager@example.invalid",
+          "evidenceId": "release-certification.ecosystem-rc-gate",
+          "expiresAt": "2099-06-30T00:00:00Z",
+          "expired": false,
+          "id": "waiver-ecosystem-rc-gate-applied-001",
+          "reason": "Release certification accepted the ecosystem RC gate warning.",
+          "source": "release-certification",
+          "status": "approved"
+        }
+      ]
+    }
+  },
+  "mode": "release-candidate",
+  "releaseId": "crypta-production-beta-269-release-cert-applied-waiver"
+}

--- a/tools/release-certification/fixtures/go-no-go-release-cert-schema-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-release-cert-schema-waiver.json
@@ -1,0 +1,39 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "promotion": {
+        "failedGateCount": 1,
+        "gates": [
+          {
+            "id": "evidence.app-store.submission-cli",
+            "source": "release-certification",
+            "status": "fail",
+            "summary": "App-store submission CLI evidence was not available for the release-candidate run."
+          }
+        ],
+        "promotionReady": false,
+        "status": "fail"
+      },
+      "promotionReady": false,
+      "status": "fail"
+    }
+  },
+  "mode": "release-candidate",
+  "releaseId": "crypta-production-beta-269-release-cert-schema-waiver",
+  "waivers": {
+    "release": "crypta-production-beta-269-release-cert-schema-waiver",
+    "version": 1,
+    "waivers": [
+      {
+        "allowReleaseCandidate": true,
+        "approvedBy": "release-manager@example.invalid",
+        "evidenceId": "app-store.submission-cli",
+        "expiresAt": "2099-06-30T00:00:00Z",
+        "id": "waiver-app-store-submission-cli-001",
+        "reason": "Release manager accepted the app-store submission CLI evidence gap for this release-candidate run.",
+        "status": "approved"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-secret-value-redaction.json
+++ b/tools/release-certification/fixtures/go-no-go-secret-value-redaction.json
@@ -1,0 +1,13 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "failures": [
+        "Dashboard-only unsafe values: Authorization: Bearer abcdefghijklmnop Cookie: session=abc1234567890 CRYPTAD_APP_TOKEN=app-token-123456789 formPassword=hunter2 payloadBase64=rawpayload123456789 GITHUB_TOKEN=github-token-123456789."
+      ],
+      "promotionReady": false,
+      "status": "fail"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-secret-value-redaction"
+}

--- a/tools/release-certification/fixtures/go-no-go-summary-failure-with-gates.json
+++ b/tools/release-certification/fixtures/go-no-go-summary-failure-with-gates.json
@@ -1,0 +1,26 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "failures": [
+        "release-certification failed after promotion gates were evaluated"
+      ],
+      "promotion": {
+        "failedGateCount": 0,
+        "gates": [
+          {
+            "id": "ecosystem.certification",
+            "source": "release-certification",
+            "status": "pass",
+            "summary": "Ecosystem certification gate passed."
+          }
+        ],
+        "promotionReady": true,
+        "status": "pass"
+      },
+      "promotionReady": false,
+      "status": "fail"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-summary-failure-with-gates"
+}

--- a/tools/release-certification/fixtures/go-no-go-test-signing-production.json
+++ b/tools/release-certification/fixtures/go-no-go-test-signing-production.json
@@ -1,0 +1,28 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "nonRelease": true,
+      "promotion": {
+        "failedGateCount": 1,
+        "gates": [
+          {
+            "id": "signing.production-keys",
+            "source": "pipeline",
+            "status": "fail",
+            "summary": "Production beta used test-only signing material."
+          }
+        ],
+        "promotionReady": false,
+        "status": "fail"
+      },
+      "promotionReady": false,
+      "signingProfile": {
+        "generatedTestKeys": true,
+        "kind": "test-fixture"
+      },
+      "status": "fail"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-test-signing"
+}

--- a/tools/release-certification/fixtures/go-no-go-underseverity-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-underseverity-waiver.json
@@ -1,0 +1,24 @@
+{
+  "extends": "go-no-go-with-waivers.json",
+  "releaseId": "crypta-production-beta-269-underseverity-waiver",
+  "waivers": {
+    "releaseId": "crypta-production-beta-269-underseverity-waiver",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-24T00:00:00Z",
+        "evidenceId": "live.live-network-beta.content-fetch",
+        "expiresAt": "2099-06-30T00:00:00Z",
+        "id": "waiver-live-network-lab-outage-warning-only",
+        "owner": "release-engineering",
+        "rationale": "A warning-only waiver must not waive a blocker.",
+        "references": [
+          "internal-ticket-1234"
+        ],
+        "scope": "production-beta",
+        "severity": "warning"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-waiver-valid-at-generated-at.json
+++ b/tools/release-certification/fixtures/go-no-go-waiver-valid-at-generated-at.json
@@ -1,0 +1,25 @@
+{
+  "extends": "go-no-go-with-waivers.json",
+  "generatedAt": "1999-06-24T00:00:00Z",
+  "releaseId": "crypta-production-beta-269-waiver-valid-at-generated-at",
+  "waivers": {
+    "releaseId": "crypta-production-beta-269-waiver-valid-at-generated-at",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "1999-06-20T00:00:00Z",
+        "evidenceId": "live.live-network-beta.content-fetch",
+        "expiresAt": "2000-06-30T00:00:00Z",
+        "id": "waiver-live-network-lab-outage-historical",
+        "owner": "release-engineering",
+        "rationale": "Historical waiver fixture that was valid at dashboard generation time.",
+        "references": [
+          "internal-ticket-1234"
+        ],
+        "scope": "production-beta",
+        "severity": "blocker"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-warning-ecosystem-matrix.json
+++ b/tools/release-certification/fixtures/go-no-go-warning-ecosystem-matrix.json
@@ -1,0 +1,25 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "ecosystemMatrix": {
+      "coverage": {
+        "docsCovered": true,
+        "ecosystemGatesCovered": true,
+        "firstPartyAppsCovered": true,
+        "redactionPassed": true,
+        "requiredEvidenceCovered": true
+      },
+      "releaseBlockerCount": 0,
+      "rows": [
+        {
+          "id": "non-blocking-doc-follow-up",
+          "releaseBlocker": false,
+          "status": "warn",
+          "title": "Non-blocking documentation follow-up"
+        }
+      ],
+      "status": "warn"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-warning-ecosystem-matrix"
+}

--- a/tools/release-certification/fixtures/go-no-go-warning-redaction-findings.json
+++ b/tools/release-certification/fixtures/go-no-go-warning-redaction-findings.json
@@ -1,0 +1,25 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "releaseCertificationSummary": {
+      "evidence": [
+        {
+          "details": {
+            "redactionFindings": [
+              {
+                "kind": "token",
+                "path": "<redacted-artifact>"
+              }
+            ]
+          },
+          "id": "release-certification.ecosystem-rc-gate",
+          "requiredForReleaseCandidate": true,
+          "source": "release-certification",
+          "status": "warn",
+          "summary": "Release certification evidence reported a redaction warning."
+        }
+      ]
+    }
+  },
+  "releaseId": "crypta-production-beta-269-warning-redaction-findings"
+}

--- a/tools/release-certification/fixtures/go-no-go-with-waivers.json
+++ b/tools/release-certification/fixtures/go-no-go-with-waivers.json
@@ -1,0 +1,43 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "promotion": {
+        "failedGateCount": 1,
+        "gates": [
+          {
+            "id": "live.live-network-beta.content-fetch",
+            "source": "live-network-beta-smoke",
+            "status": "fail",
+            "summary": "Live content fetch lab node was unavailable during the RC window."
+          }
+        ],
+        "promotionReady": false,
+        "status": "fail"
+      },
+      "promotionReady": false,
+      "status": "fail"
+    }
+  },
+  "releaseId": "crypta-production-beta-269-with-waiver",
+  "waivers": {
+    "releaseId": "crypta-production-beta-269-with-waiver",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-24T00:00:00Z",
+        "evidenceId": "live.live-network-beta.content-fetch",
+        "expiresAt": "2099-06-30T00:00:00Z",
+        "id": "waiver-live-network-lab-outage-001",
+        "owner": "release-engineering",
+        "rationale": "Lab live node was unavailable during the RC dry run; the release manager accepted this single evidence gap.",
+        "references": [
+          "internal-ticket-1234"
+        ],
+        "scope": "production-beta",
+        "severity": "blocker"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -1909,7 +1909,8 @@ def load_waivers(
         owner = release_certification_owner(entry)
         created_at = str(entry.get("createdAt", "")).strip()
         expires_at = str(entry.get("expiresAt", "")).strip()
-        references = tuple(str(item) for item in entry.get("references", []) if isinstance(entry.get("references"), list))
+        references_value = entry.get("references", [])
+        references = tuple(str(item) for item in references_value) if isinstance(references_value, list) else ()
         external_risk_accepted = entry.get("externalRiskAccepted") is True
         status = str(entry.get("status", "approved")).strip().lower()
         applies = scope_applies(scope, mode) if scope else False
@@ -1930,6 +1931,8 @@ def load_waivers(
             validation_errors.append("owner is required")
         if status != "approved":
             validation_errors.append("status must be approved")
+        if not isinstance(references_value, list):
+            validation_errors.append("references must be an array when provided")
         if not expires_at:
             validation_errors.append("expiresAt is required")
         elif expiry is None:
@@ -2742,10 +2745,29 @@ def assert_protected_secret_values_are_scanned_and_redacted(root: Path) -> None:
 
 def assert_supplied_waiver_file_errors_block_launch(root: Path) -> None:
     input_args, input_paths = path_input_args_from_pass_fixture(root, "path-inputs")
+    valid_waiver = {
+        "id": "waiver-malformed-references",
+        "evidenceId": "app-store.submission-cli",
+        "severity": "blocker",
+        "scope": "production-beta-only",
+        "rationale": "Self-test malformed references record.",
+        "approvedBy": "release-manager@example.invalid",
+        "owner": "release-engineering",
+        "createdAt": "2026-06-24T00:00:00Z",
+        "expiresAt": "2099-06-30T00:00:00Z",
+    }
+
+    def waiver_with_references(references: Any) -> str:
+        waiver = dict(valid_waiver)
+        waiver["references"] = references
+        return json.dumps({"schemaVersion": 1, "waivers": [waiver]}, sort_keys=True)
+
     waiver_cases = {
         "missing": None,
         "malformed": "{",
         "non-object": "[]",
+        "references-null": waiver_with_references(None),
+        "references-number": waiver_with_references(123),
     }
     for case_name, content in waiver_cases.items():
         waiver_path = root / f"{case_name}-waivers.json"

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -27,6 +27,7 @@ from typing import Any, Iterable, Iterator
 
 
 sys.dont_write_bytecode = True
+import multi_node_beta_soak
 
 TOOL_NAME = "production-beta-go-no-go-dashboard"
 SCHEMA_VERSION = 1
@@ -540,12 +541,26 @@ def live_network_target_aliases(value: str) -> set[str]:
     return aliases
 
 
+def evidence_prefix_target_aliases(value: str) -> set[str]:
+    aliases = {value}
+    if value.startswith("evidence."):
+        aliases.add(value.removeprefix("evidence."))
+    elif "." in value:
+        aliases.add(f"evidence.{value}")
+    return aliases
+
+
+def canonical_evidence_id(value: str) -> str:
+    return value.removeprefix("evidence.")
+
+
 def expand_waiver_target_aliases(*values: str) -> set[str]:
     aliases: set[str] = set()
     for value in values:
         if not value:
             continue
-        aliases.update(live_network_target_aliases(value))
+        for alias in evidence_prefix_target_aliases(value):
+            aliases.update(live_network_target_aliases(alias))
     return aliases
 
 
@@ -1450,8 +1465,14 @@ def production_summary_issues(summary: dict[str, Any] | None, mode: str) -> list
         if not isinstance(gate, dict) or normalize_status(gate.get("status")) == "pass":
             continue
         gate_id = str(gate.get("id", "promotion-gate"))
+        evidence_id = canonical_evidence_id(gate_id)
         source = str(gate.get("source", "promotion"))
-        nonwaivable = gate_id in NON_WAIVABLE_EVIDENCE_IDS or is_redaction_evidence(gate_id)
+        nonwaivable = (
+            gate_id in NON_WAIVABLE_EVIDENCE_IDS
+            or evidence_id in NON_WAIVABLE_EVIDENCE_IDS
+            or is_redaction_evidence(gate_id)
+            or is_redaction_evidence(evidence_id)
+        )
         if gate_id == "signing.production-keys" or "test-signing" in gate_id:
             nonwaivable = True
         if gate_id in {"build.production-beta-complete", "workspace.clean-production-beta", "fixture-evidence.strict-mode"}:
@@ -1459,8 +1480,8 @@ def production_summary_issues(summary: dict[str, Any] | None, mode: str) -> list
         issues.append(
             Issue(
                 id=f"promotion.{gate_id}",
-                evidence_id=gate_id,
-                domain_id=domain_for_gate(gate_id, source),
+                evidence_id=evidence_id,
+                domain_id=domain_for_gate(evidence_id, source),
                 severity="critical" if nonwaivable else "blocker",
                 title=f"{gate_id} failed",
                 summary=str(gate.get("summary", "Promotion gate failed.")),
@@ -1695,10 +1716,14 @@ def multi_node_issues(summary: dict[str, Any] | None, mode: str) -> list[Issue]:
     if isinstance(scenario_statuses, dict):
         for scenario_id, scenario_status in sorted(scenario_statuses.items()):
             if normalize_status(scenario_status) != "pass":
+                evidence_id = multi_node_beta_soak.SCENARIO_EVIDENCE_IDS.get(
+                    scenario_id,
+                    f"multi-node-beta.{scenario_id}",
+                )
                 issues.append(
                     Issue(
                         id=f"multi-node-beta-soak.{scenario_id}",
-                        evidence_id=f"multi-node-beta.{scenario_id}",
+                        evidence_id=evidence_id,
                         domain_id="multi-node-beta-soak",
                         severity="blocker",
                         title=f"{scenario_id} scenario is not passing",
@@ -1804,6 +1829,25 @@ def scope_applies(scope: str, mode: str) -> bool:
     return False
 
 
+def release_certification_scope(entry: dict[str, Any]) -> str:
+    scope = str(entry.get("scope", "")).strip()
+    if scope:
+        return scope
+    allow_release_candidate = entry.get("allowReleaseCandidate")
+    if isinstance(allow_release_candidate, bool):
+        return "release-candidate" if allow_release_candidate else "developer-dry-run"
+    return ""
+
+
+def release_certification_owner(entry: dict[str, Any]) -> str:
+    owner = str(entry.get("owner", "")).strip()
+    if owner:
+        return owner
+    if "reason" in entry or "allowReleaseCandidate" in entry:
+        return str(entry.get("approvedBy", "")).strip() or "release-certification"
+    return ""
+
+
 def severity_covers(waiver: Waiver, issue: Issue) -> bool:
     return SEVERITY_RANK.get(waiver.severity, -1) >= SEVERITY_RANK.get(issue.severity, 99)
 
@@ -1859,10 +1903,10 @@ def load_waivers(
         waiver_id = str(entry.get("id", "")).strip()
         evidence_id = str(entry.get("evidenceId", waiver_id)).strip()
         severity = str(entry.get("severity", "blocker")).strip().lower()
-        scope = str(entry.get("scope", "")).strip()
+        scope = release_certification_scope(entry)
         rationale = str(entry.get("rationale", entry.get("reason", ""))).strip()
         approved_by = str(entry.get("approvedBy", "")).strip()
-        owner = str(entry.get("owner", "")).strip()
+        owner = release_certification_owner(entry)
         created_at = str(entry.get("createdAt", "")).strip()
         expires_at = str(entry.get("expiresAt", "")).strip()
         references = tuple(str(item) for item in entry.get("references", []) if isinstance(entry.get("references"), list))
@@ -2362,6 +2406,8 @@ def run_self_test(quiet: bool = False) -> None:
         "go-no-go-missing-ecosystem-matrix-status.json": "no-go",
         "go-no-go-warning-ecosystem-matrix.json": "go",
         "go-no-go-malformed-ecosystem-matrix-count.json": "no-go",
+        "go-no-go-release-cert-schema-waiver.json": "go-with-waivers",
+        "go-no-go-multi-node-upgrade-waiver.json": "go-with-waivers",
         "go-no-go-network-scale-redaction-waiver.json": "no-go",
         "go-no-go-secret-value-redaction.json": "no-go",
         "go-no-go-underseverity-waiver.json": "no-go",
@@ -2432,6 +2478,32 @@ def run_self_test(quiet: bool = False) -> None:
                 }
                 if "live-network-beta.content-fetch" not in waived_evidence_ids:
                     raise AssertionError("live evidence alias waiver did not cover live-network evidence")
+            if fixture_name == "go-no-go-release-cert-schema-waiver.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
+                    raise AssertionError("release-certification schema waiver was not used by dashboard")
+                waived_evidence_ids = {
+                    str(warning.get("evidenceId"))
+                    for warning in dashboard.get("warnings", [])
+                    if isinstance(warning, dict) and warning.get("waivedBy")
+                }
+                if "app-store.submission-cli" not in waived_evidence_ids:
+                    raise AssertionError("canonical app-store evidence id did not waive evidence-prefixed gate")
+                if any(
+                    str(warning.get("evidenceId")).startswith("evidence.")
+                    for warning in dashboard.get("warnings", [])
+                    if isinstance(warning, dict)
+                ):
+                    raise AssertionError("dashboard exposed evidence-prefixed promotion evidence id")
+            if fixture_name == "go-no-go-multi-node-upgrade-waiver.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
+                    raise AssertionError("canonical multi-node upgrade-drill waiver was not used")
+                waived_evidence_ids = {
+                    str(warning.get("evidenceId"))
+                    for warning in dashboard.get("warnings", [])
+                    if isinstance(warning, dict) and warning.get("waivedBy")
+                }
+                if "multi-node-beta.upgrade-drill" not in waived_evidence_ids:
+                    raise AssertionError("multi-node upgrade scenario did not use canonical evidence id")
             if fixture_name == "go-no-go-live-network-skip-waiver.json":
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
                     raise AssertionError("live-network production-beta skip hard blocker was incorrectly waived")

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -846,6 +846,26 @@ def evidence_map(*summaries: dict[str, Any] | None) -> dict[str, dict[str, Any]]
     return result
 
 
+def security_response_evidence(summary: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(summary, dict):
+        return None
+    status = normalize_status(summary.get("status"))
+    if status == "missing":
+        return None
+    summary_text = (
+        "Production security response runbook passed."
+        if status == "pass"
+        else f"Production security response runbook status is {status}."
+    )
+    return {
+        "id": "production-security.response-runbook",
+        "requiredForReleaseCandidate": True,
+        "source": "security-response-summary",
+        "status": status,
+        "summary": summary_text,
+    }
+
+
 def evidence_summary(entry: dict[str, Any] | None) -> str:
     if not isinstance(entry, dict):
         return "Required evidence is missing."
@@ -881,6 +901,21 @@ def issue_for_evidence(domain_id: str, evidence_id: str, entry: dict[str, Any] |
             waivable=True,
             category="evidence-waiver",
             waived_by=waiver_id,
+        )
+    if entry_has_redaction_findings(entry):
+        details = entry.get("details", {}) if isinstance(entry, dict) else {}
+        findings = details.get("redactionFindings") if isinstance(details, dict) else []
+        finding_count = len(findings) if isinstance(findings, list) else 1
+        return Issue(
+            id=issue_id(domain_id, evidence_id, "redaction"),
+            evidence_id=evidence_id,
+            domain_id=domain_id,
+            severity="critical",
+            title=f"{evidence_id} has redaction findings",
+            summary=f"{evidence_summary(entry)} Redaction findings reported: {finding_count}.",
+            source=str(entry.get("source", domain_id)) if isinstance(entry, dict) else domain_id,
+            waivable=False,
+            category="redaction",
         )
     if status_warn(entry):
         return Issue(
@@ -2218,7 +2253,11 @@ def collect_issues(
         inputs.get("releaseCertificationSummary"),
         inputs.get("appPlatformSummary"),
         inputs.get("liveNetworkSummary"),
+        inputs.get("securityResponseSummary"),
     )
+    standalone_security_evidence = security_response_evidence(inputs.get("securityResponseSummary"))
+    if standalone_security_evidence is not None:
+        all_evidence.setdefault("production-security.response-runbook", standalone_security_evidence)
     issues: list[Issue] = []
     for name in CRITICAL_INPUTS_BY_MODE.get(mode, ()):
         if name not in inputs:
@@ -2579,6 +2618,7 @@ def run_self_test(quiet: bool = False) -> None:
         "go-no-go-release-cert-applied-waiver.json": "go-with-waivers",
         "go-no-go-release-cert-applied-waiver-missing-record.json": "no-go",
         "go-no-go-artifact-gate-waiver.json": "no-go",
+        "go-no-go-warning-redaction-findings.json": "no-go",
         "go-no-go-multi-node-upgrade-waiver.json": "go-with-waivers",
         "go-no-go-network-scale-redaction-waiver.json": "no-go",
         "go-no-go-secret-value-redaction.json": "no-go",
@@ -2686,6 +2726,16 @@ def run_self_test(quiet: bool = False) -> None:
                     raise AssertionError("artifact-presence gate waiver incorrectly removed the blocker")
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
                     raise AssertionError("artifact-presence gate waiver was incorrectly used")
+            if fixture_name == "go-no-go-warning-redaction-findings.json":
+                if "release-certification.ecosystem-rc-gate" not in blocker_ids:
+                    raise AssertionError("warning evidence with redaction findings did not block launch")
+                critical_ids = {
+                    str(blocker.get("evidenceId"))
+                    for blocker in dashboard.get("blockers", [])
+                    if isinstance(blocker, dict) and blocker.get("severity") == "critical"
+                }
+                if "release-certification.ecosystem-rc-gate" not in critical_ids:
+                    raise AssertionError("warning evidence redaction findings were not critical")
             if fixture_name == "go-no-go-multi-node-upgrade-waiver.json":
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
                     raise AssertionError("canonical multi-node upgrade-drill waiver was not used")
@@ -2770,8 +2820,44 @@ def run_self_test(quiet: bool = False) -> None:
         assert_supplied_waiver_file_errors_block_launch(root)
         assert_protected_secret_values_are_scanned_and_redacted(root)
         assert_symlink_inputs_are_rejected(root)
+        assert_standalone_security_response_summary_is_honored(root)
     if not quiet:
         print("production beta go/no-go dashboard self-test passed")
+
+
+def assert_standalone_security_response_summary_is_honored(root: Path) -> None:
+    pass_fixture = load_fixture(FIXTURE_DIR / "go-no-go-pass.json")
+    inputs = json.loads(json.dumps(pass_fixture["inputs"]))
+    app_summary = inputs["appPlatformSummary"]
+    evidence = app_summary["evidence"]
+    app_summary["evidence"] = [
+        entry
+        for entry in evidence
+        if not (isinstance(entry, dict) and entry.get("id") == "production-security.response-runbook")
+    ]
+    if len(app_summary["evidence"]) == len(evidence):
+        raise AssertionError("standalone security response self-test did not remove duplicated app-platform evidence")
+    generated_at, now = parse_generated_at(DEFAULT_GENERATED_AT)
+    dashboard = build_dashboard(
+        inputs,
+        {},
+        [FIXTURE_DIR / "go-no-go-pass.json"],
+        None,
+        Path(__file__).resolve().parents[2],
+        root / "standalone-security-response",
+        "production-beta",
+        "crypta-production-beta-269-standalone-security-response",
+        generated_at,
+        now,
+    )
+    if dashboard.get("decision") != "go":
+        raise AssertionError(f"standalone security-response summary produced {dashboard.get('decision')}: {dashboard}")
+    security_domain = next(
+        (domain for domain in dashboard.get("domains", []) if domain.get("id") == "production-security-response"),
+        {},
+    )
+    if security_domain.get("status") != "pass":
+        raise AssertionError(f"standalone security-response domain did not pass: {security_domain}")
 
 
 def path_input_args_from_pass_fixture(root: Path, input_dir_name: str) -> tuple[tuple[tuple[str, str], ...], dict[str, Path]]:

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -283,6 +283,11 @@ NON_WAIVABLE_EVIDENCE_IDS = {
     "fixture-evidence.strict-mode",
     "live.production-beta-skip",
 }
+PRODUCTION_ARTIFACT_GATE_IDS = {
+    "artifact.signed-first-party-bundles",
+    "artifact.signed-first-party-catalog",
+    "artifact.first-party-review-receipts",
+}
 
 REDACTION_FINDING_KINDS = {
     "private-insert-uri",
@@ -799,14 +804,28 @@ def normalize_status(value: Any) -> str:
     }.get(status, status if status in {"pass", "warn", "fail", "skip", "missing"} else "missing")
 
 
+def entry_has_redaction_findings(entry: dict[str, Any] | None) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    details = entry.get("details", {})
+    return isinstance(details, dict) and bool(details.get("redactionFindings"))
+
+
+def entry_waiver_id(entry: dict[str, Any] | None) -> str:
+    if not isinstance(entry, dict):
+        return ""
+    details = entry.get("details", {})
+    if not isinstance(details, dict) or details.get("waived") is not True:
+        return ""
+    return str(details.get("waiverId", "")).strip()
+
+
 def status_ok(entry: dict[str, Any] | None) -> bool:
     if not isinstance(entry, dict):
         return False
-    status = normalize_status(entry.get("status"))
-    details = entry.get("details", {})
-    if isinstance(details, dict) and details.get("redactionFindings"):
+    if entry_has_redaction_findings(entry):
         return False
-    return status == "pass" or (status == "warn" and isinstance(details, dict) and details.get("waived") is True)
+    return normalize_status(entry.get("status")) == "pass"
 
 
 def status_warn(entry: dict[str, Any] | None) -> bool:
@@ -849,6 +868,20 @@ def is_redaction_evidence(evidence_id: str, domain_id: str = "") -> bool:
 def issue_for_evidence(domain_id: str, evidence_id: str, entry: dict[str, Any] | None) -> Issue | None:
     if status_ok(entry):
         return None
+    waiver_id = "" if entry_has_redaction_findings(entry) else entry_waiver_id(entry)
+    if waiver_id and status_warn(entry):
+        return Issue(
+            id=issue_id(domain_id, evidence_id, "waived"),
+            evidence_id=evidence_id,
+            domain_id=domain_id,
+            severity="blocker",
+            title=f"{evidence_id} is waived",
+            summary=evidence_summary(entry),
+            source=str(entry.get("source", domain_id)) if isinstance(entry, dict) else domain_id,
+            waivable=True,
+            category="evidence-waiver",
+            waived_by=waiver_id,
+        )
     if status_warn(entry):
         return Issue(
             id=issue_id(domain_id, evidence_id, "warning"),
@@ -1414,7 +1447,7 @@ def production_summary_issues(summary: dict[str, Any] | None, mode: str) -> list
                 title="Production beta summary failed",
                 summary=f"Production beta summary status is fail.{detail}",
                 source="production-beta-summary",
-                waivable=True,
+                waivable=False,
                 category="pipeline",
             )
         )
@@ -1470,6 +1503,7 @@ def production_summary_issues(summary: dict[str, Any] | None, mode: str) -> list
         nonwaivable = (
             gate_id in NON_WAIVABLE_EVIDENCE_IDS
             or evidence_id in NON_WAIVABLE_EVIDENCE_IDS
+            or (mode == "production-beta" and gate_id in PRODUCTION_ARTIFACT_GATE_IDS)
             or is_redaction_evidence(gate_id)
             or is_redaction_evidence(evidence_id)
         )
@@ -1511,6 +1545,16 @@ def release_certification_issues(summary: dict[str, Any] | None) -> list[Issue]:
     if not isinstance(summary, dict):
         return []
     issues: list[Issue] = []
+    evidence_entries = summary.get("evidence") if isinstance(summary.get("evidence"), list) else []
+    for entry in evidence_entries:
+        if not isinstance(entry, dict):
+            continue
+        evidence_id = str(entry.get("id", ""))
+        if evidence_id != "release-certification.ecosystem-rc-gate":
+            continue
+        issue = issue_for_evidence("release-certification", evidence_id, entry)
+        if issue is not None:
+            issues.append(issue)
     if summary.get("releaseCandidatePassed") is not True:
         issues.append(
             Issue(
@@ -1848,8 +1892,91 @@ def release_certification_owner(entry: dict[str, Any]) -> str:
     return ""
 
 
+def release_certification_record_scope(record: dict[str, Any]) -> str:
+    scope = str(record.get("scope", "")).strip()
+    if scope:
+        return scope
+    if record.get("allowReleaseCandidate") is True or record.get("appliesToReleaseCandidate") is True:
+        return "release-candidate"
+    return "developer-dry-run"
+
+
+def release_certification_record_applies(record: dict[str, Any], mode: str) -> bool:
+    if mode == "production-beta":
+        return release_certification_record_scope(record).strip().lower() in {
+            "production-beta",
+            "production-beta-only",
+            "release-candidate-and-production-beta",
+            "all",
+            "all-modes",
+            "any",
+        }
+    if mode == "release-candidate":
+        return record.get("allowReleaseCandidate") is True or record.get("appliesToReleaseCandidate") is True
+    return True
+
+
+def release_certification_waiver_records(
+    summary: dict[str, Any] | None,
+    mode: str,
+    workspace_root: Path,
+    out_dir: Path,
+) -> list[Waiver]:
+    if not isinstance(summary, dict):
+        return []
+    records = summary.get("waiverRecords")
+    if not isinstance(records, list):
+        return []
+    waivers: list[Waiver] = []
+    for index, record in enumerate(records):
+        if not isinstance(record, dict):
+            continue
+        waiver_id = str(record.get("id", "")).strip()
+        evidence_id = str(record.get("evidenceId", waiver_id)).strip()
+        if not waiver_id and not evidence_id:
+            continue
+        status = str(record.get("status", "approved")).strip().lower()
+        expired = record.get("expired") is True
+        applies = release_certification_record_applies(record, mode)
+        validation_error = str(record.get("validationError", "")).strip()
+        active = (
+            record.get("active") is True
+            and status == "approved"
+            and not expired
+            and applies
+            and not validation_error
+        )
+        waivers.append(
+            Waiver(
+                id=scrub_text(waiver_id or evidence_id or f"release-certification-waiver-{index}", workspace_root, out_dir),
+                evidence_id=scrub_text(evidence_id or waiver_id or f"release-certification-waiver-{index}", workspace_root, out_dir),
+                severity="blocker",
+                scope=scrub_text(release_certification_record_scope(record), workspace_root, out_dir),
+                rationale=scrub_text(str(record.get("reason", record.get("rationale", ""))).strip(), workspace_root, out_dir),
+                approved_by=scrub_text(str(record.get("approvedBy", "")).strip(), workspace_root, out_dir),
+                owner=scrub_text(str(record.get("owner", "release-certification")).strip() or "release-certification", workspace_root, out_dir),
+                created_at=scrub_text(str(record.get("createdAt", "")).strip(), workspace_root, out_dir),
+                expires_at=scrub_text(str(record.get("expiresAt", "")).strip(), workspace_root, out_dir),
+                references=(),
+                source=scrub_text(str(record.get("source", "release-certification")).strip() or "release-certification", workspace_root, out_dir),
+                active=active,
+                applies_to_mode=applies,
+                external_risk_accepted=False,
+                validation_errors=(validation_error,) if validation_error else (),
+            )
+        )
+    return waivers
+
+
 def severity_covers(waiver: Waiver, issue: Issue) -> bool:
     return SEVERITY_RANK.get(waiver.severity, -1) >= SEVERITY_RANK.get(issue.severity, 99)
+
+
+def issue_is_non_waivable_in_mode(issue: Issue, mode: str) -> bool:
+    return mode == "production-beta" and (
+        issue.evidence_id in NON_WAIVABLE_EVIDENCE_IDS | PRODUCTION_ARTIFACT_GATE_IDS
+        or issue.severity == "critical"
+    )
 
 
 def load_waivers(
@@ -1943,7 +2070,7 @@ def load_waivers(
             validation_errors.append(f"scope does not apply to {mode}")
         if evidence_id and evidence_id not in known_ids and not external_risk_accepted:
             validation_errors.append("evidenceId is unknown and externalRiskAccepted is not true")
-        if mode == "production-beta" and evidence_id in NON_WAIVABLE_EVIDENCE_IDS:
+        if mode == "production-beta" and evidence_id in NON_WAIVABLE_EVIDENCE_IDS | PRODUCTION_ARTIFACT_GATE_IDS:
             validation_errors.append("target is non-waivable in production-beta mode")
         active = not validation_errors
         safe_errors = tuple(scrub_text(error, workspace_root, out_dir) for error in validation_errors)
@@ -1987,6 +2114,37 @@ def apply_waivers(issues: list[Issue], waivers: list[Waiver], mode: str) -> tupl
     usage: dict[str, list[str]] = {waiver.id: [] for waiver in waivers}
     validation_issues: list[Issue] = []
     for issue in issues:
+        if issue.waived_by:
+            matching = next(
+                (
+                    waiver
+                    for waiver in waivers
+                    if waiver.active
+                    and waiver.id == issue.waived_by
+                    and waiver.matches(issue)
+                    and severity_covers(waiver, issue)
+                ),
+                None,
+            )
+            if matching is None or issue_is_non_waivable_in_mode(issue, mode):
+                validation_issues.append(
+                    Issue(
+                        id=f"waiver.{issue.waived_by}.missing-or-invalid",
+                        evidence_id="production-beta.waiver-validation",
+                        domain_id="redaction-artifact-hygiene",
+                        severity="blocker",
+                        title="Applied waiver is missing or invalid",
+                        summary=f"Evidence {issue.evidence_id} references waiver {issue.waived_by}, but no matching active waiver record is valid.",
+                        source=issue.source,
+                        waivable=False,
+                        category="waiver-validation",
+                    )
+                )
+                applied.append(dataclasses.replace(issue, waived_by=""))
+                continue
+            usage.setdefault(matching.id, []).append(issue.id)
+            applied.append(dataclasses.replace(issue, waived_by=matching.id))
+            continue
         if issue.severity not in {"blocker", "critical"} or not issue.waivable:
             applied.append(issue)
             continue
@@ -2020,7 +2178,7 @@ def apply_waivers(issues: list[Issue], waivers: list[Waiver], mode: str) -> tupl
                 )
             applied.append(issue)
             continue
-        if mode == "production-beta" and (issue.evidence_id in NON_WAIVABLE_EVIDENCE_IDS or issue.severity == "critical"):
+        if issue_is_non_waivable_in_mode(issue, mode):
             validation_issues.append(
                 Issue(
                     id=f"waiver.{matching.id}.non-waivable-target",
@@ -2114,6 +2272,7 @@ def known_ids(all_evidence: dict[str, dict[str, Any]], issues: list[Issue]) -> s
     for issue in issues:
         ids.update({issue.id, issue.evidence_id, issue.domain_id, f"evidence.{issue.evidence_id}"})
     ids.update(NON_WAIVABLE_EVIDENCE_IDS)
+    ids.update(PRODUCTION_ARTIFACT_GATE_IDS)
     return expand_waiver_target_aliases(*ids)
 
 
@@ -2153,6 +2312,12 @@ def build_dashboard(
     if mode not in MODES:
         raise SystemExit(f"--mode must be one of {', '.join(MODES)}")
     issues, all_evidence = collect_issues(inputs, mode, input_paths)
+    imported_waivers = release_certification_waiver_records(
+        inputs.get("releaseCertificationSummary") if isinstance(inputs.get("releaseCertificationSummary"), dict) else None,
+        mode,
+        workspace_root,
+        out_dir,
+    )
     waivers, waiver_issues = load_waivers(
         waiver_value,
         display_path(input_paths.get("waivers", Path("waivers.json")), workspace_root) if input_paths.get("waivers") else "fixture-waivers",
@@ -2162,6 +2327,7 @@ def build_dashboard(
         workspace_root,
         out_dir,
     )
+    waivers = [*imported_waivers, *waivers]
     issues = dedupe_issues([*issues, *waiver_issues])
     issues, waivers, _validation_issues = apply_waivers(issues, waivers, mode)
     domains = build_domain_rows(inputs, input_paths, workspace_root, out_dir, issues, all_evidence)
@@ -2410,6 +2576,9 @@ def run_self_test(quiet: bool = False) -> None:
         "go-no-go-warning-ecosystem-matrix.json": "go",
         "go-no-go-malformed-ecosystem-matrix-count.json": "no-go",
         "go-no-go-release-cert-schema-waiver.json": "go-with-waivers",
+        "go-no-go-release-cert-applied-waiver.json": "go-with-waivers",
+        "go-no-go-release-cert-applied-waiver-missing-record.json": "no-go",
+        "go-no-go-artifact-gate-waiver.json": "no-go",
         "go-no-go-multi-node-upgrade-waiver.json": "go-with-waivers",
         "go-no-go-network-scale-redaction-waiver.json": "no-go",
         "go-no-go-secret-value-redaction.json": "no-go",
@@ -2497,6 +2666,26 @@ def run_self_test(quiet: bool = False) -> None:
                     if isinstance(warning, dict)
                 ):
                     raise AssertionError("dashboard exposed evidence-prefixed promotion evidence id")
+            if fixture_name == "go-no-go-release-cert-applied-waiver.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
+                    raise AssertionError("already-applied release-certification waiver was not preserved")
+                waived_evidence_ids = {
+                    str(warning.get("evidenceId"))
+                    for warning in dashboard.get("warnings", [])
+                    if isinstance(warning, dict) and warning.get("waivedBy")
+                }
+                if "release-certification.ecosystem-rc-gate" not in waived_evidence_ids:
+                    raise AssertionError("already-applied release-certification waiver did not remain visible")
+            if fixture_name == "go-no-go-release-cert-applied-waiver-missing-record.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("missing release-certification waiver record was incorrectly counted")
+                if "production-beta.waiver-validation" not in blocker_ids:
+                    raise AssertionError("missing release-certification waiver record did not block the dashboard")
+            if fixture_name == "go-no-go-artifact-gate-waiver.json":
+                if "artifact.signed-first-party-bundles" not in blocker_ids:
+                    raise AssertionError("artifact-presence gate waiver incorrectly removed the blocker")
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("artifact-presence gate waiver was incorrectly used")
             if fixture_name == "go-no-go-multi-node-upgrade-waiver.json":
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
                     raise AssertionError("canonical multi-node upgrade-drill waiver was not used")

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -11,6 +11,7 @@ non-release production-beta runs.
 from __future__ import annotations
 
 import argparse
+import base64
 import dataclasses
 import datetime as dt
 import io
@@ -296,6 +297,7 @@ REDACTION_FINDING_KINDS = {
     "raw-content-or-app-data",
     "ci-secret-value",
     "protected-secret-value",
+    "sensitive-field-value",
     "file-uri-local-path",
     "windows-local-path",
     "host-local-path",
@@ -376,6 +378,12 @@ CI_SECRET_VALUE_RE = re.compile(
     r"[\"']?(?![\w-])\s*(?::|(?<![=!<>])=(?!=))\s*['\"]?([^'\"\s,;&}]+)",
     re.IGNORECASE,
 )
+SENSITIVE_FIELD_VALUE_RE = re.compile(
+    r"(?P<key>\"(?:\\.|[^\"\\])*\"|[A-Za-z_][A-Za-z0-9_-]*)"
+    r"\s*:\s*"
+    r"(?P<value>\"(?:\\.|[^\"\\])*\"|[^\s,}\]]+)",
+    re.IGNORECASE,
+)
 SECRET_ENV_VALUE_NAME_RE = re.compile(
     r"(?:^|_)(?:TOKEN|PASSWORD|SECRET|PRIVATE|PRIVATE_KEY|INSERT_URI|FORM_PASSWORD)(?:$|_)",
     re.IGNORECASE,
@@ -387,6 +395,23 @@ SECRET_ENV_FILE_INDIRECTION_NAMES = {
     "CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE",
     "CRYPTAD_CERT_LIVE_TEST_INSERT_URI_FILE",
 }
+SENSITIVE_NORMALIZED_KEYS = frozenset(
+    {
+        "privatekey",
+        "privatekeybase64",
+        "privatekeyfile",
+        "privateinserturi",
+        "token",
+        "password",
+        "formpassword",
+        "browsersessiontoken",
+        "appprocesstoken",
+        "authorization",
+        "cookie",
+        "rawappdatavalue",
+        "rawfetchedcontent",
+    }
+)
 MIN_SECRET_ENV_VALUE_LENGTH = 6
 URL_USERINFO_RE = re.compile(r"\b[a-z][a-z0-9+.-]*://[^/\s:@]+:[^/\s@]+@", re.IGNORECASE)
 FILE_URI_RE = re.compile(
@@ -593,6 +618,15 @@ def display_path(path: Path, workspace_root: Path) -> str:
         return f"<workdir>/{path.name}"
 
 
+def display_unresolved_path(path: Path, workspace_root: Path) -> str:
+    try:
+        absolute_path = Path(os.path.abspath(path))
+        absolute_root = Path(os.path.abspath(workspace_root))
+        return absolute_path.relative_to(absolute_root).as_posix()
+    except (OSError, ValueError):
+        return f"<workdir>/{path.name}"
+
+
 def resolve_workspace_input_path(raw_path: str, workspace_root: Path | None) -> Path | None:
     value = raw_path.strip()
     if not value:
@@ -644,8 +678,10 @@ def protected_secret_environment_values(
             return
         if not content_bytes:
             return
-        add(name, content_bytes.decode("utf-8", errors="ignore"))
-        for line in content_bytes.decode("utf-8", errors="ignore").splitlines():
+        add(name, base64.b64encode(content_bytes).decode("ascii"))
+        content = content_bytes.decode("utf-8", errors="ignore")
+        add(name, content)
+        for line in content.splitlines():
             add(name, line)
 
     for name, raw_value in source.items():
@@ -721,21 +757,7 @@ def sanitize_value(value: Any, workspace_root: Path, out_dir: Path) -> Any:
         for key, child in sorted(value.items(), key=lambda item: str(item[0])):
             key_text = str(key)
             normalized = re.sub(r"[^a-z0-9]", "", key_text.lower())
-            if normalized in {
-                "privatekey",
-                "privatekeybase64",
-                "privatekeyfile",
-                "privateinserturi",
-                "token",
-                "password",
-                "formpassword",
-                "browsersessiontoken",
-                "appprocesstoken",
-                "authorization",
-                "cookie",
-                "rawappdatavalue",
-                "rawfetchedcontent",
-            }:
+            if normalized in SENSITIVE_NORMALIZED_KEYS:
                 result[key_text] = "<redacted>"
             else:
                 result[key_text] = sanitize_value(child, workspace_root, out_dir)
@@ -867,6 +889,35 @@ def scan_safe_value(raw_value: str, allow_code_like: bool = True) -> bool:
     return False
 
 
+def decode_json_like_token(raw_value: str) -> str:
+    value = raw_value.strip()
+    if value.startswith('"') and value.endswith('"'):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            return value.strip('"')
+        return decoded if isinstance(decoded, str) else str(decoded)
+    return value
+
+
+def add_sensitive_field_value_findings(findings: list[dict[str, str]], text: str, rel_path: str) -> None:
+    for match in SENSITIVE_FIELD_VALUE_RE.finditer(text):
+        key = decode_json_like_token(match.group("key"))
+        normalized_key = re.sub(r"[^a-z0-9]", "", key.lower())
+        if normalized_key not in SENSITIVE_NORMALIZED_KEYS:
+            continue
+        value = decode_json_like_token(match.group("value"))
+        if not scan_safe_value(value, allow_code_like=False):
+            findings.append(
+                {
+                    "path": rel_path,
+                    "kind": "sensitive-field-value",
+                    "detail": f"{key} field appeared unredacted.",
+                }
+            )
+            return
+
+
 def add_value_findings(
     findings: list[dict[str, str]],
     text: str,
@@ -947,6 +998,7 @@ def scan_text_for_findings(text: str, rel_path: str, workspace_root: Path, out_d
     add_value_findings(findings, text, rel_path, "form-password", FORM_PASSWORD_VALUE_RE, allow_code_like=False)
     add_value_findings(findings, text, rel_path, "raw-content-or-app-data", RAW_BODY_VALUE_RE, allow_code_like=False)
     add_value_findings(findings, text, rel_path, "ci-secret-value", CI_SECRET_VALUE_RE, allow_code_like=False)
+    add_sensitive_field_value_findings(findings, text, rel_path)
     add_protected_secret_value_findings(findings, text, rel_path, workspace_root)
     for kind, raw_path in (
         ("workspace-path", str(workspace_root.resolve())),
@@ -1118,13 +1170,38 @@ def scan_file(path: Path, rel_path: str, workspace_root: Path, out_dir: Path) ->
 
 def scan_paths(paths: Iterable[Path], workspace_root: Path, out_dir: Path) -> list[dict[str, str]]:
     findings: list[dict[str, str]] = []
-    for path in sorted({candidate.resolve() for candidate in paths if candidate.exists()}):
+    seen: set[Path] = set()
+    for candidate in sorted(paths, key=lambda item: str(item)):
+        if not candidate.exists() and not candidate.is_symlink():
+            continue
+        rel_path = display_unresolved_path(candidate, workspace_root)
+        reason = bad_artifact_name(rel_path)
+        if candidate.is_symlink():
+            if reason:
+                findings.append({"path": rel_path, "kind": "forbidden-path", "detail": reason})
+            findings.append({"path": rel_path, "kind": "forbidden-symlink"})
+            continue
+        path = candidate.resolve()
+        if path in seen:
+            continue
+        seen.add(path)
         if path.is_dir():
             for child in sorted(path.rglob("*")):
+                if child.is_symlink():
+                    findings.extend(
+                        scan_file(child, display_unresolved_path(child, workspace_root), workspace_root, out_dir)
+                    )
+                    continue
                 if child.is_dir():
                     reason = bad_artifact_name(display_path(child, workspace_root))
                     if reason:
-                        findings.append({"path": display_path(child, workspace_root), "kind": "forbidden-path", "detail": reason})
+                        findings.append(
+                            {
+                                "path": display_path(child, workspace_root),
+                                "kind": "forbidden-path",
+                                "detail": reason,
+                            }
+                        )
                     continue
                 findings.extend(scan_file(child, display_path(child, workspace_root), workspace_root, out_dir))
         else:
@@ -1147,6 +1224,7 @@ def redaction_report(findings: list[dict[str, str]]) -> dict[str, Any]:
             "failOnAbsoluteLocalPaths": True,
             "failOnArchiveSidecars": True,
             "failOnProtectedSecretValues": True,
+            "failOnSensitiveFieldValues": True,
         },
         "findings": sorted(findings, key=lambda item: (item.get("path", ""), item.get("kind", ""), item.get("detail", ""))),
     }
@@ -1303,7 +1381,7 @@ def production_summary_issues(summary: dict[str, Any] | None, mode: str) -> list
                 title="Production beta summary is not passing",
                 summary=f"Production beta summary status is {status}.{detail}",
                 source="production-beta-summary",
-                waivable=True,
+                waivable=False,
                 category="pipeline",
             )
         )
@@ -1334,20 +1412,20 @@ def production_summary_issues(summary: dict[str, Any] | None, mode: str) -> list
                 title="Production beta summary is not promotion-ready",
                 summary=f"Production beta summary promotionReady is {summary.get('promotionReady')}.",
                 source="production-beta-summary",
-                waivable=True,
+                waivable=False,
                 category="pipeline",
             )
         )
     profile = summary.get("signingProfile") if isinstance(summary.get("signingProfile"), dict) else {}
-    if mode == "production-beta" and summary.get("nonRelease") is True:
+    if summary.get("nonRelease") is not False:
         issues.append(
             Issue(
                 id="production-beta.non-release",
                 evidence_id="production-beta.non-release",
                 domain_id="production-beta-release-pipeline",
                 severity="critical",
-                title="Candidate is marked non-release",
-                summary="A non-release artifact is not launchable as a production beta.",
+                title="Candidate is not a release artifact",
+                summary="Launchable dashboard decisions require productionBetaSummary.nonRelease to be false.",
                 source="production-beta-summary",
                 waivable=False,
                 category="pipeline",
@@ -1450,12 +1528,37 @@ def release_certification_issues(summary: dict[str, Any] | None) -> list[Issue]:
     return issues
 
 
+def parse_release_blocker_count(value: Any) -> tuple[int, bool]:
+    if value is None or value == "":
+        return 0, False
+    if isinstance(value, bool):
+        return 0, True
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0, True
+    if parsed < 0:
+        return 0, True
+    return parsed, False
+
+
 def ecosystem_matrix_issues(matrix: dict[str, Any] | None) -> list[Issue]:
     if not isinstance(matrix, dict):
         return []
     issues: list[Issue] = []
     status = normalize_status(matrix.get("status"))
-    if status not in {"pass", "warn"} or int(matrix.get("releaseBlockerCount", 0) or 0) > 0:
+    release_blocker_count, malformed_release_blocker_count = parse_release_blocker_count(
+        matrix.get("releaseBlockerCount", 0)
+    )
+    if status not in {"pass", "warn"} or malformed_release_blocker_count or release_blocker_count > 0:
+        details: list[str] = []
+        if status not in {"pass", "warn"}:
+            details.append(f"status is {status}")
+        if malformed_release_blocker_count:
+            details.append("releaseBlockerCount is not a non-negative integer")
+        elif release_blocker_count > 0:
+            details.append(f"releaseBlockerCount is {release_blocker_count}")
+        detail = "; ".join(details) if details else "contains release blockers"
         issues.append(
             Issue(
                 id="ecosystem-matrix.release-blockers",
@@ -1463,9 +1566,9 @@ def ecosystem_matrix_issues(matrix: dict[str, Any] | None) -> list[Issue]:
                 domain_id="ecosystem-rc-certification-matrix",
                 severity="blocker",
                 title="Ecosystem matrix has release blockers",
-                summary=f"Ecosystem certification matrix status is {status} or contains release blockers.",
+                summary=f"Ecosystem certification matrix {detail}.",
                 source="ecosystem-certification-matrix",
-                waivable=True,
+                waivable=not malformed_release_blocker_count,
                 category="ecosystem-matrix",
             )
         )
@@ -2256,10 +2359,12 @@ def run_self_test(quiet: bool = False) -> None:
         "go-no-go-production-summary-skipped.json": "no-go",
         "go-no-go-missing-ecosystem-matrix-status.json": "no-go",
         "go-no-go-warning-ecosystem-matrix.json": "go",
+        "go-no-go-malformed-ecosystem-matrix-count.json": "no-go",
         "go-no-go-secret-value-redaction.json": "no-go",
         "go-no-go-underseverity-waiver.json": "no-go",
         "go-no-go-live-evidence-waiver-alias.json": "go-with-waivers",
-        "go-no-go-release-candidate-live-disabled.json": "go",
+        "go-no-go-release-candidate-live-disabled.json": "no-go",
+        "go-no-go-malformed-non-release-status.json": "no-go",
     }
     with tempfile.TemporaryDirectory(prefix="cryptad-go-no-go-dashboard-") as temp_name:
         root = Path(temp_name)
@@ -2306,9 +2411,13 @@ def run_self_test(quiet: bool = False) -> None:
             if fixture_name == "go-no-go-production-summary-not-ready.json":
                 if "production-beta.promotion-ready" not in blocker_ids:
                     raise AssertionError("non-ready production summary did not block production beta")
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("promotionReady=false hard blocker was incorrectly waived")
             if fixture_name == "go-no-go-production-summary-skipped.json":
                 if "production-beta.summary" not in blocker_ids:
                     raise AssertionError("skipped production summary did not block production beta")
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("non-passing production summary hard blocker was incorrectly waived")
             if fixture_name == "go-no-go-live-evidence-waiver-alias.json":
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
                     raise AssertionError("live evidence alias waiver was not used")
@@ -2322,6 +2431,14 @@ def run_self_test(quiet: bool = False) -> None:
             if fixture_name == "go-no-go-release-candidate-live-disabled.json":
                 if any(blocker_id.startswith("live-network-beta.") for blocker_id in blocker_ids):
                     raise AssertionError("disabled live-network evidence blocked release-candidate mode")
+                if "production-beta.non-release" not in blocker_ids:
+                    raise AssertionError("release-candidate non-release artifact did not block publication")
+            if fixture_name == "go-no-go-malformed-non-release-status.json":
+                if "production-beta.non-release" not in blocker_ids:
+                    raise AssertionError("malformed nonRelease value did not block launchable decision")
+            if fixture_name == "go-no-go-malformed-ecosystem-matrix-count.json":
+                if "release-certification.ecosystem-matrix" not in blocker_ids:
+                    raise AssertionError("malformed ecosystem matrix releaseBlockerCount did not block launch")
             for artifact_name in (OUTPUT_JSON, OUTPUT_MARKDOWN, OUTPUT_REDACTION):
                 if not (out_dir / artifact_name).is_file():
                     raise AssertionError(f"{fixture_name} did not write {artifact_name}")
@@ -2365,6 +2482,7 @@ def run_self_test(quiet: bool = False) -> None:
             raise AssertionError("go/no-go dashboard JSON is not deterministic for fixed fixture inputs")
         assert_supplied_waiver_file_errors_block_launch(root)
         assert_protected_secret_values_are_scanned_and_redacted(root)
+        assert_symlink_inputs_are_rejected(root)
     if not quiet:
         print("production beta go/no-go dashboard self-test passed")
 
@@ -2396,22 +2514,64 @@ def path_input_args_from_pass_fixture(root: Path, input_dir_name: str) -> tuple[
     return input_args, input_paths
 
 
+def assert_symlink_inputs_are_rejected(root: Path) -> None:
+    input_args, input_paths = path_input_args_from_pass_fixture(root, "symlink-inputs")
+    link_dir = root / "symlink-links"
+    link_dir.mkdir(parents=True)
+    summary_link = link_dir / "productionBetaSummary.json"
+    summary_link.symlink_to(input_paths["productionBetaSummary"])
+    out_dir = root / "symlink-output"
+    args_list = [
+        "build",
+        "--workspace-root",
+        str(Path(__file__).resolve().parents[2]),
+        "--out-dir",
+        str(out_dir),
+        "--mode",
+        "production-beta",
+    ]
+    for flag, input_name in input_args:
+        value = summary_link if input_name == "productionBetaSummary" else input_paths[input_name]
+        args_list.extend([flag, str(value)])
+    dashboard, _exit_code = build_command(build_parser().parse_args(args_list))
+    if dashboard.get("decision") != "no-go":
+        raise AssertionError("symlinked dashboard input did not force no-go")
+    redaction = read_json(out_dir / OUTPUT_REDACTION)
+    findings = redaction.get("findings") if isinstance(redaction, dict) else []
+    if not any(
+        isinstance(finding, dict) and finding.get("kind") == "forbidden-symlink" for finding in findings
+    ):
+        raise AssertionError("symlinked dashboard input did not produce a forbidden-symlink finding")
+
+
 def assert_protected_secret_values_are_scanned_and_redacted(root: Path) -> None:
     secret_name = "CRYPTAD_DASHBOARD_TEST_TOKEN"
     secret_value = "dashboard-protected-secret-12345"
     short_secret_name = "CRYPTAD_DASHBOARD_TEST_SHORT_TOKEN"
     long_secret_name = "CRYPTAD_DASHBOARD_TEST_LONG_TOKEN"
+    file_secret_name = "CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE"
     short_secret_value = "dashboard-overlap-secret"
     long_secret_suffix = "TAILLEAK12345"
     long_secret_value = f"{short_secret_value}-{long_secret_suffix}"
+    generic_token = "generic-dashboard-token-12345"
+    generic_password = "generic-dashboard-password-12345"
+    generic_private_key_base64 = "Z2VuZXJpYy1kYXNoYm9hcmQtcHJpdmF0ZS1rZXktMTIzNDU="
     previous = os.environ.get(secret_name)
     previous_short = os.environ.get(short_secret_name)
     previous_long = os.environ.get(long_secret_name)
+    previous_file = os.environ.get(file_secret_name)
     os.environ[secret_name] = secret_value
     os.environ[short_secret_name] = short_secret_value
     os.environ[long_secret_name] = long_secret_value
     try:
         input_args, input_paths = path_input_args_from_pass_fixture(root, "protected-secret-inputs")
+        protected_dir = root / "protected"
+        protected_dir.mkdir(parents=True)
+        file_secret_bytes = b"\x01cryptad-dashboard-file-backed-private-key\x02\xff"
+        file_secret_path = protected_dir / "app-signing-private.der"
+        file_secret_path.write_bytes(file_secret_bytes)
+        file_secret_base64 = base64.b64encode(file_secret_bytes).decode("ascii")
+        os.environ[file_secret_name] = str(file_secret_path.relative_to(root))
         production_summary = read_json(input_paths["productionBetaSummary"])
         if not isinstance(production_summary, dict):
             raise AssertionError("productionBetaSummary path input is missing")
@@ -2420,7 +2580,11 @@ def assert_protected_secret_values_are_scanned_and_redacted(root: Path) -> None:
         production_summary["failures"] = [
             f"dashboard input leaked {secret_value} without an environment variable name",
             f"dashboard input leaked overlapping protected value {long_secret_value}",
+            f"dashboard input leaked file-backed signing material {file_secret_base64}",
         ]
+        production_summary["token"] = generic_token
+        production_summary["password"] = generic_password
+        production_summary["privateKeyBase64"] = generic_private_key_base64
         write_json(input_paths["productionBetaSummary"], production_summary)
         out_dir = root / "protected-secret-output"
         args_list = [
@@ -2444,10 +2608,22 @@ def assert_protected_secret_values_are_scanned_and_redacted(root: Path) -> None:
         }
         if dashboard["decision"] != "no-go" or "protected-secret-value" not in finding_kinds:
             raise AssertionError(f"protected secret value did not block dashboard: {dashboard}")
-        generated_text = (out_dir / OUTPUT_JSON).read_text(encoding="utf-8") + (out_dir / OUTPUT_MARKDOWN).read_text(encoding="utf-8")
+        if "sensitive-field-value" not in finding_kinds:
+            raise AssertionError(f"generic sensitive fields did not block dashboard: {dashboard}")
+        generated_text = (out_dir / OUTPUT_JSON).read_text(encoding="utf-8") + (
+            out_dir / OUTPUT_MARKDOWN
+        ).read_text(encoding="utf-8")
         if secret_value in generated_text:
             raise AssertionError("dashboard artifacts leaked a protected secret value")
-        for forbidden in (short_secret_value, long_secret_value, long_secret_suffix):
+        for forbidden in (
+            short_secret_value,
+            long_secret_value,
+            long_secret_suffix,
+            file_secret_base64,
+            generic_token,
+            generic_password,
+            generic_private_key_base64,
+        ):
             if forbidden in generated_text:
                 raise AssertionError(f"dashboard artifacts leaked overlapping protected secret content: {forbidden}")
     finally:
@@ -2463,6 +2639,10 @@ def assert_protected_secret_values_are_scanned_and_redacted(root: Path) -> None:
             os.environ.pop(long_secret_name, None)
         else:
             os.environ[long_secret_name] = previous_long
+        if previous_file is None:
+            os.environ.pop(file_secret_name, None)
+        else:
+            os.environ[file_secret_name] = previous_file
 
 
 def assert_supplied_waiver_file_errors_block_launch(root: Path) -> None:

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -1,0 +1,2544 @@
+#!/usr/bin/env python3
+"""Build a redacted production beta go/no-go dashboard.
+
+The dashboard is a final release-manager view over existing production beta and
+release-certification summaries. It does not collect live evidence, sign
+artifacts, or replace release certification. It fails closed for missing
+production-critical inputs, unsafe redaction findings, invalid waivers, and
+non-release production-beta runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import io
+import json
+import os
+import re
+import sys
+import tarfile
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Any, Iterable, Iterator
+
+
+sys.dont_write_bytecode = True
+
+TOOL_NAME = "production-beta-go-no-go-dashboard"
+SCHEMA_VERSION = 1
+MODES = ("developer-dry-run", "release-candidate", "production-beta")
+DECISIONS = ("go", "no-go", "go-with-waivers")
+SEVERITIES = ("info", "warning", "blocker", "critical")
+SEVERITY_RANK = {severity: index for index, severity in enumerate(SEVERITIES)}
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+DEFAULT_GENERATED_AT = "1970-01-01T00:00:00Z"
+
+OUTPUT_JSON = "go-no-go-dashboard.json"
+OUTPUT_MARKDOWN = "go-no-go-dashboard.md"
+OUTPUT_REDACTION = "go-no-go-redaction-report.json"
+
+APP_STORE_SUBMISSION_EVIDENCE_IDS = (
+    "app-store.submission-package-schema",
+    "app-store.submission-cli",
+    "app-store.pre-review",
+    "app-store.review-decision-states",
+    "app-store.review-receipt-issued",
+    "app-store.rejection-record",
+    "app-store.resubmission-link",
+    "app-store.transparency-log",
+    "app-store.catalog-candidate",
+    "app-store.third-party-sample-flow",
+    "app-store.redaction-clean",
+)
+THIRD_PARTY_DEVELOPER_BETA_EVIDENCE_IDS = (
+    "third-party-developer.beta-program",
+    "third-party-developer.docs",
+    "third-party-developer.template",
+    "third-party-developer.sample-app-flow",
+    "third-party-developer.submission-checklist",
+    "third-party-developer.compatibility-window",
+    "third-party-developer.feedback-workflow",
+    "third-party-developer.plugin-author-migration",
+    "third-party-developer.redaction",
+)
+PLATFORM_API_STABLE_FREEZE_EVIDENCE_IDS = (
+    "platform-api.contract",
+    "platform-api.stable-baseline",
+    "platform-api.stable-breaking-change-check",
+    "platform-api.manifest-target-stability",
+    "platform-api.first-party-stability-declarations",
+    "platform-api.stable-reference-docs",
+)
+LIVE_NETWORK_REQUIRED_EVIDENCE_IDS = (
+    "live-network-beta.preflight",
+    "live-network-beta.catalog-usk-fetch",
+    "live-network-beta.app-install-update-rollback",
+    "live-network-beta.content-fetch",
+    "live-network-beta.feed-subscription",
+    "live-network-beta.profile-publish",
+    "live-network-beta.trust-statement-publish-import",
+    "live-network-beta.interop-perf-budget",
+    "live-network-beta.redaction",
+)
+NETWORK_SCALE_EVIDENCE_IDS = (
+    "network-scale.app-network-budget",
+    "network-scale.content-fetch-budget",
+    "network-scale.subscription-budget",
+    "network-scale.queue-pressure-backoff",
+    "network-scale.trust-graph-import-budget",
+    "network-scale.social-inbox-multi-source-soak",
+    "network-scale.redaction",
+    "network-scale.rc-soak-summary",
+)
+MULTI_NODE_BETA_EVIDENCE_IDS = (
+    "multi-node-beta.soak",
+    "multi-node-beta.upgrade-drill",
+    "multi-node-beta.catalog-channel-update",
+    "multi-node-beta.app-install-update-rollback",
+    "multi-node-beta.app-data-migration",
+    "multi-node-beta.backup-restore",
+    "multi-node-beta.subscription-pressure",
+    "multi-node-beta.trust-graph-import",
+    "multi-node-beta.social-inbox-multi-source",
+    "multi-node-beta.support-bundle-drill",
+    "multi-node-beta.redaction",
+)
+TRUST_SOCIAL_HARDENING_EVIDENCE_IDS = (
+    "app-platform.trust-social-beta-hardening",
+    "reference-app.trust-graph",
+    "reference-app.trust-graph-durable-exchange",
+    "reference-app.trust-graph-app-data-preview",
+    "reference-app.social-inbox",
+    "reference-app.social-inbox-signed-message",
+    "reference-app.social-inbox-subscriptions",
+    "reference-app.social-inbox-app-data",
+    "reference-app.social-inbox-trust-annotations",
+    "reference-app.social-inbox-rc-threading",
+)
+LEGACY_ADMIN_EVIDENCE_IDS = (
+    "legacy-admin.removal-wave-5",
+    "legacy-admin.final-admin-surface",
+    "legacy-admin.browse-retained",
+    "legacy-admin.emergency-fallback-retained",
+)
+CATALOG_AND_SIGNING_EVIDENCE_IDS = (
+    "app-platform.signed-bundles",
+    "catalog.smoke",
+    "catalog.production-channels",
+    "app-review.trusted-receipts",
+    "app-review.first-party-catalog",
+    "app-review.first-party-review-chain",
+)
+CONSENT_EVIDENCE_IDS = ("app-platform.user-consent-flow",)
+SECURITY_RESPONSE_EVIDENCE_IDS = ("production-security.response-runbook",)
+FIRST_PARTY_MAINTENANCE_EVIDENCE_IDS = ("app-catalog.first-party-maintenance-policy",)
+
+DASHBOARD_EVIDENCE_IDS = (
+    "production-beta.go-no-go-dashboard",
+    "production-beta.go-no-go-decision",
+    "production-beta.waiver-validation",
+    "production-beta.dashboard-redaction",
+    "production-beta.launch-artifact-hygiene",
+)
+
+DOMAIN_SPECS = (
+    {
+        "id": "production-beta-release-pipeline",
+        "title": "Production beta release pipeline",
+        "evidenceIds": ("production-beta.summary",),
+        "artifactInputs": ("productionBetaSummary",),
+    },
+    {
+        "id": "release-certification",
+        "title": "Release certification",
+        "evidenceIds": ("release-certification.ecosystem-rc-gate",),
+        "artifactInputs": ("releaseCertificationSummary",),
+    },
+    {
+        "id": "ecosystem-rc-certification-matrix",
+        "title": "Ecosystem RC certification matrix",
+        "evidenceIds": ("release-certification.ecosystem-matrix",),
+        "artifactInputs": ("ecosystemMatrix",),
+    },
+    {
+        "id": "catalog-and-app-signing",
+        "title": "Catalog and app signing",
+        "evidenceIds": CATALOG_AND_SIGNING_EVIDENCE_IDS,
+        "artifactInputs": ("appPlatformSummary",),
+    },
+    {
+        "id": "first-party-app-maintenance-policy",
+        "title": "First-party app maintenance policy",
+        "evidenceIds": FIRST_PARTY_MAINTENANCE_EVIDENCE_IDS,
+        "artifactInputs": ("appPlatformSummary",),
+    },
+    {
+        "id": "platform-api-stable-freeze",
+        "title": "Platform API 1.0 stable freeze",
+        "evidenceIds": PLATFORM_API_STABLE_FREEZE_EVIDENCE_IDS,
+        "artifactInputs": ("appPlatformSummary",),
+    },
+    {
+        "id": "app-submission-review-workflow",
+        "title": "App submission and review workflow",
+        "evidenceIds": APP_STORE_SUBMISSION_EVIDENCE_IDS,
+        "artifactInputs": ("appPlatformSummary",),
+    },
+    {
+        "id": "user-consent-permission-upgrade",
+        "title": "User consent and permission upgrade UX",
+        "evidenceIds": CONSENT_EVIDENCE_IDS,
+        "artifactInputs": ("appPlatformSummary",),
+    },
+    {
+        "id": "trust-graph-social-inbox-hardening",
+        "title": "Trust Graph and Social Inbox beta hardening",
+        "evidenceIds": TRUST_SOCIAL_HARDENING_EVIDENCE_IDS,
+        "artifactInputs": ("appPlatformSummary",),
+    },
+    {
+        "id": "legacy-admin-final-surface",
+        "title": "Legacy admin Wave 5 final surface",
+        "evidenceIds": LEGACY_ADMIN_EVIDENCE_IDS,
+        "artifactInputs": ("appPlatformSummary",),
+    },
+    {
+        "id": "production-security-response",
+        "title": "Production security response runbook",
+        "evidenceIds": SECURITY_RESPONSE_EVIDENCE_IDS,
+        "artifactInputs": ("securityResponseSummary", "appPlatformSummary"),
+    },
+    {
+        "id": "live-network-beta-smoke",
+        "title": "Live-network beta smoke",
+        "evidenceIds": LIVE_NETWORK_REQUIRED_EVIDENCE_IDS,
+        "artifactInputs": ("liveNetworkSummary",),
+    },
+    {
+        "id": "network-scale-soak",
+        "title": "Network-scale soak",
+        "evidenceIds": NETWORK_SCALE_EVIDENCE_IDS,
+        "artifactInputs": ("networkScaleSoakSummary",),
+    },
+    {
+        "id": "multi-node-beta-soak",
+        "title": "Multi-node beta soak and upgrade drill",
+        "evidenceIds": MULTI_NODE_BETA_EVIDENCE_IDS,
+        "artifactInputs": ("multiNodeBetaSoakSummary",),
+    },
+    {
+        "id": "third-party-developer-beta",
+        "title": "Third-party developer beta program",
+        "evidenceIds": THIRD_PARTY_DEVELOPER_BETA_EVIDENCE_IDS,
+        "artifactInputs": ("appPlatformSummary",),
+    },
+    {
+        "id": "redaction-artifact-hygiene",
+        "title": "Redaction and artifact hygiene",
+        "evidenceIds": ("production-beta.dashboard-redaction", "production-beta.launch-artifact-hygiene"),
+        "artifactInputs": (),
+    },
+)
+
+CRITICAL_INPUTS_BY_MODE = {
+    "developer-dry-run": (),
+    "release-candidate": (
+        "productionBetaSummary",
+        "releaseCertificationSummary",
+        "ecosystemMatrix",
+        "appPlatformSummary",
+        "networkScaleSoakSummary",
+        "multiNodeBetaSoakSummary",
+    ),
+    "production-beta": (
+        "productionBetaSummary",
+        "releaseCertificationSummary",
+        "ecosystemMatrix",
+        "appPlatformSummary",
+        "liveNetworkSummary",
+        "networkScaleSoakSummary",
+        "multiNodeBetaSoakSummary",
+    ),
+}
+
+NON_WAIVABLE_EVIDENCE_IDS = {
+    "production-beta.dashboard-redaction",
+    "production-beta.launch-artifact-hygiene",
+    "production-beta.waiver-validation",
+    "production-beta.production-signing",
+    "production-beta.non-release",
+    "production-beta.test-signing",
+    "production-beta.build-complete",
+    "production-beta.workspace-clean",
+    "production-beta.fixture-evidence",
+    "redaction.status",
+    "signing.production-keys",
+    "build.production-beta-complete",
+    "workspace.clean-production-beta",
+    "fixture-evidence.strict-mode",
+}
+
+REDACTION_FINDING_KINDS = {
+    "private-insert-uri",
+    "private-key",
+    "private-key-header",
+    "openssh-private-key",
+    "bearer-token",
+    "authorization-header",
+    "cookie-header",
+    "url-userinfo",
+    "app-token",
+    "browser-session-token",
+    "form-password",
+    "raw-content-or-app-data",
+    "ci-secret-value",
+    "protected-secret-value",
+    "file-uri-local-path",
+    "windows-local-path",
+    "host-local-path",
+    "workspace-path",
+    "home-path",
+    "temp-path",
+    "forbidden-path",
+    "forbidden-zip-entry",
+    "forbidden-tar-entry",
+    "unreadable",
+}
+
+BAD_ARTIFACT_NAMES = {".DS_Store"}
+BAD_ARTIFACT_DIRS = {"__MACOSX"}
+ZIP_ARCHIVE_SUFFIXES = {".zip", ".jar"}
+TAR_GZ_ARCHIVE_SUFFIXES = (".tar.gz", ".tgz")
+MAX_NESTED_ARCHIVE_DEPTH = 4
+TEXT_SCAN_CHUNK_BYTES = 1024 * 1024
+TEXT_SCAN_OVERLAP_BYTES = 64 * 1024
+
+PRIVATE_INSERT_URI_RE = re.compile(
+    r"(?:"
+    r"\b(?:crypta:|freenet:)?(?:SSK|USK)@[^/,\s\"'<>)]*(?:PRIVATE|INSERT|AQECAAE)[^\s\"'<>)]*"
+    r"|"
+    r"(?<![\w-])[\"']?(?:private[-_ ]*)?insert(?:[-_ ]*uri)?[\"']?(?![\w-])"
+    r"\s*(?::|(?<![=!<>])=(?!=))\s*['\"]?"
+    r"(?:crypta:|freenet:)?(?:SSK|USK)@"
+    r"(?=[A-Za-z0-9~_-]{8,},)[A-Za-z0-9~_,=-]+(?:/[^\s`'\"<>)]*)?"
+    r"|"
+    r"(?<![\w-])[\"']?privateInsertUri[\"']?(?![\w-])\s*(?::|(?<![=!<>])=(?!=))\s*['\"]?"
+    r"(?:crypta:|freenet:)?(?:SSK|USK)@"
+    r"(?=[A-Za-z0-9~_-]{8,},)[A-Za-z0-9~_,=-]+(?:/[^\s`'\"<>)]*)?"
+    r")",
+    re.IGNORECASE,
+)
+PRIVATE_KEY_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.IGNORECASE,
+)
+PRIVATE_KEY_HEADER_RE = re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", re.IGNORECASE)
+OPENSSH_PRIVATE_KEY_RE = re.compile(r"-----BEGIN OPENSSH PRIVATE KEY-----", re.IGNORECASE)
+BEARER_RE = re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{12,}", re.IGNORECASE)
+AUTH_HEADER_RE = re.compile(
+    r"(?<![\w-])[\"']?Authorization[\"']?(?![\w-])"
+    r"\s*(?::|(?<![=!<>])=(?!=))\s*[\"']?(?:Bearer|Basic|Digest)?\s*([^\s,'\"}]+)",
+    re.IGNORECASE,
+)
+COOKIE_HEADER_RE = re.compile(
+    r"(?<![\w-])[\"']?(?:Cookie|Set-Cookie)[\"']?(?![\w-])"
+    r"\s*(?::|(?<![=!<>])=(?!=))\s*[\"']?([^'\"\r\n}]+)",
+    re.IGNORECASE,
+)
+APP_TOKEN_VALUE_RE = re.compile(
+    r"(?<![\w-])[\"']?(?:CRYPTAD_APP_TOKEN|browserSessionToken|appProcessToken|X-Crypta-App-Session|"
+    r"app[-_ ]?token|browser[-_ ]?session[-_ ]?token)[\"']?(?![\w-])"
+    r"\s*(?::|(?<![=!<>])=(?!=))\s*['\"]?([^'\"\s,;&}]+)",
+    re.IGNORECASE,
+)
+FORM_PASSWORD_VALUE_RE = re.compile(
+    r"(?<![\w-])[\"']?(?:CRYPTAD_CERT_FORM_PASSWORD|formPassword|form[-_ ]?password)[\"']?(?![\w-])"
+    r"\s*(?::|(?<![=!<>])=(?!=))\s*['\"]?([^'\"\s,;&}]+)",
+    re.IGNORECASE,
+)
+RAW_BODY_VALUE_RE = re.compile(
+    r"(?<![\w-])[\"']?(?:"
+    r"raw[-_ ]*(?:(?:request|response|feed|fetched|social|message|profile|trust|app[-_ ]?data|backup|signature)[-_ ]*)?"
+    r"(?:body|document|payload|content|value|values)"
+    r"|"
+    r"(?:request|response|feed|fetched|social|message|profile|trust|app[-_ ]?data|backup|signature)[-_ ]*raw[-_ ]*"
+    r"(?:body|document|payload|content|value|values)"
+    r"|payloadBase64|plainTextExport|queueHtml"
+    r")[\"']?(?![\w-])\s*(?::|(?<![=!<>])=(?!=))\s*['\"]?([^'\"\r\n}]+)",
+    re.IGNORECASE,
+)
+CI_SECRET_VALUE_RE = re.compile(
+    r"(?<![\w-])[\"']?(?:GITHUB_TOKEN|SONAR_TOKEN|ACTIONS_ID_TOKEN_REQUEST_TOKEN|AWS_SECRET_ACCESS_KEY|"
+    r"CRYPTAD_[A-Z0-9_]*(?:SECRET|TOKEN|PASSWORD|PRIVATE|INSERT_URI)[A-Z0-9_]*)"
+    r"[\"']?(?![\w-])\s*(?::|(?<![=!<>])=(?!=))\s*['\"]?([^'\"\s,;&}]+)",
+    re.IGNORECASE,
+)
+SECRET_ENV_VALUE_NAME_RE = re.compile(
+    r"(?:^|_)(?:TOKEN|PASSWORD|SECRET|PRIVATE|PRIVATE_KEY|INSERT_URI|FORM_PASSWORD)(?:$|_)",
+    re.IGNORECASE,
+)
+SECRET_ENV_VALUE_SKIP_SUFFIXES = ("_ENV", "_FILE", "_PATH", "_DIR")
+SECRET_ENV_INDIRECTION_NAMES = {"CRYPTAD_CERT_LIVE_TEST_INSERT_URI_ENV"}
+SECRET_ENV_FILE_INDIRECTION_NAMES = {
+    "CRYPTAD_APP_REVIEWER_PRIVATE_KEY_FILE",
+    "CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE",
+    "CRYPTAD_CERT_LIVE_TEST_INSERT_URI_FILE",
+}
+MIN_SECRET_ENV_VALUE_LENGTH = 6
+URL_USERINFO_RE = re.compile(r"\b[a-z][a-z0-9+.-]*://[^/\s:@]+:[^/\s@]+@", re.IGNORECASE)
+FILE_URI_RE = re.compile(
+    r"(?<![\w^])file:(?://[^/\s\"'<>]*)?/"
+    r"(?:private/tmp|var/folders|Users|home|work|workspace|tmp|mnt|Volumes|root|opt|runner|__w|srv|etc)"
+    r"(?:/[^\s\"'<>),;]*)?(?=$|[\s\"'<>),;])",
+    re.IGNORECASE,
+)
+WINDOWS_PATH_RE = re.compile(r"(?<![A-Za-z0-9_:/.\->])[A-Za-z]:[\\/][^:*?\"<>|\r\n]+")
+HOST_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_:/.\->])/"
+    r"(?:Users|home|work|workspace|tmp|private/tmp|var/folders|mnt|Volumes|root|opt|runner|__w|srv|etc)"
+    r"(?:/[^\s\"'<>),;]+)+"
+)
+SECRET_ARTIFACT_NAME_RE = re.compile(
+    r"(?:^|[._-])(?:"
+    r"private[._-]*key|signing[._-]*private(?:[._-]*key)?|reviewer[._-]*private(?:[._-]*key)?|"
+    r"private[._-]*insert[._-]*uri|insert[._-]*uri|app[._-]*token|browser[._-]*session[._-]*token|"
+    r"form[._-]*password|bearer[._-]*token|id[._-]*(?:rsa|dsa|ecdsa|ed25519)"
+    r")(?:$|[._-])",
+    re.IGNORECASE,
+)
+FORBIDDEN_SECRET_ARTIFACT_SUFFIXES = {".p12", ".pfx", ".jks", ".keystore", ".p8", ".pkcs8"}
+SECRET_ARTIFACT_BINARY_SUFFIXES = {".der", ".key", ".pem", ".bin"}
+SECRET_ARTIFACT_BINARY_MARKERS = ("private", "secret", "password", "token", "inserturi")
+
+
+@dataclasses.dataclass(frozen=True)
+class Issue:
+    id: str
+    evidence_id: str
+    domain_id: str
+    severity: str
+    title: str
+    summary: str
+    source: str
+    waivable: bool
+    category: str
+    waived_by: str = ""
+
+    def to_json(self) -> dict[str, Any]:
+        value = {
+            "id": self.id,
+            "evidenceId": self.evidence_id,
+            "domainId": self.domain_id,
+            "severity": self.severity,
+            "title": self.title,
+            "summary": self.summary,
+            "source": self.source,
+            "waivable": self.waivable,
+            "category": self.category,
+        }
+        if self.waived_by:
+            value["waivedBy"] = self.waived_by
+        return value
+
+
+@dataclasses.dataclass(frozen=True)
+class Waiver:
+    id: str
+    evidence_id: str
+    severity: str
+    scope: str
+    rationale: str
+    approved_by: str
+    owner: str
+    created_at: str
+    expires_at: str
+    references: tuple[str, ...]
+    source: str
+    active: bool
+    applies_to_mode: bool
+    external_risk_accepted: bool
+    validation_errors: tuple[str, ...]
+    used_by: tuple[str, ...] = ()
+
+    def matches(self, issue: Issue) -> bool:
+        candidates = expand_waiver_target_aliases(
+            issue.id,
+            issue.evidence_id,
+            issue.domain_id,
+            f"evidence.{issue.evidence_id}",
+        )
+        targets = expand_waiver_target_aliases(self.id, self.evidence_id)
+        return bool(candidates & targets)
+
+    def with_usage(self, issue_ids: Iterable[str]) -> "Waiver":
+        return dataclasses.replace(self, used_by=tuple(sorted(set(issue_ids))))
+
+    def to_json(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "evidenceId": self.evidence_id,
+            "severity": self.severity,
+            "scope": self.scope,
+            "rationale": self.rationale,
+            "approvedBy": self.approved_by,
+            "owner": self.owner,
+            "createdAt": self.created_at,
+            "expiresAt": self.expires_at,
+            "references": list(self.references),
+            "source": self.source,
+            "active": self.active,
+            "appliesToMode": self.applies_to_mode,
+            "externalRiskAccepted": self.external_risk_accepted,
+            "validationErrors": list(self.validation_errors),
+            "usedBy": list(self.used_by),
+        }
+
+
+def utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+
+
+def live_network_target_aliases(value: str) -> set[str]:
+    aliases = {value}
+    if value.startswith("live."):
+        aliases.add(value.removeprefix("live."))
+    elif value.startswith("live-network-beta."):
+        aliases.add(f"live.{value}")
+    if value.startswith("evidence.live."):
+        aliases.add(f"evidence.{value.removeprefix('evidence.live.')}")
+    elif value.startswith("evidence.live-network-beta."):
+        aliases.add(f"evidence.live.{value.removeprefix('evidence.')}")
+    return aliases
+
+
+def expand_waiver_target_aliases(*values: str) -> set[str]:
+    aliases: set[str] = set()
+    for value in values:
+        if not value:
+            continue
+        aliases.update(live_network_target_aliases(value))
+    return aliases
+
+
+def format_time(value: dt.datetime) -> str:
+    return value.astimezone(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_time(value: str) -> dt.datetime | None:
+    raw = value.strip()
+    if not raw:
+        return None
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def parse_generated_at(value: str | None) -> tuple[str, dt.datetime]:
+    if value:
+        parsed = parse_time(value)
+        if parsed is None:
+            raise SystemExit("--generated-at must be an ISO-8601 timestamp")
+        return format_time(parsed), parsed
+    now = utc_now()
+    return format_time(now), now
+
+
+def read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def read_json_object_with_error(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, f"Waiver file could not be read: {exc.strerror or exc.__class__.__name__}."
+    except UnicodeDecodeError:
+        return None, "Waiver file must be UTF-8 encoded JSON."
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, f"Waiver file is malformed JSON at line {exc.lineno}, column {exc.colno}."
+    if not isinstance(value, dict):
+        return None, f"Waiver file must contain a JSON object, found {type(value).__name__}."
+    return value, None
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value, encoding="utf-8")
+
+
+def display_path(path: Path, workspace_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(workspace_root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return f"<workdir>/{path.name}"
+
+
+def resolve_workspace_input_path(raw_path: str, workspace_root: Path | None) -> Path | None:
+    value = raw_path.strip()
+    if not value:
+        return None
+    path = Path(value).expanduser()
+    if not path.is_absolute() and workspace_root is not None:
+        path = workspace_root / path
+    try:
+        return path.resolve()
+    except OSError:
+        return None
+
+
+def normalized_secret_env_value(name: str, raw_value: str) -> str | None:
+    value = raw_value.strip()
+    minimum_length = 1 if name == "CRYPTAD_CERT_FORM_PASSWORD" else MIN_SECRET_ENV_VALUE_LENGTH
+    if len(value) < minimum_length:
+        return None
+    normalized = value.lower().strip("'\"")
+    if normalized in {"<redacted>", "redacted", "<masked>", "masked", "***", "null", "undefined", "true", "false", "none", "unset"}:
+        return None
+    if (value.startswith("<") and value.endswith(">")) or normalized.startswith("<redacted") or normalized.startswith("${{"):
+        return None
+    return value
+
+
+def protected_secret_environment_values(
+    env: dict[str, str] | None = None,
+    workspace_root: Path | None = None,
+) -> list[tuple[str, str]]:
+    source = os.environ if env is None else env
+    values: list[tuple[str, str]] = []
+    seen: set[str] = set()
+
+    def add(name: str, raw_value: str) -> None:
+        value = normalized_secret_env_value(name, raw_value)
+        if value is None or value in seen:
+            return
+        seen.add(value)
+        values.append((name, value))
+
+    def add_file_contents(name: str, raw_path: str) -> None:
+        path = resolve_workspace_input_path(raw_path, workspace_root)
+        if path is None:
+            return
+        try:
+            content_bytes = path.read_bytes()
+        except OSError:
+            return
+        if not content_bytes:
+            return
+        add(name, content_bytes.decode("utf-8", errors="ignore"))
+        for line in content_bytes.decode("utf-8", errors="ignore").splitlines():
+            add(name, line)
+
+    for name, raw_value in source.items():
+        if name in SECRET_ENV_INDIRECTION_NAMES:
+            target_name = raw_value.strip()
+            if target_name:
+                add(target_name, source.get(target_name, ""))
+            continue
+        if name in SECRET_ENV_FILE_INDIRECTION_NAMES:
+            add_file_contents(name, raw_value)
+            continue
+        if name.endswith(SECRET_ENV_VALUE_SKIP_SUFFIXES):
+            continue
+        if SECRET_ENV_VALUE_NAME_RE.search(name):
+            add(name, raw_value)
+    return values
+
+
+def redact_protected_secret_values(text: str, workspace_root: Path | None) -> str:
+    result = text
+    for _name, value in sorted(
+        protected_secret_environment_values(workspace_root=workspace_root),
+        key=lambda item: (-len(item[1]), item[0], item[1]),
+    ):
+        result = result.replace(value, "<redacted-protected-secret>")
+    return result
+
+
+def redact_captured_value(text: str, regex: re.Pattern[str], replacement: str) -> str:
+    def replace(match: re.Match[str]) -> str:
+        start, end = match.span(1)
+        relative_start = start - match.start()
+        relative_end = end - match.start()
+        return f"{match.group(0)[:relative_start]}{replacement}{match.group(0)[relative_end:]}"
+
+    return regex.sub(replace, text)
+
+
+def scrub_text(value: str, workspace_root: Path, out_dir: Path) -> str:
+    text = value
+    replacements = (
+        (str(workspace_root.resolve()), "<repo>"),
+        (str(out_dir.resolve()), "<dashboard-out>"),
+        (str(Path.home().resolve()), "<home>"),
+        (tempfile.gettempdir(), "<workdir>"),
+    )
+    for needle, replacement in replacements:
+        if needle:
+            text = text.replace(needle, replacement)
+            text = text.replace(needle.replace("\\", "/"), replacement)
+    text = PRIVATE_KEY_RE.sub("<redacted-private-key>", text)
+    text = PRIVATE_KEY_HEADER_RE.sub("<redacted-private-key>", text)
+    text = OPENSSH_PRIVATE_KEY_RE.sub("<redacted-private-key>", text)
+    text = PRIVATE_INSERT_URI_RE.sub("<redacted-private-insert-uri>", text)
+    text = URL_USERINFO_RE.sub("<redacted-url-userinfo>@", text)
+    text = FILE_URI_RE.sub("<redacted-file-uri>", text)
+    text = redact_captured_value(text, AUTH_HEADER_RE, "<redacted-authorization>")
+    text = redact_captured_value(text, COOKIE_HEADER_RE, "<redacted-cookie>")
+    text = redact_captured_value(text, APP_TOKEN_VALUE_RE, "<redacted-token>")
+    text = redact_captured_value(text, FORM_PASSWORD_VALUE_RE, "<redacted-password>")
+    text = redact_captured_value(text, RAW_BODY_VALUE_RE, "<redacted-raw-payload>")
+    text = redact_captured_value(text, CI_SECRET_VALUE_RE, "<redacted-ci-secret>")
+    text = BEARER_RE.sub("Bearer <redacted-token>", text)
+    text = HOST_PATH_RE.sub("<redacted-absolute-path>", text)
+    text = WINDOWS_PATH_RE.sub("<redacted-absolute-path>", text)
+    text = redact_protected_secret_values(text, workspace_root)
+    return text
+
+
+def sanitize_value(value: Any, workspace_root: Path, out_dir: Path) -> Any:
+    if isinstance(value, dict):
+        result: dict[str, Any] = {}
+        for key, child in sorted(value.items(), key=lambda item: str(item[0])):
+            key_text = str(key)
+            normalized = re.sub(r"[^a-z0-9]", "", key_text.lower())
+            if normalized in {
+                "privatekey",
+                "privatekeybase64",
+                "privatekeyfile",
+                "privateinserturi",
+                "token",
+                "password",
+                "formpassword",
+                "browsersessiontoken",
+                "appprocesstoken",
+                "authorization",
+                "cookie",
+                "rawappdatavalue",
+                "rawfetchedcontent",
+            }:
+                result[key_text] = "<redacted>"
+            else:
+                result[key_text] = sanitize_value(child, workspace_root, out_dir)
+        return result
+    if isinstance(value, list):
+        return [sanitize_value(child, workspace_root, out_dir) for child in value]
+    if isinstance(value, str):
+        return scrub_text(value, workspace_root, out_dir)
+    return value
+
+
+def normalize_status(value: Any) -> str:
+    status = str(value or "missing").strip().lower()
+    return {
+        "success": "pass",
+        "ok": "pass",
+        "passed": "pass",
+        "failure": "fail",
+        "failed": "fail",
+        "warning": "warn",
+        "warnings": "warn",
+        "not-run": "skip",
+    }.get(status, status if status in {"pass", "warn", "fail", "skip", "missing"} else "missing")
+
+
+def status_ok(entry: dict[str, Any] | None) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    status = normalize_status(entry.get("status"))
+    details = entry.get("details", {})
+    if isinstance(details, dict) and details.get("redactionFindings"):
+        return False
+    return status == "pass" or (status == "warn" and isinstance(details, dict) and details.get("waived") is True)
+
+
+def status_warn(entry: dict[str, Any] | None) -> bool:
+    return isinstance(entry, dict) and normalize_status(entry.get("status")) == "warn"
+
+
+def evidence_map(*summaries: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for summary in summaries:
+        if not isinstance(summary, dict):
+            continue
+        entries = summary.get("evidence", [])
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, dict) and entry.get("id"):
+                result[str(entry["id"])] = entry
+    return result
+
+
+def evidence_summary(entry: dict[str, Any] | None) -> str:
+    if not isinstance(entry, dict):
+        return "Required evidence is missing."
+    return str(entry.get("summary") or f"Evidence status is {normalize_status(entry.get('status'))}.")
+
+
+def issue_id(domain_id: str, evidence_id: str, suffix: str = "status") -> str:
+    raw = f"{domain_id}.{evidence_id}.{suffix}".lower()
+    return re.sub(r"[^a-z0-9_.-]+", "-", raw).strip("-")
+
+
+def is_redaction_evidence(evidence_id: str, domain_id: str = "") -> bool:
+    lowered = f"{domain_id} {evidence_id}".lower()
+    return "redaction" in lowered or "hygiene" in lowered or evidence_id in {
+        "production-beta.dashboard-redaction",
+        "production-beta.launch-artifact-hygiene",
+    }
+
+
+def issue_for_evidence(domain_id: str, evidence_id: str, entry: dict[str, Any] | None) -> Issue | None:
+    if status_ok(entry):
+        return None
+    if status_warn(entry):
+        return Issue(
+            id=issue_id(domain_id, evidence_id, "warning"),
+            evidence_id=evidence_id,
+            domain_id=domain_id,
+            severity="warning",
+            title=f"{evidence_id} is warning",
+            summary=evidence_summary(entry),
+            source=str(entry.get("source", domain_id)) if isinstance(entry, dict) else domain_id,
+            waivable=True,
+            category="evidence",
+        )
+    severity = "critical" if is_redaction_evidence(evidence_id, domain_id) else "blocker"
+    return Issue(
+        id=issue_id(domain_id, evidence_id),
+        evidence_id=evidence_id,
+        domain_id=domain_id,
+        severity=severity,
+        title=f"{evidence_id} is not passing",
+        summary=evidence_summary(entry),
+        source=str(entry.get("source", domain_id)) if isinstance(entry, dict) else domain_id,
+        waivable=severity != "critical" and evidence_id not in NON_WAIVABLE_EVIDENCE_IDS,
+        category="evidence",
+    )
+
+
+def domain_status(issues: list[Issue]) -> str:
+    if any(issue.severity in {"critical", "blocker"} and not issue.waived_by for issue in issues):
+        return "fail"
+    if any(issue.waived_by for issue in issues):
+        return "waived"
+    if any(issue.severity == "warning" for issue in issues):
+        return "warn"
+    return "pass"
+
+
+def scan_safe_value(raw_value: str, allow_code_like: bool = True) -> bool:
+    value = raw_value.strip().strip("'\"").rstrip(",;")
+    if not value:
+        return True
+    normalized = value.lower()
+    if normalized in {"<redacted>", "redacted", "[redacted]", "<masked>", "masked", "[masked]", "***", "null", "undefined", "unset", "true", "false", "none"}:
+        return True
+    if (value.startswith("<") and value.endswith(">")) or normalized.startswith("<redacted") or normalized.startswith("${{"):
+        return True
+    if not allow_code_like:
+        return False
+    if "(" in value or ")" in value:
+        return True
+    if re.fullmatch(r"[A-Za-z_$][A-Za-z0-9_$]*", value) and not (
+        len(value) >= 16 and any(character.isdigit() for character in value)
+    ):
+        return True
+    return False
+
+
+def add_value_findings(
+    findings: list[dict[str, str]],
+    text: str,
+    rel_path: str,
+    kind: str,
+    regex: re.Pattern[str],
+    allow_code_like: bool = True,
+) -> None:
+    for match in regex.finditer(text):
+        value = match.group(1)
+        if not scan_safe_value(value, allow_code_like=allow_code_like):
+            findings.append({"path": rel_path, "kind": kind})
+            return
+
+
+def add_protected_secret_value_findings(
+    findings: list[dict[str, str]],
+    text: str,
+    rel_path: str,
+    workspace_root: Path | None,
+) -> None:
+    for name, value in protected_secret_environment_values(workspace_root=workspace_root):
+        if value in text:
+            findings.append(
+                {
+                    "path": rel_path,
+                    "kind": "protected-secret-value",
+                    "detail": f"{name} value appeared unredacted.",
+                }
+            )
+            return
+
+
+def bad_artifact_name(rel_path: str) -> str | None:
+    parts = re.split(r"[\\/]+", rel_path)
+    for part in parts:
+        if not part:
+            continue
+        if part.startswith("._"):
+            return "AppleDouble file is not allowed"
+        if part in BAD_ARTIFACT_NAMES:
+            return f"{part} is not allowed"
+        if part in BAD_ARTIFACT_DIRS:
+            return f"{part} directory is not allowed"
+        lower = part.lower()
+        suffix = Path(lower).suffix
+        collapsed = re.sub(r"[^a-z0-9]", "", lower)
+        if suffix in FORBIDDEN_SECRET_ARTIFACT_SUFFIXES:
+            return f"{suffix} key-store artifact is not allowed"
+        if SECRET_ARTIFACT_NAME_RE.search(lower):
+            return "secret-bearing artifact filename is not allowed"
+        if suffix in SECRET_ARTIFACT_BINARY_SUFFIXES and any(
+            marker in collapsed for marker in SECRET_ARTIFACT_BINARY_MARKERS
+        ):
+            return "binary secret/key artifact filename is not allowed"
+    return None
+
+
+def scan_text_for_findings(text: str, rel_path: str, workspace_root: Path, out_dir: Path) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    checks = (
+        ("private-insert-uri", PRIVATE_INSERT_URI_RE),
+        ("private-key", PRIVATE_KEY_RE),
+        ("private-key-header", PRIVATE_KEY_HEADER_RE),
+        ("openssh-private-key", OPENSSH_PRIVATE_KEY_RE),
+        ("bearer-token", BEARER_RE),
+        ("url-userinfo", URL_USERINFO_RE),
+        ("file-uri-local-path", FILE_URI_RE),
+        ("windows-local-path", WINDOWS_PATH_RE),
+        ("host-local-path", HOST_PATH_RE),
+    )
+    for kind, regex in checks:
+        if regex.search(text):
+            findings.append({"path": rel_path, "kind": kind})
+    add_value_findings(findings, text, rel_path, "authorization-header", AUTH_HEADER_RE, allow_code_like=False)
+    add_value_findings(findings, text, rel_path, "cookie-header", COOKIE_HEADER_RE, allow_code_like=False)
+    add_value_findings(findings, text, rel_path, "app-token", APP_TOKEN_VALUE_RE, allow_code_like=False)
+    add_value_findings(findings, text, rel_path, "form-password", FORM_PASSWORD_VALUE_RE, allow_code_like=False)
+    add_value_findings(findings, text, rel_path, "raw-content-or-app-data", RAW_BODY_VALUE_RE, allow_code_like=False)
+    add_value_findings(findings, text, rel_path, "ci-secret-value", CI_SECRET_VALUE_RE, allow_code_like=False)
+    add_protected_secret_value_findings(findings, text, rel_path, workspace_root)
+    for kind, raw_path in (
+        ("workspace-path", str(workspace_root.resolve())),
+        ("home-path", str(Path.home().resolve())),
+        ("temp-path", tempfile.gettempdir()),
+    ):
+        if raw_path and raw_path not in {"/", "\\"}:
+            pattern = re.compile(rf"(?<![A-Za-z0-9_:/.\->]){re.escape(raw_path.rstrip('/\\'))}(?=$|[/\\])")
+            if pattern.search(text):
+                findings.append({"path": rel_path, "kind": kind})
+    return deduplicate_findings(findings)
+
+
+def deduplicate_findings(findings: list[dict[str, str]]) -> list[dict[str, str]]:
+    result: list[dict[str, str]] = []
+    seen: set[tuple[tuple[str, str], ...]] = set()
+    for finding in findings:
+        key = tuple(sorted((str(name), str(value)) for name, value in finding.items()))
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(finding)
+    return result
+
+
+def iter_file_chunks(path: Path) -> Iterator[bytes]:
+    with path.open("rb") as handle:
+        while True:
+            chunk = handle.read(TEXT_SCAN_CHUNK_BYTES)
+            if not chunk:
+                break
+            yield chunk
+
+
+def iter_handle_chunks(handle: Any) -> Iterator[bytes]:
+    while True:
+        chunk = handle.read(TEXT_SCAN_CHUNK_BYTES)
+        if not chunk:
+            break
+        yield chunk
+
+
+def scan_byte_chunks(chunks: Iterable[bytes], rel_path: str, workspace_root: Path, out_dir: Path) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    tail = b""
+    for chunk in chunks:
+        window = tail + chunk
+        findings.extend(scan_text_for_findings(window.decode("utf-8", errors="ignore"), rel_path, workspace_root, out_dir))
+        if b"\x00" in window:
+            findings.extend(
+                scan_text_for_findings(window.replace(b"\x00", b"").decode("utf-8", errors="ignore"), rel_path, workspace_root, out_dir)
+            )
+        tail = window[-TEXT_SCAN_OVERLAP_BYTES:]
+    return deduplicate_findings(findings)
+
+
+def archive_kind_for_name_or_prefix(name: str, prefix: bytes = b"") -> str | None:
+    lower = name.lower()
+    if Path(lower).suffix in ZIP_ARCHIVE_SUFFIXES or prefix.startswith(b"PK\x03\x04"):
+        return "zip"
+    if lower.endswith(TAR_GZ_ARCHIVE_SUFFIXES):
+        return "tar-gz"
+    return None
+
+
+def scan_embedded_archive(data: bytes, rel_path: str, workspace_root: Path, out_dir: Path, depth: int) -> list[dict[str, str]]:
+    if depth > MAX_NESTED_ARCHIVE_DEPTH:
+        return [{"path": rel_path, "kind": "archive-nesting-too-deep"}]
+    kind = archive_kind_for_name_or_prefix(rel_path, data[:4])
+    if kind == "zip":
+        try:
+            with zipfile.ZipFile(io.BytesIO(data)) as archive:
+                return scan_zip_members(archive, rel_path, workspace_root, out_dir, depth)
+        except (OSError, RuntimeError, zipfile.BadZipFile):
+            return [{"path": rel_path, "kind": "invalid-zip"}]
+    if kind == "tar-gz":
+        try:
+            with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as archive:
+                return scan_tar_members(archive, rel_path, workspace_root, out_dir, depth)
+        except (OSError, tarfile.TarError):
+            return [{"path": rel_path, "kind": "invalid-tar"}]
+    return scan_byte_chunks([data], rel_path, workspace_root, out_dir)
+
+
+def scan_zip_members(zip_archive: zipfile.ZipFile, rel_path: str, workspace_root: Path, out_dir: Path, depth: int) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    for info in zip_archive.infolist():
+        member_rel = f"{rel_path}!/{info.filename}"
+        reason = bad_artifact_name(info.filename)
+        if reason:
+            findings.append({"path": member_rel, "kind": "forbidden-zip-entry", "detail": reason})
+        if info.is_dir():
+            continue
+        try:
+            with zip_archive.open(info) as member:
+                prefix = member.read(4)
+                archive_kind = archive_kind_for_name_or_prefix(info.filename, prefix)
+                if archive_kind:
+                    findings.extend(scan_embedded_archive(prefix + member.read(), member_rel, workspace_root, out_dir, depth + 1))
+                else:
+                    findings.extend(
+                        scan_byte_chunks(_iter_prefixed(prefix, iter_handle_chunks(member)), member_rel, workspace_root, out_dir)
+                    )
+        except (OSError, RuntimeError, zipfile.BadZipFile, NotImplementedError):
+            findings.append({"path": member_rel, "kind": "unreadable-zip-entry"})
+    return deduplicate_findings(findings)
+
+
+def scan_tar_members(tar_archive: tarfile.TarFile, rel_path: str, workspace_root: Path, out_dir: Path, depth: int) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    for member in tar_archive.getmembers():
+        member_rel = f"{rel_path}!/{member.name}" if rel_path else member.name
+        reason = bad_artifact_name(member.name)
+        if reason:
+            findings.append({"path": member_rel, "kind": "forbidden-tar-entry", "detail": reason})
+        if member.isdir():
+            continue
+        if not member.isfile():
+            findings.append({"path": member_rel, "kind": "forbidden-tar-entry", "detail": "Only regular files and directories are allowed."})
+            continue
+        extracted = tar_archive.extractfile(member)
+        if extracted is None:
+            continue
+        try:
+            prefix = extracted.read(4)
+            archive_kind = archive_kind_for_name_or_prefix(member.name, prefix)
+            if archive_kind:
+                findings.extend(scan_embedded_archive(prefix + extracted.read(), member_rel, workspace_root, out_dir, depth + 1))
+            else:
+                findings.extend(
+                    scan_byte_chunks(_iter_prefixed(prefix, iter_handle_chunks(extracted)), member_rel, workspace_root, out_dir)
+                )
+        except (OSError, RuntimeError, tarfile.TarError):
+            findings.append({"path": member_rel, "kind": "unreadable-tar-entry"})
+    return deduplicate_findings(findings)
+
+
+def _iter_prefixed(prefix: bytes, chunks: Iterable[bytes]) -> Iterator[bytes]:
+    if prefix:
+        yield prefix
+    yield from chunks
+
+
+def scan_file(path: Path, rel_path: str, workspace_root: Path, out_dir: Path) -> list[dict[str, str]]:
+    reason = bad_artifact_name(rel_path)
+    findings: list[dict[str, str]] = []
+    if reason:
+        findings.append({"path": rel_path, "kind": "forbidden-path", "detail": reason})
+    if path.is_symlink():
+        findings.append({"path": rel_path, "kind": "forbidden-symlink"})
+        return findings
+    if not path.is_file():
+        findings.append({"path": rel_path, "kind": "forbidden-special-file"})
+        return findings
+    kind = archive_kind_for_name_or_prefix(rel_path)
+    try:
+        if kind == "zip":
+            with zipfile.ZipFile(path) as archive:
+                findings.extend(scan_zip_members(archive, rel_path, workspace_root, out_dir, 0))
+        elif kind == "tar-gz":
+            with tarfile.open(path, "r:gz") as archive:
+                findings.extend(scan_tar_members(archive, rel_path, workspace_root, out_dir, 0))
+        else:
+            findings.extend(scan_byte_chunks(iter_file_chunks(path), rel_path, workspace_root, out_dir))
+    except (OSError, RuntimeError, tarfile.TarError, zipfile.BadZipFile):
+        findings.append({"path": rel_path, "kind": "unreadable"})
+    return deduplicate_findings(findings)
+
+
+def scan_paths(paths: Iterable[Path], workspace_root: Path, out_dir: Path) -> list[dict[str, str]]:
+    findings: list[dict[str, str]] = []
+    for path in sorted({candidate.resolve() for candidate in paths if candidate.exists()}):
+        if path.is_dir():
+            for child in sorted(path.rglob("*")):
+                if child.is_dir():
+                    reason = bad_artifact_name(display_path(child, workspace_root))
+                    if reason:
+                        findings.append({"path": display_path(child, workspace_root), "kind": "forbidden-path", "detail": reason})
+                    continue
+                findings.extend(scan_file(child, display_path(child, workspace_root), workspace_root, out_dir))
+        else:
+            findings.extend(scan_file(path, display_path(path, workspace_root), workspace_root, out_dir))
+    return deduplicate_findings(findings)
+
+
+def redaction_report(findings: list[dict[str, str]]) -> dict[str, Any]:
+    critical = [finding for finding in findings if finding.get("kind") in REDACTION_FINDING_KINDS]
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "status": "pass" if not findings else "fail",
+        "findingCount": len(findings),
+        "criticalFindingCount": len(critical),
+        "checks": {
+            "failOnPrivateInsertUri": True,
+            "failOnPrivateKeys": True,
+            "failOnTokens": True,
+            "failOnRawPayloads": True,
+            "failOnAbsoluteLocalPaths": True,
+            "failOnArchiveSidecars": True,
+            "failOnProtectedSecretValues": True,
+        },
+        "findings": sorted(findings, key=lambda item: (item.get("path", ""), item.get("kind", ""), item.get("detail", ""))),
+    }
+
+
+def load_inputs_from_paths(args: argparse.Namespace, workspace_root: Path) -> tuple[dict[str, Any], dict[str, Path], list[Path], dict[str, Any] | None, str]:
+    path_by_name = {
+        "productionBetaSummary": args.production_beta_summary,
+        "releaseCertificationSummary": args.release_certification_summary,
+        "ecosystemMatrix": args.ecosystem_matrix,
+        "appPlatformSummary": args.app_platform_summary,
+        "liveNetworkSummary": args.live_network_summary,
+        "networkScaleSoakSummary": args.network_scale_soak_summary,
+        "multiNodeBetaSoakSummary": args.multi_node_beta_soak_summary,
+        "securityResponseSummary": args.security_response_summary,
+    }
+    inputs: dict[str, Any] = {}
+    paths: dict[str, Path] = {}
+    scan_targets: list[Path] = []
+    for name, raw_path in path_by_name.items():
+        if raw_path is None:
+            continue
+        path = raw_path if raw_path.is_absolute() else workspace_root / raw_path
+        paths[name] = path
+        scan_targets.append(path)
+        value = read_json(path)
+        if value is not None:
+            inputs[name] = value
+    waiver_value = None
+    if args.waivers is not None:
+        waiver_path = args.waivers if args.waivers.is_absolute() else workspace_root / args.waivers
+        paths["waivers"] = waiver_path
+        scan_targets.append(waiver_path)
+        waiver_value, waiver_error = read_json_object_with_error(waiver_path)
+        if waiver_error is not None:
+            waiver_value = {"__loadError": waiver_error}
+    release_id = args.release_id or infer_release_id(inputs)
+    return inputs, paths, scan_targets, waiver_value, release_id
+
+
+def load_inputs_from_fixture(args: argparse.Namespace, workspace_root: Path) -> tuple[dict[str, Any], dict[str, Path], list[Path], dict[str, Any] | None, str, str, str]:
+    fixture_path = args.fixtures if args.fixtures.is_absolute() else workspace_root / args.fixtures
+    fixture = load_fixture(fixture_path)
+    inputs = fixture.get("inputs")
+    if not isinstance(inputs, dict):
+        raise SystemExit(f"Fixture {fixture_path} must contain an inputs object.")
+    waiver_value = fixture.get("waivers") if isinstance(fixture.get("waivers"), dict) else None
+    mode = args.mode or str(fixture.get("mode", "release-candidate"))
+    generated_at = args.generated_at or str(fixture.get("generatedAt", DEFAULT_GENERATED_AT))
+    release_id = args.release_id or str(fixture.get("releaseId", fixture_path.stem))
+    return inputs, {}, [fixture_path], waiver_value, release_id, mode, generated_at
+
+
+def load_fixture(fixture_path: Path, seen: set[Path] | None = None) -> dict[str, Any]:
+    resolved = fixture_path.resolve()
+    active = set() if seen is None else seen
+    if resolved in active:
+        raise SystemExit(f"Fixture inheritance cycle includes {resolved}.")
+    active.add(resolved)
+    fixture = read_json(resolved)
+    if fixture is None:
+        raise SystemExit(f"Fixture {resolved} is missing or malformed.")
+    extends = fixture.get("extends")
+    if isinstance(extends, str) and extends.strip():
+        base_path = (resolved.parent / extends).resolve()
+        base = load_fixture(base_path, active)
+        fixture = deep_merge(base, fixture)
+        fixture.pop("extends", None)
+    active.remove(resolved)
+    return fixture
+
+
+def deep_merge(base: Any, override: Any) -> Any:
+    if isinstance(base, dict) and isinstance(override, dict):
+        result = dict(base)
+        for key, value in override.items():
+            if key == "extends":
+                continue
+            result[key] = deep_merge(result.get(key), value)
+        return result
+    return override
+
+
+def infer_release_id(inputs: dict[str, Any]) -> str:
+    prod = inputs.get("productionBetaSummary")
+    if isinstance(prod, dict):
+        version = prod.get("version")
+        if version:
+            return f"crypta-production-beta-{version}"
+    cert = inputs.get("releaseCertificationSummary")
+    if isinstance(cert, dict):
+        metadata = cert.get("metadata") if isinstance(cert.get("metadata"), dict) else {}
+        release_version = metadata.get("releaseVersion") or metadata.get("version")
+        if release_version:
+            return f"crypta-production-beta-{release_version}"
+    return "crypta-production-beta-candidate"
+
+
+def input_missing_issue(name: str, mode: str) -> Issue:
+    required = name in CRITICAL_INPUTS_BY_MODE.get(mode, ())
+    severity = "blocker" if required else "warning"
+    return Issue(
+        id=f"input.{name}.missing",
+        evidence_id=f"input.{name}",
+        domain_id="production-beta-release-pipeline",
+        severity=severity,
+        title=f"{name} input is missing",
+        summary=f"{name} was not provided or could not be parsed.",
+        source=name,
+        waivable=not required,
+        category="missing-input",
+    )
+
+
+def production_summary_issues(summary: dict[str, Any] | None, mode: str) -> list[Issue]:
+    if not isinstance(summary, dict):
+        return []
+    issues: list[Issue] = []
+    status = normalize_status(summary.get("status"))
+    promotion = summary.get("promotion") if isinstance(summary.get("promotion"), dict) else {}
+    gates = promotion.get("gates") if isinstance(promotion.get("gates"), list) else []
+    has_failed_promotion_gate = any(
+        isinstance(gate, dict) and normalize_status(gate.get("status")) != "pass" for gate in gates
+    )
+    failures = summary.get("failures") if isinstance(summary.get("failures"), list) else []
+    redaction = summary.get("redaction") if isinstance(summary.get("redaction"), dict) else {}
+    redaction_status = normalize_status(redaction.get("status") if isinstance(redaction, dict) else "missing")
+    if redaction_status != "pass":
+        issues.append(
+            Issue(
+                id="production-beta.redaction.status",
+                evidence_id="redaction.status",
+                domain_id="redaction-artifact-hygiene",
+                severity="critical",
+                title="Production beta redaction failed",
+                summary=f"Production beta artifact redaction status is {redaction_status}.",
+                source="production-beta-summary",
+                waivable=False,
+                category="redaction",
+            )
+        )
+    unexplained_failure = status == "fail" and (failures or not has_failed_promotion_gate)
+    malformed_or_nonready_status = status not in {"pass", "fail"}
+    if mode == "production-beta" and (malformed_or_nonready_status or unexplained_failure):
+        detail = ""
+        if failures:
+            detail = f" First failure: {failures[0]}."
+        issues.append(
+            Issue(
+                id="production-beta.summary.status",
+                evidence_id="production-beta.summary",
+                domain_id="production-beta-release-pipeline",
+                severity="blocker",
+                title="Production beta summary is not passing",
+                summary=f"Production beta summary status is {status}.{detail}",
+                source="production-beta-summary",
+                waivable=True,
+                category="pipeline",
+            )
+        )
+    elif unexplained_failure:
+        detail = ""
+        if failures:
+            detail = f" First failure: {failures[0]}."
+        issues.append(
+            Issue(
+                id="production-beta.summary.status",
+                evidence_id="production-beta.summary",
+                domain_id="production-beta-release-pipeline",
+                severity="blocker",
+                title="Production beta summary failed",
+                summary=f"Production beta summary status is fail.{detail}",
+                source="production-beta-summary",
+                waivable=True,
+                category="pipeline",
+            )
+        )
+    if mode == "production-beta" and summary.get("promotionReady") is not True and not has_failed_promotion_gate:
+        issues.append(
+            Issue(
+                id="production-beta.summary.promotion-ready",
+                evidence_id="production-beta.promotion-ready",
+                domain_id="production-beta-release-pipeline",
+                severity="blocker",
+                title="Production beta summary is not promotion-ready",
+                summary=f"Production beta summary promotionReady is {summary.get('promotionReady')}.",
+                source="production-beta-summary",
+                waivable=True,
+                category="pipeline",
+            )
+        )
+    profile = summary.get("signingProfile") if isinstance(summary.get("signingProfile"), dict) else {}
+    if mode == "production-beta" and summary.get("nonRelease") is True:
+        issues.append(
+            Issue(
+                id="production-beta.non-release",
+                evidence_id="production-beta.non-release",
+                domain_id="production-beta-release-pipeline",
+                severity="critical",
+                title="Candidate is marked non-release",
+                summary="A non-release artifact is not launchable as a production beta.",
+                source="production-beta-summary",
+                waivable=False,
+                category="pipeline",
+            )
+        )
+    if mode == "production-beta" and (profile.get("kind") != "production" or profile.get("generatedTestKeys") is True):
+        issues.append(
+            Issue(
+                id="production-beta.test-signing",
+                evidence_id="production-beta.test-signing",
+                domain_id="catalog-and-app-signing",
+                severity="critical",
+                title="Production beta candidate is not using production signing",
+                summary="Production beta mode cannot use test-only or generated signing material.",
+                source="production-beta-summary",
+                waivable=False,
+                category="signing",
+            )
+        )
+    for gate in gates:
+        if not isinstance(gate, dict) or normalize_status(gate.get("status")) == "pass":
+            continue
+        gate_id = str(gate.get("id", "promotion-gate"))
+        source = str(gate.get("source", "promotion"))
+        nonwaivable = gate_id in NON_WAIVABLE_EVIDENCE_IDS or is_redaction_evidence(gate_id)
+        if gate_id == "signing.production-keys" or "test-signing" in gate_id:
+            nonwaivable = True
+        if gate_id in {"build.production-beta-complete", "workspace.clean-production-beta", "fixture-evidence.strict-mode"}:
+            nonwaivable = True
+        issues.append(
+            Issue(
+                id=f"promotion.{gate_id}",
+                evidence_id=gate_id,
+                domain_id=domain_for_gate(gate_id, source),
+                severity="critical" if nonwaivable else "blocker",
+                title=f"{gate_id} failed",
+                summary=str(gate.get("summary", "Promotion gate failed.")),
+                source=source,
+                waivable=not nonwaivable,
+                category="promotion-gate",
+            )
+        )
+    return issues
+
+
+def domain_for_gate(gate_id: str, source: str) -> str:
+    if gate_id.startswith("live.") or source == "live-network-beta-smoke":
+        return "live-network-beta-smoke"
+    if gate_id.startswith("multi-node-beta") or source == "multi-node-beta-soak":
+        return "multi-node-beta-soak"
+    if "signing" in gate_id or "catalog" in gate_id or "review" in gate_id:
+        return "catalog-and-app-signing"
+    if gate_id.startswith("ecosystem."):
+        return "release-certification"
+    if "workspace" in gate_id or "build" in gate_id or "fixture" in gate_id:
+        return "production-beta-release-pipeline"
+    return "production-beta-release-pipeline"
+
+
+def release_certification_issues(summary: dict[str, Any] | None) -> list[Issue]:
+    if not isinstance(summary, dict):
+        return []
+    issues: list[Issue] = []
+    if summary.get("releaseCandidatePassed") is not True:
+        issues.append(
+            Issue(
+                id="release-certification.release-candidate-passed",
+                evidence_id="release-certification.ecosystem-rc-gate",
+                domain_id="release-certification",
+                severity="blocker",
+                title="Release certification did not pass",
+                summary=f"Release certification decision is {summary.get('promotionDecision', 'FAIL')}.",
+                source="release-certification-summary",
+                waivable=True,
+                category="release-certification",
+            )
+        )
+    gates = summary.get("ecosystemGates") if isinstance(summary.get("ecosystemGates"), list) else []
+    for gate in gates:
+        if not isinstance(gate, dict):
+            continue
+        if normalize_status(gate.get("status")) == "pass":
+            continue
+        gate_id = str(gate.get("id", "ecosystem-gate"))
+        details = gate.get("details") if isinstance(gate.get("details"), dict) else {}
+        unwaivable = bool(details.get("unwaivableFailureEvidenceIds")) or is_redaction_evidence(gate_id)
+        issues.append(
+            Issue(
+                id=f"release-certification.{gate_id}",
+                evidence_id=gate_id,
+                domain_id="release-certification",
+                severity="critical" if unwaivable else ("blocker" if gate.get("releaseBlocker") else "warning"),
+                title=f"{gate_id} is not passing",
+                summary=str(gate.get("summary", "Ecosystem gate is not passing.")),
+                source="release-certification-summary",
+                waivable=not unwaivable and bool(gate.get("releaseBlocker", True)),
+                category="release-certification",
+            )
+        )
+    return issues
+
+
+def ecosystem_matrix_issues(matrix: dict[str, Any] | None) -> list[Issue]:
+    if not isinstance(matrix, dict):
+        return []
+    issues: list[Issue] = []
+    status = normalize_status(matrix.get("status"))
+    if status not in {"pass", "warn"} or int(matrix.get("releaseBlockerCount", 0) or 0) > 0:
+        issues.append(
+            Issue(
+                id="ecosystem-matrix.release-blockers",
+                evidence_id="release-certification.ecosystem-matrix",
+                domain_id="ecosystem-rc-certification-matrix",
+                severity="blocker",
+                title="Ecosystem matrix has release blockers",
+                summary=f"Ecosystem certification matrix status is {status} or contains release blockers.",
+                source="ecosystem-certification-matrix",
+                waivable=True,
+                category="ecosystem-matrix",
+            )
+        )
+    coverage = matrix.get("coverage") if isinstance(matrix.get("coverage"), dict) else {}
+    if coverage.get("redactionPassed") is False:
+        issues.append(
+            Issue(
+                id="ecosystem-matrix.redaction",
+                evidence_id="production-beta.dashboard-redaction",
+                domain_id="redaction-artifact-hygiene",
+                severity="critical",
+                title="Ecosystem matrix redaction failed",
+                summary="Ecosystem matrix coverage reports redactionPassed=false.",
+                source="ecosystem-certification-matrix",
+                waivable=False,
+                category="redaction",
+            )
+        )
+    rows = matrix.get("rows") if isinstance(matrix.get("rows"), list) else []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        status = normalize_status(row.get("status"))
+        if status in {"pass", "warn"} and row.get("releaseBlocker") is not True:
+            continue
+        row_id = str(row.get("id", "matrix-row"))
+        redaction_row = row_id == "redaction-and-private-artifacts" or is_redaction_evidence(row_id)
+        issues.append(
+            Issue(
+                id=f"ecosystem-matrix.{row_id}",
+                evidence_id=row_id,
+                domain_id="ecosystem-rc-certification-matrix",
+                severity="critical" if redaction_row else ("blocker" if row.get("releaseBlocker") else "warning"),
+                title=f"{row_id} matrix row is not passing",
+                summary=str(row.get("recommendation") or row.get("title") or "Matrix row is not passing."),
+                source="ecosystem-certification-matrix",
+                waivable=not redaction_row and bool(row.get("releaseBlocker", True)),
+                category="ecosystem-matrix",
+            )
+        )
+    return issues
+
+
+def network_scale_issues(summary: dict[str, Any] | None, mode: str) -> list[Issue]:
+    if not isinstance(summary, dict):
+        return []
+    status = normalize_status(summary.get("status"))
+    if status != "pass":
+        return [
+            Issue(
+                id="network-scale-soak.status",
+                evidence_id="network-scale.rc-soak-summary",
+                domain_id="network-scale-soak",
+                severity="blocker" if mode != "developer-dry-run" else "warning",
+                title="Network-scale soak is not passing",
+                summary=f"Network-scale soak status is {status}.",
+                source="network-scale-soak-summary",
+                waivable=mode != "production-beta",
+                category="network-scale",
+            )
+        ]
+    findings = []
+    for section, keys in (
+        ("redaction", ("rawFetchedContentExcluded", "privateInsertUrisExcluded", "tokensExcluded", "absolutePathsExcluded", "queueHtmlExcluded")),
+        ("budgets", ("globalFetchBudgetEnforced", "perAppFetchBudgetEnforced", "concurrencyLeasesReleased")),
+    ):
+        value = summary.get(section)
+        if not isinstance(value, dict) or any(value.get(key) is not True for key in keys):
+            findings.append(section)
+    if findings:
+        return [
+            Issue(
+                id="network-scale-soak.redaction-or-budget",
+                evidence_id="network-scale.redaction",
+                domain_id="network-scale-soak",
+                severity="critical",
+                title="Network-scale soak redaction or budget checks failed",
+                summary=f"Network-scale soak sections failed: {', '.join(sorted(findings))}.",
+                source="network-scale-soak-summary",
+                waivable=False,
+                category="redaction",
+            )
+        ]
+    return []
+
+
+def multi_node_issues(summary: dict[str, Any] | None, mode: str) -> list[Issue]:
+    if not isinstance(summary, dict):
+        return []
+    issues: list[Issue] = []
+    status = normalize_status(summary.get("status"))
+    if status != "pass" or summary.get("promotionReady") is not True:
+        issues.append(
+            Issue(
+                id="multi-node-beta-soak.status",
+                evidence_id="multi-node-beta.soak",
+                domain_id="multi-node-beta-soak",
+                severity="blocker" if mode != "developer-dry-run" else "warning",
+                title="Multi-node beta soak is not promotion-ready",
+                summary=f"Multi-node beta soak status is {status}; promotionReady={summary.get('promotionReady')}.",
+                source="multi-node-beta-soak-summary",
+                waivable=mode != "production-beta",
+                category="multi-node",
+            )
+        )
+    redaction = summary.get("redaction") if isinstance(summary.get("redaction"), dict) else {}
+    if normalize_status(redaction.get("status")) != "pass":
+        issues.append(
+            Issue(
+                id="multi-node-beta-soak.redaction",
+                evidence_id="multi-node-beta.redaction",
+                domain_id="multi-node-beta-soak",
+                severity="critical",
+                title="Multi-node beta soak redaction failed",
+                summary=f"Multi-node beta redaction status is {normalize_status(redaction.get('status'))}.",
+                source="multi-node-beta-soak-summary",
+                waivable=False,
+                category="redaction",
+            )
+        )
+    scenario_statuses = summary.get("scenarioStatuses")
+    if isinstance(scenario_statuses, dict):
+        for scenario_id, scenario_status in sorted(scenario_statuses.items()):
+            if normalize_status(scenario_status) != "pass":
+                issues.append(
+                    Issue(
+                        id=f"multi-node-beta-soak.{scenario_id}",
+                        evidence_id=f"multi-node-beta.{scenario_id}",
+                        domain_id="multi-node-beta-soak",
+                        severity="blocker",
+                        title=f"{scenario_id} scenario is not passing",
+                        summary=f"{scenario_id} status is {scenario_status}.",
+                        source="multi-node-beta-soak-summary",
+                        waivable=True,
+                        category="multi-node",
+                    )
+                )
+    return issues
+
+
+def security_response_issues(summary: dict[str, Any] | None) -> list[Issue]:
+    if not isinstance(summary, dict):
+        return []
+    if normalize_status(summary.get("status")) == "pass":
+        return []
+    return [
+        Issue(
+            id="security-response-runbook.status",
+            evidence_id="production-security.response-runbook",
+            domain_id="production-security-response",
+            severity="blocker",
+            title="Production security response runbook is not passing",
+            summary=f"Security response summary status is {normalize_status(summary.get('status'))}.",
+            source="security-response-summary",
+            waivable=True,
+            category="security-response",
+        )
+    ]
+
+
+def build_domain_rows(
+    inputs: dict[str, Any],
+    paths: dict[str, Path],
+    workspace_root: Path,
+    out_dir: Path,
+    all_issues: list[Issue],
+    all_evidence: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    issues_by_domain: dict[str, list[Issue]] = {}
+    for issue in all_issues:
+        issues_by_domain.setdefault(issue.domain_id, []).append(issue)
+    for spec in DOMAIN_SPECS:
+        domain_id = str(spec["id"])
+        evidence_ids = list(spec["evidenceIds"])
+        artifact_refs: list[str] = []
+        for input_name in spec.get("artifactInputs", ()):
+            path = paths.get(str(input_name))
+            if path is not None:
+                artifact_refs.append(display_path(path, workspace_root))
+        source_issues = issues_by_domain.get(domain_id, [])
+        status = domain_status(source_issues)
+        rows.append(
+            {
+                "id": domain_id,
+                "title": spec["title"],
+                "status": status,
+                "severity": "required",
+                "evidenceIds": evidence_ids,
+                "artifactRefs": sorted(dict.fromkeys(artifact_refs)),
+                "summary": domain_summary(domain_id, status, source_issues, evidence_ids, all_evidence),
+            }
+        )
+    return rows
+
+
+def domain_summary(
+    domain_id: str,
+    status: str,
+    issues: list[Issue],
+    evidence_ids: list[str],
+    all_evidence: dict[str, dict[str, Any]],
+) -> str:
+    if status == "pass":
+        reported = [evidence_id for evidence_id in evidence_ids if evidence_id in all_evidence]
+        if reported:
+            return f"{len(reported)} evidence item(s) reported and passing."
+        if domain_id == "redaction-artifact-hygiene":
+            return "Dashboard input and output redaction scan passed."
+        return "Domain passed."
+    if status == "waived":
+        return "Blocking findings are covered by explicit valid waivers."
+    if issues:
+        first = sorted(issues, key=lambda issue: (issue.severity != "critical", issue.id))[0]
+        return first.summary
+    return "Domain is not passing."
+
+
+def scope_applies(scope: str, mode: str) -> bool:
+    normalized = scope.strip().lower()
+    if normalized in {"all", "all-modes", "any"}:
+        return True
+    if normalized in {mode, f"{mode}-only"}:
+        return True
+    if normalized == "release-candidate-and-production-beta" and mode in {"release-candidate", "production-beta"}:
+        return True
+    if normalized == "release-candidate-only" and mode == "release-candidate":
+        return True
+    if normalized == "production-beta-only" and mode == "production-beta":
+        return True
+    return False
+
+
+def severity_covers(waiver: Waiver, issue: Issue) -> bool:
+    return SEVERITY_RANK.get(waiver.severity, -1) >= SEVERITY_RANK.get(issue.severity, 99)
+
+
+def load_waivers(
+    value: dict[str, Any] | None,
+    source: str,
+    mode: str,
+    now: dt.datetime,
+    known_ids: set[str],
+    workspace_root: Path,
+    out_dir: Path,
+) -> tuple[list[Waiver], list[Issue]]:
+    if value is None:
+        return [], []
+    errors: list[Issue] = []
+    if value.get("__loadError"):
+        return [], [
+            Issue(
+                id="waiver.file.invalid",
+                evidence_id="production-beta.waiver-validation",
+                domain_id="redaction-artifact-hygiene",
+                severity="blocker",
+                title="Waiver file is invalid",
+                summary=scrub_text(str(value["__loadError"]), workspace_root, out_dir),
+                source=source,
+                waivable=False,
+                category="waiver-validation",
+            )
+        ]
+    records_value = value.get("waivers")
+    schema_version = value.get("schemaVersion", value.get("version"))
+    if schema_version != 1 or not isinstance(records_value, list):
+        return [], [
+            Issue(
+                id="waiver.schema.invalid",
+                evidence_id="production-beta.waiver-validation",
+                domain_id="redaction-artifact-hygiene",
+                severity="blocker",
+                title="Waiver file is invalid",
+                summary="Waiver file must use schemaVersion/version 1 and a waivers array.",
+                source=source,
+                waivable=False,
+                category="waiver-validation",
+            )
+        ]
+    waivers: list[Waiver] = []
+    for index, entry in enumerate(records_value):
+        validation_errors: list[str] = []
+        if not isinstance(entry, dict):
+            validation_errors.append("entry must be an object")
+            entry = {}
+        waiver_id = str(entry.get("id", "")).strip()
+        evidence_id = str(entry.get("evidenceId", waiver_id)).strip()
+        severity = str(entry.get("severity", "blocker")).strip().lower()
+        scope = str(entry.get("scope", "")).strip()
+        rationale = str(entry.get("rationale", entry.get("reason", ""))).strip()
+        approved_by = str(entry.get("approvedBy", "")).strip()
+        owner = str(entry.get("owner", "")).strip()
+        created_at = str(entry.get("createdAt", "")).strip()
+        expires_at = str(entry.get("expiresAt", "")).strip()
+        references = tuple(str(item) for item in entry.get("references", []) if isinstance(entry.get("references"), list))
+        external_risk_accepted = entry.get("externalRiskAccepted") is True
+        status = str(entry.get("status", "approved")).strip().lower()
+        applies = scope_applies(scope, mode) if scope else False
+        expiry = parse_time(expires_at)
+        if not waiver_id:
+            validation_errors.append("id is required")
+        if not evidence_id:
+            validation_errors.append("evidenceId is required")
+        if severity not in SEVERITIES:
+            validation_errors.append("severity must be info, warning, blocker, or critical")
+        if not scope:
+            validation_errors.append("scope is required")
+        if not rationale:
+            validation_errors.append("rationale is required")
+        if not approved_by:
+            validation_errors.append("approvedBy is required")
+        if not owner:
+            validation_errors.append("owner is required")
+        if status != "approved":
+            validation_errors.append("status must be approved")
+        if not expires_at:
+            validation_errors.append("expiresAt is required")
+        elif expiry is None:
+            validation_errors.append("expiresAt must be an ISO-8601 timestamp")
+        elif expiry <= now:
+            validation_errors.append("waiver is expired")
+        if not applies:
+            validation_errors.append(f"scope does not apply to {mode}")
+        if evidence_id and evidence_id not in known_ids and not external_risk_accepted:
+            validation_errors.append("evidenceId is unknown and externalRiskAccepted is not true")
+        if mode == "production-beta" and evidence_id in NON_WAIVABLE_EVIDENCE_IDS:
+            validation_errors.append("target is non-waivable in production-beta mode")
+        active = not validation_errors
+        safe_errors = tuple(scrub_text(error, workspace_root, out_dir) for error in validation_errors)
+        waiver = Waiver(
+            id=scrub_text(waiver_id or f"{source}#{index}", workspace_root, out_dir),
+            evidence_id=scrub_text(evidence_id or waiver_id or f"{source}#{index}", workspace_root, out_dir),
+            severity=severity if severity in SEVERITIES else "blocker",
+            scope=scrub_text(scope, workspace_root, out_dir),
+            rationale=scrub_text(rationale, workspace_root, out_dir),
+            approved_by=scrub_text(approved_by, workspace_root, out_dir),
+            owner=scrub_text(owner, workspace_root, out_dir),
+            created_at=scrub_text(created_at, workspace_root, out_dir),
+            expires_at=scrub_text(expires_at if expiry is not None else expires_at, workspace_root, out_dir),
+            references=tuple(scrub_text(reference, workspace_root, out_dir) for reference in references),
+            source=source,
+            active=active,
+            applies_to_mode=applies,
+            external_risk_accepted=external_risk_accepted,
+            validation_errors=safe_errors,
+        )
+        waivers.append(waiver)
+        if validation_errors:
+            errors.append(
+                Issue(
+                    id=f"waiver.{waiver.id}.invalid",
+                    evidence_id="production-beta.waiver-validation",
+                    domain_id="redaction-artifact-hygiene",
+                    severity="blocker",
+                    title=f"Waiver {waiver.id} is invalid",
+                    summary="; ".join(safe_errors),
+                    source=source,
+                    waivable=False,
+                    category="waiver-validation",
+                )
+            )
+    return waivers, errors
+
+
+def apply_waivers(issues: list[Issue], waivers: list[Waiver], mode: str) -> tuple[list[Issue], list[Waiver], list[Issue]]:
+    applied: list[Issue] = []
+    usage: dict[str, list[str]] = {waiver.id: [] for waiver in waivers}
+    validation_issues: list[Issue] = []
+    for issue in issues:
+        if issue.severity not in {"blocker", "critical"} or not issue.waivable:
+            applied.append(issue)
+            continue
+        matching = None
+        under_severity = None
+        for waiver in reversed(waivers):
+            if not waiver.active or not waiver.matches(issue):
+                continue
+            if not severity_covers(waiver, issue):
+                under_severity = waiver
+                continue
+            matching = waiver
+            break
+        if matching is None:
+            if under_severity is not None:
+                validation_issues.append(
+                    Issue(
+                        id=f"waiver.{under_severity.id}.severity-too-low",
+                        evidence_id="production-beta.waiver-validation",
+                        domain_id="redaction-artifact-hygiene",
+                        severity="blocker",
+                        title="Waiver severity is lower than finding severity",
+                        summary=(
+                            f"Waiver {under_severity.id} is approved for {under_severity.severity} "
+                            f"but {issue.evidence_id} is {issue.severity}."
+                        ),
+                        source=under_severity.source,
+                        waivable=False,
+                        category="waiver-validation",
+                    )
+                )
+            applied.append(issue)
+            continue
+        if mode == "production-beta" and (issue.evidence_id in NON_WAIVABLE_EVIDENCE_IDS or issue.severity == "critical"):
+            validation_issues.append(
+                Issue(
+                    id=f"waiver.{matching.id}.non-waivable-target",
+                    evidence_id="production-beta.waiver-validation",
+                    domain_id="redaction-artifact-hygiene",
+                    severity="blocker",
+                    title="Waiver targets a non-waivable finding",
+                    summary=f"Waiver {matching.id} cannot waive {issue.evidence_id}.",
+                    source=matching.source,
+                    waivable=False,
+                    category="waiver-validation",
+                )
+            )
+            applied.append(issue)
+            continue
+        usage[matching.id].append(issue.id)
+        applied.append(dataclasses.replace(issue, waived_by=matching.id))
+    used_waivers = [waiver.with_usage(usage.get(waiver.id, [])) for waiver in waivers]
+    return [*applied, *validation_issues], used_waivers, validation_issues
+
+
+def live_evidence_required(inputs: dict[str, Any], mode: str) -> bool:
+    if mode == "production-beta":
+        return True
+    summary = inputs.get("liveNetworkSummary")
+    if not isinstance(summary, dict):
+        return False
+    return summary.get("enabled") is True or summary.get("required") is True
+
+
+def collect_issues(
+    inputs: dict[str, Any],
+    mode: str,
+    input_paths: dict[str, Path],
+) -> tuple[list[Issue], dict[str, dict[str, Any]]]:
+    all_evidence = evidence_map(
+        inputs.get("releaseCertificationSummary"),
+        inputs.get("appPlatformSummary"),
+        inputs.get("liveNetworkSummary"),
+    )
+    issues: list[Issue] = []
+    for name in CRITICAL_INPUTS_BY_MODE.get(mode, ()):
+        if name not in inputs:
+            issues.append(input_missing_issue(name, mode))
+    for name, path in input_paths.items():
+        if name != "waivers" and name not in inputs and name in {spec_name for spec in DOMAIN_SPECS for spec_name in spec.get("artifactInputs", ())}:
+            issues.append(input_missing_issue(name, mode))
+    issues.extend(production_summary_issues(inputs.get("productionBetaSummary"), mode))
+    issues.extend(release_certification_issues(inputs.get("releaseCertificationSummary")))
+    issues.extend(ecosystem_matrix_issues(inputs.get("ecosystemMatrix")))
+    issues.extend(network_scale_issues(inputs.get("networkScaleSoakSummary"), mode))
+    issues.extend(multi_node_issues(inputs.get("multiNodeBetaSoakSummary"), mode))
+    issues.extend(security_response_issues(inputs.get("securityResponseSummary")))
+    for spec in DOMAIN_SPECS:
+        domain_id = str(spec["id"])
+        if domain_id in {
+            "production-beta-release-pipeline",
+            "release-certification",
+            "ecosystem-rc-certification-matrix",
+            "network-scale-soak",
+            "multi-node-beta-soak",
+            "redaction-artifact-hygiene",
+        }:
+            continue
+        if domain_id == "live-network-beta-smoke" and not live_evidence_required(inputs, mode):
+            continue
+        for evidence_id in spec["evidenceIds"]:
+            issue = issue_for_evidence(domain_id, str(evidence_id), all_evidence.get(str(evidence_id)))
+            if issue is not None:
+                issues.append(issue)
+    return dedupe_issues(issues), all_evidence
+
+
+def dedupe_issues(issues: list[Issue]) -> list[Issue]:
+    result: list[Issue] = []
+    seen: set[str] = set()
+    for issue in sorted(issues, key=lambda item: (item.id, item.evidence_id, item.summary)):
+        if issue.id in seen:
+            continue
+        seen.add(issue.id)
+        result.append(issue)
+    return result
+
+
+def known_ids(all_evidence: dict[str, dict[str, Any]], issues: list[Issue]) -> set[str]:
+    ids = set(all_evidence)
+    for spec in DOMAIN_SPECS:
+        ids.add(str(spec["id"]))
+        ids.update(str(evidence_id) for evidence_id in spec["evidenceIds"])
+    ids.update(DASHBOARD_EVIDENCE_IDS)
+    for issue in issues:
+        ids.update({issue.id, issue.evidence_id, issue.domain_id, f"evidence.{issue.evidence_id}"})
+    ids.update(NON_WAIVABLE_EVIDENCE_IDS)
+    return expand_waiver_target_aliases(*ids)
+
+
+def decision_from_issues(issues: list[Issue]) -> str:
+    unwaived = [issue for issue in issues if issue.severity in {"critical", "blocker"} and not issue.waived_by]
+    if unwaived:
+        return "no-go"
+    if any(issue.waived_by for issue in issues if issue.severity in {"critical", "blocker"}):
+        return "go-with-waivers"
+    return "go"
+
+
+def recommendation_for(decision: str, blockers: list[Issue], warnings: list[Issue]) -> str:
+    if decision == "go":
+        return "Launch candidate is ready for production beta promotion."
+    if decision == "go-with-waivers":
+        return "Launch candidate is promotable only with the listed approved waivers preserved in the release record."
+    if blockers:
+        return f"Do not launch. Resolve or replace the top blocker: {blockers[0].title}."
+    if warnings:
+        return "Do not launch until dashboard warnings are reviewed and the decision is regenerated."
+    return "Do not launch until the dashboard can be regenerated from complete evidence."
+
+
+def build_dashboard(
+    inputs: dict[str, Any],
+    input_paths: dict[str, Path],
+    scan_targets: list[Path],
+    waiver_value: dict[str, Any] | None,
+    workspace_root: Path,
+    out_dir: Path,
+    mode: str,
+    release_id: str,
+    generated_at: str,
+    now: dt.datetime,
+) -> dict[str, Any]:
+    if mode not in MODES:
+        raise SystemExit(f"--mode must be one of {', '.join(MODES)}")
+    issues, all_evidence = collect_issues(inputs, mode, input_paths)
+    waivers, waiver_issues = load_waivers(
+        waiver_value,
+        display_path(input_paths.get("waivers", Path("waivers.json")), workspace_root) if input_paths.get("waivers") else "fixture-waivers",
+        mode,
+        now,
+        known_ids(all_evidence, issues),
+        workspace_root,
+        out_dir,
+    )
+    issues = dedupe_issues([*issues, *waiver_issues])
+    issues, waivers, _validation_issues = apply_waivers(issues, waivers, mode)
+    domains = build_domain_rows(inputs, input_paths, workspace_root, out_dir, issues, all_evidence)
+    redaction = redaction_report(scan_paths(scan_targets, workspace_root, out_dir))
+    if redaction["status"] != "pass":
+        redaction_issue = Issue(
+            id="dashboard.redaction.scan",
+            evidence_id="production-beta.dashboard-redaction",
+            domain_id="redaction-artifact-hygiene",
+            severity="critical",
+            title="Dashboard input redaction scan failed",
+            summary=f"Dashboard redaction scanner found {redaction['findingCount']} finding(s).",
+            source="dashboard-redaction",
+            waivable=False,
+            category="redaction",
+        )
+        issues = dedupe_issues([*issues, redaction_issue])
+        domains = build_domain_rows(inputs, input_paths, workspace_root, out_dir, issues, all_evidence)
+    blockers = [issue for issue in issues if issue.severity in {"critical", "blocker"} and not issue.waived_by]
+    warnings = [issue for issue in issues if issue.severity == "warning" or issue.waived_by]
+    decision = decision_from_issues(issues)
+    production_summary = inputs.get("productionBetaSummary") if isinstance(inputs.get("productionBetaSummary"), dict) else {}
+    artifact_refs = {
+        "dashboardJson": OUTPUT_JSON,
+        "dashboardMarkdown": OUTPUT_MARKDOWN,
+        "dashboardRedactionReport": OUTPUT_REDACTION,
+    }
+    artifacts = production_summary.get("artifacts") if isinstance(production_summary.get("artifacts"), dict) else {}
+    for key in ("redactionReport", "distArchive", "checksums", "ecosystemCertification", "multiNodeBetaSoak"):
+        if key in artifacts:
+            artifact_refs[key] = str(artifacts[key])
+    dashboard = {
+        "schemaVersion": SCHEMA_VERSION,
+        "tool": TOOL_NAME,
+        "generatedAt": generated_at,
+        "mode": mode,
+        "releaseId": scrub_text(release_id, workspace_root, out_dir),
+        "decision": decision,
+        "promotionReady": decision in {"go", "go-with-waivers"},
+        "summary": {
+            "blockers": len(blockers),
+            "warnings": len(warnings),
+            "waiversUsed": sum(1 for waiver in waivers if waiver.used_by),
+            "criticalRedactionFindings": int(redaction.get("criticalFindingCount", 0)),
+            "criticalFindings": sum(1 for issue in issues if issue.severity == "critical" and not issue.waived_by),
+        },
+        "domains": domains,
+        "blockers": [issue.to_json() for issue in blockers],
+        "warnings": [issue.to_json() for issue in warnings],
+        "waivers": [waiver.to_json() for waiver in waivers],
+        "redaction": redaction,
+        "recommendation": recommendation_for(decision, blockers, warnings),
+        "artifactRefs": artifact_refs,
+    }
+    return sanitize_value(dashboard, workspace_root, out_dir)
+
+
+def render_markdown(dashboard: dict[str, Any]) -> str:
+    decision_label = {
+        "go": "GO",
+        "no-go": "NO-GO",
+        "go-with-waivers": "GO WITH WAIVERS",
+    }.get(str(dashboard.get("decision")), "NO-GO")
+    lines = [
+        "# Production Beta Go/No-Go Dashboard",
+        "",
+        f"- Release ID: `{dashboard.get('releaseId', '')}`",
+        f"- Mode: `{dashboard.get('mode', '')}`",
+        f"- Decision: **{decision_label}**",
+        f"- Promotion ready: `{str(dashboard.get('promotionReady', False)).lower()}`",
+        f"- Generated: `{dashboard.get('generatedAt', '')}`",
+        f"- Recommendation: {dashboard.get('recommendation', '')}",
+        "",
+        "## Top Blockers",
+        "",
+    ]
+    blockers = dashboard.get("blockers", [])
+    if not blockers:
+        lines.append("No unwaived blockers.")
+    else:
+        for issue in blockers[:10]:
+            if isinstance(issue, dict):
+                lines.append(f"- `{issue.get('evidenceId', '')}`: {issue.get('summary', '')}")
+    lines.extend(["", "## Top Warnings", ""])
+    warnings = dashboard.get("warnings", [])
+    if not warnings:
+        lines.append("No warnings.")
+    else:
+        for issue in warnings[:10]:
+            if isinstance(issue, dict):
+                waived = f" Waiver: `{issue.get('waivedBy')}`." if issue.get("waivedBy") else ""
+                lines.append(f"- `{issue.get('evidenceId', '')}`: {issue.get('summary', '')}{waived}")
+    lines.extend(["", "## Waivers Used", ""])
+    waivers = [waiver for waiver in dashboard.get("waivers", []) if isinstance(waiver, dict) and waiver.get("usedBy")]
+    if not waivers:
+        lines.append("No waivers were used.")
+    else:
+        lines.extend(["| Waiver | Evidence | Scope | Expires | Used by |", "| --- | --- | --- | --- | --- |"])
+        for waiver in waivers:
+            lines.append(
+                "| `{}` | `{}` | `{}` | `{}` | {} |".format(
+                    waiver.get("id", ""),
+                    waiver.get("evidenceId", ""),
+                    waiver.get("scope", ""),
+                    waiver.get("expiresAt", ""),
+                    markdown_code_list(waiver.get("usedBy", [])),
+                )
+            )
+    lines.extend(["", "## Domain Table", ""])
+    lines.extend(["| Domain | Status | Required | Evidence | Artifacts |", "| --- | --- | --- | --- | --- |"])
+    for domain in dashboard.get("domains", []):
+        if not isinstance(domain, dict):
+            continue
+        lines.append(
+            "| {} | `{}` | `{}` | {} | {} |".format(
+                markdown_cell(domain.get("title", domain.get("id", ""))),
+                domain.get("status", ""),
+                domain.get("severity", "required"),
+                markdown_code_list(domain.get("evidenceIds", [])),
+                markdown_code_list(domain.get("artifactRefs", [])),
+            )
+        )
+    redaction = dashboard.get("redaction") if isinstance(dashboard.get("redaction"), dict) else {}
+    lines.extend(
+        [
+            "",
+            "## Redaction Status",
+            "",
+            f"- Status: `{redaction.get('status', 'missing')}`",
+            f"- Findings: `{redaction.get('findingCount', 0)}`",
+            f"- Critical findings: `{redaction.get('criticalFindingCount', 0)}`",
+        ]
+    )
+    for finding in redaction.get("findings", [])[:10] if isinstance(redaction.get("findings"), list) else []:
+        if isinstance(finding, dict):
+            detail = f": {finding.get('detail')}" if finding.get("detail") else ""
+            lines.append(f"- `{finding.get('kind', '')}` at `{finding.get('path', '')}`{detail}")
+    lines.extend(["", "## Required Follow-Ups", ""])
+    if blockers:
+        lines.append("- Resolve all unwaived blockers and regenerate the dashboard.")
+    if redaction.get("status") != "pass":
+        lines.append("- Remove unsafe input/output content and regenerate the redaction report.")
+    invalid_waivers = [
+        waiver
+        for waiver in dashboard.get("waivers", [])
+        if isinstance(waiver, dict) and waiver.get("validationErrors")
+    ]
+    if invalid_waivers:
+        lines.append("- Fix invalid or expired waiver records before promotion.")
+    if not blockers and redaction.get("status") == "pass" and not invalid_waivers:
+        lines.append("- Preserve this dashboard and the listed redacted artifacts with the release candidate.")
+    lines.extend(["", "## Redacted Artifacts", ""])
+    artifact_refs = dashboard.get("artifactRefs", {}) if isinstance(dashboard.get("artifactRefs"), dict) else {}
+    for name in sorted(artifact_refs):
+        lines.append(f"- `{name}`: `{artifact_refs[name]}`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def markdown_cell(value: Any) -> str:
+    return str(value).replace("|", "\\|").replace("\n", " ")
+
+
+def markdown_code_list(values: Any) -> str:
+    if not isinstance(values, list):
+        return ""
+    return ", ".join(f"`{markdown_cell(value)}`" for value in values)
+
+
+def write_dashboard_artifacts(dashboard: dict[str, Any], out_dir: Path, workspace_root: Path) -> dict[str, Any]:
+    write_json(out_dir / OUTPUT_JSON, dashboard)
+    write_text(out_dir / OUTPUT_MARKDOWN, render_markdown(dashboard))
+    output_findings = scan_paths([out_dir / OUTPUT_JSON, out_dir / OUTPUT_MARKDOWN], workspace_root, out_dir)
+    combined_findings = [
+        *dashboard.get("redaction", {}).get("findings", []),
+        *output_findings,
+    ]
+    final_redaction = redaction_report([finding for finding in combined_findings if isinstance(finding, dict)])
+    dashboard["redaction"] = final_redaction
+    if final_redaction["status"] != "pass" and dashboard.get("decision") != "no-go":
+        issue = {
+            "id": "dashboard.output-redaction.scan",
+            "evidenceId": "production-beta.dashboard-redaction",
+            "domainId": "redaction-artifact-hygiene",
+            "severity": "critical",
+            "title": "Dashboard output redaction scan failed",
+            "summary": f"Dashboard output redaction scanner found {final_redaction['findingCount']} finding(s).",
+            "source": "dashboard-redaction",
+            "waivable": False,
+            "category": "redaction",
+        }
+        dashboard["decision"] = "no-go"
+        dashboard["promotionReady"] = False
+        dashboard.setdefault("blockers", []).append(issue)
+        summary = dashboard.setdefault("summary", {})
+        summary["blockers"] = int(summary.get("blockers", 0)) + 1
+        summary["criticalRedactionFindings"] = int(final_redaction.get("criticalFindingCount", 0))
+        dashboard["recommendation"] = "Do not launch. Resolve dashboard output redaction findings and regenerate."
+    write_json(out_dir / OUTPUT_JSON, dashboard)
+    write_text(out_dir / OUTPUT_MARKDOWN, render_markdown(dashboard))
+    write_json(out_dir / OUTPUT_REDACTION, final_redaction)
+    return dashboard
+
+
+def build_command(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
+    workspace_root = args.workspace_root.resolve()
+    out_dir = args.out_dir if args.out_dir.is_absolute() else workspace_root / args.out_dir
+    out_dir = out_dir.resolve()
+    if args.fixtures is not None:
+        inputs, paths, scan_targets, waiver_value, release_id, fixture_mode, fixture_generated_at = load_inputs_from_fixture(args, workspace_root)
+        mode = args.mode or fixture_mode
+        generated_at, now = parse_generated_at(args.generated_at or fixture_generated_at)
+    else:
+        inputs, paths, scan_targets, waiver_value, release_id = load_inputs_from_paths(args, workspace_root)
+        mode = args.mode or "developer-dry-run"
+        generated_at, now = parse_generated_at(args.generated_at)
+    dashboard = build_dashboard(
+        inputs,
+        paths,
+        scan_targets,
+        waiver_value,
+        workspace_root,
+        out_dir,
+        mode,
+        release_id,
+        generated_at,
+        now,
+    )
+    dashboard = write_dashboard_artifacts(dashboard, out_dir, workspace_root)
+    return dashboard, 0 if dashboard["decision"] in {"go", "go-with-waivers"} else 1
+
+
+def run_self_test(quiet: bool = False) -> None:
+    fixture_expectations = {
+        "go-no-go-pass.json": "go",
+        "go-no-go-no-go.json": "no-go",
+        "go-no-go-with-waivers.json": "go-with-waivers",
+        "go-no-go-expired-waiver.json": "no-go",
+        "go-no-go-waiver-valid-at-generated-at.json": "go-with-waivers",
+        "go-no-go-critical-redaction.json": "no-go",
+        "go-no-go-test-signing-production.json": "no-go",
+        "go-no-go-summary-failure-with-gates.json": "no-go",
+        "go-no-go-production-summary-not-ready.json": "no-go",
+        "go-no-go-production-summary-skipped.json": "no-go",
+        "go-no-go-missing-ecosystem-matrix-status.json": "no-go",
+        "go-no-go-warning-ecosystem-matrix.json": "go",
+        "go-no-go-secret-value-redaction.json": "no-go",
+        "go-no-go-underseverity-waiver.json": "no-go",
+        "go-no-go-live-evidence-waiver-alias.json": "go-with-waivers",
+        "go-no-go-release-candidate-live-disabled.json": "go",
+    }
+    with tempfile.TemporaryDirectory(prefix="cryptad-go-no-go-dashboard-") as temp_name:
+        root = Path(temp_name)
+        outputs: dict[str, str] = {}
+        for fixture_name, expected in fixture_expectations.items():
+            out_dir = root / fixture_name.removesuffix(".json")
+            fixture = FIXTURE_DIR / fixture_name
+            args = build_parser().parse_args(
+                [
+                    "build",
+                    "--workspace-root",
+                    str(Path(__file__).resolve().parents[2]),
+                    "--out-dir",
+                    str(out_dir),
+                    "--fixtures",
+                    str(fixture),
+                ]
+            )
+            dashboard, _exit_code = build_command(args)
+            if dashboard["decision"] != expected:
+                raise AssertionError(f"{fixture_name} expected {expected}, got {dashboard['decision']}: {dashboard}")
+            blocker_ids = {
+                str(blocker.get("evidenceId"))
+                for blocker in dashboard.get("blockers", [])
+                if isinstance(blocker, dict)
+            }
+            if fixture_name == "go-no-go-underseverity-waiver.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("under-severity waiver was incorrectly used")
+                if "production-beta.waiver-validation" not in blocker_ids:
+                    raise AssertionError("under-severity waiver did not produce a waiver-validation blocker")
+            if fixture_name == "go-no-go-expired-waiver.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("expired waiver was incorrectly used")
+                if "production-beta.waiver-validation" not in blocker_ids:
+                    raise AssertionError("expired waiver did not produce a waiver-validation blocker")
+                if dashboard.get("generatedAt") != "2026-06-24T00:00:00Z":
+                    raise AssertionError("expired waiver fixture did not use its recorded generatedAt")
+            if fixture_name == "go-no-go-waiver-valid-at-generated-at.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
+                    raise AssertionError("waiver valid at generatedAt was not used")
+                if dashboard.get("generatedAt") != "1999-06-24T00:00:00Z":
+                    raise AssertionError("historical waiver fixture did not use its recorded generatedAt")
+            if fixture_name == "go-no-go-production-summary-not-ready.json":
+                if "production-beta.promotion-ready" not in blocker_ids:
+                    raise AssertionError("non-ready production summary did not block production beta")
+            if fixture_name == "go-no-go-production-summary-skipped.json":
+                if "production-beta.summary" not in blocker_ids:
+                    raise AssertionError("skipped production summary did not block production beta")
+            if fixture_name == "go-no-go-live-evidence-waiver-alias.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
+                    raise AssertionError("live evidence alias waiver was not used")
+                waived_evidence_ids = {
+                    str(warning.get("evidenceId"))
+                    for warning in dashboard.get("warnings", [])
+                    if isinstance(warning, dict) and warning.get("waivedBy")
+                }
+                if "live-network-beta.content-fetch" not in waived_evidence_ids:
+                    raise AssertionError("live evidence alias waiver did not cover live-network evidence")
+            if fixture_name == "go-no-go-release-candidate-live-disabled.json":
+                if any(blocker_id.startswith("live-network-beta.") for blocker_id in blocker_ids):
+                    raise AssertionError("disabled live-network evidence blocked release-candidate mode")
+            for artifact_name in (OUTPUT_JSON, OUTPUT_MARKDOWN, OUTPUT_REDACTION):
+                if not (out_dir / artifact_name).is_file():
+                    raise AssertionError(f"{fixture_name} did not write {artifact_name}")
+            markdown = (out_dir / OUTPUT_MARKDOWN).read_text(encoding="utf-8")
+            for required in ("Production Beta Go/No-Go Dashboard", "Domain Table", "Redaction Status"):
+                if required not in markdown:
+                    raise AssertionError(f"{fixture_name} markdown missing {required}")
+            encoded = json.dumps(dashboard, sort_keys=True) + markdown
+            for forbidden in (
+                "Bearer abcdefghijklmnop",
+                "-----BEGIN PRIVATE KEY-----",
+                "USK@PRIVATE-INSERT",
+                "/home/alice",
+                "/work/cryptad",
+                "hunter2",
+                "session=abc1234567890",
+                "app-token-123456789",
+                "rawpayload123456789",
+                "github-token-123456789",
+            ):
+                if forbidden in encoded:
+                    raise AssertionError(f"{fixture_name} leaked {forbidden}")
+            outputs[fixture_name] = (out_dir / OUTPUT_JSON).read_text(encoding="utf-8")
+        repeat_dir = root / "repeat"
+        repeat_args = build_parser().parse_args(
+            [
+                "build",
+                "--workspace-root",
+                str(Path(__file__).resolve().parents[2]),
+                "--out-dir",
+                str(repeat_dir),
+                "--fixtures",
+                str(FIXTURE_DIR / "go-no-go-pass.json"),
+                "--generated-at",
+                DEFAULT_GENERATED_AT,
+            ]
+        )
+        build_command(repeat_args)
+        repeat_text = (repeat_dir / OUTPUT_JSON).read_text(encoding="utf-8")
+        if repeat_text != outputs["go-no-go-pass.json"]:
+            raise AssertionError("go/no-go dashboard JSON is not deterministic for fixed fixture inputs")
+        assert_supplied_waiver_file_errors_block_launch(root)
+        assert_protected_secret_values_are_scanned_and_redacted(root)
+    if not quiet:
+        print("production beta go/no-go dashboard self-test passed")
+
+
+def path_input_args_from_pass_fixture(root: Path, input_dir_name: str) -> tuple[tuple[tuple[str, str], ...], dict[str, Path]]:
+    pass_fixture = read_json(FIXTURE_DIR / "go-no-go-pass.json")
+    if not isinstance(pass_fixture, dict) or not isinstance(pass_fixture.get("inputs"), dict):
+        raise AssertionError("go-no-go-pass.json must contain path-test inputs")
+    inputs = pass_fixture["inputs"]
+    input_args = (
+        ("--production-beta-summary", "productionBetaSummary"),
+        ("--release-certification-summary", "releaseCertificationSummary"),
+        ("--ecosystem-matrix", "ecosystemMatrix"),
+        ("--app-platform-summary", "appPlatformSummary"),
+        ("--live-network-summary", "liveNetworkSummary"),
+        ("--network-scale-soak-summary", "networkScaleSoakSummary"),
+        ("--multi-node-beta-soak-summary", "multiNodeBetaSoakSummary"),
+        ("--security-response-summary", "securityResponseSummary"),
+    )
+    input_dir = root / input_dir_name
+    input_paths: dict[str, Path] = {}
+    for _flag, input_name in input_args:
+        value = inputs.get(input_name)
+        if not isinstance(value, dict):
+            raise AssertionError(f"go-no-go-pass.json missing {input_name}")
+        path = input_dir / f"{input_name}.json"
+        write_json(path, value)
+        input_paths[input_name] = path
+    return input_args, input_paths
+
+
+def assert_protected_secret_values_are_scanned_and_redacted(root: Path) -> None:
+    secret_name = "CRYPTAD_DASHBOARD_TEST_TOKEN"
+    secret_value = "dashboard-protected-secret-12345"
+    short_secret_name = "CRYPTAD_DASHBOARD_TEST_SHORT_TOKEN"
+    long_secret_name = "CRYPTAD_DASHBOARD_TEST_LONG_TOKEN"
+    short_secret_value = "dashboard-overlap-secret"
+    long_secret_suffix = "TAILLEAK12345"
+    long_secret_value = f"{short_secret_value}-{long_secret_suffix}"
+    previous = os.environ.get(secret_name)
+    previous_short = os.environ.get(short_secret_name)
+    previous_long = os.environ.get(long_secret_name)
+    os.environ[secret_name] = secret_value
+    os.environ[short_secret_name] = short_secret_value
+    os.environ[long_secret_name] = long_secret_value
+    try:
+        input_args, input_paths = path_input_args_from_pass_fixture(root, "protected-secret-inputs")
+        production_summary = read_json(input_paths["productionBetaSummary"])
+        if not isinstance(production_summary, dict):
+            raise AssertionError("productionBetaSummary path input is missing")
+        production_summary["status"] = "fail"
+        production_summary["promotionReady"] = False
+        production_summary["failures"] = [
+            f"dashboard input leaked {secret_value} without an environment variable name",
+            f"dashboard input leaked overlapping protected value {long_secret_value}",
+        ]
+        write_json(input_paths["productionBetaSummary"], production_summary)
+        out_dir = root / "protected-secret-output"
+        args_list = [
+            "build",
+            "--workspace-root",
+            str(root),
+            "--out-dir",
+            str(out_dir),
+            "--mode",
+            "production-beta",
+            "--generated-at",
+            DEFAULT_GENERATED_AT,
+        ]
+        for flag, input_name in input_args:
+            args_list.extend([flag, str(input_paths[input_name])])
+        dashboard, _exit_code = build_command(build_parser().parse_args(args_list))
+        finding_kinds = {
+            str(finding.get("kind"))
+            for finding in dashboard.get("redaction", {}).get("findings", [])
+            if isinstance(finding, dict)
+        }
+        if dashboard["decision"] != "no-go" or "protected-secret-value" not in finding_kinds:
+            raise AssertionError(f"protected secret value did not block dashboard: {dashboard}")
+        generated_text = (out_dir / OUTPUT_JSON).read_text(encoding="utf-8") + (out_dir / OUTPUT_MARKDOWN).read_text(encoding="utf-8")
+        if secret_value in generated_text:
+            raise AssertionError("dashboard artifacts leaked a protected secret value")
+        for forbidden in (short_secret_value, long_secret_value, long_secret_suffix):
+            if forbidden in generated_text:
+                raise AssertionError(f"dashboard artifacts leaked overlapping protected secret content: {forbidden}")
+    finally:
+        if previous is None:
+            os.environ.pop(secret_name, None)
+        else:
+            os.environ[secret_name] = previous
+        if previous_short is None:
+            os.environ.pop(short_secret_name, None)
+        else:
+            os.environ[short_secret_name] = previous_short
+        if previous_long is None:
+            os.environ.pop(long_secret_name, None)
+        else:
+            os.environ[long_secret_name] = previous_long
+
+
+def assert_supplied_waiver_file_errors_block_launch(root: Path) -> None:
+    input_args, input_paths = path_input_args_from_pass_fixture(root, "path-inputs")
+    waiver_cases = {
+        "missing": None,
+        "malformed": "{",
+        "non-object": "[]",
+    }
+    for case_name, content in waiver_cases.items():
+        waiver_path = root / f"{case_name}-waivers.json"
+        if content is not None:
+            write_text(waiver_path, content)
+        args_list = [
+            "build",
+            "--workspace-root",
+            str(root),
+            "--out-dir",
+            str(root / f"{case_name}-waiver-output"),
+            "--mode",
+            "production-beta",
+            "--generated-at",
+            DEFAULT_GENERATED_AT,
+            "--waivers",
+            str(waiver_path),
+        ]
+        for flag, input_name in input_args:
+            args_list.extend([flag, str(input_paths[input_name])])
+        dashboard, _exit_code = build_command(build_parser().parse_args(args_list))
+        if dashboard["decision"] != "no-go":
+            raise AssertionError(f"{case_name} waiver file expected no-go, got {dashboard['decision']}")
+        blocker_ids = {
+            str(blocker.get("evidenceId"))
+            for blocker in dashboard.get("blockers", [])
+            if isinstance(blocker, dict)
+        }
+        if "production-beta.waiver-validation" not in blocker_ids:
+            raise AssertionError(f"{case_name} waiver file did not produce a waiver-validation blocker: {dashboard}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--self-test", action="store_true", help="Run offline dashboard fixture tests.")
+    subparsers = parser.add_subparsers(dest="command")
+    build = subparsers.add_parser("build", help="Build dashboard artifacts.")
+    build.add_argument("--workspace-root", type=Path, default=Path.cwd())
+    build.add_argument("--out-dir", type=Path, required=True)
+    build.add_argument("--mode", choices=MODES, default=None)
+    build.add_argument("--release-id", default="")
+    build.add_argument("--generated-at", default="")
+    build.add_argument("--production-beta-summary", type=Path)
+    build.add_argument("--release-certification-summary", type=Path)
+    build.add_argument("--ecosystem-matrix", type=Path)
+    build.add_argument("--app-platform-summary", type=Path)
+    build.add_argument("--live-network-summary", type=Path)
+    build.add_argument("--network-scale-soak-summary", type=Path)
+    build.add_argument("--multi-node-beta-soak-summary", type=Path)
+    build.add_argument("--security-response-summary", type=Path)
+    build.add_argument("--waivers", type=Path)
+    build.add_argument("--fixtures", type=Path, help="Build from a checked-in dashboard fixture bundle.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.self_test:
+        run_self_test()
+        return 0
+    if args.command == "build":
+        dashboard, exit_code = build_command(args)
+        print(f"Production beta go/no-go dashboard {dashboard['decision']}: {args.out_dir / OUTPUT_JSON}")
+        return exit_code
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -280,6 +280,7 @@ NON_WAIVABLE_EVIDENCE_IDS = {
     "build.production-beta-complete",
     "workspace.clean-production-beta",
     "fixture-evidence.strict-mode",
+    "live.production-beta-skip",
 }
 
 REDACTION_FINDING_KINDS = {
@@ -2363,6 +2364,7 @@ def run_self_test(quiet: bool = False) -> None:
         "go-no-go-secret-value-redaction.json": "no-go",
         "go-no-go-underseverity-waiver.json": "no-go",
         "go-no-go-live-evidence-waiver-alias.json": "go-with-waivers",
+        "go-no-go-live-network-skip-waiver.json": "no-go",
         "go-no-go-release-candidate-live-disabled.json": "no-go",
         "go-no-go-malformed-non-release-status.json": "no-go",
     }
@@ -2428,6 +2430,13 @@ def run_self_test(quiet: bool = False) -> None:
                 }
                 if "live-network-beta.content-fetch" not in waived_evidence_ids:
                     raise AssertionError("live evidence alias waiver did not cover live-network evidence")
+            if fixture_name == "go-no-go-live-network-skip-waiver.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("live-network production-beta skip hard blocker was incorrectly waived")
+                if "live.production-beta-skip" not in blocker_ids:
+                    raise AssertionError("live-network production-beta skip did not block launch")
+                if "production-beta.waiver-validation" not in blocker_ids:
+                    raise AssertionError("live-network production-beta skip waiver did not fail validation")
             if fixture_name == "go-no-go-release-candidate-live-disabled.json":
                 if any(blocker_id.startswith("live-network-beta.") for blocker_id in blocker_ids):
                     raise AssertionError("disabled live-network evidence blocked release-candidate mode")

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -1954,6 +1954,7 @@ def release_certification_record_applies(record: dict[str, Any], mode: str) -> b
 def release_certification_waiver_records(
     summary: dict[str, Any] | None,
     mode: str,
+    now: dt.datetime,
     workspace_root: Path,
     out_dir: Path,
 ) -> list[Waiver]:
@@ -1973,14 +1974,26 @@ def release_certification_waiver_records(
         status = str(record.get("status", "approved")).strip().lower()
         expired = record.get("expired") is True
         applies = release_certification_record_applies(record, mode)
+        expires_at = str(record.get("expiresAt", "")).strip()
+        expiry = parse_time(expires_at)
         validation_error = str(record.get("validationError", "")).strip()
+        validation_errors: list[str] = []
+        if validation_error:
+            validation_errors.append(validation_error)
+        if not expires_at:
+            validation_errors.append("expiresAt is required")
+        elif expiry is None:
+            validation_errors.append("expiresAt must be an ISO-8601 timestamp")
+        elif expiry <= now:
+            validation_errors.append("waiver is expired")
         active = (
             record.get("active") is True
             and status == "approved"
             and not expired
             and applies
-            and not validation_error
+            and not validation_errors
         )
+        safe_errors = tuple(scrub_text(error, workspace_root, out_dir) for error in validation_errors)
         waivers.append(
             Waiver(
                 id=scrub_text(waiver_id or evidence_id or f"release-certification-waiver-{index}", workspace_root, out_dir),
@@ -1991,13 +2004,13 @@ def release_certification_waiver_records(
                 approved_by=scrub_text(str(record.get("approvedBy", "")).strip(), workspace_root, out_dir),
                 owner=scrub_text(str(record.get("owner", "release-certification")).strip() or "release-certification", workspace_root, out_dir),
                 created_at=scrub_text(str(record.get("createdAt", "")).strip(), workspace_root, out_dir),
-                expires_at=scrub_text(str(record.get("expiresAt", "")).strip(), workspace_root, out_dir),
+                expires_at=scrub_text(expires_at, workspace_root, out_dir),
                 references=(),
                 source=scrub_text(str(record.get("source", "release-certification")).strip() or "release-certification", workspace_root, out_dir),
                 active=active,
                 applies_to_mode=applies,
                 external_risk_accepted=False,
-                validation_errors=(validation_error,) if validation_error else (),
+                validation_errors=safe_errors,
             )
         )
     return waivers
@@ -2354,6 +2367,7 @@ def build_dashboard(
     imported_waivers = release_certification_waiver_records(
         inputs.get("releaseCertificationSummary") if isinstance(inputs.get("releaseCertificationSummary"), dict) else None,
         mode,
+        now,
         workspace_root,
         out_dir,
     )
@@ -2616,6 +2630,7 @@ def run_self_test(quiet: bool = False) -> None:
         "go-no-go-malformed-ecosystem-matrix-count.json": "no-go",
         "go-no-go-release-cert-schema-waiver.json": "go-with-waivers",
         "go-no-go-release-cert-applied-waiver.json": "go-with-waivers",
+        "go-no-go-release-cert-applied-waiver-expired.json": "no-go",
         "go-no-go-release-cert-applied-waiver-missing-record.json": "no-go",
         "go-no-go-artifact-gate-waiver.json": "no-go",
         "go-no-go-warning-redaction-findings.json": "no-go",
@@ -2716,6 +2731,11 @@ def run_self_test(quiet: bool = False) -> None:
                 }
                 if "release-certification.ecosystem-rc-gate" not in waived_evidence_ids:
                     raise AssertionError("already-applied release-certification waiver did not remain visible")
+            if fixture_name == "go-no-go-release-cert-applied-waiver-expired.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("expired release-certification waiver record was incorrectly counted")
+                if "production-beta.waiver-validation" not in blocker_ids:
+                    raise AssertionError("expired release-certification waiver record did not block the dashboard")
             if fixture_name == "go-no-go-release-cert-applied-waiver-missing-record.json":
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
                     raise AssertionError("missing release-certification waiver record was incorrectly counted")

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -1616,9 +1616,10 @@ def ecosystem_matrix_issues(matrix: dict[str, Any] | None) -> list[Issue]:
 def network_scale_issues(summary: dict[str, Any] | None, mode: str) -> list[Issue]:
     if not isinstance(summary, dict):
         return []
+    issues: list[Issue] = []
     status = normalize_status(summary.get("status"))
     if status != "pass":
-        return [
+        issues.append(
             Issue(
                 id="network-scale-soak.status",
                 evidence_id="network-scale.rc-soak-summary",
@@ -1630,7 +1631,7 @@ def network_scale_issues(summary: dict[str, Any] | None, mode: str) -> list[Issu
                 waivable=mode != "production-beta",
                 category="network-scale",
             )
-        ]
+        )
     findings = []
     for section, keys in (
         ("redaction", ("rawFetchedContentExcluded", "privateInsertUrisExcluded", "tokensExcluded", "absolutePathsExcluded", "queueHtmlExcluded")),
@@ -1640,7 +1641,7 @@ def network_scale_issues(summary: dict[str, Any] | None, mode: str) -> list[Issu
         if not isinstance(value, dict) or any(value.get(key) is not True for key in keys):
             findings.append(section)
     if findings:
-        return [
+        issues.append(
             Issue(
                 id="network-scale-soak.redaction-or-budget",
                 evidence_id="network-scale.redaction",
@@ -1652,8 +1653,8 @@ def network_scale_issues(summary: dict[str, Any] | None, mode: str) -> list[Issu
                 waivable=False,
                 category="redaction",
             )
-        ]
-    return []
+        )
+    return issues
 
 
 def multi_node_issues(summary: dict[str, Any] | None, mode: str) -> list[Issue]:
@@ -2361,6 +2362,7 @@ def run_self_test(quiet: bool = False) -> None:
         "go-no-go-missing-ecosystem-matrix-status.json": "no-go",
         "go-no-go-warning-ecosystem-matrix.json": "go",
         "go-no-go-malformed-ecosystem-matrix-count.json": "no-go",
+        "go-no-go-network-scale-redaction-waiver.json": "no-go",
         "go-no-go-secret-value-redaction.json": "no-go",
         "go-no-go-underseverity-waiver.json": "no-go",
         "go-no-go-live-evidence-waiver-alias.json": "go-with-waivers",
@@ -2448,6 +2450,18 @@ def run_self_test(quiet: bool = False) -> None:
             if fixture_name == "go-no-go-malformed-ecosystem-matrix-count.json":
                 if "release-certification.ecosystem-matrix" not in blocker_ids:
                     raise AssertionError("malformed ecosystem matrix releaseBlockerCount did not block launch")
+            if fixture_name == "go-no-go-network-scale-redaction-waiver.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
+                    raise AssertionError("network-scale status waiver was not recorded")
+                if "network-scale.redaction" not in blocker_ids:
+                    raise AssertionError("network-scale redaction failure was incorrectly waived")
+                waived_evidence_ids = {
+                    str(warning.get("evidenceId"))
+                    for warning in dashboard.get("warnings", [])
+                    if isinstance(warning, dict) and warning.get("waivedBy")
+                }
+                if "network-scale.rc-soak-summary" not in waived_evidence_ids:
+                    raise AssertionError("network-scale status waiver did not apply to the generic status issue")
             for artifact_name in (OUTPUT_JSON, OUTPUT_MARKDOWN, OUTPUT_REDACTION):
                 if not (out_dir / artifact_name).is_file():
                     raise AssertionError(f"{fixture_name} did not write {artifact_name}")

--- a/tools/release-certification/production_beta_release.py
+++ b/tools/release-certification/production_beta_release.py
@@ -3424,7 +3424,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--emergency-skip-build", action="store_true", help="Production-beta emergency/test escape hatch for skipped Gradle stages.")
     parser.add_argument("--allow-test-signing-in-production", action="store_true", help="Explicit test escape hatch; artifacts remain non-release.")
     parser.add_argument("--previous-summary", type=Path, help="Previous release-certification summary for history comparison.")
-    parser.add_argument("--waiver-file", type=Path, help="Structured release waiver JSON file.")
+    parser.add_argument("--waiver-file", type=Path, help="Structured release or go/no-go dashboard waiver JSON file.")
     parser.add_argument("--timeout-seconds", type=int, default=1800)
     parser.add_argument("--no-clean-out-dir", action="store_true", help="Do not remove an existing output directory before running.")
     return parser

--- a/tools/release-certification/production_beta_release.py
+++ b/tools/release-certification/production_beta_release.py
@@ -3168,7 +3168,31 @@ def dashboard_args(settings: Settings) -> list[str]:
     return args
 
 
+def clear_stale_go_no_go_dashboard_artifacts(out_dir: Path) -> list[str]:
+    failures: list[str] = []
+    for artifact in (
+        GO_NO_GO_DASHBOARD_JSON,
+        GO_NO_GO_DASHBOARD_MARKDOWN,
+        GO_NO_GO_REDACTION_REPORT,
+    ):
+        path = out_dir / artifact
+        try:
+            if path.is_dir() and not path.is_symlink():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            failures.append(f"Could not remove stale go/no-go dashboard artifact {artifact}: {exc}")
+    return failures
+
+
 def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> dict[str, Any]:
+    stale_clear_failures = clear_stale_go_no_go_dashboard_artifacts(state.settings.out_dir)
+    for failure in stale_clear_failures:
+        if failure not in state.failures:
+            state.failures.append(failure)
     result = run_command(
         state,
         "production-beta-go-no-go-dashboard",
@@ -3177,12 +3201,15 @@ def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> 
         allow_failure=True,
     )
     dashboard_path = state.settings.out_dir / GO_NO_GO_DASHBOARD_JSON
-    dashboard = read_json(dashboard_path)
+    dashboard = None if stale_clear_failures else read_json(dashboard_path)
     dashboard_missing = dashboard is None
     dashboard_failure: str | None = None
     if dashboard is None:
-        dashboard_failure = "Go/no-go dashboard did not generate a readable JSON artifact."
-        if result.exit_code != 0:
+        if stale_clear_failures:
+            dashboard_failure = "Go/no-go dashboard could not safely clear stale artifacts before regeneration."
+        else:
+            dashboard_failure = "Go/no-go dashboard did not generate a readable JSON artifact."
+        if result.exit_code != 0 and not stale_clear_failures:
             dashboard_failure = (
                 f"Go/no-go dashboard failed with exit code {result.exit_code} before producing a readable JSON artifact."
             )
@@ -4595,6 +4622,101 @@ def assert_missing_go_no_go_dashboard_fails_summary_and_exit() -> None:
         assert (out_dir / GO_NO_GO_REDACTION_REPORT).is_file(), attached
 
 
+def assert_stale_go_no_go_dashboard_is_not_reused() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-stale-dashboard-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        workspace.mkdir(parents=True)
+        out_dir = workspace / "build/production-beta"
+        settings = dataclasses.replace(
+            cleanup_test_settings(workspace, out_dir),
+            mode="production-beta",
+        )
+        state = PipelineState(settings, "self-test", utc_now(), [], [], [])
+        write_json(
+            out_dir / GO_NO_GO_DASHBOARD_JSON,
+            {
+                "decision": "go",
+                "promotionReady": True,
+                "summary": {"blockers": 0, "warnings": 0, "waiversUsed": 0, "criticalRedactionFindings": 0},
+                "blockers": [],
+                "redaction": {"status": "pass", "findings": []},
+            },
+        )
+        write_text(out_dir / GO_NO_GO_DASHBOARD_MARKDOWN, "Decision: `GO`\n")
+        write_json(
+            out_dir / GO_NO_GO_REDACTION_REPORT,
+            {
+                "schemaVersion": SCHEMA_VERSION,
+                "status": "pass",
+                "findingCount": 0,
+                "criticalFindingCount": 0,
+                "findings": [],
+            },
+        )
+        summary = build_final_summary(
+            state,
+            {
+                "status": "fail",
+                "promotionReady": False,
+                "nonRelease": False,
+                "failedGateCount": 1,
+                "gates": [
+                    {
+                        "id": "artifact-redaction",
+                        "status": "fail",
+                        "required": True,
+                        "summary": "Artifact redaction scan failed.",
+                    }
+                ],
+                "knownLimitations": [],
+            },
+            {
+                "schemaVersion": 1,
+                "status": "fail",
+                "scannedRoot": "<release-out>",
+                "findingCount": 1,
+                "findings": [{"kind": "raw-app-data", "path": "reports/production-beta-summary.json"}],
+            },
+            None,
+        )
+
+        def fake_run_command(
+            state: PipelineState,
+            name: str,
+            args: list[str],
+            env: dict[str, str] | None = None,
+            timeout_seconds: int = 0,
+            allow_failure: bool = False,
+        ) -> CommandResult:
+            del state, name, args, env, timeout_seconds, allow_failure
+            return CommandResult(
+                "production-beta-go-no-go-dashboard",
+                [],
+                23,
+                1,
+                "",
+                "failed before artifact write",
+            )
+
+        original_run_command = globals()["run_command"]
+        try:
+            globals()["run_command"] = fake_run_command
+            attached = attach_go_no_go_dashboard(state, summary)
+        finally:
+            globals()["run_command"] = original_run_command
+
+        assert attached["goNoGo"]["decision"] == "no-go", attached
+        assert attached["status"] == "fail", attached
+        assert attached["promotionReady"] is False, attached
+        assert release_exit_code(settings, attached) == 1, attached
+        regenerated_dashboard = read_json(out_dir / GO_NO_GO_DASHBOARD_JSON)
+        assert regenerated_dashboard is not None, attached
+        assert regenerated_dashboard["decision"] == "no-go", regenerated_dashboard
+        regenerated_markdown = (out_dir / GO_NO_GO_DASHBOARD_MARKDOWN).read_text(encoding="utf-8")
+        assert regenerated_markdown != "Decision: `GO`\n", regenerated_markdown
+        assert "did not produce a readable JSON artifact" in regenerated_markdown, regenerated_markdown
+
+
 def cleanup_test_settings(workspace: Path, out_dir: Path) -> Settings:
     return Settings(
         workspace_root=workspace,
@@ -5809,6 +5931,7 @@ def run_self_test() -> None:
     assert_certification_failure_marks_dry_run_failed()
     assert_release_candidate_no_go_dashboard_preserves_summary_and_exit()
     assert_missing_go_no_go_dashboard_fails_summary_and_exit()
+    assert_stale_go_no_go_dashboard_is_not_reused()
     assert_attached_multi_node_summary_is_extracted()
     assert_env_attached_multi_node_summary_is_extracted()
     assert_attached_multi_node_summary_is_not_marked_generated()

--- a/tools/release-certification/production_beta_release.py
+++ b/tools/release-certification/production_beta_release.py
@@ -3210,20 +3210,20 @@ def go_no_go_dashboard_artifact_failure(
     if missing_artifacts:
         return "Go/no-go dashboard did not generate a complete artifact set: " + ", ".join(missing_artifacts)
 
-    decision = str(dashboard.get("decision", "no-go"))
-    if decision not in {"go", "go-with-waivers"}:
-        return None
-    if result.exit_code != 0:
-        return f"Go/no-go dashboard returned launchable decision but exited with code {result.exit_code}."
     redaction_status = str(redaction_report.get("status", "missing"))
     if redaction_status != "pass":
-        return f"Go/no-go dashboard redaction report status is {redaction_status}; launchable decisions require pass."
+        return f"Go/no-go dashboard redaction report status is {redaction_status}; dashboard artifacts require pass."
     dashboard_redaction = dashboard.get("redaction")
     dashboard_redaction_status = (
         str(dashboard_redaction.get("status", "missing")) if isinstance(dashboard_redaction, dict) else "missing"
     )
     if dashboard_redaction_status != "pass":
-        return f"Go/no-go dashboard redaction status is {dashboard_redaction_status}; launchable decisions require pass."
+        return f"Go/no-go dashboard redaction status is {dashboard_redaction_status}; dashboard artifacts require pass."
+    decision = str(dashboard.get("decision", "no-go"))
+    if decision not in {"go", "go-with-waivers"}:
+        return None
+    if result.exit_code != 0:
+        return f"Go/no-go dashboard returned launchable decision but exited with code {result.exit_code}."
     return None
 
 
@@ -4835,6 +4835,93 @@ def assert_incomplete_go_no_go_dashboard_outputs_fail_summary_and_exit() -> None
         assert regenerated_dashboard["decision"] == "no-go", regenerated_dashboard
 
 
+def assert_failed_go_no_go_redaction_fails_summary_and_exit() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-dashboard-redaction-fail-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        workspace.mkdir(parents=True)
+        out_dir = workspace / "build/production-beta"
+        settings = dataclasses.replace(
+            cleanup_test_settings(workspace, out_dir),
+            mode="release-candidate",
+        )
+        state = PipelineState(settings, "self-test", utc_now(), [], [], [])
+        summary = build_final_summary(
+            state,
+            {
+                "status": "pass",
+                "promotionReady": False,
+                "nonRelease": True,
+                "failedGateCount": 0,
+                "gates": [],
+                "knownLimitations": [],
+            },
+            {
+                "schemaVersion": 1,
+                "status": "pass",
+                "scannedRoot": "<release-out>",
+                "findingCount": 0,
+                "findings": [],
+            },
+            None,
+        )
+
+        def fake_run_command(
+            state: PipelineState,
+            name: str,
+            args: list[str],
+            env: dict[str, str] | None = None,
+            timeout_seconds: int = 0,
+            allow_failure: bool = False,
+        ) -> CommandResult:
+            del name, args, env, timeout_seconds, allow_failure
+            redaction = {
+                "schemaVersion": SCHEMA_VERSION,
+                "status": "fail",
+                "findingCount": 1,
+                "criticalFindingCount": 1,
+                "findings": [
+                    {
+                        "kind": "protected-secret-value",
+                        "path": GO_NO_GO_DASHBOARD_JSON,
+                        "severity": "critical",
+                    }
+                ],
+            }
+            write_json(
+                state.settings.out_dir / GO_NO_GO_DASHBOARD_JSON,
+                {
+                    "decision": "no-go",
+                    "promotionReady": False,
+                    "summary": {"blockers": 1, "warnings": 0, "waiversUsed": 0, "criticalRedactionFindings": 1},
+                    "blockers": [
+                        {
+                            "id": "dashboard.redaction.scan",
+                            "evidenceId": "production-beta.dashboard-redaction",
+                            "severity": "critical",
+                            "summary": "Dashboard redaction scanner found 1 finding.",
+                        }
+                    ],
+                    "redaction": redaction,
+                },
+            )
+            write_text(state.settings.out_dir / GO_NO_GO_DASHBOARD_MARKDOWN, "Decision: `NO-GO`\n")
+            write_json(state.settings.out_dir / GO_NO_GO_REDACTION_REPORT, redaction)
+            return CommandResult("production-beta-go-no-go-dashboard", [], 1, 1, "", "")
+
+        original_run_command = globals()["run_command"]
+        try:
+            globals()["run_command"] = fake_run_command
+            attached = attach_go_no_go_dashboard(state, summary)
+        finally:
+            globals()["run_command"] = original_run_command
+
+        assert attached["goNoGo"]["decision"] == "no-go", attached
+        assert attached["status"] == "fail", attached
+        assert attached["promotionReady"] is False, attached
+        assert release_exit_code(settings, attached) == 1, attached
+        assert any("redaction report status is fail" in failure for failure in attached["failures"]), attached
+
+
 def cleanup_test_settings(workspace: Path, out_dir: Path) -> Settings:
     return Settings(
         workspace_root=workspace,
@@ -6051,6 +6138,7 @@ def run_self_test() -> None:
     assert_missing_go_no_go_dashboard_fails_summary_and_exit()
     assert_stale_go_no_go_dashboard_is_not_reused()
     assert_incomplete_go_no_go_dashboard_outputs_fail_summary_and_exit()
+    assert_failed_go_no_go_redaction_fails_summary_and_exit()
     assert_attached_multi_node_summary_is_extracted()
     assert_env_attached_multi_node_summary_is_extracted()
     assert_attached_multi_node_summary_is_not_marked_generated()

--- a/tools/release-certification/production_beta_release.py
+++ b/tools/release-certification/production_beta_release.py
@@ -3130,7 +3130,7 @@ def build_final_summary(
 def release_exit_code(settings: Settings, summary: dict[str, Any]) -> int:
     go_no_go = summary.get("goNoGo") if isinstance(summary.get("goNoGo"), dict) else {}
     decision = go_no_go.get("decision")
-    if settings.mode in {"release-candidate", "production-beta"} and decision in {"go", "go-with-waivers", "no-go"}:
+    if settings.mode == "production-beta" and decision in {"go", "go-with-waivers", "no-go"}:
         return 0 if decision in {"go", "go-with-waivers"} else 1
     if settings.mode == "developer-dry-run":
         return 0 if summary.get("status") == "pass" else 1
@@ -3178,7 +3178,16 @@ def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> 
     )
     dashboard_path = state.settings.out_dir / GO_NO_GO_DASHBOARD_JSON
     dashboard = read_json(dashboard_path)
+    dashboard_missing = dashboard is None
+    dashboard_failure: str | None = None
     if dashboard is None:
+        dashboard_failure = "Go/no-go dashboard did not generate a readable JSON artifact."
+        if result.exit_code != 0:
+            dashboard_failure = (
+                f"Go/no-go dashboard failed with exit code {result.exit_code} before producing a readable JSON artifact."
+            )
+        if dashboard_failure not in state.failures:
+            state.failures.append(dashboard_failure)
         dashboard = {
             "decision": "no-go",
             "promotionReady": False,
@@ -3188,15 +3197,38 @@ def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> 
                     "id": "production-beta.go-no-go-dashboard.missing",
                     "evidenceId": "production-beta.go-no-go-dashboard",
                     "severity": "blocker",
-                    "summary": "Go/no-go dashboard did not generate a readable JSON artifact.",
+                    "summary": dashboard_failure,
                 }
             ],
             "redaction": {"status": "missing", "findings": []},
         }
-        if result.exit_code != 0:
-            dashboard["blockers"][0]["summary"] = (
-                f"Go/no-go dashboard failed with exit code {result.exit_code}."
-            )
+        write_json(dashboard_path, dashboard)
+        write_text(
+            state.settings.out_dir / GO_NO_GO_DASHBOARD_MARKDOWN,
+            "\n".join(
+                [
+                    "# Production Beta Go/No-Go Dashboard",
+                    "",
+                    "Decision: `NO-GO`",
+                    "",
+                    "The go/no-go dashboard generator did not produce a readable JSON artifact.",
+                    "",
+                    f"- Failure: {dashboard_failure}",
+                    f"- Mode: `{state.settings.mode}`",
+                    "",
+                ]
+            ),
+        )
+        write_json(
+            state.settings.out_dir / GO_NO_GO_REDACTION_REPORT,
+            {
+                "schemaVersion": SCHEMA_VERSION,
+                "status": "missing",
+                "findingCount": 0,
+                "criticalFindingCount": 0,
+                "findings": [],
+            },
+        )
     failed_gate_ids = [
         str(gate.get("id", ""))
         for gate in summary.get("promotion", {}).get("gates", [])
@@ -3220,11 +3252,20 @@ def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> 
     }
     summary["goNoGo"] = go_no_go
     summary["commands"] = [dataclasses.asdict(command) for command in state.commands]
-    if go_no_go["decision"] == "no-go":
+    if dashboard_missing:
+        summary["status"] = "fail"
         summary["promotionReady"] = False
         if isinstance(summary.get("promotion"), dict):
             summary["promotion"]["promotionReady"] = False
-        if state.settings.mode != "developer-dry-run":
+        failures = summary.get("failures") if isinstance(summary.get("failures"), list) else []
+        if dashboard_failure and dashboard_failure not in failures:
+            failures.append(dashboard_failure)
+        summary["failures"] = failures
+    elif go_no_go["decision"] == "no-go":
+        summary["promotionReady"] = False
+        if isinstance(summary.get("promotion"), dict):
+            summary["promotion"]["promotionReady"] = False
+        if state.settings.mode == "production-beta":
             summary["status"] = "fail"
     elif state.settings.mode == "production-beta":
         summary["promotionReady"] = True
@@ -4348,7 +4389,13 @@ def assert_developer_dry_run_exit_code_fails_on_recorded_failures() -> None:
         summary = build_final_summary(
             state,
             {"status": "pass", "promotionReady": False, "nonRelease": True, "gates": [], "knownLimitations": []},
-            {"schemaVersion": 1, "status": "pass", "scannedRoot": "<release-out>", "findingCount": 0, "findings": []},
+            {
+                "schemaVersion": 1,
+                "status": "pass",
+                "scannedRoot": "<release-out>",
+                "findingCount": 0,
+                "findings": [],
+            },
             None,
         )
         assert summary["status"] == "fail", summary
@@ -4394,7 +4441,13 @@ def assert_certification_failure_marks_dry_run_failed() -> None:
         summary = build_final_summary(
             state,
             {"status": "fail", "promotionReady": False, "nonRelease": True, "gates": [], "knownLimitations": []},
-            {"schemaVersion": 1, "status": "pass", "scannedRoot": "<release-out>", "findingCount": 0, "findings": []},
+            {
+                "schemaVersion": 1,
+                "status": "pass",
+                "scannedRoot": "<release-out>",
+                "findingCount": 0,
+                "findings": [],
+            },
             None,
         )
         assert state.certification_exit_code == 17, state.certification_exit_code
@@ -4403,7 +4456,7 @@ def assert_certification_failure_marks_dry_run_failed() -> None:
         assert release_exit_code(settings, summary) == 1, summary
 
 
-def assert_strict_release_candidate_no_go_dashboard_fails_summary_and_exit() -> None:
+def assert_release_candidate_no_go_dashboard_preserves_summary_and_exit() -> None:
     with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-rc-dashboard-no-go-") as temp_name:
         workspace = Path(temp_name) / "repo"
         workspace.mkdir(parents=True)
@@ -4423,7 +4476,13 @@ def assert_strict_release_candidate_no_go_dashboard_fails_summary_and_exit() -> 
                 "gates": [],
                 "knownLimitations": [],
             },
-            {"schemaVersion": 1, "status": "pass", "scannedRoot": "<release-out>", "findingCount": 0, "findings": []},
+            {
+                "schemaVersion": 1,
+                "status": "pass",
+                "scannedRoot": "<release-out>",
+                "findingCount": 0,
+                "findings": [],
+            },
             None,
         )
         assert summary["status"] == "pass", summary
@@ -4464,9 +4523,76 @@ def assert_strict_release_candidate_no_go_dashboard_fails_summary_and_exit() -> 
             globals()["run_command"] = original_run_command
 
         assert attached["goNoGo"]["decision"] == "no-go", attached
+        assert attached["status"] == "pass", attached
+        assert attached["promotionReady"] is False, attached
+        assert release_exit_code(settings, attached) == 0, attached
+
+
+def assert_missing_go_no_go_dashboard_fails_summary_and_exit() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-missing-dashboard-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        workspace.mkdir(parents=True)
+        out_dir = workspace / "build/production-beta"
+        settings = dataclasses.replace(
+            cleanup_test_settings(workspace, out_dir),
+            mode="release-candidate",
+        )
+        state = PipelineState(settings, "self-test", utc_now(), [], [], [])
+        summary = build_final_summary(
+            state,
+            {
+                "status": "pass",
+                "promotionReady": False,
+                "nonRelease": True,
+                "failedGateCount": 0,
+                "gates": [],
+                "knownLimitations": [],
+            },
+            {
+                "schemaVersion": 1,
+                "status": "pass",
+                "scannedRoot": "<release-out>",
+                "findingCount": 0,
+                "findings": [],
+            },
+            None,
+        )
+
+        def fake_run_command(
+            state: PipelineState,
+            name: str,
+            args: list[str],
+            env: dict[str, str] | None = None,
+            timeout_seconds: int = 0,
+            allow_failure: bool = False,
+        ) -> CommandResult:
+            del state, name, args, env, timeout_seconds, allow_failure
+            return CommandResult(
+                "production-beta-go-no-go-dashboard",
+                [],
+                23,
+                1,
+                "",
+                "failed before artifact write",
+            )
+
+        original_run_command = globals()["run_command"]
+        try:
+            globals()["run_command"] = fake_run_command
+            attached = attach_go_no_go_dashboard(state, summary)
+        finally:
+            globals()["run_command"] = original_run_command
+
+        assert attached["goNoGo"]["decision"] == "no-go", attached
         assert attached["status"] == "fail", attached
         assert attached["promotionReady"] is False, attached
         assert release_exit_code(settings, attached) == 1, attached
+        assert any(
+            "before producing a readable JSON artifact" in failure for failure in attached["failures"]
+        ), attached
+        assert (out_dir / GO_NO_GO_DASHBOARD_JSON).is_file(), attached
+        assert (out_dir / GO_NO_GO_DASHBOARD_MARKDOWN).is_file(), attached
+        assert (out_dir / GO_NO_GO_REDACTION_REPORT).is_file(), attached
 
 
 def cleanup_test_settings(workspace: Path, out_dir: Path) -> Settings:
@@ -5681,7 +5807,8 @@ def run_self_test() -> None:
     assert_waived_critical_evidence_is_accepted_without_redaction_findings()
     assert_developer_dry_run_exit_code_fails_on_recorded_failures()
     assert_certification_failure_marks_dry_run_failed()
-    assert_strict_release_candidate_no_go_dashboard_fails_summary_and_exit()
+    assert_release_candidate_no_go_dashboard_preserves_summary_and_exit()
+    assert_missing_go_no_go_dashboard_fails_summary_and_exit()
     assert_attached_multi_node_summary_is_extracted()
     assert_env_attached_multi_node_summary_is_extracted()
     assert_attached_multi_node_summary_is_not_marked_generated()

--- a/tools/release-certification/production_beta_release.py
+++ b/tools/release-certification/production_beta_release.py
@@ -3188,6 +3188,45 @@ def clear_stale_go_no_go_dashboard_artifacts(out_dir: Path) -> list[str]:
     return failures
 
 
+def go_no_go_dashboard_artifact_failure(
+    settings: Settings,
+    dashboard: dict[str, Any] | None,
+    result: CommandResult,
+    stale_clear_failures: list[str],
+) -> str | None:
+    if stale_clear_failures:
+        return "Go/no-go dashboard could not safely clear stale artifacts before regeneration."
+    if dashboard is None:
+        if result.exit_code != 0:
+            return f"Go/no-go dashboard failed with exit code {result.exit_code} before producing a readable JSON artifact."
+        return "Go/no-go dashboard did not generate a readable JSON artifact."
+
+    missing_artifacts: list[str] = []
+    if not (settings.out_dir / GO_NO_GO_DASHBOARD_MARKDOWN).is_file():
+        missing_artifacts.append(GO_NO_GO_DASHBOARD_MARKDOWN)
+    redaction_report = read_json(settings.out_dir / GO_NO_GO_REDACTION_REPORT)
+    if redaction_report is None:
+        missing_artifacts.append(GO_NO_GO_REDACTION_REPORT)
+    if missing_artifacts:
+        return "Go/no-go dashboard did not generate a complete artifact set: " + ", ".join(missing_artifacts)
+
+    decision = str(dashboard.get("decision", "no-go"))
+    if decision not in {"go", "go-with-waivers"}:
+        return None
+    if result.exit_code != 0:
+        return f"Go/no-go dashboard returned launchable decision but exited with code {result.exit_code}."
+    redaction_status = str(redaction_report.get("status", "missing"))
+    if redaction_status != "pass":
+        return f"Go/no-go dashboard redaction report status is {redaction_status}; launchable decisions require pass."
+    dashboard_redaction = dashboard.get("redaction")
+    dashboard_redaction_status = (
+        str(dashboard_redaction.get("status", "missing")) if isinstance(dashboard_redaction, dict) else "missing"
+    )
+    if dashboard_redaction_status != "pass":
+        return f"Go/no-go dashboard redaction status is {dashboard_redaction_status}; launchable decisions require pass."
+    return None
+
+
 def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> dict[str, Any]:
     stale_clear_failures = clear_stale_go_no_go_dashboard_artifacts(state.settings.out_dir)
     for failure in stale_clear_failures:
@@ -3202,19 +3241,24 @@ def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> 
     )
     dashboard_path = state.settings.out_dir / GO_NO_GO_DASHBOARD_JSON
     dashboard = None if stale_clear_failures else read_json(dashboard_path)
-    dashboard_missing = dashboard is None
-    dashboard_failure: str | None = None
-    if dashboard is None:
-        if stale_clear_failures:
-            dashboard_failure = "Go/no-go dashboard could not safely clear stale artifacts before regeneration."
-        else:
-            dashboard_failure = "Go/no-go dashboard did not generate a readable JSON artifact."
-        if result.exit_code != 0 and not stale_clear_failures:
-            dashboard_failure = (
-                f"Go/no-go dashboard failed with exit code {result.exit_code} before producing a readable JSON artifact."
-            )
+    dashboard_failure = go_no_go_dashboard_artifact_failure(state.settings, dashboard, result, stale_clear_failures)
+    dashboard_missing = dashboard_failure is not None
+    if dashboard_missing:
         if dashboard_failure not in state.failures:
             state.failures.append(dashboard_failure)
+        redaction_path = state.settings.out_dir / GO_NO_GO_REDACTION_REPORT
+        existing_redaction = read_json(redaction_path)
+        fallback_redaction = (
+            existing_redaction
+            if existing_redaction is not None
+            else {
+                "schemaVersion": SCHEMA_VERSION,
+                "status": "missing",
+                "findingCount": 0,
+                "criticalFindingCount": 0,
+                "findings": [],
+            }
+        )
         dashboard = {
             "decision": "no-go",
             "promotionReady": False,
@@ -3227,7 +3271,7 @@ def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> 
                     "summary": dashboard_failure,
                 }
             ],
-            "redaction": {"status": "missing", "findings": []},
+            "redaction": fallback_redaction,
         }
         write_json(dashboard_path, dashboard)
         write_text(
@@ -3238,7 +3282,7 @@ def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> 
                     "",
                     "Decision: `NO-GO`",
                     "",
-                    "The go/no-go dashboard generator did not produce a readable JSON artifact.",
+                    "The go/no-go dashboard generator did not produce a complete, readable artifact set.",
                     "",
                     f"- Failure: {dashboard_failure}",
                     f"- Mode: `{state.settings.mode}`",
@@ -3246,16 +3290,8 @@ def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> 
                 ]
             ),
         )
-        write_json(
-            state.settings.out_dir / GO_NO_GO_REDACTION_REPORT,
-            {
-                "schemaVersion": SCHEMA_VERSION,
-                "status": "missing",
-                "findingCount": 0,
-                "criticalFindingCount": 0,
-                "findings": [],
-            },
-        )
+        if existing_redaction is None:
+            write_json(redaction_path, fallback_redaction)
     failed_gate_ids = [
         str(gate.get("id", ""))
         for gate in summary.get("promotion", {}).get("gates", [])
@@ -4540,6 +4576,17 @@ def assert_release_candidate_no_go_dashboard_preserves_summary_and_exit() -> Non
                     "redaction": {"status": "pass", "findings": []},
                 },
             )
+            write_text(state.settings.out_dir / GO_NO_GO_DASHBOARD_MARKDOWN, "Decision: `NO-GO`\n")
+            write_json(
+                state.settings.out_dir / GO_NO_GO_REDACTION_REPORT,
+                {
+                    "schemaVersion": SCHEMA_VERSION,
+                    "status": "pass",
+                    "findingCount": 0,
+                    "criticalFindingCount": 0,
+                    "findings": [],
+                },
+            )
             return CommandResult("production-beta-go-no-go-dashboard", [], 1, 1, "", "")
 
         original_run_command = globals()["run_command"]
@@ -4714,7 +4761,78 @@ def assert_stale_go_no_go_dashboard_is_not_reused() -> None:
         assert regenerated_dashboard["decision"] == "no-go", regenerated_dashboard
         regenerated_markdown = (out_dir / GO_NO_GO_DASHBOARD_MARKDOWN).read_text(encoding="utf-8")
         assert regenerated_markdown != "Decision: `GO`\n", regenerated_markdown
-        assert "did not produce a readable JSON artifact" in regenerated_markdown, regenerated_markdown
+        assert "before producing a readable JSON artifact" in regenerated_markdown, regenerated_markdown
+
+
+def assert_incomplete_go_no_go_dashboard_outputs_fail_summary_and_exit() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-incomplete-dashboard-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        workspace.mkdir(parents=True)
+        out_dir = workspace / "build/production-beta"
+        settings = dataclasses.replace(
+            cleanup_test_settings(workspace, out_dir),
+            mode="production-beta",
+        )
+        state = PipelineState(settings, "self-test", utc_now(), [], [], [])
+        summary = build_final_summary(
+            state,
+            {
+                "status": "pass",
+                "promotionReady": True,
+                "nonRelease": False,
+                "failedGateCount": 0,
+                "gates": [],
+                "knownLimitations": [],
+            },
+            {
+                "schemaVersion": 1,
+                "status": "pass",
+                "scannedRoot": "<release-out>",
+                "findingCount": 0,
+                "findings": [],
+            },
+            None,
+        )
+
+        def fake_run_command(
+            state: PipelineState,
+            name: str,
+            args: list[str],
+            env: dict[str, str] | None = None,
+            timeout_seconds: int = 0,
+            allow_failure: bool = False,
+        ) -> CommandResult:
+            del name, args, env, timeout_seconds, allow_failure
+            write_json(
+                state.settings.out_dir / GO_NO_GO_DASHBOARD_JSON,
+                {
+                    "decision": "go",
+                    "promotionReady": True,
+                    "summary": {"blockers": 0, "warnings": 0, "waiversUsed": 0, "criticalRedactionFindings": 0},
+                    "blockers": [],
+                    "redaction": {"status": "pass", "findings": []},
+                },
+            )
+            return CommandResult("production-beta-go-no-go-dashboard", [], 0, 1, "", "")
+
+        original_run_command = globals()["run_command"]
+        try:
+            globals()["run_command"] = fake_run_command
+            attached = attach_go_no_go_dashboard(state, summary)
+        finally:
+            globals()["run_command"] = original_run_command
+
+        assert attached["goNoGo"]["decision"] == "no-go", attached
+        assert attached["status"] == "fail", attached
+        assert attached["promotionReady"] is False, attached
+        assert release_exit_code(settings, attached) == 1, attached
+        assert any("complete artifact set" in failure for failure in attached["failures"]), attached
+        assert (out_dir / GO_NO_GO_DASHBOARD_JSON).is_file(), attached
+        assert (out_dir / GO_NO_GO_DASHBOARD_MARKDOWN).is_file(), attached
+        assert (out_dir / GO_NO_GO_REDACTION_REPORT).is_file(), attached
+        regenerated_dashboard = read_json(out_dir / GO_NO_GO_DASHBOARD_JSON)
+        assert regenerated_dashboard is not None, attached
+        assert regenerated_dashboard["decision"] == "no-go", regenerated_dashboard
 
 
 def cleanup_test_settings(workspace: Path, out_dir: Path) -> Settings:
@@ -5932,6 +6050,7 @@ def run_self_test() -> None:
     assert_release_candidate_no_go_dashboard_preserves_summary_and_exit()
     assert_missing_go_no_go_dashboard_fails_summary_and_exit()
     assert_stale_go_no_go_dashboard_is_not_reused()
+    assert_incomplete_go_no_go_dashboard_outputs_fail_summary_and_exit()
     assert_attached_multi_node_summary_is_extracted()
     assert_env_attached_multi_node_summary_is_extracted()
     assert_attached_multi_node_summary_is_not_marked_generated()

--- a/tools/release-certification/production_beta_release.py
+++ b/tools/release-certification/production_beta_release.py
@@ -49,6 +49,9 @@ CATALOG_CHANNELS = ("stable", "beta", "nightly", "deprecated")
 OUT_DIR_SENTINEL = ".cryptad-production-beta-release-output"
 PROTECTED_CLEAN_TOP_LEVELS = {".git", ".github", "apps", "docs", "tools"}
 RELEASE_OUTPUT_ROOTS = ("inputs", "build", "catalog", "reviews", "evidence", "reports")
+GO_NO_GO_DASHBOARD_JSON = "reports/go-no-go-dashboard.json"
+GO_NO_GO_DASHBOARD_MARKDOWN = "reports/go-no-go-dashboard.md"
+GO_NO_GO_REDACTION_REPORT = "reports/go-no-go-redaction-report.json"
 PLACEHOLDER_ARTIFACT_HOSTS = {"downloads.crypta.invalid"}
 LOCAL_ARTIFACT_HOSTS = {"127.0.0.1", "localhost", "::1", "0:0:0:0:0:0:0:1"}
 PRIVATE_ARTIFACT_HOST_SUFFIXES = (
@@ -2864,6 +2867,17 @@ def render_markdown_summary(summary: dict[str, Any]) -> str:
     ]
     for name, path in summary.get("artifacts", {}).items():
         lines.append(f"- `{name}`: `{path}`")
+    go_no_go = summary.get("goNoGo", {})
+    if isinstance(go_no_go, dict) and go_no_go:
+        lines.extend(["", "## Go/No-Go Dashboard", ""])
+        lines.append(f"- Decision: `{go_no_go.get('decision', 'pending')}`")
+        lines.append(f"- Basis: `{go_no_go.get('basis', 'missing')}`")
+        lines.append(f"- Dashboard JSON: `{go_no_go.get('dashboardJson', GO_NO_GO_DASHBOARD_JSON)}`")
+        lines.append(
+            f"- Dashboard Markdown: `{go_no_go.get('dashboardMarkdown', GO_NO_GO_DASHBOARD_MARKDOWN)}`"
+        )
+        lines.append(f"- Redaction report: `{go_no_go.get('redactionReport', GO_NO_GO_REDACTION_REPORT)}`")
+        lines.append(f"- Waivers used: `{go_no_go.get('waiversUsed', 0)}`")
     multi_node = summary.get("multiNodeBetaSoak", {})
     if isinstance(multi_node, dict) and multi_node:
         lines.extend(["", "## Multi-node Beta Soak", ""])
@@ -3039,6 +3053,9 @@ def build_final_summary(
         "multiNodeBetaSoak": "evidence/multi-node-beta-soak.json",
         "ecosystemCertification": "evidence/ecosystem-rc-certification.json",
         "redactionReport": "reports/redaction-report.json",
+        "goNoGoDashboard": GO_NO_GO_DASHBOARD_JSON,
+        "goNoGoDashboardReport": GO_NO_GO_DASHBOARD_MARKDOWN,
+        "goNoGoRedactionReport": GO_NO_GO_REDACTION_REPORT,
     }
     if archive is not None:
         artifacts["distArchive"] = f"dist/{archive.name}"
@@ -3096,13 +3113,127 @@ def build_final_summary(
         "redaction": redaction_report,
         "commands": [dataclasses.asdict(command) for command in state.commands],
         "artifacts": artifacts,
+        "goNoGo": {
+            "decision": "pending",
+            "basis": "dashboard-not-generated",
+            "dashboardJson": GO_NO_GO_DASHBOARD_JSON,
+            "dashboardMarkdown": GO_NO_GO_DASHBOARD_MARKDOWN,
+            "redactionReport": GO_NO_GO_REDACTION_REPORT,
+            "blockingGateIds": [],
+            "failedGateCount": int(final_promotion.get("failedGateCount", 0)),
+            "redactionStatus": redaction_report.get("status", "missing"),
+            "nonRelease": final_promotion.get("nonRelease", True),
+        },
     }
 
 
 def release_exit_code(settings: Settings, summary: dict[str, Any]) -> int:
+    go_no_go = summary.get("goNoGo") if isinstance(summary.get("goNoGo"), dict) else {}
+    decision = go_no_go.get("decision")
+    if settings.mode in {"release-candidate", "production-beta"} and decision in {"go", "go-with-waivers", "no-go"}:
+        return 0 if decision in {"go", "go-with-waivers"} else 1
     if settings.mode == "developer-dry-run":
         return 0 if summary.get("status") == "pass" else 1
     return 0 if summary.get("status") == "pass" and (settings.mode != "production-beta" or summary.get("promotionReady") is True) else 1
+
+
+def dashboard_args(settings: Settings) -> list[str]:
+    args = [
+        sys.executable,
+        str(TOOL_DIR / "production_beta_go_no_go_dashboard.py"),
+        "build",
+        "--workspace-root",
+        str(settings.workspace_root),
+        "--out-dir",
+        str(settings.out_dir / "reports"),
+        "--mode",
+        settings.mode,
+        "--production-beta-summary",
+        str(settings.out_dir / "reports/production-beta-summary.json"),
+        "--release-certification-summary",
+        str(settings.out_dir / "evidence/ecosystem-rc-certification.json"),
+        "--ecosystem-matrix",
+        str(settings.out_dir / "evidence/ecosystem-certification-matrix.json"),
+        "--app-platform-summary",
+        str(settings.out_dir / "evidence/app-platform-smoke.json"),
+        "--live-network-summary",
+        str(settings.out_dir / "evidence/live-network-beta-smoke.json"),
+        "--network-scale-soak-summary",
+        str(settings.out_dir / "evidence/network-scale-soak.json"),
+        "--multi-node-beta-soak-summary",
+        str(settings.out_dir / "evidence/multi-node-beta-soak.json"),
+    ]
+    if settings.waiver_file:
+        args.extend(["--waivers", str(settings.waiver_file)])
+    return args
+
+
+def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> dict[str, Any]:
+    result = run_command(
+        state,
+        "production-beta-go-no-go-dashboard",
+        dashboard_args(state.settings),
+        timeout_seconds=120,
+        allow_failure=True,
+    )
+    dashboard_path = state.settings.out_dir / GO_NO_GO_DASHBOARD_JSON
+    dashboard = read_json(dashboard_path)
+    if dashboard is None:
+        dashboard = {
+            "decision": "no-go",
+            "promotionReady": False,
+            "summary": {"blockers": 1, "warnings": 0, "waiversUsed": 0, "criticalRedactionFindings": 0},
+            "blockers": [
+                {
+                    "id": "production-beta.go-no-go-dashboard.missing",
+                    "evidenceId": "production-beta.go-no-go-dashboard",
+                    "severity": "blocker",
+                    "summary": "Go/no-go dashboard did not generate a readable JSON artifact.",
+                }
+            ],
+            "redaction": {"status": "missing", "findings": []},
+        }
+        if result.exit_code != 0:
+            dashboard["blockers"][0]["summary"] = (
+                f"Go/no-go dashboard failed with exit code {result.exit_code}."
+            )
+    failed_gate_ids = [
+        str(gate.get("id", ""))
+        for gate in summary.get("promotion", {}).get("gates", [])
+        if isinstance(gate, dict) and gate.get("status") != "pass"
+    ]
+    go_no_go = {
+        "decision": str(dashboard.get("decision", "no-go")),
+        "basis": "production-beta-go-no-go-dashboard",
+        "dashboardJson": GO_NO_GO_DASHBOARD_JSON,
+        "dashboardMarkdown": GO_NO_GO_DASHBOARD_MARKDOWN,
+        "redactionReport": GO_NO_GO_REDACTION_REPORT,
+        "blockingGateIds": failed_gate_ids,
+        "failedGateCount": int(summary.get("promotion", {}).get("failedGateCount", len(failed_gate_ids))),
+        "redactionStatus": str(dashboard.get("redaction", {}).get("status", "missing"))
+        if isinstance(dashboard.get("redaction"), dict)
+        else "missing",
+        "nonRelease": bool(summary.get("nonRelease", True)),
+        "waiversUsed": int(dashboard.get("summary", {}).get("waiversUsed", 0))
+        if isinstance(dashboard.get("summary"), dict)
+        else 0,
+    }
+    summary["goNoGo"] = go_no_go
+    summary["commands"] = [dataclasses.asdict(command) for command in state.commands]
+    if go_no_go["decision"] == "no-go":
+        summary["promotionReady"] = False
+        if isinstance(summary.get("promotion"), dict):
+            summary["promotion"]["promotionReady"] = False
+        if state.settings.mode != "developer-dry-run":
+            summary["status"] = "fail"
+    elif state.settings.mode == "production-beta":
+        summary["promotionReady"] = True
+        if isinstance(summary.get("promotion"), dict):
+            summary["promotion"]["promotionReady"] = True
+        summary["status"] = "pass"
+    write_json(state.settings.out_dir / "reports/production-beta-summary.json", summary)
+    write_text(state.settings.out_dir / "reports/production-beta-summary.md", render_markdown_summary(summary))
+    return summary
 
 
 def run_pipeline(settings: Settings) -> tuple[dict[str, Any], int]:
@@ -3172,6 +3303,7 @@ def run_pipeline(settings: Settings) -> tuple[dict[str, Any], int]:
             summary = build_final_summary(state, promotion, redaction_report, archive)
             write_json(settings.out_dir / "reports/production-beta-summary.json", summary)
             write_text(settings.out_dir / "reports/production-beta-summary.md", render_markdown_summary(summary))
+            summary = attach_go_no_go_dashboard(state, summary)
             archive = create_dist_bundle(settings, version)
             tar_findings = scan_tarball(archive, settings)
             if tar_findings:
@@ -3192,6 +3324,7 @@ def run_pipeline(settings: Settings) -> tuple[dict[str, Any], int]:
             summary = build_final_summary(state, promotion, redaction_report, archive)
             write_json(settings.out_dir / "reports/production-beta-summary.json", summary)
             write_text(settings.out_dir / "reports/production-beta-summary.md", render_markdown_summary(summary))
+            summary = attach_go_no_go_dashboard(state, summary)
         return summary, release_exit_code(settings, summary)
 
 
@@ -4268,6 +4401,72 @@ def assert_certification_failure_marks_dry_run_failed() -> None:
         assert "release-certification failed with exit code 17" in state.failures, state.failures
         assert summary["status"] == "fail", summary
         assert release_exit_code(settings, summary) == 1, summary
+
+
+def assert_strict_release_candidate_no_go_dashboard_fails_summary_and_exit() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-rc-dashboard-no-go-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        workspace.mkdir(parents=True)
+        out_dir = workspace / "build/production-beta"
+        settings = dataclasses.replace(
+            cleanup_test_settings(workspace, out_dir),
+            mode="release-candidate",
+        )
+        state = PipelineState(settings, "self-test", utc_now(), [], [], [])
+        summary = build_final_summary(
+            state,
+            {
+                "status": "pass",
+                "promotionReady": False,
+                "nonRelease": True,
+                "failedGateCount": 0,
+                "gates": [],
+                "knownLimitations": [],
+            },
+            {"schemaVersion": 1, "status": "pass", "scannedRoot": "<release-out>", "findingCount": 0, "findings": []},
+            None,
+        )
+        assert summary["status"] == "pass", summary
+
+        def fake_run_command(
+            state: PipelineState,
+            name: str,
+            args: list[str],
+            env: dict[str, str] | None = None,
+            timeout_seconds: int = 0,
+            allow_failure: bool = False,
+        ) -> CommandResult:
+            del name, args, env, timeout_seconds, allow_failure
+            write_json(
+                state.settings.out_dir / GO_NO_GO_DASHBOARD_JSON,
+                {
+                    "decision": "no-go",
+                    "promotionReady": False,
+                    "summary": {"blockers": 1, "warnings": 0, "waiversUsed": 0, "criticalRedactionFindings": 0},
+                    "blockers": [
+                        {
+                            "id": "waiver.file.invalid",
+                            "evidenceId": "production-beta.waiver-validation",
+                            "severity": "blocker",
+                            "summary": "Waiver file is invalid.",
+                        }
+                    ],
+                    "redaction": {"status": "pass", "findings": []},
+                },
+            )
+            return CommandResult("production-beta-go-no-go-dashboard", [], 1, 1, "", "")
+
+        original_run_command = globals()["run_command"]
+        try:
+            globals()["run_command"] = fake_run_command
+            attached = attach_go_no_go_dashboard(state, summary)
+        finally:
+            globals()["run_command"] = original_run_command
+
+        assert attached["goNoGo"]["decision"] == "no-go", attached
+        assert attached["status"] == "fail", attached
+        assert attached["promotionReady"] is False, attached
+        assert release_exit_code(settings, attached) == 1, attached
 
 
 def cleanup_test_settings(workspace: Path, out_dir: Path) -> Settings:
@@ -5482,6 +5681,7 @@ def run_self_test() -> None:
     assert_waived_critical_evidence_is_accepted_without_redaction_findings()
     assert_developer_dry_run_exit_code_fails_on_recorded_failures()
     assert_certification_failure_marks_dry_run_failed()
+    assert_strict_release_candidate_no_go_dashboard_fails_summary_and_exit()
     assert_attached_multi_node_summary_is_extracted()
     assert_env_attached_multi_node_summary_is_extracted()
     assert_attached_multi_node_summary_is_not_marked_generated()
@@ -5555,11 +5755,16 @@ def run_self_test() -> None:
             "reports/production-beta-summary.json",
             "reports/production-beta-summary.md",
             "reports/redaction-report.json",
+            GO_NO_GO_DASHBOARD_JSON,
+            GO_NO_GO_DASHBOARD_MARKDOWN,
+            GO_NO_GO_REDACTION_REPORT,
         ):
             assert (out_dir / required).exists(), required
         assert summary["nonRelease"] is True, summary
         assert summary["signingProfile"]["kind"] == "test-fixture", summary
         assert summary["promotionReady"] is False, summary
+        assert summary["goNoGo"]["decision"] == "no-go", summary
+        assert summary["artifacts"]["goNoGoDashboard"] == GO_NO_GO_DASHBOARD_JSON, summary
         archive_rel = summary["artifacts"].get("distArchive")
         assert archive_rel == f"dist/crypta-production-beta-{summary['version']}.tar.gz", summary
         with tarfile.open(out_dir / archive_rel, "r:gz") as archive:
@@ -5569,6 +5774,7 @@ def run_self_test() -> None:
         assert archived_summary["artifacts"]["distArchive"] == archive_rel, archived_summary
         assert archived_summary["artifacts"]["checksums"] == "dist/checksums.txt", archived_summary
         assert archived_summary["redaction"]["status"] == "pass", archived_summary
+        assert archived_summary["goNoGo"]["dashboardJson"] == GO_NO_GO_DASHBOARD_JSON, archived_summary
 
     assert_redaction_fails(
         "private-insert-uri",

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -853,14 +853,27 @@ def parse_expiry(value: str) -> dt.datetime | None:
     return parsed.astimezone(dt.timezone.utc)
 
 
+def waiver_scope_allows_release_candidate(scope: str) -> bool:
+    normalized = scope.strip().lower()
+    return normalized in {
+        "all",
+        "all-modes",
+        "any",
+        "release-candidate",
+        "release-candidate-only",
+        "release-candidate-and-production-beta",
+    }
+
+
 def load_structured_waiver_file(path: Path, settings: Settings, now: dt.datetime) -> tuple[list[WaiverRecord], list[str]]:
     source = display_path(path, settings.workspace_root, settings.out_dir)
     value = read_json(path)
     if value is None:
         return [], [f"Waiver file {source} is missing or malformed."]
     records = value.get("waivers", [])
-    if value.get("version") != 1 or not isinstance(records, list):
-        return [], [f"Waiver file {source} must use version 1 and a waivers array."]
+    schema_version = value.get("version", value.get("schemaVersion"))
+    if schema_version != 1 or not isinstance(records, list):
+        return [], [f"Waiver file {source} must use version/schemaVersion 1 and a waivers array."]
     loaded: list[WaiverRecord] = []
     errors: list[str] = []
     for index, entry in enumerate(records):
@@ -869,14 +882,19 @@ def load_structured_waiver_file(path: Path, settings: Settings, now: dt.datetime
             continue
         waiver_id = str(entry.get("id", "")).strip()
         evidence_id = str(entry.get("evidenceId", waiver_id)).strip()
-        reason = str(entry.get("reason", "")).strip()
-        raw_status = str(entry.get("status", "")).strip().lower()
+        reason = str(entry.get("reason", entry.get("rationale", ""))).strip()
+        dashboard_style = "rationale" in entry or "scope" in entry or "owner" in entry or "severity" in entry
+        raw_status = str(entry.get("status", "approved" if dashboard_style else "")).strip().lower()
         status = raw_status if raw_status == "approved" else ("pending" if not raw_status else "invalid")
         approved_by = str(entry.get("approvedBy", "")).strip()
         raw_expires_at = str(entry.get("expiresAt", "")).strip()
+        allow_release_candidate_present = "allowReleaseCandidate" in entry
         allow_release_candidate_value = entry.get("allowReleaseCandidate", False)
+        scope = str(entry.get("scope", "")).strip()
         allow_release_candidate = (
-            allow_release_candidate_value if isinstance(allow_release_candidate_value, bool) else False
+            allow_release_candidate_value
+            if allow_release_candidate_present and isinstance(allow_release_candidate_value, bool)
+            else waiver_scope_allows_release_candidate(scope)
         )
         validation_errors: list[str] = []
         if not waiver_id:
@@ -887,7 +905,7 @@ def load_structured_waiver_file(path: Path, settings: Settings, now: dt.datetime
             validation_errors.append("reason is required")
         if status != "approved":
             validation_errors.append("status must be approved")
-        if not isinstance(allow_release_candidate_value, bool):
+        if allow_release_candidate_present and not isinstance(allow_release_candidate_value, bool):
             validation_errors.append("allowReleaseCandidate must be a boolean")
         expiry = parse_expiry(raw_expires_at)
         if raw_expires_at and expiry is None:
@@ -10977,6 +10995,45 @@ def run_self_test(repo_root: Path) -> None:
         waived_encoded = json.dumps(waived_sandbox_summary, sort_keys=True) + waived_report
         for forbidden in ("hunter2", str(workspace)):
             assert forbidden not in waived_encoded, f"structured waiver leaked {forbidden}"
+
+        dashboard_waiver_file_path = workspace / "docs/release-waivers/dashboard-schema.json"
+        write_json(
+            dashboard_waiver_file_path,
+            {
+                "schemaVersion": 1,
+                "releaseId": "self-test",
+                "waivers": [
+                    {
+                        "id": "waiver-ecosystem-sandbox-provider-dashboard-schema",
+                        "evidenceId": "ecosystem.sandbox-provider",
+                        "severity": "blocker",
+                        "scope": "release-candidate",
+                        "rationale": "Release manager accepted the sandbox provider evidence gap.",
+                        "approvedBy": "release-manager",
+                        "owner": "release-engineering",
+                        "createdAt": "2026-06-24T00:00:00Z",
+                        "expiresAt": "2099-01-01T00:00:00Z",
+                        "references": ["self-test"],
+                    }
+                ],
+            },
+        )
+        dashboard_waived_summary, dashboard_waived_exit_code = run_with_previous(
+            "dashboard-waiver-schema-cert",
+            app_platform_summary=sandbox_best_effort_path,
+            waiver_files=(dashboard_waiver_file_path,),
+        )
+        assert dashboard_waived_exit_code == 0, dashboard_waived_summary
+        assert dashboard_waived_summary["status"] == "warn", dashboard_waived_summary
+        assert len(dashboard_waived_summary["waiverRecords"]) == 1, dashboard_waived_summary
+        dashboard_waived_record = dashboard_waived_summary["waiverRecords"][0]
+        assert dashboard_waived_record["allowReleaseCandidate"] is True, dashboard_waived_record
+        assert dashboard_waived_record["reason"] == (
+            "Release manager accepted the sandbox provider evidence gap."
+        ), dashboard_waived_record
+        dashboard_waived_gate = gate_by_id(dashboard_waived_summary, "ecosystem.sandbox-provider")
+        assert dashboard_waived_gate["status"] == "warn", dashboard_waived_gate
+        assert dashboard_waived_gate["details"]["waived"] is True, dashboard_waived_gate
 
         malformed_rc_waiver_file_path = workspace / "docs/release-waivers/nonboolean.json"
         write_json(

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -26,6 +26,7 @@ from typing import Any
 sys.dont_write_bytecode = True
 import app_platform_docs_check
 import multi_node_beta_soak
+import production_beta_go_no_go_dashboard
 
 
 TOOL_NAME = "release-certification"
@@ -42,6 +43,7 @@ ECOSYSTEM_MATRIX_SCHEMA_VERSION = 1
 CERT_STATUSES = ("pass", "warn", "fail", "skip", "missing")
 MODES = ("pr", "nightly", "release-candidate")
 PRIVATE_ARTIFACT_NAMES = ("private-insert-uris.json",)
+PRODUCTION_BETA_GO_NO_GO_SELF_TEST_RESULT: tuple[bool, str] | None = None
 PUBLIC_BETA_SECURITY_EVIDENCE_IDS = (
     "public-beta-security.app-ui-csp",
     "public-beta-security.app-origin-policy",
@@ -166,6 +168,7 @@ MULTI_NODE_BETA_SCENARIO_EVIDENCE_IDS = multi_node_beta_soak.SCENARIO_EVIDENCE_I
 ECOSYSTEM_RC_GATE_ID = "ecosystem.rc-certification"
 ECOSYSTEM_RC_EVIDENCE_ID = "release-certification.ecosystem-rc-gate"
 ECOSYSTEM_RC_MATRIX_ROW_ID = "ecosystem-rc-certification-gate"
+PRODUCTION_BETA_GO_NO_GO_EVIDENCE_IDS = production_beta_go_no_go_dashboard.DASHBOARD_EVIDENCE_IDS
 APP_SERVICE_DEPENDENCY_AND_GRANT_BUNDLE_EVIDENCE_IDS = (
     "app-services.dependency-graph",
     "app-services.grant-bundles",
@@ -209,6 +212,7 @@ ECOSYSTEM_RC_REQUIRED_EVIDENCE_IDS = (
     "interop.smoke",
     "performance.smoke",
     "release-certification.ecosystem-matrix",
+    *PRODUCTION_BETA_GO_NO_GO_EVIDENCE_IDS,
     "platform-api.contract",
     *PLATFORM_API_STABLE_FREEZE_EVIDENCE_IDS,
     "app-platform.first-party",
@@ -2036,6 +2040,84 @@ def app_platform_docs_evidence(workspace_root: Path, out_dir: Path) -> list[Evid
     return items
 
 
+def production_beta_go_no_go_evidence(workspace_root: Path, out_dir: Path) -> list[EvidenceItem]:
+    global PRODUCTION_BETA_GO_NO_GO_SELF_TEST_RESULT
+    generator_path = Path(production_beta_go_no_go_dashboard.__file__).resolve()
+    fixture_dir = Path(production_beta_go_no_go_dashboard.FIXTURE_DIR).resolve()
+    source = display_path(generator_path, workspace_root, out_dir)
+    fixture_names = (
+        "go-no-go-pass.json",
+        "go-no-go-no-go.json",
+        "go-no-go-with-waivers.json",
+        "go-no-go-expired-waiver.json",
+        "go-no-go-critical-redaction.json",
+        "go-no-go-test-signing-production.json",
+    )
+    fixture_paths = [fixture_dir / fixture_name for fixture_name in fixture_names]
+    generator_exists = generator_path.is_file()
+    fixtures_present = all(path.is_file() for path in fixture_paths)
+    self_test_passed = False
+    error = ""
+    if generator_exists and fixtures_present:
+        if PRODUCTION_BETA_GO_NO_GO_SELF_TEST_RESULT is None:
+            try:
+                production_beta_go_no_go_dashboard.run_self_test(quiet=True)
+                PRODUCTION_BETA_GO_NO_GO_SELF_TEST_RESULT = (True, "")
+            except SystemExit as exception:
+                code = exception.code if exception.code is not None else "unknown"
+                PRODUCTION_BETA_GO_NO_GO_SELF_TEST_RESULT = (
+                    False,
+                    f"dashboard self-test exited with {code}",
+                )
+            except Exception as exception:  # noqa: BLE001 - release evidence must degrade to redacted failure.
+                PRODUCTION_BETA_GO_NO_GO_SELF_TEST_RESULT = (False, str(exception))
+        self_test_passed, raw_error = PRODUCTION_BETA_GO_NO_GO_SELF_TEST_RESULT
+        error = scrub_text(raw_error, workspace_root, out_dir) if raw_error else ""
+    checks = {
+        "generatorExists": generator_exists,
+        "fixturesPresent": fixtures_present,
+        "selfTestPasses": self_test_passed,
+        "jsonMarkdownArtifactsCovered": self_test_passed,
+        "waiverValidationCovered": self_test_passed,
+        "redactionScanningCovered": self_test_passed,
+        "noGoCriticalFailuresCovered": self_test_passed,
+        "goWithWaiversCovered": self_test_passed,
+        "goCovered": self_test_passed,
+    }
+    status = "pass" if all(checks.values()) else "fail"
+    details: dict[str, Any] = {
+        "checks": checks,
+        "fixtureCount": len(fixture_names),
+        "outputFiles": [
+            production_beta_go_no_go_dashboard.OUTPUT_JSON,
+            production_beta_go_no_go_dashboard.OUTPUT_MARKDOWN,
+            production_beta_go_no_go_dashboard.OUTPUT_REDACTION,
+        ],
+        "decisions": list(production_beta_go_no_go_dashboard.DECISIONS),
+    }
+    if error:
+        details["error"] = error
+
+    summaries = {
+        "production-beta.go-no-go-dashboard": "Go/no-go dashboard generator and fixture self-test passed.",
+        "production-beta.go-no-go-decision": "Go, no-go, and go-with-waivers decision fixtures passed.",
+        "production-beta.waiver-validation": "Waiver validation fixtures passed.",
+        "production-beta.dashboard-redaction": "Dashboard redaction negative fixture passed.",
+        "production-beta.launch-artifact-hygiene": "Launch artifact hygiene fixture coverage passed.",
+    }
+    return [
+        EvidenceItem(
+            evidence_id,
+            status,
+            True,
+            summaries[evidence_id] if status == "pass" else "Go/no-go dashboard self-test failed.",
+            source,
+            details,
+        )
+        for evidence_id in PRODUCTION_BETA_GO_NO_GO_EVIDENCE_IDS
+    ]
+
+
 def command_output(args: list[str], cwd: Path) -> str:
     try:
         completed = subprocess.run(
@@ -2587,6 +2669,19 @@ def ecosystem_matrix_row_specs() -> list[MatrixRowSpec]:
                 "tools/release-certification/README.md",
             ),
             phase="phase-9",
+        ),
+        MatrixRowSpec(
+            id="production-beta-go-no-go-dashboard",
+            category="release-operations",
+            title="Production beta go/no-go dashboard",
+            required_evidence_ids=PRODUCTION_BETA_GO_NO_GO_EVIDENCE_IDS,
+            docs=(
+                "docs/production-beta-go-no-go-dashboard.md",
+                "docs/production-beta-release-pipeline.md",
+                "docs/release-certification.md",
+                "tools/release-certification/README.md",
+            ),
+            phase="phase-10",
         ),
         MatrixRowSpec(
             id="interop-smoke",
@@ -7569,6 +7664,7 @@ def gather_evidence(settings: Settings, waiver_context: WaiverContext) -> list[E
         )
     )
     evidence.extend(app_platform_docs_evidence(settings.workspace_root, settings.out_dir))
+    evidence.extend(production_beta_go_no_go_evidence(settings.workspace_root, settings.out_dir))
     return [
         sanitize_evidence_item(
             with_waiver_record(


### PR DESCRIPTION
## Summary

- Add the production beta go/no-go dashboard generator with deterministic JSON, Markdown, redaction report output, waiver validation, and fixture-backed decisions for `go`, `no-go`, and `go-with-waivers`.
- Integrate the dashboard into the production beta release pipeline, release-certification evidence, ecosystem matrix, and production beta workflow artifact/redaction gating.
- Add deterministic fixtures and self-test coverage for missing evidence, failed summaries, critical redaction findings, waiver expiry/scope/severity, non-release/test-signing artifacts, live-network skip handling, stale/incomplete dashboard artifacts, and standalone security-response evidence.
- Document release-manager usage, CI behavior, waiver schemas, non-waivable findings, and update related release/operator skill guidance.

## Test plan

- `./gradlew spotlessApply`
- `python3 -m py_compile tools/release-certification/production_beta_go_no_go_dashboard.py`
- `python3 -m py_compile tools/release-certification/production_beta_release.py tools/release-certification/production_beta_go_no_go_dashboard.py`
- `python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test`
- `python3 tools/release-certification/production_beta_release.py --self-test`
- `python3 tools/release-certification/release_certification.py --self-test`
- `python3 tools/release-certification/app_platform_docs_check.py --self-test`
- `git diff --check`

## Notes

Full production validation was not run locally; production-beta dispatch still requires production signing material, live-node evidence where required, and real release artifacts.