### PR TITLE
feat(release): Harden production beta

### DIFF
--- a/.github/workflows/production-beta-release.yml
+++ b/.github/workflows/production-beta-release.yml
@@ -43,17 +43,17 @@ on:
         default: ''
         type: string
       multi_node_soak_summary:
-        description: Existing multi-node soak summary path for protected production promotion.
+        description: Existing multi-node soak summary path, HTTPS JSON URL, or actions-artifact://run/artifact/path reference for protected production promotion.
         required: false
         default: ''
         type: string
       previous_summary:
-        description: Previous release-certification summary path for production history and upgrade evidence.
+        description: Previous release-certification summary path, HTTPS JSON URL, or actions-artifact://run/artifact/path reference for production history and upgrade evidence.
         required: false
         default: ''
         type: string
       waiver_file:
-        description: Optional structured go/no-go waiver file path. Production-beta cannot waive mandatory launch evidence.
+        description: Optional structured go/no-go waiver file path, HTTPS JSON URL, or actions-artifact://run/artifact/path reference. Production-beta cannot waive mandatory launch evidence.
         required: false
         default: ''
         type: string
@@ -298,6 +298,7 @@ jobs:
           INPUT_MULTI_NODE_SOAK_SUMMARY: ${{ inputs.multi_node_soak_summary || '' }}
           INPUT_PREVIOUS_SUMMARY: ${{ inputs.previous_summary || '' }}
           INPUT_WAIVER_FILE: ${{ inputs.waiver_file || '' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           materialize_secret_file() {
             local encoded="$1"
@@ -331,10 +332,77 @@ jobs:
             fi
           }
 
+          materialize_input_file() {
+            local value="$1"
+            local env_name="$2"
+            local file_name="$3"
+            local description="$4"
+            if [[ -z "$value" ]]; then
+              return 0
+            fi
+            case "$value" in
+              https://*)
+                local path="$RUNNER_TEMP/cryptad-production-beta-inputs/$file_name"
+                mkdir -p "$(dirname "$path")"
+                curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 --retry 3 --output "$path" "$value"
+                chmod 600 "$path"
+                export "$env_name=$path"
+                ;;
+              http://*)
+                echo "::error::$description URL must use HTTPS: $value"
+                exit 1
+                ;;
+              actions-artifact://*)
+                materialize_actions_artifact_file "$value" "$env_name" "$file_name" "$description"
+                ;;
+              *)
+                export "$env_name=$value"
+                ;;
+            esac
+          }
+
+          materialize_actions_artifact_file() {
+            local value="$1"
+            local env_name="$2"
+            local file_name="$3"
+            local description="$4"
+            local rest="${value#actions-artifact://}"
+            local run_id="${rest%%/*}"
+            if [[ -z "$run_id" || "$run_id" == "$rest" ]]; then
+              echo "::error::$description actions artifact reference must be actions-artifact://<run-id>/<artifact-name>/<path>."
+              exit 1
+            fi
+            rest="${rest#*/}"
+            local artifact_name="${rest%%/*}"
+            if [[ -z "$artifact_name" || "$artifact_name" == "$rest" ]]; then
+              echo "::error::$description actions artifact reference must include an artifact name and path."
+              exit 1
+            fi
+            local artifact_path="${rest#*/}"
+            if [[ -z "$artifact_path" || "$artifact_path" == /* || "$artifact_path" == *".."* ]]; then
+              echo "::error::$description actions artifact path must be relative and cannot contain '..'."
+              exit 1
+            fi
+            local download_dir="$RUNNER_TEMP/cryptad-production-beta-inputs/$file_name-artifact"
+            rm -rf "$download_dir"
+            mkdir -p "$download_dir"
+            gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name "$artifact_name" --dir "$download_dir"
+            local path="$download_dir/$artifact_path"
+            if [[ ! -f "$path" && -f "$download_dir/$artifact_name/$artifact_path" ]]; then
+              path="$download_dir/$artifact_name/$artifact_path"
+            fi
+            require_file "$path" "$description from $value"
+            chmod 600 "$path"
+            export "$env_name=$path"
+          }
+
           materialize_secret_file "${CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64:-}" CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE app-signing-private.der
           materialize_secret_file "${CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64:-}" CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE app-signing-public.der
           materialize_secret_file "${CRYPTAD_APP_REVIEWER_PRIVATE_KEY_BASE64:-}" CRYPTAD_APP_REVIEWER_PRIVATE_KEY_FILE reviewer-private.der
           materialize_secret_file "${CRYPTAD_APP_REVIEWER_PUBLIC_KEY_BASE64:-}" CRYPTAD_APP_REVIEWER_PUBLIC_KEY_FILE reviewer-public.der
+          materialize_input_file "$INPUT_PREVIOUS_SUMMARY" INPUT_PREVIOUS_SUMMARY previous-release-certification-summary.json "Previous release-certification summary"
+          materialize_input_file "$INPUT_MULTI_NODE_SOAK_SUMMARY" INPUT_MULTI_NODE_SOAK_SUMMARY multi-node-beta-soak-summary.json "Multi-node soak summary"
+          materialize_input_file "$INPUT_WAIVER_FILE" INPUT_WAIVER_FILE go-no-go-waivers.json "Go/no-go waiver file"
 
           if [[ -z "$INPUT_ARTIFACT_BASE_URI" ]]; then
             echo "::error::CRYPTAD_PRODUCTION_BETA_ARTIFACT_BASE_URI or workflow artifact_base_uri input is required for production-beta."

--- a/.github/workflows/production-beta-release.yml
+++ b/.github/workflows/production-beta-release.yml
@@ -109,6 +109,7 @@ jobs:
           INPUT_WAIVER_FILE: ${{ inputs.waiver_file || '' }}
           INPUT_REQUIRE_MULTI_NODE_SOAK: ${{ inputs.require_multi_node_soak || 'false' }}
           INPUT_ARTIFACT_BASE_URI: ${{ inputs.artifact_base_uri || vars.CRYPTAD_PRODUCTION_BETA_ARTIFACT_BASE_URI || (github.event_name != 'pull_request' && secrets.CRYPTAD_PRODUCTION_BETA_ARTIFACT_BASE_URI) || '' }}
+          GH_TOKEN: ${{ github.event_name == 'workflow_dispatch' && github.token || '' }}
           CRYPTAD_CERT_NODE_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.require_live_network && secrets.CRYPTAD_CERT_NODE_BASE_URL || '' }}
           CRYPTAD_CERT_FORM_PASSWORD: ${{ github.event_name == 'workflow_dispatch' && inputs.require_live_network && secrets.CRYPTAD_CERT_FORM_PASSWORD || '' }}
           CRYPTAD_CERT_LIVE_CATALOG_SOURCE: ${{ github.event_name == 'workflow_dispatch' && inputs.require_live_network && secrets.CRYPTAD_CERT_LIVE_CATALOG_SOURCE || '' }}
@@ -128,6 +129,87 @@ jobs:
               mode="release-candidate"
             fi
           fi
+
+          require_file() {
+            local path="$1"
+            local description="$2"
+            if [[ -z "$path" || ! -f "$path" ]]; then
+              echo "::error::$description must point to a readable file: $path"
+              exit 1
+            fi
+          }
+
+          materialize_input_file() {
+            local value="$1"
+            local env_name="$2"
+            local file_name="$3"
+            local description="$4"
+            if [[ -z "$value" ]]; then
+              return 0
+            fi
+            case "$value" in
+              https://*)
+                local path="$RUNNER_TEMP/cryptad-production-beta-inputs/$file_name"
+                mkdir -p "$(dirname "$path")"
+                curl --fail --silent --show-error --location --proto '=https' --tlsv1.2 --retry 3 --output "$path" "$value"
+                chmod 600 "$path"
+                export "$env_name=$path"
+                ;;
+              http://*)
+                echo "::error::$description URL must use HTTPS: $value"
+                exit 1
+                ;;
+              actions-artifact://*)
+                materialize_actions_artifact_file "$value" "$env_name" "$file_name" "$description"
+                ;;
+              *)
+                export "$env_name=$value"
+                ;;
+            esac
+          }
+
+          materialize_actions_artifact_file() {
+            local value="$1"
+            local env_name="$2"
+            local file_name="$3"
+            local description="$4"
+            if [[ -z "${GH_TOKEN:-}" ]]; then
+              echo "::error::$description actions artifact reference requires a workflow dispatch GitHub token."
+              exit 1
+            fi
+            local rest="${value#actions-artifact://}"
+            local run_id="${rest%%/*}"
+            if [[ -z "$run_id" || "$run_id" == "$rest" ]]; then
+              echo "::error::$description actions artifact reference must be actions-artifact://<run-id>/<artifact-name>/<path>."
+              exit 1
+            fi
+            rest="${rest#*/}"
+            local artifact_name="${rest%%/*}"
+            if [[ -z "$artifact_name" || "$artifact_name" == "$rest" ]]; then
+              echo "::error::$description actions artifact reference must include an artifact name and path."
+              exit 1
+            fi
+            local artifact_path="${rest#*/}"
+            if [[ -z "$artifact_path" || "$artifact_path" == /* || "$artifact_path" == *".."* ]]; then
+              echo "::error::$description actions artifact path must be relative and cannot contain '..'."
+              exit 1
+            fi
+            local download_dir="$RUNNER_TEMP/cryptad-production-beta-inputs/$file_name-artifact"
+            rm -rf "$download_dir"
+            mkdir -p "$download_dir"
+            gh run download "$run_id" --repo "$GITHUB_REPOSITORY" --name "$artifact_name" --dir "$download_dir"
+            local path="$download_dir/$artifact_path"
+            if [[ ! -f "$path" && -f "$download_dir/$artifact_name/$artifact_path" ]]; then
+              path="$download_dir/$artifact_name/$artifact_path"
+            fi
+            require_file "$path" "$description from $value"
+            chmod 600 "$path"
+            export "$env_name=$path"
+          }
+
+          materialize_input_file "$INPUT_PREVIOUS_SUMMARY" INPUT_PREVIOUS_SUMMARY previous-release-certification-summary.json "Previous release-certification summary"
+          materialize_input_file "$INPUT_MULTI_NODE_SOAK_SUMMARY" INPUT_MULTI_NODE_SOAK_SUMMARY multi-node-beta-soak-summary.json "Multi-node soak summary"
+          materialize_input_file "$INPUT_WAIVER_FILE" INPUT_WAIVER_FILE go-no-go-waivers.json "Go/no-go waiver file"
 
           args=(
             --workspace-root .
@@ -366,6 +448,10 @@ jobs:
             local env_name="$2"
             local file_name="$3"
             local description="$4"
+            if [[ -z "${GH_TOKEN:-}" ]]; then
+              echo "::error::$description actions artifact reference requires a workflow dispatch GitHub token."
+              exit 1
+            fi
             local rest="${value#actions-artifact://}"
             local run_id="${rest%%/*}"
             if [[ -z "$run_id" || "$run_id" == "$rest" ]]; then

--- a/.github/workflows/production-beta-release.yml
+++ b/.github/workflows/production-beta-release.yml
@@ -346,6 +346,9 @@ jobs:
           require_env CRYPTAD_APP_REVIEWER_KEY_ID "App reviewer key ID"
           require_file "${CRYPTAD_APP_REVIEWER_PRIVATE_KEY_FILE:-}" "Reviewer private key"
           require_file "${CRYPTAD_APP_REVIEWER_PUBLIC_KEY_FILE:-}" "Reviewer public key"
+          : "${CRYPTAD_APP_REVIEW_POLICY_ID:=crypta-app-review-v1}"
+          : "${CRYPTAD_APP_REVIEW_POLICY_VERSION:=1}"
+          export CRYPTAD_APP_REVIEW_POLICY_ID CRYPTAD_APP_REVIEW_POLICY_VERSION
           require_env CRYPTAD_APP_REVIEW_POLICY_ID "App review policy ID"
           require_env CRYPTAD_APP_REVIEW_POLICY_VERSION "App review policy version"
           require_env CRYPTAD_CERT_NODE_BASE_URL "Live-node base URL"

--- a/.github/workflows/production-beta-release.yml
+++ b/.github/workflows/production-beta-release.yml
@@ -47,6 +47,16 @@ on:
         required: false
         default: ''
         type: string
+      previous_summary:
+        description: Previous release-certification summary path for production history and upgrade evidence.
+        required: false
+        default: ''
+        type: string
+      waiver_file:
+        description: Optional structured go/no-go waiver file path. Production-beta cannot waive mandatory launch evidence.
+        required: false
+        default: ''
+        type: string
       require_multi_node_soak:
         description: Require multi-node beta soak evidence.
         required: true
@@ -95,6 +105,8 @@ jobs:
           INPUT_MULTI_NODE_MODE: ${{ inputs.multi_node_mode || '' }}
           INPUT_MULTI_NODE_SOAK_CONFIG: ${{ inputs.multi_node_soak_config || 'tools/release-certification/fixtures/self-test-multi-node-beta-soak.json' }}
           INPUT_MULTI_NODE_SOAK_SUMMARY: ${{ inputs.multi_node_soak_summary || '' }}
+          INPUT_PREVIOUS_SUMMARY: ${{ inputs.previous_summary || '' }}
+          INPUT_WAIVER_FILE: ${{ inputs.waiver_file || '' }}
           INPUT_REQUIRE_MULTI_NODE_SOAK: ${{ inputs.require_multi_node_soak || 'false' }}
           INPUT_ARTIFACT_BASE_URI: ${{ inputs.artifact_base_uri || vars.CRYPTAD_PRODUCTION_BETA_ARTIFACT_BASE_URI || (github.event_name != 'pull_request' && secrets.CRYPTAD_PRODUCTION_BETA_ARTIFACT_BASE_URI) || '' }}
           CRYPTAD_CERT_NODE_BASE_URL: ${{ github.event_name == 'workflow_dispatch' && inputs.require_live_network && secrets.CRYPTAD_CERT_NODE_BASE_URL || '' }}
@@ -151,6 +163,12 @@ jobs:
 
           if [[ "$INPUT_REQUIRE_MULTI_NODE_SOAK" == "true" ]]; then
             args+=(--require-multi-node-soak)
+          fi
+          if [[ -n "$INPUT_PREVIOUS_SUMMARY" ]]; then
+            args+=(--previous-summary "$INPUT_PREVIOUS_SUMMARY")
+          fi
+          if [[ -n "$INPUT_WAIVER_FILE" ]]; then
+            args+=(--waiver-file "$INPUT_WAIVER_FILE")
           fi
 
           if [[ -n "$INPUT_ARTIFACT_BASE_URI" ]]; then
@@ -278,11 +296,67 @@ jobs:
           INPUT_MULTI_NODE_MODE: ${{ inputs.multi_node_mode || '' }}
           INPUT_MULTI_NODE_SOAK_CONFIG: ${{ inputs.multi_node_soak_config || '' }}
           INPUT_MULTI_NODE_SOAK_SUMMARY: ${{ inputs.multi_node_soak_summary || '' }}
+          INPUT_PREVIOUS_SUMMARY: ${{ inputs.previous_summary || '' }}
+          INPUT_WAIVER_FILE: ${{ inputs.waiver_file || '' }}
         run: |
+          materialize_secret_file() {
+            local encoded="$1"
+            local env_name="$2"
+            local file_name="$3"
+            if [[ -z "$encoded" ]]; then
+              return 0
+            fi
+            local path="$RUNNER_TEMP/cryptad-production-beta-secrets/$file_name"
+            mkdir -p "$(dirname "$path")"
+            printf '%s' "$encoded" | base64 --decode > "$path"
+            chmod 600 "$path"
+            export "$env_name=$path"
+          }
+
+          require_env() {
+            local name="$1"
+            local description="$2"
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::$description ($name) is required for production-beta."
+              exit 1
+            fi
+          }
+
+          require_file() {
+            local path="$1"
+            local description="$2"
+            if [[ -z "$path" || ! -f "$path" ]]; then
+              echo "::error::$description must point to a readable file: $path"
+              exit 1
+            fi
+          }
+
+          materialize_secret_file "${CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64:-}" CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE app-signing-private.der
+          materialize_secret_file "${CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64:-}" CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE app-signing-public.der
+          materialize_secret_file "${CRYPTAD_APP_REVIEWER_PRIVATE_KEY_BASE64:-}" CRYPTAD_APP_REVIEWER_PRIVATE_KEY_FILE reviewer-private.der
+          materialize_secret_file "${CRYPTAD_APP_REVIEWER_PUBLIC_KEY_BASE64:-}" CRYPTAD_APP_REVIEWER_PUBLIC_KEY_FILE reviewer-public.der
+
           if [[ -z "$INPUT_ARTIFACT_BASE_URI" ]]; then
             echo "::error::CRYPTAD_PRODUCTION_BETA_ARTIFACT_BASE_URI or workflow artifact_base_uri input is required for production-beta."
             exit 1
           fi
+          require_env CRYPTAD_APP_SIGNING_KEY_ID "App signing key ID"
+          require_file "${CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE:-}" "App signing private key"
+          require_file "${CRYPTAD_APP_SIGNING_PUBLIC_KEY_FILE:-}" "App signing public key"
+          require_env CRYPTAD_APP_REVIEWER_KEY_ID "App reviewer key ID"
+          require_file "${CRYPTAD_APP_REVIEWER_PRIVATE_KEY_FILE:-}" "Reviewer private key"
+          require_file "${CRYPTAD_APP_REVIEWER_PUBLIC_KEY_FILE:-}" "Reviewer public key"
+          require_env CRYPTAD_APP_REVIEW_POLICY_ID "App review policy ID"
+          require_env CRYPTAD_APP_REVIEW_POLICY_VERSION "App review policy version"
+          require_env CRYPTAD_CERT_NODE_BASE_URL "Live-node base URL"
+          require_env CRYPTAD_CERT_FORM_PASSWORD "Live-node form password"
+          require_env CRYPTAD_CERT_LIVE_CATALOG_SOURCE "Live catalog source URI"
+          require_env CRYPTAD_CERT_LIVE_CATALOG_EXPECTED_KEY_ID "Live catalog expected signing key ID"
+          require_env CRYPTAD_CERT_LIVE_CATALOG_ID "Live catalog ID"
+          require_env CRYPTAD_CERT_LIVE_CONTENT_FETCH_URI "Live content fetch URI"
+          require_env CRYPTAD_CERT_LIVE_FEED_USK_URI "Live feed USK URI"
+          require_env CRYPTAD_CERT_LIVE_PROFILE_PUBLIC_URI "Live profile public URI"
+          require_env CRYPTAD_CERT_LIVE_TRUST_PUBLIC_URI "Live trust statement public URI"
           if [[ -z "${CRYPTAD_CERT_LIVE_TEST_INSERT_URI:-}" ]]; then
             echo "::error::CRYPTAD_CERT_LIVE_TEST_INSERT_URI secret is required for production-beta live profile/trust evidence."
             exit 1
@@ -290,13 +364,31 @@ jobs:
           export CRYPTAD_CERT_LIVE_TEST_INSERT_URI_ENV=CRYPTAD_CERT_LIVE_TEST_INSERT_URI
 
           self_test_multi_node_config="tools/release-certification/fixtures/self-test-multi-node-beta-soak.json"
+          if [[ -z "$INPUT_PREVIOUS_SUMMARY" ]]; then
+            echo "::error::production-beta requires previous_summary pointing to the previous release-certification summary."
+            exit 1
+          fi
+          require_file "$INPUT_PREVIOUS_SUMMARY" "Previous release-certification summary"
           if [[ -z "$INPUT_MULTI_NODE_SOAK_SUMMARY" && -z "$INPUT_MULTI_NODE_SOAK_CONFIG" ]]; then
             echo "::error::production-beta requires multi_node_soak_summary or a production multi_node_soak_config."
             exit 1
           fi
+          if [[ -n "$INPUT_MULTI_NODE_SOAK_SUMMARY" ]]; then
+            require_file "$INPUT_MULTI_NODE_SOAK_SUMMARY" "Multi-node soak summary"
+          fi
+          if [[ -n "$INPUT_MULTI_NODE_SOAK_CONFIG" ]]; then
+            require_file "$INPUT_MULTI_NODE_SOAK_CONFIG" "Multi-node soak topology config"
+          fi
           if [[ -z "$INPUT_MULTI_NODE_SOAK_SUMMARY" && "$INPUT_MULTI_NODE_SOAK_CONFIG" == "$self_test_multi_node_config" ]]; then
             echo "::error::production-beta cannot use the self-test multi-node soak topology as required promotion evidence."
             exit 1
+          fi
+          if [[ "$INPUT_MULTI_NODE_MODE" == "simulated" ]]; then
+            echo "::error::production-beta cannot use simulated multi-node mode as required promotion evidence."
+            exit 1
+          fi
+          if [[ -n "$INPUT_WAIVER_FILE" ]]; then
+            require_file "$INPUT_WAIVER_FILE" "Go/no-go waiver file"
           fi
 
           args=(
@@ -309,6 +401,7 @@ jobs:
             --require-multi-node-soak
             --require-live-network
             --require-sandbox-provider-tests
+            --previous-summary "$INPUT_PREVIOUS_SUMMARY"
           )
           if [[ -n "$INPUT_MULTI_NODE_SOAK_SUMMARY" ]]; then
             args+=(--multi-node-soak-summary "$INPUT_MULTI_NODE_SOAK_SUMMARY")
@@ -317,6 +410,9 @@ jobs:
           fi
           if [[ -n "$INPUT_MULTI_NODE_MODE" ]]; then
             args+=(--multi-node-mode "$INPUT_MULTI_NODE_MODE")
+          fi
+          if [[ -n "$INPUT_WAIVER_FILE" ]]; then
+            args+=(--waiver-file "$INPUT_WAIVER_FILE")
           fi
           "${args[@]}"
 

--- a/docs/multi-node-beta-soak-and-upgrade-drill.md
+++ b/docs/multi-node-beta-soak-and-upgrade-drill.md
@@ -192,6 +192,18 @@ candidate summaries, simulated mode, the checked-in self-test topology, failed s
 redaction findings are production blockers and cannot be waived into a launchable dashboard
 decision.
 
+When the protected GitHub Actions workflow consumes prior evidence from another run, the
+`previous_summary` and `multi_node_soak_summary` dispatch inputs may be a checked-out local path, an
+HTTPS JSON URL, or an Actions artifact reference:
+
+```text
+actions-artifact://<run-id>/<artifact-name>/<path-inside-artifact>
+```
+
+The workflow downloads or restores those sources into a private runner temp directory before it runs
+the production-beta file checks, so the release manager does not need to commit previous-candidate
+summaries into the repository.
+
 ## Previous candidate summaries
 
 Set `previousCandidate.summaryPath` in the topology config to consume a previous production beta or

--- a/docs/multi-node-beta-soak-and-upgrade-drill.md
+++ b/docs/multi-node-beta-soak-and-upgrade-drill.md
@@ -192,7 +192,7 @@ candidate summaries, simulated mode, the checked-in self-test topology, failed s
 redaction findings are production blockers and cannot be waived into a launchable dashboard
 decision.
 
-When the protected GitHub Actions workflow consumes prior evidence from another run, the
+When the manual GitHub Actions workflow consumes prior evidence from another run, the
 `previous_summary` and `multi_node_soak_summary` dispatch inputs may be a checked-out local path, an
 HTTPS JSON URL, or an Actions artifact reference:
 

--- a/docs/multi-node-beta-soak-and-upgrade-drill.md
+++ b/docs/multi-node-beta-soak-and-upgrade-drill.md
@@ -24,8 +24,9 @@ release-certification tools. It consumes and complements those tools.
 | `live` | Release-manager drill against prepared local beta nodes. | May check configured localhost node base URLs. `--require-live` fails closed if no configured localhost node is reachable. |
 
 Normal pull requests and developer dry-runs use `simulated`. Release-candidate runs can use
-`simulated` or `hybrid`. Protected production beta runs may use `live` only when the release
-environment provides the required local node endpoints and fixture inputs.
+`simulated` or `hybrid`. Protected production beta promotion requires attached passing evidence or
+an explicit production `hybrid`/`live` topology. `simulated` and the checked-in self-test topology
+are PR-safe only and cannot satisfy production promotion gates.
 
 ## Topology config
 
@@ -152,6 +153,22 @@ tools/release-certification/run-production-beta-release.sh \
   --run-multi-node-soak
 ```
 
+The canonical protected production command attaches real previous-candidate and multi-node evidence:
+
+```bash
+tools/release-certification/run-production-beta-release.sh \
+  --workspace-root . \
+  --out-dir build/production-beta-release \
+  --mode production-beta \
+  --catalog-channel stable \
+  --artifact-base-uri "$CRYPTAD_PRODUCTION_BETA_ARTIFACT_BASE_URI" \
+  --require-live-network \
+  --require-multi-node-soak \
+  --require-sandbox-provider-tests \
+  --previous-summary "$PREVIOUS_RELEASE_CERTIFICATION_SUMMARY" \
+  --multi-node-soak-summary "$MULTI_NODE_BETA_SOAK_SUMMARY"
+```
+
 Useful flags are:
 
 | Flag | Meaning |
@@ -159,24 +176,29 @@ Useful flags are:
 | `--run-multi-node-soak` | Generate multi-node evidence during release certification. |
 | `--multi-node-soak-config <path>` | Use a specific topology config. |
 | `--multi-node-soak-summary <path>` | Attach an existing summary instead of generated evidence. |
-| `--multi-node-mode simulated|hybrid|live` | Select the drill mode for generated evidence. |
+| `--multi-node-mode simulated|hybrid|live` | Select the drill mode for generated evidence. Production-beta promotion rejects `simulated`. |
 | `--require-multi-node-soak` | Require passing multi-node evidence for production beta promotion gates. |
 
-Production beta mode requires multi-node soak evidence by default. The final
-`reports/production-beta-summary.json` includes a compact `multiNodeBetaSoak` object with status,
-mode, scenario statuses, blockers, warnings, and the evidence artifact path.
+Production beta mode requires multi-node soak evidence by default. It also requires
+`--previous-summary`, passing `upgrade-from-previous-candidate` evidence, and a real attached summary
+or explicit non-self-test `hybrid`/`live` topology. The final `reports/production-beta-summary.json`
+includes a compact `multiNodeBetaSoak` object with status, mode, scenario statuses, blockers,
+warnings, and the evidence artifact path.
 
 The checked-in self-test topology is suitable for developer dry-runs and PR-safe validation only.
 Protected production-beta workflow dispatches must use an attached passing summary or a production
-topology whose previous-candidate upgrade evidence can pass without warnings.
+topology whose previous-candidate upgrade evidence can pass without warnings. Missing previous
+candidate summaries, simulated mode, the checked-in self-test topology, failed scenario evidence, or
+redaction findings are production blockers and cannot be waived into a launchable dashboard
+decision.
 
 ## Previous candidate summaries
 
 Set `previousCandidate.summaryPath` in the topology config to consume a previous production beta or
 release-certification summary. In simulated and release-candidate contexts, a missing previous
-summary is recorded as a warning so the rest of the drill can still prove the gates. In strict
-production contexts, set `strict.requirePreviousSummary=true` or run strict verification so missing
-previous-candidate evidence becomes blocking.
+summary is recorded as a warning so the rest of the drill can still prove the gates. In
+production-beta promotion, missing previous-candidate evidence is blocking even if the topology
+would otherwise pass.
 
 When a previous summary path is supplied, the file must be a `schemaVersion=1` summary with passing
 or warning status, or a release-certification summary with `releaseCandidatePassed=true`. Empty,

--- a/docs/production-beta-go-no-go-dashboard.md
+++ b/docs/production-beta-go-no-go-dashboard.md
@@ -82,7 +82,9 @@ blockers.
 
 `go-with-waivers` means every remaining blocker is waivable and has a valid, scoped, approved, and
 unexpired waiver. The waiver remains visible in JSON and Markdown. Waived blockers are not hidden
-or converted to `pass`.
+or converted to `pass`. In `production-beta` mode, mandatory launch evidence is not waivable; a
+`go-with-waivers` decision is possible only for waiverable residual blockers outside the strict
+production launch set.
 
 `no-go` means at least one of these conditions exists:
 
@@ -93,7 +95,8 @@ or converted to `pass`.
 - critical redaction finding;
 - unsafe artifact hygiene finding such as AppleDouble metadata, `.DS_Store`, or `__MACOSX`;
 - production beta mode using test-only or generated signing material;
-- production beta artifact marked `nonRelease=true`.
+- production beta artifact marked `nonRelease=true`;
+- production beta summary with failed promotion gates or `promotionReady=false`.
 
 ## Waiver format
 
@@ -105,11 +108,11 @@ The dashboard accepts a JSON waiver file:
   "releaseId": "crypta-production-beta-2026-06-24",
   "waivers": [
     {
-      "id": "waiver-live-network-lab-outage-001",
-      "evidenceId": "live.live-network-beta.content-fetch",
+      "id": "waiver-release-candidate-doc-followup-001",
+      "evidenceId": "app-store.submission-cli",
       "severity": "blocker",
-      "scope": "production-beta",
-      "rationale": "Lab live node unavailable during the RC window.",
+      "scope": "release-candidate",
+      "rationale": "Release-candidate docs follow-up is accepted before production-beta promotion.",
       "approvedBy": "release-manager@example.invalid",
       "owner": "release-engineering",
       "createdAt": "2026-06-24T00:00:00Z",
@@ -145,6 +148,11 @@ These findings always produce `no-go`:
   special files, invalid archives, or unsafe nested archive entries;
 - production beta using test-only signing material or generated test keys;
 - production beta output marked `nonRelease=true`;
+- fixture evidence, skipped Gradle build/stage/sign/verify stages, or dirty/unknown workspace in
+  production beta;
+- missing or failing live-network beta evidence, sandbox provider evidence, production signing,
+  previous-candidate multi-node upgrade evidence, multi-node redaction, or ecosystem RC gates in
+  production beta;
 - malformed or expired waiver records.
 
 The scanner allows deterministic placeholders such as `<redacted-private-insert-uri>`,
@@ -182,7 +190,9 @@ production beta redaction status is `pass` and the dashboard's own redaction rep
 
 Protected `production-beta` dispatches fail on `no-go`. A `go-with-waivers` decision is allowed
 only when the dashboard validates and records the waiver records that made the candidate
-launchable.
+launchable and the production summary already has `promotionReady=true`, `nonRelease=false`, no
+failed promotion gates, and passing redaction. The release wrapper treats any launchable dashboard
+decision over a failed or non-release production summary as a failed run.
 
 ## Release-manager workflow
 

--- a/docs/production-beta-release-pipeline.md
+++ b/docs/production-beta-release-pipeline.md
@@ -114,8 +114,8 @@ inputs through environment variables or protected files:
 | `CRYPTAD_CERT_FORM_PASSWORD` | Local node form password for live collectors. Pass it through the environment only. |
 | Live fixture variables from `live_network_beta_smoke.py` | Catalog source, expected catalog key id, content/feed/profile/trust fixtures, and protected private insert URI indirection for required live evidence. |
 | `CRYPTAD_CERT_LIVE_TEST_INSERT_URI_ENV=CRYPTAD_CERT_LIVE_TEST_INSERT_URI` plus `CRYPTAD_CERT_LIVE_TEST_INSERT_URI` | GitHub Actions production-beta runs use this environment-name indirection for the private insert URI fixture. The raw URI lives only in the secret-valued `CRYPTAD_CERT_LIVE_TEST_INSERT_URI` variable. |
-| `--previous-summary "$PREVIOUS_RELEASE_CERTIFICATION_SUMMARY"` | Previous release-certification summary used for history comparison and previous-candidate upgrade evidence. Required for protected production-beta promotion. CLI runs pass a local JSON path. Protected workflow dispatches may pass a local checked-out path, an HTTPS JSON URL, or `actions-artifact://<run-id>/<artifact-name>/<path-inside-artifact>`. |
-| `--multi-node-soak-summary "$MULTI_NODE_BETA_SOAK_SUMMARY"` or `--run-multi-node-soak --multi-node-soak-config <production topology>` | Passing multi-node soak and upgrade evidence. CLI runs pass a local summary path. Protected workflow dispatches may pass a local checked-out path, an HTTPS JSON URL, or `actions-artifact://<run-id>/<artifact-name>/<path-inside-artifact>` for `multi_node_soak_summary`. Production-beta rejects the self-test topology and simulated mode as required promotion evidence. |
+| `--previous-summary "$PREVIOUS_RELEASE_CERTIFICATION_SUMMARY"` | Previous release-certification summary used for history comparison and previous-candidate upgrade evidence. Required for protected production-beta promotion. CLI runs pass a local JSON path. Manual workflow dispatches may pass a local checked-out path, an HTTPS JSON URL, or `actions-artifact://<run-id>/<artifact-name>/<path-inside-artifact>`. |
+| `--multi-node-soak-summary "$MULTI_NODE_BETA_SOAK_SUMMARY"` or `--run-multi-node-soak --multi-node-soak-config <production topology>` | Passing multi-node soak and upgrade evidence. CLI runs pass a local summary path. Manual workflow dispatches may pass a local checked-out path, an HTTPS JSON URL, or `actions-artifact://<run-id>/<artifact-name>/<path-inside-artifact>` for `multi_node_soak_summary`. Production-beta rejects the self-test topology and simulated mode as required promotion evidence. |
 
 Do not pass private keys, private insert URIs, form passwords, app tokens, or browser session tokens
 as command-line arguments.
@@ -367,7 +367,7 @@ The workflow uploads the full production beta artifact tree only when both
 output on the runner and do not publish rejected artifacts or the dashboard Markdown through
 GitHub Actions.
 
-Protected `production-beta` dispatch file inputs are materialized before strict validation. For
+Manual workflow dispatch file inputs are materialized before strict validation. For
 `previous_summary`, `multi_node_soak_summary`, and `waiver_file`, use one of these forms:
 
 ```text

--- a/docs/production-beta-release-pipeline.md
+++ b/docs/production-beta-release-pipeline.md
@@ -22,26 +22,34 @@ tools/release-certification/run-production-beta-release.sh \
   --catalog-channel stable \
   --artifact-base-uri "$CRYPTAD_PRODUCTION_BETA_ARTIFACT_BASE_URI" \
   --require-live-network \
-  --require-sandbox-provider-tests
+  --require-multi-node-soak \
+  --require-sandbox-provider-tests \
+  --previous-summary "$PREVIOUS_RELEASE_CERTIFICATION_SUMMARY" \
+  --multi-node-soak-summary "$MULTI_NODE_BETA_SOAK_SUMMARY"
 ```
 
 Add multi-node drill flags when a release run needs a specific topology or attached evidence:
 
 ```bash
 tools/release-certification/run-production-beta-release.sh \
+  --workspace-root . \
+  --out-dir build/production-beta-release-dry-run \
   --mode developer-dry-run \
+  --catalog-channel stable \
+  --use-fixture-evidence \
   --multi-node-mode simulated \
-  --run-multi-node-soak
+  --run-multi-node-soak \
+  --allow-dirty-workspace
 ```
 
 Use `--multi-node-soak-config <path>` for a topology config, `--multi-node-soak-summary <path>` to
 attach existing evidence, and `--require-multi-node-soak` to make the promotion gate fail closed
 outside production beta mode.
 
-Protected `production-beta` workflow dispatches must provide either a production multi-node topology
-config or an attached passing multi-node summary. The checked-in self-test topology is only for
-developer dry-runs and PR-safe validation because it intentionally leaves previous-candidate
-upgrade evidence as a warning.
+Protected `production-beta` workflow dispatches must provide `--previous-summary` and either a
+passing attached multi-node summary or an explicit production `hybrid`/`live` multi-node topology
+config. The checked-in self-test topology and `--multi-node-mode simulated` are only for developer
+dry-runs and PR-safe validation; they cannot satisfy production promotion evidence.
 
 Relative `--out-dir` values are resolved under the workspace root. The command cleans that output
 directory by default only when it is under the dedicated `build/production-beta*` prefix or already
@@ -58,7 +66,7 @@ upload.
 | --- | --- | --- | --- |
 | `developer-dry-run` | Local and PR-safe pipeline exercise. | Uses configured keys when present, otherwise generates ephemeral non-production keys outside the artifact tree. Live network is not required. If no artifact base URI is supplied, the command uses a `.invalid` non-release URI. | Exits successfully only when pipeline commands and redaction pass, and always marks artifacts as `nonRelease=true` and `promotionReady=false`. |
 | `release-candidate` | Release branch or manual candidate evidence. | Requires staged apps, signed bundles, signed catalog artifacts, review receipts, smoke summaries, ecosystem certification, and a real HTTPS artifact base URI. Test keys are allowed when no release keys are configured, and outputs remain labeled non-production. | Fails on critical missing evidence. Promotion is not marked ready unless all production-beta-only requirements are also satisfied. |
-| `production-beta` | Protected production beta candidate build. | Requires real signing/reviewer inputs, a full in-pipeline Gradle build/stage/sign run, a real HTTPS artifact base URI, app-platform evidence, sandbox evidence, ecosystem RC certification, and live-network beta evidence unless an explicitly named emergency/test flag is used. | Fails closed when critical evidence, live evidence, production signing, a complete build, or redaction is missing. |
+| `production-beta` | Protected production beta candidate build. | Requires real signing/reviewer inputs, a full in-pipeline Gradle `build`, `:platform-devtools:installDist`, first-party app staging/signing/verification, a real HTTPS artifact base URI, app-platform evidence, sandbox evidence, ecosystem RC certification, live-network beta evidence, and previous-candidate multi-node upgrade evidence unless an explicitly named emergency/test flag is used. | Fails closed when critical evidence, live evidence, production signing, a complete build, previous-candidate multi-node evidence, sandbox evidence, go/no-go validation, or redaction is missing. |
 
 `--use-fixture-evidence` is accepted only with `developer-dry-run` and internal self-tests. Strict
 `release-candidate` and `production-beta` runs reject fixture evidence before certification.
@@ -68,8 +76,9 @@ Production beta supports three explicit test/emergency escape hatches:
 - `--emergency-skip-live-network` records that live-network evidence was skipped. The run still
   records a failed live-skip gate and keeps `promotionReady=false`.
 - `--emergency-skip-build` allows a controlled test or emergency run to continue after
-  `--skip-gradle` or `--skip-full-build`. The run still records a failed build-complete gate,
-  sets `nonRelease=true`, and keeps `promotionReady=false`.
+  `--skip-gradle` or `--skip-full-build`. Without this flag, production-beta rejects skipped Gradle
+  flags before running. With it, the run still records a failed build-complete gate, sets
+  `nonRelease=true`, and keeps `promotionReady=false`.
 - `--allow-test-signing-in-production` permits a controlled test run of production-beta mode with
   non-production signing labels. It sets `nonRelease=true`, keeps `promotionReady=false`, and must
   not be used for release publication.
@@ -81,9 +90,9 @@ notes template is a production blocker. The runbook procedure is
 [production-security-response-runbook.md](production-security-response-runbook.md).
 
 Production beta mode requires multi-node beta soak evidence by default. Missing soak,
-upgrade-drill, scenario, or redaction evidence keeps `promotionReady=false`. Developer dry-runs may
-run the deterministic simulated drill without live nodes and may show warnings for missing previous
-candidate summaries.
+previous-candidate summary, upgrade-drill, scenario, real `hybrid`/`live` mode, or redaction
+evidence keeps `promotionReady=false`. Developer dry-runs may run the deterministic simulated drill
+without live nodes and may show warnings for missing previous-candidate summaries.
 
 ## Required inputs
 
@@ -105,6 +114,8 @@ inputs through environment variables or protected files:
 | `CRYPTAD_CERT_FORM_PASSWORD` | Local node form password for live collectors. Pass it through the environment only. |
 | Live fixture variables from `live_network_beta_smoke.py` | Catalog source, expected catalog key id, content/feed/profile/trust fixtures, and protected private insert URI indirection for required live evidence. |
 | `CRYPTAD_CERT_LIVE_TEST_INSERT_URI_ENV=CRYPTAD_CERT_LIVE_TEST_INSERT_URI` plus `CRYPTAD_CERT_LIVE_TEST_INSERT_URI` | GitHub Actions production-beta runs use this environment-name indirection for the private insert URI fixture. The raw URI lives only in the secret-valued `CRYPTAD_CERT_LIVE_TEST_INSERT_URI` variable. |
+| `--previous-summary "$PREVIOUS_RELEASE_CERTIFICATION_SUMMARY"` | Previous release-certification summary used for history comparison and previous-candidate upgrade evidence. Required for protected production-beta promotion. |
+| `--multi-node-soak-summary "$MULTI_NODE_BETA_SOAK_SUMMARY"` or `--run-multi-node-soak --multi-node-soak-config <production topology>` | Passing multi-node soak and upgrade evidence. Production-beta rejects the self-test topology and simulated mode as required promotion evidence. |
 
 Do not pass private keys, private insert URIs, form passwords, app tokens, or browser session tokens
 as command-line arguments.
@@ -155,6 +166,12 @@ build/production-beta-release/
 Temporary descriptors, generated test private keys, trusted-key scratch files, and raw command work
 directories are kept outside the public artifact tree.
 
+The public `dist/` archive is created only after the main artifact redaction report and the
+go/no-go dashboard redaction report both pass. Archive creation rejects AppleDouble files,
+`.DS_Store`, `__MACOSX/`, secret-looking filenames, symlinks, hard links, device nodes, nested
+unsafe archives, private insert URIs, private keys, app or browser-session tokens, raw fetched
+content, raw app data, and host-local absolute paths.
+
 ## Summary files
 
 `reports/production-beta-summary.json` is the machine-readable result. Important fields:
@@ -167,6 +184,7 @@ directories are kept outside the public artifact tree.
 | `workspaceStatusKnown` | `false` when `git status --porcelain` could not be read. Strict `release-candidate` and `production-beta` runs fail closed when workspace cleanliness is unknown. |
 | `dirtyWorkspace` | `true` when `git status --porcelain` found uncommitted changes. Dirty production-beta runs fail the `workspace.clean-production-beta` gate even if `--allow-dirty-workspace` was used for a controlled rerun. |
 | `signingProfile.kind` | `production`, `configured`, `test`, `test-fixture`, or `missing`. |
+| `pipelineStages` | Per-stage proof for launcher installation, full Gradle build, first-party app staging, signing, and verification. Production-beta promotion requires all required stages to be `pass` from this pipeline execution. |
 | `promotion.gates` | Per-gate pass/fail records for signed artifacts, evidence ids, live-network evidence, ecosystem certification, and signing profile checks. |
 | `promotion.securityResponse` | Compact status for the production security response runbook, advisory lifecycle, reviewer compromise drill, catalog key rotation drill, app signing key compromise drill, emergency catalog update drill, support redaction, security release notes template, blockers, and warnings. |
 | `multiNodeBetaSoak` | Compact status for multi-node soak and upgrade evidence, including mode, scenario statuses, blockers, warnings, promotion readiness, and the `evidence/multi-node-beta-soak.json` artifact path. |
@@ -190,7 +208,9 @@ The dashboard consumes sanitized summaries and emits one decision:
 
 - `go`: production beta promotion is ready.
 - `go-with-waivers`: promotion is launchable only with the listed approved, scoped, unexpired
-  waivers preserved in the release record.
+  waivers preserved in the release record. Production-beta cannot waive fixture evidence, test
+  signing, skipped build, dirty workspace, live-network evidence, sandbox provider evidence,
+  previous-candidate multi-node upgrade evidence, multi-node redaction, or redaction findings.
 - `no-go`: at least one unwaived blocker, invalid waiver, critical redaction finding, unsafe
   artifact hygiene finding, test signing in production mode, or non-release production artifact
   remains.

--- a/docs/production-beta-release-pipeline.md
+++ b/docs/production-beta-release-pipeline.md
@@ -114,8 +114,8 @@ inputs through environment variables or protected files:
 | `CRYPTAD_CERT_FORM_PASSWORD` | Local node form password for live collectors. Pass it through the environment only. |
 | Live fixture variables from `live_network_beta_smoke.py` | Catalog source, expected catalog key id, content/feed/profile/trust fixtures, and protected private insert URI indirection for required live evidence. |
 | `CRYPTAD_CERT_LIVE_TEST_INSERT_URI_ENV=CRYPTAD_CERT_LIVE_TEST_INSERT_URI` plus `CRYPTAD_CERT_LIVE_TEST_INSERT_URI` | GitHub Actions production-beta runs use this environment-name indirection for the private insert URI fixture. The raw URI lives only in the secret-valued `CRYPTAD_CERT_LIVE_TEST_INSERT_URI` variable. |
-| `--previous-summary "$PREVIOUS_RELEASE_CERTIFICATION_SUMMARY"` | Previous release-certification summary used for history comparison and previous-candidate upgrade evidence. Required for protected production-beta promotion. |
-| `--multi-node-soak-summary "$MULTI_NODE_BETA_SOAK_SUMMARY"` or `--run-multi-node-soak --multi-node-soak-config <production topology>` | Passing multi-node soak and upgrade evidence. Production-beta rejects the self-test topology and simulated mode as required promotion evidence. |
+| `--previous-summary "$PREVIOUS_RELEASE_CERTIFICATION_SUMMARY"` | Previous release-certification summary used for history comparison and previous-candidate upgrade evidence. Required for protected production-beta promotion. CLI runs pass a local JSON path. Protected workflow dispatches may pass a local checked-out path, an HTTPS JSON URL, or `actions-artifact://<run-id>/<artifact-name>/<path-inside-artifact>`. |
+| `--multi-node-soak-summary "$MULTI_NODE_BETA_SOAK_SUMMARY"` or `--run-multi-node-soak --multi-node-soak-config <production topology>` | Passing multi-node soak and upgrade evidence. CLI runs pass a local summary path. Protected workflow dispatches may pass a local checked-out path, an HTTPS JSON URL, or `actions-artifact://<run-id>/<artifact-name>/<path-inside-artifact>` for `multi_node_soak_summary`. Production-beta rejects the self-test topology and simulated mode as required promotion evidence. |
 
 Do not pass private keys, private insert URIs, form passwords, app tokens, or browser session tokens
 as command-line arguments.
@@ -366,6 +366,20 @@ The workflow uploads the full production beta artifact tree only when both
 `reports/go-no-go-redaction-report.json` reports `status=pass`. Redaction failures keep the raw
 output on the runner and do not publish rejected artifacts or the dashboard Markdown through
 GitHub Actions.
+
+Protected `production-beta` dispatch file inputs are materialized before strict validation. For
+`previous_summary`, `multi_node_soak_summary`, and `waiver_file`, use one of these forms:
+
+```text
+build/release-certification-history/latest-summary.json
+https://release-artifacts.example.org/release-certification-summary.json
+actions-artifact://1234567890/release-certification-history/release-certification-summary.json
+```
+
+The workflow downloads HTTPS sources with `curl` and restores `actions-artifact://` references with
+`gh run download` using the protected run token, then passes the resulting private `$RUNNER_TEMP`
+path to the release tool. HTTP URLs, missing artifact paths, absolute artifact paths, and artifact
+paths containing `..` fail before the pipeline starts.
 
 ## Known limitations
 

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -592,6 +592,19 @@ Do not commit generated history summaries by default. Release managers should re
 the previous release's sanitized certification artifact into the local workspace or CI job before
 running certification, then pass its path with `--previous-summary`.
 
+Protected `production-beta` GitHub Actions dispatches can also materialize prior JSON evidence
+before the pipeline starts. For the `previous_summary`, `multi_node_soak_summary`, and `waiver_file`
+workflow inputs, pass a local checked-out path, an HTTPS JSON URL, or a GitHub Actions artifact
+reference:
+
+```text
+actions-artifact://<run-id>/<artifact-name>/<path-inside-artifact>
+```
+
+The workflow restores these inputs into `$RUNNER_TEMP` and then passes the restored local path to
+the release tool. Plain `http://` URLs, missing artifact paths, absolute artifact paths, and
+artifact paths containing `..` are rejected before strict production-beta validation runs.
+
 ## Structured waiver files
 
 CLI `--waive ID=REASON` remains supported. Structured waiver files can be merged in with

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -592,7 +592,7 @@ Do not commit generated history summaries by default. Release managers should re
 the previous release's sanitized certification artifact into the local workspace or CI job before
 running certification, then pass its path with `--previous-summary`.
 
-Protected `production-beta` GitHub Actions dispatches can also materialize prior JSON evidence
+Manual production beta pipeline GitHub Actions dispatches can also materialize prior JSON evidence
 before the pipeline starts. For the `previous_summary`, `multi_node_soak_summary`, and `waiver_file`
 workflow inputs, pass a local checked-out path, an HTTPS JSON URL, or a GitHub Actions artifact
 reference:

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -66,7 +66,10 @@ tools/release-certification/run-production-beta-release.sh \
   --catalog-channel stable \
   --artifact-base-uri "$CRYPTAD_PRODUCTION_BETA_ARTIFACT_BASE_URI" \
   --require-live-network \
-  --require-sandbox-provider-tests
+  --require-multi-node-soak \
+  --require-sandbox-provider-tests \
+  --previous-summary "$PREVIOUS_RELEASE_CERTIFICATION_SUMMARY" \
+  --multi-node-soak-summary "$MULTI_NODE_BETA_SOAK_SUMMARY"
 ```
 
 The production beta command writes signed first-party app bundles, a signed first-party catalog,
@@ -78,7 +81,12 @@ go/no-go dashboard under `reports/`, plus `dist/crypta-production-beta-<version>
 URI. Catalog bundle URLs are signed under the published layout root, for example
 `<base>/build/app-bundles/<app>-<version>.zip`. `--use-fixture-evidence` is accepted only for
 `developer-dry-run` and internal self-tests. Use
-`developer-dry-run` for PR-safe local runs without release keys or live-network access. See
+`developer-dry-run` for PR-safe local runs without release keys or live-network access. Protected
+`production-beta` also requires previous release-certification history and passing multi-node
+upgrade evidence through `--previous-summary` plus either `--multi-node-soak-summary` or an explicit
+non-self-test `hybrid`/`live` topology config. Simulated multi-node mode, fixture evidence, test
+signing, skipped build stages, missing sandbox evidence, and missing live-network evidence remain
+non-release/no-go in production-beta. See
 [docs/production-beta-release-pipeline.md](../../docs/production-beta-release-pipeline.md) for
 mode semantics, required environment variables, artifact layout, failure classes, redaction rules,
 and rerun guidance.
@@ -195,7 +203,8 @@ Each item contains `id`, `status`, `requiredForReleaseCandidate`, `summary`, `so
 
 The production beta go/no-go dashboard emits `go`, `no-go`, or `go-with-waivers` from the sanitized
 pipeline summaries. Waiver rendering preserves ids, rationale, owner, approver, expiry, scope, and
-usage, but redaction findings and unsafe artifact hygiene findings are never downgraded by waivers.
+usage, but production-beta launch evidence, redaction findings, and unsafe artifact hygiene
+findings are never downgraded by waivers.
 
 ## Required release-candidate evidence
 

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -16743,7 +16743,7 @@ def run_self_test(repo_root: Path) -> None:
         )
         canonical_sdk = repo_root / "platform-sdk-js/src/main/resources/network/crypta/platform/sdk/js/crypta-platform.js"
         if canonical_sdk.is_file():
-            shutil.copy2(canonical_sdk, static_dir / "crypta-platform.js")
+            shutil.copy(canonical_sdk, static_dir / "crypta-platform.js")
         else:
             (static_dir / "crypta-platform.js").write_text(
                 'window.CryptaPlatform={}; X="X-Crypta-App-Session";\n',
@@ -18524,8 +18524,8 @@ def make_self_test_workspace(workspace: Path) -> None:
                     encoding="utf-8",
                 )
             for asset_name in design_system_asset_names():
-                shutil.copy2(design_dir / asset_name, root / "static/crypta-ui" / asset_name)
-            shutil.copy2(sdk, root / "static/crypta-platform.js")
+                shutil.copy(design_dir / asset_name, root / "static/crypta-ui" / asset_name)
+            shutil.copy(sdk, root / "static/crypta-platform.js")
         is_profile_publisher = app_id == "profile-publisher"
         is_feed_reader = app_id == "feed-reader"
         is_social_inbox = app_id == "social-inbox"

--- a/tools/release-certification/fixtures/go-no-go-production-critical-evidence-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-production-critical-evidence-waiver.json
@@ -1,0 +1,49 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "productionBetaSummary": {
+      "nonRelease": false,
+      "promotion": {
+        "failedGateCount": 1,
+        "gates": [
+          {
+            "id": "evidence.app-store.submission-cli",
+            "source": "release-certification-summary",
+            "status": "fail",
+            "summary": "App-store submission CLI evidence is missing from the production beta launch record."
+          }
+        ],
+        "promotionReady": false,
+        "status": "fail"
+      },
+      "promotionReady": false,
+      "redaction": {
+        "findings": [],
+        "status": "pass"
+      },
+      "status": "fail"
+    }
+  },
+  "mode": "production-beta",
+  "releaseId": "crypta-production-beta-270-critical-evidence-waiver",
+  "waivers": {
+    "releaseId": "crypta-production-beta-270-critical-evidence-waiver",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-24T00:00:00Z",
+        "evidenceId": "app-store.submission-cli",
+        "expiresAt": "2099-06-30T00:00:00Z",
+        "id": "waiver-production-critical-app-store-cli-001",
+        "owner": "release-engineering",
+        "rationale": "Fixture waiver attempt for mandatory production app-store submission CLI evidence.",
+        "references": [
+          "fixture-pr-270-production-critical-waiver"
+        ],
+        "scope": "production-beta",
+        "severity": "blocker"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-release-candidate-live-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-release-candidate-live-waiver.json
@@ -1,0 +1,47 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "liveNetworkSummary": {
+      "enabled": true,
+      "evidence": [
+        {
+          "id": "live-network-beta.content-fetch",
+          "requiredForReleaseCandidate": true,
+          "source": "fixture-live-network",
+          "status": "fail",
+          "summary": "Release-candidate live content fetch evidence failed during a controlled lab outage."
+        }
+      ],
+      "kind": "live-network-beta-smoke",
+      "mode": "release-candidate",
+      "redaction": {
+        "findings": [],
+        "status": "pass"
+      },
+      "required": true,
+      "status": "fail"
+    }
+  },
+  "mode": "release-candidate",
+  "releaseId": "crypta-production-beta-270-release-candidate-live-waiver",
+  "waivers": {
+    "releaseId": "crypta-production-beta-270-release-candidate-live-waiver",
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "approvedBy": "release-manager@example.invalid",
+        "createdAt": "2026-06-24T00:00:00Z",
+        "evidenceId": "live-network-beta.content-fetch",
+        "expiresAt": "2099-06-30T00:00:00Z",
+        "id": "waiver-release-candidate-live-content-fetch-001",
+        "owner": "release-engineering",
+        "rationale": "Release manager accepted the release-candidate live content fetch gap for this dry-run evidence window.",
+        "references": [
+          "fixture-pr-270-release-candidate-live-waiver"
+        ],
+        "scope": "release-candidate",
+        "severity": "blocker"
+      }
+    ]
+  }
+}

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -270,24 +270,81 @@ NON_WAIVABLE_EVIDENCE_IDS = {
     "production-beta.dashboard-redaction",
     "production-beta.launch-artifact-hygiene",
     "production-beta.waiver-validation",
-    "production-beta.production-signing",
     "production-beta.non-release",
+    "redaction.status",
+}
+PRODUCTION_BETA_NON_WAIVABLE_EVIDENCE_IDS = {
+    "production-beta.production-signing",
     "production-beta.test-signing",
     "production-beta.build-complete",
     "production-beta.workspace-clean",
     "production-beta.fixture-evidence",
-    "redaction.status",
     "signing.production-keys",
+    "apphost.sandbox-provider",
+    "evidence.required-sandbox-provider-tests",
+    "evidence.apphost.sandbox-provider",
     "build.production-beta-complete",
+    "build.crypta-app-launcher-install",
+    "build.gradle-full-build",
+    "build.first-party-app-staging",
+    "build.first-party-app-signing",
+    "build.first-party-app-verification",
     "workspace.clean-production-beta",
     "fixture-evidence.strict-mode",
     "live.production-beta-skip",
+    "live-network-beta.preflight",
+    "live-network-beta.catalog-usk-fetch",
+    "live-network-beta.app-install-update-rollback",
+    "live-network-beta.content-fetch",
+    "live-network-beta.feed-subscription",
+    "live-network-beta.profile-publish",
+    "live-network-beta.trust-statement-publish-import",
+    "live-network-beta.interop-perf-budget",
+    "live-network-beta.redaction",
+    "live.live-network-beta.preflight",
+    "live.live-network-beta.catalog-usk-fetch",
+    "live.live-network-beta.app-install-update-rollback",
+    "live.live-network-beta.content-fetch",
+    "live.live-network-beta.feed-subscription",
+    "live.live-network-beta.profile-publish",
+    "live.live-network-beta.trust-statement-publish-import",
+    "live.live-network-beta.interop-perf-budget",
+    "live.live-network-beta.redaction",
+    "multi-node-beta.soak",
+    "multi-node-beta.redaction",
+    "multi-node-beta.previous-candidate-summary",
+    "multi-node-beta.production-evidence-mode",
+    "multi-node-beta.upgrade-drill",
+    "multi-node-beta.catalog-channel-update",
+    "multi-node-beta.app-install-update-rollback",
+    "multi-node-beta.app-data-migration",
+    "multi-node-beta.backup-restore",
+    "multi-node-beta.subscription-pressure",
+    "multi-node-beta.trust-graph-import",
+    "multi-node-beta.social-inbox-multi-source",
+    "multi-node-beta.support-bundle-drill",
+    "release-certification.ecosystem-rc-gate",
+    "ecosystem.release-candidate-passed",
+    "ecosystem.certification-matrix",
 }
 PRODUCTION_ARTIFACT_GATE_IDS = {
     "artifact.signed-first-party-bundles",
     "artifact.signed-first-party-catalog",
     "artifact.first-party-review-receipts",
 }
+
+
+def non_waivable_evidence_ids_for_mode(mode: str) -> set[str]:
+    ids = set(NON_WAIVABLE_EVIDENCE_IDS)
+    if mode == "production-beta":
+        ids.update(PRODUCTION_BETA_NON_WAIVABLE_EVIDENCE_IDS)
+        ids.update(PRODUCTION_ARTIFACT_GATE_IDS)
+    return ids
+
+
+def evidence_id_is_non_waivable_in_mode(evidence_id: str, mode: str) -> bool:
+    return evidence_id in non_waivable_evidence_ids_for_mode(mode)
+
 
 REDACTION_FINDING_KINDS = {
     "private-insert-uri",
@@ -364,7 +421,7 @@ APP_TOKEN_VALUE_RE = re.compile(
     re.IGNORECASE,
 )
 FORM_PASSWORD_VALUE_RE = re.compile(
-    r"(?<![\w-])[\"']?(?:CRYPTAD_CERT_FORM_PASSWORD|formPassword|form[-_ ]?password)[\"']?(?![\w-])"
+    r"(?<![\w-])[\"']?(?:CRYPTAD_CERT_FORM_PASSWORD|formPassword|form[-_ ]?password|X-Crypta-Form-Password)[\"']?(?![\w-])"
     r"\s*(?::|(?<![=!<>])=(?!=))\s*['\"]?([^'\"\s,;&}]+)",
     re.IGNORECASE,
 )
@@ -885,7 +942,7 @@ def is_redaction_evidence(evidence_id: str, domain_id: str = "") -> bool:
     }
 
 
-def issue_for_evidence(domain_id: str, evidence_id: str, entry: dict[str, Any] | None) -> Issue | None:
+def issue_for_evidence(domain_id: str, evidence_id: str, entry: dict[str, Any] | None, mode: str) -> Issue | None:
     if status_ok(entry):
         return None
     waiver_id = "" if entry_has_redaction_findings(entry) else entry_waiver_id(entry)
@@ -938,7 +995,7 @@ def issue_for_evidence(domain_id: str, evidence_id: str, entry: dict[str, Any] |
         title=f"{evidence_id} is not passing",
         summary=evidence_summary(entry),
         source=str(entry.get("source", domain_id)) if isinstance(entry, dict) else domain_id,
-        waivable=severity != "critical" and evidence_id not in NON_WAIVABLE_EVIDENCE_IDS,
+        waivable=severity != "critical" and not evidence_id_is_non_waivable_in_mode(evidence_id, mode),
         category="evidence",
     )
 
@@ -1535,16 +1592,20 @@ def production_summary_issues(summary: dict[str, Any] | None, mode: str) -> list
         gate_id = str(gate.get("id", "promotion-gate"))
         evidence_id = canonical_evidence_id(gate_id)
         source = str(gate.get("source", "promotion"))
+        mode_non_waivable_ids = non_waivable_evidence_ids_for_mode(mode)
         nonwaivable = (
-            gate_id in NON_WAIVABLE_EVIDENCE_IDS
-            or evidence_id in NON_WAIVABLE_EVIDENCE_IDS
-            or (mode == "production-beta" and gate_id in PRODUCTION_ARTIFACT_GATE_IDS)
+            gate_id in mode_non_waivable_ids
+            or evidence_id in mode_non_waivable_ids
             or is_redaction_evidence(gate_id)
             or is_redaction_evidence(evidence_id)
         )
-        if gate_id == "signing.production-keys" or "test-signing" in gate_id:
+        if mode == "production-beta" and (gate_id == "signing.production-keys" or "test-signing" in gate_id):
             nonwaivable = True
-        if gate_id in {"build.production-beta-complete", "workspace.clean-production-beta", "fixture-evidence.strict-mode"}:
+        if mode == "production-beta" and gate_id in {
+            "build.production-beta-complete",
+            "workspace.clean-production-beta",
+            "fixture-evidence.strict-mode",
+        }:
             nonwaivable = True
         issues.append(
             Issue(
@@ -1576,7 +1637,7 @@ def domain_for_gate(gate_id: str, source: str) -> str:
     return "production-beta-release-pipeline"
 
 
-def release_certification_issues(summary: dict[str, Any] | None) -> list[Issue]:
+def release_certification_issues(summary: dict[str, Any] | None, mode: str) -> list[Issue]:
     if not isinstance(summary, dict):
         return []
     issues: list[Issue] = []
@@ -1587,7 +1648,7 @@ def release_certification_issues(summary: dict[str, Any] | None) -> list[Issue]:
         evidence_id = str(entry.get("id", ""))
         if evidence_id != "release-certification.ecosystem-rc-gate":
             continue
-        issue = issue_for_evidence("release-certification", evidence_id, entry)
+        issue = issue_for_evidence("release-certification", evidence_id, entry, mode)
         if issue is not None:
             issues.append(issue)
     if summary.get("releaseCandidatePassed") is not True:
@@ -1808,7 +1869,7 @@ def multi_node_issues(summary: dict[str, Any] | None, mode: str) -> list[Issue]:
                         title=f"{scenario_id} scenario is not passing",
                         summary=f"{scenario_id} status is {scenario_status}.",
                         source="multi-node-beta-soak-summary",
-                        waivable=True,
+                        waivable=mode != "production-beta",
                         category="multi-node",
                     )
                 )
@@ -2021,10 +2082,10 @@ def severity_covers(waiver: Waiver, issue: Issue) -> bool:
 
 
 def issue_is_non_waivable_in_mode(issue: Issue, mode: str) -> bool:
-    return mode == "production-beta" and (
-        issue.evidence_id in NON_WAIVABLE_EVIDENCE_IDS | PRODUCTION_ARTIFACT_GATE_IDS
-        or issue.severity == "critical"
-    )
+    if issue.severity == "critical":
+        return True
+    mode_non_waivable_ids = non_waivable_evidence_ids_for_mode(mode)
+    return issue.id in mode_non_waivable_ids or issue.evidence_id in mode_non_waivable_ids
 
 
 def load_waivers(
@@ -2118,7 +2179,7 @@ def load_waivers(
             validation_errors.append(f"scope does not apply to {mode}")
         if evidence_id and evidence_id not in known_ids and not external_risk_accepted:
             validation_errors.append("evidenceId is unknown and externalRiskAccepted is not true")
-        if mode == "production-beta" and evidence_id in NON_WAIVABLE_EVIDENCE_IDS | PRODUCTION_ARTIFACT_GATE_IDS:
+        if mode == "production-beta" and evidence_id_is_non_waivable_in_mode(evidence_id, mode):
             validation_errors.append("target is non-waivable in production-beta mode")
         active = not validation_errors
         safe_errors = tuple(scrub_text(error, workspace_root, out_dir) for error in validation_errors)
@@ -2279,7 +2340,7 @@ def collect_issues(
         if name != "waivers" and name not in inputs and name in {spec_name for spec in DOMAIN_SPECS for spec_name in spec.get("artifactInputs", ())}:
             issues.append(input_missing_issue(name, mode))
     issues.extend(production_summary_issues(inputs.get("productionBetaSummary"), mode))
-    issues.extend(release_certification_issues(inputs.get("releaseCertificationSummary")))
+    issues.extend(release_certification_issues(inputs.get("releaseCertificationSummary"), mode))
     issues.extend(ecosystem_matrix_issues(inputs.get("ecosystemMatrix")))
     issues.extend(network_scale_issues(inputs.get("networkScaleSoakSummary"), mode))
     issues.extend(multi_node_issues(inputs.get("multiNodeBetaSoakSummary"), mode))
@@ -2298,7 +2359,7 @@ def collect_issues(
         if domain_id == "live-network-beta-smoke" and not live_evidence_required(inputs, mode):
             continue
         for evidence_id in spec["evidenceIds"]:
-            issue = issue_for_evidence(domain_id, str(evidence_id), all_evidence.get(str(evidence_id)))
+            issue = issue_for_evidence(domain_id, str(evidence_id), all_evidence.get(str(evidence_id)), mode)
             if issue is not None:
                 issues.append(issue)
     return dedupe_issues(issues), all_evidence
@@ -2324,6 +2385,7 @@ def known_ids(all_evidence: dict[str, dict[str, Any]], issues: list[Issue]) -> s
     for issue in issues:
         ids.update({issue.id, issue.evidence_id, issue.domain_id, f"evidence.{issue.evidence_id}"})
     ids.update(NON_WAIVABLE_EVIDENCE_IDS)
+    ids.update(PRODUCTION_BETA_NON_WAIVABLE_EVIDENCE_IDS)
     ids.update(PRODUCTION_ARTIFACT_GATE_IDS)
     return expand_waiver_target_aliases(*ids)
 
@@ -2617,9 +2679,9 @@ def run_self_test(quiet: bool = False) -> None:
     fixture_expectations = {
         "go-no-go-pass.json": "go",
         "go-no-go-no-go.json": "no-go",
-        "go-no-go-with-waivers.json": "go-with-waivers",
+        "go-no-go-with-waivers.json": "no-go",
         "go-no-go-expired-waiver.json": "no-go",
-        "go-no-go-waiver-valid-at-generated-at.json": "go-with-waivers",
+        "go-no-go-waiver-valid-at-generated-at.json": "no-go",
         "go-no-go-critical-redaction.json": "no-go",
         "go-no-go-test-signing-production.json": "no-go",
         "go-no-go-summary-failure-with-gates.json": "no-go",
@@ -2638,8 +2700,9 @@ def run_self_test(quiet: bool = False) -> None:
         "go-no-go-network-scale-redaction-waiver.json": "no-go",
         "go-no-go-secret-value-redaction.json": "no-go",
         "go-no-go-underseverity-waiver.json": "no-go",
-        "go-no-go-live-evidence-waiver-alias.json": "go-with-waivers",
+        "go-no-go-live-evidence-waiver-alias.json": "no-go",
         "go-no-go-live-network-skip-waiver.json": "no-go",
+        "go-no-go-release-candidate-live-waiver.json": "go-with-waivers",
         "go-no-go-release-candidate-live-disabled.json": "no-go",
         "go-no-go-malformed-non-release-status.json": "no-go",
     }
@@ -2681,10 +2744,12 @@ def run_self_test(quiet: bool = False) -> None:
                 if dashboard.get("generatedAt") != "2026-06-24T00:00:00Z":
                     raise AssertionError("expired waiver fixture did not use its recorded generatedAt")
             if fixture_name == "go-no-go-waiver-valid-at-generated-at.json":
-                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
-                    raise AssertionError("waiver valid at generatedAt was not used")
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("non-waivable live evidence waiver was incorrectly used")
                 if dashboard.get("generatedAt") != "1999-06-24T00:00:00Z":
                     raise AssertionError("historical waiver fixture did not use its recorded generatedAt")
+                if "production-beta.waiver-validation" not in blocker_ids:
+                    raise AssertionError("historical non-waivable live evidence waiver did not fail validation")
             if fixture_name == "go-no-go-production-summary-not-ready.json":
                 if "production-beta.promotion-ready" not in blocker_ids:
                     raise AssertionError("non-ready production summary did not block production beta")
@@ -2696,15 +2761,22 @@ def run_self_test(quiet: bool = False) -> None:
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
                     raise AssertionError("non-passing production summary hard blocker was incorrectly waived")
             if fixture_name == "go-no-go-live-evidence-waiver-alias.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("live evidence alias waiver was incorrectly used")
+                if "live-network-beta.content-fetch" not in blocker_ids:
+                    raise AssertionError("live evidence waiver attempt did not leave live-network evidence blocked")
+                if "production-beta.waiver-validation" not in blocker_ids:
+                    raise AssertionError("live evidence waiver attempt did not fail waiver validation")
+            if fixture_name == "go-no-go-release-candidate-live-waiver.json":
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
-                    raise AssertionError("live evidence alias waiver was not used")
+                    raise AssertionError("release-candidate live evidence waiver was not used")
                 waived_evidence_ids = {
                     str(warning.get("evidenceId"))
                     for warning in dashboard.get("warnings", [])
                     if isinstance(warning, dict) and warning.get("waivedBy")
                 }
                 if "live-network-beta.content-fetch" not in waived_evidence_ids:
-                    raise AssertionError("live evidence alias waiver did not cover live-network evidence")
+                    raise AssertionError("release-candidate live evidence waiver did not waive content-fetch evidence")
             if fixture_name == "go-no-go-release-cert-schema-waiver.json":
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
                     raise AssertionError("release-certification schema waiver was not used by dashboard")

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -137,6 +137,33 @@ CATALOG_AND_SIGNING_EVIDENCE_IDS = (
 CONSENT_EVIDENCE_IDS = ("app-platform.user-consent-flow",)
 SECURITY_RESPONSE_EVIDENCE_IDS = ("production-security.response-runbook",)
 FIRST_PARTY_MAINTENANCE_EVIDENCE_IDS = ("app-catalog.first-party-maintenance-policy",)
+CRITICAL_PRODUCTION_BETA_EVIDENCE_IDS = (
+    "app-platform.signed-bundles",
+    "app-catalog.first-party-maintenance-policy",
+    "catalog.smoke",
+    "app-review.trusted-receipts",
+    "app-review.first-party-catalog",
+    "app-review.first-party-review-chain",
+    *APP_STORE_SUBMISSION_EVIDENCE_IDS,
+    *THIRD_PARTY_DEVELOPER_BETA_EVIDENCE_IDS,
+    *PLATFORM_API_STABLE_FREEZE_EVIDENCE_IDS,
+    "app-ui.lint",
+    "apphost.sandbox-provider",
+    "app-update.data-migration-contract",
+    "app-data.backup-restore-portability",
+    "catalog.security-advisories",
+    "catalog.version-denylist",
+    "app-review.receipt-revocation",
+    "app-review.reviewer-key-compromise-flow",
+    "app-update.security-denylist-gates",
+    "app-services.registry",
+    "app-services.grants",
+    "app-services.dependency-graph",
+    "app-services.grant-bundles",
+    "app-services.dependency-redaction",
+    "production-security.response-runbook",
+    *LEGACY_ADMIN_EVIDENCE_IDS,
+)
 
 DASHBOARD_EVIDENCE_IDS = (
     "production-beta.go-no-go-dashboard",
@@ -334,10 +361,19 @@ PRODUCTION_ARTIFACT_GATE_IDS = {
 }
 
 
+def evidence_ids_with_gate_aliases(evidence_ids: Iterable[str]) -> set[str]:
+    ids: set[str] = set()
+    for evidence_id in evidence_ids:
+        ids.add(evidence_id)
+        ids.add(f"evidence.{evidence_id}")
+    return ids
+
+
 def non_waivable_evidence_ids_for_mode(mode: str) -> set[str]:
     ids = set(NON_WAIVABLE_EVIDENCE_IDS)
     if mode == "production-beta":
         ids.update(PRODUCTION_BETA_NON_WAIVABLE_EVIDENCE_IDS)
+        ids.update(evidence_ids_with_gate_aliases(CRITICAL_PRODUCTION_BETA_EVIDENCE_IDS))
         ids.update(PRODUCTION_ARTIFACT_GATE_IDS)
     return ids
 
@@ -2676,6 +2712,15 @@ def build_command(args: argparse.Namespace) -> tuple[dict[str, Any], int]:
 
 
 def run_self_test(quiet: bool = False) -> None:
+    for evidence_id in CRITICAL_PRODUCTION_BETA_EVIDENCE_IDS:
+        if not evidence_id_is_non_waivable_in_mode(evidence_id, "production-beta"):
+            raise AssertionError(f"production critical evidence is waivable in production-beta: {evidence_id}")
+        gate_id = f"evidence.{evidence_id}"
+        if not evidence_id_is_non_waivable_in_mode(gate_id, "production-beta"):
+            raise AssertionError(f"production critical evidence gate is waivable in production-beta: {gate_id}")
+    if evidence_id_is_non_waivable_in_mode("app-store.submission-cli", "release-candidate"):
+        raise AssertionError("release-candidate app-store evidence should remain waiverable")
+
     fixture_expectations = {
         "go-no-go-pass.json": "go",
         "go-no-go-no-go.json": "no-go",
@@ -2702,6 +2747,7 @@ def run_self_test(quiet: bool = False) -> None:
         "go-no-go-underseverity-waiver.json": "no-go",
         "go-no-go-live-evidence-waiver-alias.json": "no-go",
         "go-no-go-live-network-skip-waiver.json": "no-go",
+        "go-no-go-production-critical-evidence-waiver.json": "no-go",
         "go-no-go-release-candidate-live-waiver.json": "go-with-waivers",
         "go-no-go-release-candidate-live-disabled.json": "no-go",
         "go-no-go-malformed-non-release-status.json": "no-go",
@@ -2777,6 +2823,13 @@ def run_self_test(quiet: bool = False) -> None:
                 }
                 if "live-network-beta.content-fetch" not in waived_evidence_ids:
                     raise AssertionError("release-candidate live evidence waiver did not waive content-fetch evidence")
+            if fixture_name == "go-no-go-production-critical-evidence-waiver.json":
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("production-critical evidence waiver was incorrectly used")
+                if "app-store.submission-cli" not in blocker_ids:
+                    raise AssertionError("production-critical app-store evidence did not remain blocked")
+                if "production-beta.waiver-validation" not in blocker_ids:
+                    raise AssertionError("production-critical evidence waiver attempt did not fail validation")
             if fixture_name == "go-no-go-release-cert-schema-waiver.json":
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 1:
                     raise AssertionError("release-certification schema waiver was not used by dashboard")

--- a/tools/release-certification/production_beta_release.py
+++ b/tools/release-certification/production_beta_release.py
@@ -327,21 +327,22 @@ APP_TOKEN_VALUE_RE = re.compile(
     re.IGNORECASE,
 )
 FORM_PASSWORD_VALUE_RE = re.compile(
-    r"(?<![\w-])[\"']?(?:CRYPTAD_CERT_FORM_PASSWORD|formPassword|form[-_ ]?password)[\"']?(?![\w-])"
+    r"(?<![\w-])[\"']?(?:CRYPTAD_CERT_FORM_PASSWORD|formPassword|form[-_ ]?password|X-Crypta-Form-Password)[\"']?(?![\w-])"
     r"\s*(?::|(?<![=!<>])=(?!=))\s*['\"]?([^'\"\s,;&}]+)",
     re.IGNORECASE,
 )
 RAW_BODY_VALUE_RE = re.compile(
     r"(?<![\w-])[\"']?(?:"
-    r"raw[-_ ]*(?:(?:request|response|feed|fetched|social|message|profile|trust|app[-_ ]?data)[-_ ]*)?"
+    r"raw[-_ ]*(?:(?:request|response|feed|fetched|social|message|profile|trust|app[-_ ]?data|backup|signature)[-_ ]*)?"
     r"(?:body|document|payload|content|value|values)"
     r"|"
-    r"(?:request|response|feed|fetched|social|message|profile|trust|app[-_ ]?data)[-_ ]*raw[-_ ]*"
+    r"(?:request|response|feed|fetched|social|message|profile|trust|app[-_ ]?data|backup|signature)[-_ ]*raw[-_ ]*"
     r"(?:body|document|payload|content|value|values)"
     r"|"
     r"(?:private|unredacted)[-_ ]*"
-    r"(?:(?:request|response|feed|fetched|social|message|profile|trust|app[-_ ]?data)[-_ ]*)?"
+    r"(?:(?:request|response|feed|fetched|social|message|profile|trust|app[-_ ]?data|backup|signature)[-_ ]*)?"
     r"(?:body|document|payload|content|value|values)"
+    r"|payloadBase64|plainTextExport|queueHtml"
     r")[\"']?(?![\w-])\s*(?::|(?<![=!<>])=(?!=))\s*['\"]?([^'\"\r\n}]+)",
     re.IGNORECASE,
 )
@@ -373,13 +374,17 @@ FILE_URI_RE = re.compile(
 WINDOWS_PATH_RE = re.compile(r"(?<![A-Za-z0-9_:/.\->])[A-Za-z]:[\\/][^:*?\"<>|\r\n]+")
 HOST_PATH_RE = re.compile(
     r"(?<![A-Za-z0-9_:/.\->])/"
-    r"(?:Users|home|work|workspace|tmp|private/tmp|var/folders|mnt|Volumes|root|opt|runner|__w)"
+    r"(?:Users|home|work|workspace|tmp|private/tmp|var/folders|var/lib|var/log|mnt|Volumes|root|opt|runner|__w|srv|etc)"
     r"(?:/[^\s\"'<>),;]+)+"
 )
 DEFAULT_REVIEW_POLICY_ID = "crypta-app-review-v1"
 DEFAULT_REVIEW_POLICY_VERSION = "1"
 FIXTURE_APP_SIGNING_KEY_ID = "crypta-production-beta-test-app"
 FIXTURE_REVIEWER_KEY_ID = "crypta-production-beta-test-review"
+NON_PRODUCTION_KEY_ID_RE = re.compile(
+    r"(?:^|[._-])(?:test|fixture|dry[-_]?run|sample|example|dev|development|local)(?:$|[._-])",
+    re.IGNORECASE,
+)
 SIGNING_PROFILE_ENV_KEYS = (
     "CRYPTAD_APP_SIGNING_KEY_ID",
     "CRYPTAD_APP_SIGNING_PRIVATE_KEY_FILE",
@@ -460,10 +465,20 @@ class PipelineState:
     certification_exit_code: int | None = None
     workspace_status_known: bool = True
     dirty_workspace: bool = False
+    pipeline_stages: dict[str, dict[str, Any]] = dataclasses.field(default_factory=dict)
 
 
 class ReleaseArtifactError(RuntimeError):
     """Raised when a staged release artifact source is unsafe to publish."""
+
+
+PRODUCTION_BETA_REQUIRED_PIPELINE_STAGES = (
+    "crypta-app-launcher-install",
+    "gradle-full-build",
+    "first-party-app-staging",
+    "first-party-app-signing",
+    "first-party-app-verification",
+)
 
 
 def production_build_skipped(settings: Settings) -> bool:
@@ -475,10 +490,49 @@ def release_config_non_release(settings: Settings, profile: SigningProfile | Non
         settings.mode == "developer-dry-run"
         or settings.allow_test_signing_in_production
         or production_build_skipped(settings)
+        or (settings.mode == "production-beta" and not all_required_production_pipeline_stages_completed(state))
         or state.dirty_workspace
         or not state.workspace_status_known
         or bool(profile and profile.kind != "production")
     )
+
+
+def pipeline_stage_completed(state: PipelineState, stage_id: str) -> bool:
+    return state.pipeline_stages.get(stage_id, {}).get("status") == "pass"
+
+
+def record_pipeline_stage(
+    state: PipelineState,
+    stage_id: str,
+    status: str,
+    summary: str,
+    command: CommandResult | None = None,
+) -> None:
+    entry: dict[str, Any] = {
+        "status": status,
+        "summary": summary,
+    }
+    if command is not None:
+        entry["command"] = command.name
+        entry["exitCode"] = command.exit_code
+        entry["durationMs"] = command.duration_ms
+    state.pipeline_stages[stage_id] = entry
+
+
+def record_gradle_stage(
+    state: PipelineState,
+    stage_id: str,
+    result: CommandResult | None,
+    summary: str,
+) -> None:
+    if result is None:
+        record_pipeline_stage(state, stage_id, "skipped", summary)
+        return
+    record_pipeline_stage(state, stage_id, "pass" if result.ok() else "fail", summary, result)
+
+
+def all_required_production_pipeline_stages_completed(state: PipelineState) -> bool:
+    return all(pipeline_stage_completed(state, stage_id) for stage_id in PRODUCTION_BETA_REQUIRED_PIPELINE_STAGES)
 
 
 def utc_now() -> str:
@@ -857,6 +911,11 @@ def env_value_or_default(env: dict[str, str], key: str, default: str) -> str:
     return env.get(key, "").strip() or default
 
 
+def key_id_looks_non_production(key_id: str) -> bool:
+    normalized = key_id.strip()
+    return bool(normalized and NON_PRODUCTION_KEY_ID_RE.search(normalized))
+
+
 def fixture_signing_env(source: dict[str, str]) -> dict[str, str]:
     env = source.copy()
     for key in SIGNING_PROFILE_ENV_KEYS:
@@ -935,6 +994,18 @@ def prepare_signing_profile(state: PipelineState, key_dir: Path) -> SigningProfi
             state.warnings.append(
                 "Production-beta test-signing escape hatch is enabled; configured signing inputs are labelled non-production and outputs remain non-release."
             )
+        elif state.settings.mode == "production-beta":
+            non_production_key_ids = [
+                key_id
+                for key_id in (app_key_id, reviewer_key_id)
+                if key_id_looks_non_production(key_id) or key_id in {FIXTURE_APP_SIGNING_KEY_ID, FIXTURE_REVIEWER_KEY_ID}
+            ]
+            if non_production_key_ids:
+                kind = "configured"
+                state.failures.append(
+                    "production-beta signing and reviewer key IDs must be production key IDs; "
+                    "test, fixture, dry-run, sample, local, or example key IDs are not release material."
+                )
         return SigningProfile(
             kind=kind,
             generated_test_keys=False,
@@ -1069,7 +1140,7 @@ def safe_copy_tree(src: Path, dst: Path, label: str) -> None:
     if dst.exists():
         shutil.rmtree(dst)
     ignore = shutil.ignore_patterns("._*", ".DS_Store", "__MACOSX")
-    shutil.copytree(src, dst, ignore=ignore, symlinks=True)
+    shutil.copytree(src, dst, ignore=ignore, symlinks=True, copy_function=shutil.copy)
     try:
         reject_tree_symlinks(dst, f"copied {label}")
     except ReleaseArtifactError:
@@ -1079,6 +1150,27 @@ def safe_copy_tree(src: Path, dst: Path, label: str) -> None:
 
 def launcher_install_dir(settings: Settings) -> Path:
     return settings.workspace_root / "platform-devtools/build/install/crypta-app"
+
+
+def clear_workspace_generated_release_outputs(state: PipelineState) -> None:
+    if state.settings.mode != "production-beta" or state.settings.skip_gradle:
+        return
+    generated_paths = [
+        launcher_install_dir(state.settings),
+        state.settings.workspace_root / "build/cryptad-dist",
+        *[
+            state.settings.workspace_root / APP_PROJECT_DIRS[app_id] / "build/cryptad-app"
+            for app_id in APP_IDS
+        ],
+    ]
+    for path in generated_paths:
+        try:
+            if path.exists() and not path.is_symlink():
+                shutil.rmtree(path)
+            elif path.exists():
+                path.unlink()
+        except OSError as exc:
+            state.failures.append(f"Could not remove stale generated release output {path}: {exc}")
 
 
 def copy_launcher_distribution(state: PipelineState) -> None:
@@ -1667,10 +1759,10 @@ def package_catalog_and_reviews(
     )
     signature = working_catalog.with_name(CANONICAL_CATALOG_SIGNATURE)
     if working_catalog.is_file():
-        shutil.copy2(working_catalog, catalog_dir / "first-party-catalog.properties")
+        shutil.copy(working_catalog, catalog_dir / "first-party-catalog.properties")
     if signature.is_file():
-        shutil.copy2(signature, catalog_dir / CANONICAL_CATALOG_SIGNATURE)
-        shutil.copy2(signature, catalog_dir / RELEASE_CATALOG_SIGNATURE_ALIAS)
+        shutil.copy(signature, catalog_dir / CANONICAL_CATALOG_SIGNATURE)
+        shutil.copy(signature, catalog_dir / RELEASE_CATALOG_SIGNATURE_ALIAS)
     write_json(
         catalog_dir / "channel-metadata.json",
         {
@@ -1810,6 +1902,7 @@ def release_config(state: PipelineState) -> dict[str, Any]:
         "workspaceStatusKnown": state.workspace_status_known,
         "dirtyWorkspace": state.dirty_workspace,
         "nonRelease": release_config_non_release(settings, profile, state),
+        "pipelineStages": state.pipeline_stages,
         "signingProfile": None
         if profile is None
         else {
@@ -1846,8 +1939,8 @@ def run_fixture_certification(state: PipelineState, cert_out: Path) -> None:
     network_summary.parent.mkdir(parents=True, exist_ok=True)
     app_summary.parent.mkdir(parents=True, exist_ok=True)
     multi_node_summary.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(fixtures / "self-test-network-scale-soak.json", network_summary)
-    shutil.copy2(fixtures / "self-test-app-platform-smoke.json", app_summary)
+    shutil.copy(fixtures / "self-test-network-scale-soak.json", network_summary)
+    shutil.copy(fixtures / "self-test-app-platform-smoke.json", app_summary)
     multi_node_config = multi_node_beta_soak.validate_config(
         multi_node_beta_soak.load_config(fixtures / "self-test-multi-node-beta-soak.json")
     )
@@ -1959,11 +2052,22 @@ def multi_node_summary_path(settings: Settings, cert_out: Path) -> Path:
     return cert_out / "multi-node-beta-soak/summary.json"
 
 
-def compact_multi_node_summary_for_release(summary: dict[str, Any] | None) -> dict[str, Any]:
+def uses_self_test_multi_node_topology(settings: Settings) -> bool:
+    config = settings.multi_node_soak_config
+    if config is None:
+        return False
+    try:
+        rel = config.resolve().relative_to(settings.workspace_root.resolve()).as_posix()
+    except ValueError:
+        rel = config.name
+    return rel == "tools/release-certification/fixtures/self-test-multi-node-beta-soak.json"
+
+
+def compact_multi_node_summary_for_release(summary: dict[str, Any] | None, *, strict: bool = False) -> dict[str, Any]:
     if not isinstance(summary, dict):
         return {"status": "missing"}
     compact = multi_node_beta_soak.compact_for_release(summary)
-    validation_errors = multi_node_beta_soak.validate_summary(summary, strict=False)
+    validation_errors = multi_node_beta_soak.validate_summary(summary, strict=strict)
     if not validation_errors:
         return compact
 
@@ -2009,7 +2113,10 @@ def write_evidence_extracts(settings: Settings, cert_out: Path) -> dict[str, Any
     write_json(evidence_dir / "network-scale-soak.json", network_summary or {"status": "missing"})
     write_json(
         evidence_dir / "multi-node-beta-soak.json",
-        compact_multi_node_summary_for_release(multi_node_summary),
+        compact_multi_node_summary_for_release(
+            multi_node_summary,
+            strict=settings.mode == "production-beta" and settings.require_multi_node_soak,
+        ),
     )
     write_json(evidence_dir / "ecosystem-rc-certification.json", cert_summary or {"status": "missing"})
     write_json(evidence_dir / "ecosystem-certification-matrix.json", matrix_summary or {"status": "missing"})
@@ -2265,7 +2372,10 @@ def evaluate_promotion(state: PipelineState, summaries: dict[str, Any]) -> dict[
         )
 
     multi_node_compact = (
-        compact_multi_node_summary_for_release(multi_node_summary)
+        compact_multi_node_summary_for_release(
+            multi_node_summary,
+            strict=settings.mode == "production-beta" and settings.require_multi_node_soak,
+        )
         if isinstance(multi_node_summary, dict)
         else {
             "status": "missing",
@@ -2308,6 +2418,24 @@ def evaluate_promotion(state: PipelineState, summaries: dict[str, Any]) -> dict[
             f"Multi-node beta soak redaction status is {multi_node_redaction_status}.",
             "multi-node-beta-soak",
         )
+        if settings.mode == "production-beta":
+            add_gate(
+                "multi-node-beta.previous-candidate-summary",
+                settings.previous_summary is not None
+                and settings.previous_summary.is_file()
+                and scenario_statuses.get("upgrade-from-previous-candidate") == "pass",
+                "Production beta promotion requires a previous release-certification summary and passing previous-candidate upgrade drill evidence.",
+                "multi-node-beta-soak",
+            )
+            multi_node_mode = str(multi_node_compact.get("mode", "missing"))
+            add_gate(
+                "multi-node-beta.production-evidence-mode",
+                multi_node_mode in {"hybrid", "live"}
+                and not uses_self_test_multi_node_topology(settings)
+                and not (settings.run_multi_node_soak and settings.multi_node_soak_config is None),
+                "Production beta multi-node evidence must be attached from a real run or generated from an explicit non-self-test hybrid/live topology.",
+                "multi-node-beta-soak",
+            )
 
     cert_ok = isinstance(cert_summary, dict) and cert_summary.get("releaseCandidatePassed") is True
     add_gate("ecosystem.release-candidate-passed", cert_ok, "Ecosystem RC certification passed.", "release-certification")
@@ -2325,9 +2453,17 @@ def evaluate_promotion(state: PipelineState, summaries: dict[str, Any]) -> dict[
     profile = state.signing_profile
     production_signing = bool(profile and profile.kind == "production" and not profile.generated_test_keys)
     if settings.mode == "production-beta":
+        for stage_id in PRODUCTION_BETA_REQUIRED_PIPELINE_STAGES:
+            stage = state.pipeline_stages.get(stage_id, {})
+            stage_status = stage.get("status", "missing") if isinstance(stage, dict) else "missing"
+            add_gate(
+                f"build.{stage_id}",
+                stage_status == "pass",
+                f"Pipeline stage {stage_id} status is {stage_status}.",
+            )
         add_gate(
             "build.production-beta-complete",
-            not production_build_skipped(settings),
+            not production_build_skipped(settings) and all_required_production_pipeline_stages_completed(state),
             "Production beta promotion requires the Gradle build and first-party app staging/signing stages to run in this pipeline execution.",
         )
         add_gate(
@@ -2352,6 +2488,7 @@ def evaluate_promotion(state: PipelineState, summaries: dict[str, Any]) -> dict[
         settings.mode == "developer-dry-run"
         or settings.allow_test_signing_in_production
         or production_build_skipped(settings)
+        or (settings.mode == "production-beta" and not all_required_production_pipeline_stages_completed(state))
         or state.dirty_workspace
         or not state.workspace_status_known
         or bool(profile and profile.kind != "production")
@@ -3022,11 +3159,22 @@ def create_dist_bundle(settings: Settings, version: str) -> Path:
     dist_dir = settings.out_dir / "dist"
     dist_dir.mkdir(parents=True, exist_ok=True)
     tar_path = dist_bundle_path(settings, version)
+
+    def tar_filter(info: tarfile.TarInfo) -> tarfile.TarInfo:
+        reason = bad_artifact_name(info.name)
+        if reason:
+            raise ReleaseArtifactError(f"dist archive would include forbidden artifact {info.name}: {reason}")
+        if info.issym() or info.islnk():
+            raise ReleaseArtifactError(f"dist archive would include a link entry, which is not allowed: {info.name}")
+        if info.isdev():
+            raise ReleaseArtifactError(f"dist archive would include a device entry, which is not allowed: {info.name}")
+        return info
+
     with tarfile.open(tar_path, "w:gz", format=tarfile.PAX_FORMAT) as archive:
         for root_name in RELEASE_OUTPUT_ROOTS:
             root_path = settings.out_dir / root_name
             if root_path.exists():
-                archive.add(root_path, arcname=root_name, recursive=True)
+                archive.add(root_path, arcname=root_name, recursive=True, filter=tar_filter)
     checksums = dist_checksums_path(settings)
     checksum_lines = [f"{sha256_file(tar_path)}  {tar_path.name}"]
     write_text(checksums, "\n".join(checksum_lines) + "\n")
@@ -3102,6 +3250,7 @@ def build_final_summary(
             "privateKeyMaterialIncluded": False,
         },
         "certificationExitCode": state.certification_exit_code,
+        "pipelineStages": state.pipeline_stages,
         "warnings": state.warnings,
         "failures": state.failures,
         "multiNodeBetaSoak": multi_node_compact,
@@ -3131,7 +3280,9 @@ def release_exit_code(settings: Settings, summary: dict[str, Any]) -> int:
     go_no_go = summary.get("goNoGo") if isinstance(summary.get("goNoGo"), dict) else {}
     decision = go_no_go.get("decision")
     if settings.mode == "production-beta" and decision in {"go", "go-with-waivers", "no-go"}:
-        return 0 if decision in {"go", "go-with-waivers"} else 1
+        if decision == "no-go":
+            return 1
+        return 0 if summary.get("status") == "pass" and summary.get("promotionReady") is True and summary.get("nonRelease") is False else 1
     if settings.mode == "developer-dry-run":
         return 0 if summary.get("status") == "pass" else 1
     return 0 if summary.get("status") == "pass" and (settings.mode != "production-beta" or summary.get("promotionReady") is True) else 1
@@ -3331,10 +3482,40 @@ def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> 
         if state.settings.mode == "production-beta":
             summary["status"] = "fail"
     elif state.settings.mode == "production-beta":
-        summary["promotionReady"] = True
-        if isinstance(summary.get("promotion"), dict):
-            summary["promotion"]["promotionReady"] = True
-        summary["status"] = "pass"
+        promotion = summary.get("promotion") if isinstance(summary.get("promotion"), dict) else {}
+        try:
+            failed_gate_count = int(promotion.get("failedGateCount", go_no_go["failedGateCount"]))
+        except (TypeError, ValueError):
+            failed_gate_count = go_no_go["failedGateCount"]
+        dashboard_confirms_ready = (
+            dashboard.get("promotionReady") is True
+            and summary.get("promotionReady") is True
+            and promotion.get("promotionReady") is True
+            and summary.get("nonRelease") is False
+            and failed_gate_count == 0
+            and go_no_go["redactionStatus"] == "pass"
+            and not state.failures
+        )
+        if dashboard_confirms_ready:
+            summary["promotionReady"] = True
+            promotion["promotionReady"] = True
+            summary["promotion"] = promotion
+            summary["status"] = "pass"
+        else:
+            summary["promotionReady"] = False
+            promotion["promotionReady"] = False
+            summary["promotion"] = promotion
+            summary["status"] = "fail"
+            failure = (
+                "Go/no-go dashboard returned a launchable decision, but the pre-dashboard production "
+                "summary was not promotion-ready."
+            )
+            failures = summary.get("failures") if isinstance(summary.get("failures"), list) else []
+            if failure not in failures:
+                failures.append(failure)
+            if failure not in state.failures:
+                state.failures.append(failure)
+            summary["failures"] = failures
     write_json(state.settings.out_dir / "reports/production-beta-summary.json", summary)
     write_text(state.settings.out_dir / "reports/production-beta-summary.md", render_markdown_summary(summary))
     return summary
@@ -3361,28 +3542,67 @@ def run_pipeline(settings: Settings) -> tuple[dict[str, Any], int]:
             copy_first_party_maintenance_policy_input(state)
             create_fixture_artifacts(state)
         else:
-            run_gradle(state, "gradle-install-crypta-app", [":platform-devtools:installDist"])
+            clear_workspace_generated_release_outputs(state)
+            install_result = run_gradle(state, "gradle-install-crypta-app", [":platform-devtools:installDist"])
+            record_gradle_stage(
+                state,
+                "crypta-app-launcher-install",
+                install_result,
+                "Installed the crypta-app launcher distribution in this pipeline execution.",
+            )
             state.signing_profile = prepare_signing_profile(state, key_dir)
             copy_first_party_maintenance_policy_input(state)
             write_json(settings.out_dir / "inputs/release-config.json", release_config(state))
             if not settings.skip_full_build:
-                run_gradle(
+                build_tasks = ["build"] if settings.mode == "production-beta" else ["buildJar", "assembleCryptadDist"]
+                build_result = run_gradle(
                     state,
                     "gradle-release-build",
-                    ["buildJar", "assembleCryptadDist"],
+                    build_tasks,
                     env=state.signing_profile.env if state.signing_profile else None,
+                )
+                record_gradle_stage(
+                    state,
+                    "gradle-full-build",
+                    build_result,
+                    "Ran the full Gradle build in this pipeline execution.",
                 )
             elif settings.mode in {"release-candidate", "production-beta"} and not settings.emergency_skip_build:
                 state.failures.append("release-candidate and production-beta modes require the build stage unless --emergency-skip-build is used.")
-            run_gradle(
+                record_pipeline_stage(
+                    state,
+                    "gradle-full-build",
+                    "skipped",
+                    "Skipped the Gradle build stage without an emergency build skip.",
+                )
+            else:
+                record_pipeline_stage(
+                    state,
+                    "gradle-full-build",
+                    "skipped",
+                    "Skipped the Gradle build stage by explicit emergency or non-production request.",
+                )
+            stage_result = run_gradle(
                 state,
                 "gradle-stage-sign-verify-first-party-apps",
                 ["stageFirstPartyApps", "signFirstPartyApps", "verifyFirstPartyApps"],
                 env=state.signing_profile.env if state.signing_profile else None,
             )
-            copy_launcher_distribution(state)
-            copied_apps = copy_staged_apps(state)
-            package_catalog_and_reviews(state, state.signing_profile, copied_apps, work_dir)
+            for stage_id, summary in (
+                ("first-party-app-staging", "Staged first-party app bundles in this pipeline execution."),
+                ("first-party-app-signing", "Signed first-party app bundles in this pipeline execution."),
+                ("first-party-app-verification", "Verified first-party app bundle signatures in this pipeline execution."),
+            ):
+                record_gradle_stage(state, stage_id, stage_result, summary)
+            if settings.mode == "production-beta" and not all_required_production_pipeline_stages_completed(state):
+                state.failures.append(
+                    "production-beta mode did not complete all required Gradle build/stage/sign/verify stages; "
+                    "stale workspace artifacts will not be packaged."
+                )
+            else:
+                copy_launcher_distribution(state)
+                copied_apps = copy_staged_apps(state)
+                package_catalog_and_reviews(state, state.signing_profile, copied_apps, work_dir)
 
         check_workspace_clean(state, "post-artifact-build")
         write_json(settings.out_dir / "inputs/release-config.json", release_config(state))
@@ -3403,14 +3623,36 @@ def run_pipeline(settings: Settings) -> tuple[dict[str, Any], int]:
         archive: Path | None = None
         summary: dict[str, Any] | None = None
         if redaction_report["status"] == "pass":
-            archive = dist_bundle_path(settings, version)
-            summary = build_final_summary(state, promotion, redaction_report, archive)
+            planned_archive = dist_bundle_path(settings, version)
+            summary = build_final_summary(state, promotion, redaction_report, planned_archive)
             write_json(settings.out_dir / "reports/production-beta-summary.json", summary)
             write_text(settings.out_dir / "reports/production-beta-summary.md", render_markdown_summary(summary))
             summary = attach_go_no_go_dashboard(state, summary)
-            archive = create_dist_bundle(settings, version)
-            tar_findings = scan_tarball(archive, settings)
-            if tar_findings:
+            if summary.get("goNoGo", {}).get("redactionStatus") == "pass":
+                try:
+                    archive = create_dist_bundle(settings, version)
+                except ReleaseArtifactError as exc:
+                    tar_findings = [{"kind": "forbidden-tar-entry", "path": "dist", "detail": str(exc)}]
+                    partial_archive = dist_bundle_path(settings, version)
+                    remove_dist_bundle(settings, partial_archive)
+                    archive = None
+                else:
+                    tar_findings = scan_tarball(archive, settings)
+            else:
+                tar_findings = []
+                archive = None
+                artifacts = summary.get("artifacts") if isinstance(summary.get("artifacts"), dict) else {}
+                artifacts.pop("distArchive", None)
+                artifacts.pop("checksums", None)
+                summary["artifacts"] = artifacts
+                write_json(settings.out_dir / "reports/production-beta-summary.json", summary)
+                write_text(settings.out_dir / "reports/production-beta-summary.md", render_markdown_summary(summary))
+            if archive is not None and not tar_findings:
+                summary.setdefault("artifacts", {})["distArchive"] = f"dist/{archive.name}"
+                summary.setdefault("artifacts", {})["checksums"] = "dist/checksums.txt"
+                write_json(settings.out_dir / "reports/production-beta-summary.json", summary)
+                write_text(settings.out_dir / "reports/production-beta-summary.md", render_markdown_summary(summary))
+            elif tar_findings:
                 redaction_report = {
                     "schemaVersion": 1,
                     "status": "fail",
@@ -3419,7 +3661,8 @@ def run_pipeline(settings: Settings) -> tuple[dict[str, Any], int]:
                     "findings": tar_findings,
                 }
                 write_json(settings.out_dir / "reports/redaction-report.json", redaction_report)
-                remove_dist_bundle(settings, archive)
+                if archive is not None:
+                    remove_dist_bundle(settings, archive)
                 archive = None
                 summary = None
         if redaction_report["status"] != "pass":
@@ -3525,6 +3768,32 @@ def settings_from_args(args: argparse.Namespace) -> Settings:
     require_multi_node_soak = args.require_multi_node_soak or args.mode == "production-beta"
     run_multi_node_soak = args.run_multi_node_soak or multi_node_soak_summary is None
     require_sandbox = args.require_sandbox_provider_tests or args.mode == "production-beta"
+    if args.mode == "production-beta":
+        if (args.skip_gradle or args.skip_full_build) and not args.emergency_skip_build:
+            raise SystemExit(
+                "production-beta mode cannot use --skip-gradle or --skip-full-build without --emergency-skip-build; "
+                "emergency build skips are always non-release and cannot be promoted."
+            )
+        if require_multi_node_soak and multi_node_soak_summary is None:
+            if not args.run_multi_node_soak:
+                raise SystemExit(
+                    "production-beta mode requires --multi-node-soak-summary or explicit --run-multi-node-soak "
+                    "with a production --multi-node-soak-config."
+                )
+            if multi_node_soak_config is None:
+                raise SystemExit(
+                    "production-beta --run-multi-node-soak requires an explicit production --multi-node-soak-config."
+                )
+            if args.multi_node_mode == "simulated":
+                raise SystemExit("production-beta cannot use --multi-node-mode simulated as required promotion evidence.")
+            try:
+                rel_config = multi_node_soak_config.resolve().relative_to(workspace).as_posix()
+            except ValueError:
+                rel_config = multi_node_soak_config.name
+            if rel_config == "tools/release-certification/fixtures/self-test-multi-node-beta-soak.json":
+                raise SystemExit(
+                    "production-beta cannot use the self-test multi-node soak topology as required promotion evidence."
+                )
     return Settings(
         workspace_root=workspace,
         out_dir=out_dir,
@@ -3540,8 +3809,8 @@ def settings_from_args(args: argparse.Namespace) -> Settings:
         emergency_skip_live_network=args.emergency_skip_live_network,
         emergency_skip_build=args.emergency_skip_build,
         allow_test_signing_in_production=args.allow_test_signing_in_production,
-        previous_summary=args.previous_summary.resolve() if args.previous_summary else None,
-        waiver_file=args.waiver_file.resolve() if args.waiver_file else None,
+        previous_summary=resolve_workspace_path_arg(args.previous_summary, workspace),
+        waiver_file=resolve_workspace_path_arg(args.waiver_file, workspace),
         timeout_seconds=args.timeout_seconds,
         clean_out_dir=not args.no_clean_out_dir,
         multi_node_soak_summary=multi_node_soak_summary,
@@ -3597,9 +3866,16 @@ def validate_artifact_base_uri(mode: str, artifact_base_uri: str) -> None:
 
 
 def make_self_test_workspace(root: Path) -> None:
-    shutil.copytree(REPO_ROOT / "tools", root / "tools")
-    shutil.copytree(REPO_ROOT / "docs", root / "docs")
-    shutil.copy2(REPO_ROOT / "build.gradle.kts", root / "build.gradle.kts")
+    root.mkdir(parents=True, exist_ok=True)
+    ignore = shutil.ignore_patterns("._*", ".DS_Store", "__MACOSX", "__pycache__", "*.pyc")
+    shutil.copytree(
+        REPO_ROOT / "tools/release-certification",
+        root / "tools/release-certification",
+        ignore=ignore,
+        copy_function=shutil.copy,
+    )
+    shutil.copytree(REPO_ROOT / "docs", root / "docs", ignore=ignore, copy_function=shutil.copy)
+    shutil.copy(REPO_ROOT / "build.gradle.kts", root / "build.gradle.kts")
     write_text(root / "gradlew", "#!/usr/bin/env sh\nexit 0\n")
     (root / "gradlew").chmod(0o755)
 
@@ -3680,7 +3956,7 @@ def write_fake_crypta_app_cli(workspace: Path) -> Path:
     if platform.system() == "Windows":
         write_text(cli, f'@echo off\r\n"{sys.executable}" "%~dp0crypta-app.py" %*\r\n')
     else:
-        shutil.copy2(python_cli, cli)
+        shutil.copy(python_cli, cli)
         cli.chmod(0o755)
     return cli
 
@@ -4065,7 +4341,7 @@ def passing_multi_node_beta_soak_summary() -> dict[str, Any]:
             {
                 "schemaVersion": 1,
                 "kind": multi_node_beta_soak.CONFIG_KIND,
-                "mode": "simulated",
+                "mode": "hybrid",
                 "durationProfile": "ci-smoke",
                 "previousCandidate": {
                     "version": "previous-beta",
@@ -4152,6 +4428,15 @@ def production_signing_profile() -> SigningProfile:
     )
 
 
+def mark_required_pipeline_stages_passed(state: PipelineState) -> None:
+    for stage_id in PRODUCTION_BETA_REQUIRED_PIPELINE_STAGES:
+        record_pipeline_stage(state, stage_id, "pass", f"{stage_id} passed in self-test.")
+
+
+def write_previous_release_summary(path: Path) -> None:
+    write_json(path, {"schemaVersion": 1, "status": "pass", "promotionReady": True})
+
+
 def assert_emergency_build_skip_is_non_promotable() -> None:
     with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-build-skip-") as temp_name:
         workspace = Path(temp_name) / "repo"
@@ -4226,6 +4511,8 @@ def assert_allow_test_signing_env_profile_is_non_release() -> None:
             workspace = Path(temp_name) / "repo"
             make_self_test_workspace(workspace)
             out_dir = workspace / "build/production-beta"
+            previous_summary = workspace / "previous-summary.json"
+            write_previous_release_summary(previous_summary)
             write_minimal_promotion_artifacts(out_dir)
             settings = Settings(
                 workspace_root=workspace,
@@ -4242,7 +4529,7 @@ def assert_allow_test_signing_env_profile_is_non_release() -> None:
                 emergency_skip_live_network=False,
                 emergency_skip_build=False,
                 allow_test_signing_in_production=True,
-                previous_summary=None,
+                previous_summary=previous_summary,
                 waiver_file=None,
                 timeout_seconds=60,
                 clean_out_dir=True,
@@ -4250,12 +4537,73 @@ def assert_allow_test_signing_env_profile_is_non_release() -> None:
             state = PipelineState(settings, "self-test", utc_now(), [], [], [])
             profile = prepare_signing_profile(state, workspace / "keys")
             state.signing_profile = profile
+            mark_required_pipeline_stages_passed(state)
             assert profile.kind == "configured", profile
             assert profile.generated_test_keys is False, profile
             assert release_config(state)["nonRelease"] is True
             promotion = evaluate_promotion(state, passing_promotion_summaries())
             assert promotion_gate_by_id(promotion, "signing.production-keys")["status"] == "pass", promotion
             assert promotion["status"] == "pass", promotion
+            assert promotion["nonRelease"] is True, promotion
+            assert promotion["promotionReady"] is False, promotion
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+
+def assert_test_key_ids_without_escape_hatch_are_rejected() -> None:
+    saved = {key: os.environ.get(key) for key in SIGNING_PROFILE_ENV_KEYS}
+    try:
+        for key in SIGNING_PROFILE_ENV_KEYS:
+            os.environ.pop(key, None)
+        os.environ.update(
+            {
+                "CRYPTAD_APP_SIGNING_KEY_ID": "test-app-key",
+                "CRYPTAD_APP_SIGNING_PRIVATE_KEY_BASE64": "dGVzdC1hcHAtcHJpdmF0ZS1rZXk=",
+                "CRYPTAD_APP_SIGNING_PUBLIC_KEY_BASE64": "dGVzdC1hcHAtcHVibGljLWtleQ==",
+                "CRYPTAD_APP_REVIEWER_KEY_ID": "fixture-reviewer-key",
+                "CRYPTAD_APP_REVIEWER_PRIVATE_KEY_BASE64": "dGVzdC1yZXZpZXdlci1wcml2YXRlLWtleQ==",
+                "CRYPTAD_APP_REVIEWER_PUBLIC_KEY_BASE64": "dGVzdC1yZXZpZXdlci1wdWJsaWMta2V5",
+            }
+        )
+        with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-test-key-policy-") as temp_name:
+            workspace = Path(temp_name) / "repo"
+            make_self_test_workspace(workspace)
+            out_dir = workspace / "build/production-beta"
+            previous_summary = workspace / "previous-summary.json"
+            write_previous_release_summary(previous_summary)
+            write_minimal_promotion_artifacts(out_dir)
+            settings = Settings(
+                workspace_root=workspace,
+                out_dir=out_dir,
+                mode="production-beta",
+                catalog_channel="stable",
+                artifact_base_uri="https://downloads.crypta.network/production-beta/self-test",
+                require_live_network=True,
+                require_sandbox_provider_tests=True,
+                skip_gradle=False,
+                skip_full_build=False,
+                use_fixture_evidence=False,
+                allow_dirty_workspace=False,
+                emergency_skip_live_network=False,
+                emergency_skip_build=False,
+                allow_test_signing_in_production=False,
+                previous_summary=previous_summary,
+                waiver_file=None,
+                timeout_seconds=60,
+                clean_out_dir=True,
+            )
+            state = PipelineState(settings, "self-test", utc_now(), [], [], [])
+            profile = prepare_signing_profile(state, workspace / "keys")
+            state.signing_profile = profile
+            mark_required_pipeline_stages_passed(state)
+            promotion = evaluate_promotion(state, passing_promotion_summaries())
+            assert profile.kind == "configured", profile
+            assert any("key IDs must be production key IDs" in failure for failure in state.failures), state.failures
+            assert promotion_gate_by_id(promotion, "signing.production-keys")["status"] == "fail", promotion
             assert promotion["nonRelease"] is True, promotion
             assert promotion["promotionReady"] is False, promotion
     finally:
@@ -4600,6 +4948,100 @@ def assert_release_candidate_no_go_dashboard_preserves_summary_and_exit() -> Non
         assert attached["status"] == "pass", attached
         assert attached["promotionReady"] is False, attached
         assert release_exit_code(settings, attached) == 0, attached
+
+
+def assert_go_with_waivers_cannot_promote_failed_production_summary() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-waived-dashboard-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        workspace.mkdir(parents=True)
+        out_dir = workspace / "build/production-beta"
+        settings = dataclasses.replace(
+            cleanup_test_settings(workspace, out_dir),
+            mode="production-beta",
+            artifact_base_uri="https://downloads.crypta.network/production-beta/self-test",
+            skip_gradle=False,
+            skip_full_build=False,
+            allow_dirty_workspace=False,
+        )
+        state = PipelineState(settings, "self-test", utc_now(), [], [], [])
+        summary = build_final_summary(
+            state,
+            {
+                "status": "fail",
+                "promotionReady": False,
+                "nonRelease": False,
+                "failedGateCount": 1,
+                "gates": [
+                    {
+                        "id": "live.live-network-beta.content-fetch",
+                        "status": "fail",
+                        "summary": "Live content fetch evidence is missing.",
+                    }
+                ],
+                "knownLimitations": [],
+            },
+            {
+                "schemaVersion": 1,
+                "status": "pass",
+                "scannedRoot": "<release-out>",
+                "findingCount": 0,
+                "findings": [],
+            },
+            None,
+        )
+
+        def fake_run_command(
+            state: PipelineState,
+            name: str,
+            args: list[str],
+            env: dict[str, str] | None = None,
+            timeout_seconds: int = 0,
+            allow_failure: bool = False,
+        ) -> CommandResult:
+            del name, args, env, timeout_seconds, allow_failure
+            write_json(
+                state.settings.out_dir / GO_NO_GO_DASHBOARD_JSON,
+                {
+                    "decision": "go-with-waivers",
+                    "promotionReady": True,
+                    "summary": {"blockers": 0, "warnings": 1, "waiversUsed": 1, "criticalRedactionFindings": 0},
+                    "warnings": [
+                        {
+                            "id": "promotion.live.live-network-beta.content-fetch",
+                            "evidenceId": "live-network-beta.content-fetch",
+                            "severity": "blocker",
+                            "summary": "Waived live content fetch evidence.",
+                            "waivedBy": "waiver-live-content",
+                        }
+                    ],
+                    "redaction": {"status": "pass", "findings": []},
+                },
+            )
+            write_text(state.settings.out_dir / GO_NO_GO_DASHBOARD_MARKDOWN, "Decision: `GO WITH WAIVERS`\n")
+            write_json(
+                state.settings.out_dir / GO_NO_GO_REDACTION_REPORT,
+                {
+                    "schemaVersion": SCHEMA_VERSION,
+                    "status": "pass",
+                    "findingCount": 0,
+                    "criticalFindingCount": 0,
+                    "findings": [],
+                },
+            )
+            return CommandResult("production-beta-go-no-go-dashboard", [], 0, 1, "", "")
+
+        original_run_command = globals()["run_command"]
+        try:
+            globals()["run_command"] = fake_run_command
+            attached = attach_go_no_go_dashboard(state, summary)
+        finally:
+            globals()["run_command"] = original_run_command
+
+        assert attached["goNoGo"]["decision"] == "go-with-waivers", attached
+        assert attached["status"] == "fail", attached
+        assert attached["promotionReady"] is False, attached
+        assert attached["promotion"]["promotionReady"] is False, attached
+        assert release_exit_code(settings, attached) == 1, attached
 
 
 def assert_missing_go_no_go_dashboard_fails_summary_and_exit() -> None:
@@ -5235,6 +5677,34 @@ def assert_attached_multi_node_blockers_and_warnings_block_promotion() -> None:
             assert expected_error in multi_node["validationErrors"], multi_node
 
 
+def assert_missing_previous_summary_blocks_production_multi_node_promotion() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-missing-previous-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        workspace.mkdir(parents=True)
+        out_dir = workspace / "build/production-beta"
+        settings = dataclasses.replace(
+            cleanup_test_settings(workspace, out_dir),
+            mode="production-beta",
+            artifact_base_uri="https://downloads.crypta.network/production-beta/self-test",
+            require_live_network=True,
+            require_sandbox_provider_tests=True,
+            skip_gradle=False,
+            skip_full_build=False,
+            allow_dirty_workspace=False,
+            require_multi_node_soak=True,
+        )
+        write_minimal_promotion_artifacts(out_dir)
+        state = PipelineState(settings, "self-test", utc_now(), [], [], [])
+        state.signing_profile = production_signing_profile()
+        mark_required_pipeline_stages_passed(state)
+
+        promotion = evaluate_promotion(state, passing_promotion_summaries())
+        failed_ids = {gate["id"] for gate in promotion["gates"] if gate["status"] == "fail"}
+
+        assert "multi-node-beta.previous-candidate-summary" in failed_ids, promotion
+        assert promotion["promotionReady"] is False, promotion
+
+
 def assert_multi_node_mode_is_only_forwarded_when_overridden() -> None:
     with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-multi-node-mode-") as temp_name:
         workspace = Path(temp_name) / "repo"
@@ -5318,6 +5788,57 @@ def assert_multi_node_paths_resolve_from_workspace() -> None:
         assert settings.multi_node_soak_summary == summary_path.resolve(), settings.multi_node_soak_summary
         assert settings.multi_node_soak_config == config_path.resolve(), settings.multi_node_soak_config
         assert settings.multi_node_mode is None, settings.multi_node_mode
+
+
+def assert_production_beta_cli_rejects_unsafe_strict_inputs() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-cli-strict-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        make_self_test_workspace(workspace)
+        parser = build_parser()
+        summary_path = workspace / "multi-node-summary.json"
+        write_json(summary_path, passing_promotion_summaries()["multiNodeBetaSoak"])
+        base_args = [
+            "--workspace-root",
+            str(workspace),
+            "--out-dir",
+            "build/production-beta",
+            "--mode",
+            "production-beta",
+            "--artifact-base-uri",
+            "https://downloads.crypta.network/production-beta/self-test",
+        ]
+
+        for extra_args, expected in (
+            (
+                ["--skip-gradle", "--multi-node-soak-summary", str(summary_path.relative_to(workspace))],
+                "cannot use --skip-gradle or --skip-full-build",
+            ),
+            ([], "requires --multi-node-soak-summary or explicit --run-multi-node-soak"),
+            (
+                [
+                    "--run-multi-node-soak",
+                    "--multi-node-soak-config",
+                    "topology.json",
+                    "--multi-node-mode",
+                    "simulated",
+                ],
+                "cannot use --multi-node-mode simulated",
+            ),
+            (
+                [
+                    "--run-multi-node-soak",
+                    "--multi-node-soak-config",
+                    "tools/release-certification/fixtures/self-test-multi-node-beta-soak.json",
+                ],
+                "cannot use the self-test multi-node soak topology",
+            ),
+        ):
+            try:
+                settings_from_args(parser.parse_args([*base_args, *extra_args]))
+            except SystemExit as exc:
+                assert expected in str(exc), exc
+            else:
+                raise AssertionError(f"production-beta accepted unsafe input combination: {extra_args}")
 
 
 def create_git_tracked_output_target(workspace: Path) -> Path | None:
@@ -6130,11 +6651,13 @@ def run_self_test() -> None:
     assert_dirty_production_beta_is_non_promotable()
     assert_emergency_build_skip_is_non_promotable()
     assert_allow_test_signing_env_profile_is_non_release()
+    assert_test_key_ids_without_escape_hatch_are_rejected()
     assert_failed_final_summary_clears_promotion_ready()
     assert_waived_critical_evidence_is_accepted_without_redaction_findings()
     assert_developer_dry_run_exit_code_fails_on_recorded_failures()
     assert_certification_failure_marks_dry_run_failed()
     assert_release_candidate_no_go_dashboard_preserves_summary_and_exit()
+    assert_go_with_waivers_cannot_promote_failed_production_summary()
     assert_missing_go_no_go_dashboard_fails_summary_and_exit()
     assert_stale_go_no_go_dashboard_is_not_reused()
     assert_incomplete_go_no_go_dashboard_outputs_fail_summary_and_exit()
@@ -6147,8 +6670,10 @@ def run_self_test() -> None:
     assert_attached_multi_node_safety_flags_block_promotion()
     assert_attached_multi_node_non_promotable_summary_blocks_promotion()
     assert_attached_multi_node_blockers_and_warnings_block_promotion()
+    assert_missing_previous_summary_blocks_production_multi_node_promotion()
     assert_multi_node_mode_is_only_forwarded_when_overridden()
     assert_multi_node_paths_resolve_from_workspace()
+    assert_production_beta_cli_rejects_unsafe_strict_inputs()
     assert_cleanup_refuses_protected_workspace_paths()
     assert_cleanup_refuses_arbitrary_existing_directory_without_sentinel()
     assert_no_clean_refuses_arbitrary_existing_directory_without_sentinel()
@@ -6404,6 +6929,12 @@ def run_self_test() -> None:
         lambda out_dir: write_redaction_fixture_text(out_dir / "secret.json", '{"formPassword": "hunter2-password"}\n'),
     )
     assert_redaction_fails(
+        "form-password-header",
+        lambda out_dir: write_redaction_fixture_text(
+            out_dir / "secret.http", "X-Crypta-Form-Password: hunter2-password\n"
+        ),
+    )
+    assert_redaction_fails(
         "parenthesized-form-password-field",
         lambda out_dir: write_redaction_fixture_text(
             out_dir / "secret.json", '{"formPassword": "(hunter2-password)"}\n'
@@ -6444,6 +6975,18 @@ def run_self_test() -> None:
     assert_redaction_fails(
         "raw-app-data-value",
         lambda out_dir: write_redaction_fixture_text(out_dir / "raw.txt", "rawAppDataValue=abcdefghijklmnop\n"),
+    )
+    assert_redaction_fails(
+        "queue-html-raw-payload",
+        lambda out_dir: write_redaction_fixture_text(
+            out_dir / "raw.json", '{"queueHtml": "private-queue-html-payload-abcdefghijklmnop"}\n'
+        ),
+    )
+    assert_redaction_fails(
+        "payload-base64-raw-payload",
+        lambda out_dir: write_redaction_fixture_text(
+            out_dir / "raw.json", '{"payloadBase64": "cHJpdmF0ZS1wYXlsb2FkLWFiY2RlZmdoaWprbG1ub3A="}\n'
+        ),
     )
     assert_redaction_fails(
         "unredacted-payload",
@@ -6544,6 +7087,14 @@ def run_self_test() -> None:
         lambda out_dir: write_redaction_fixture_text(
             out_dir / "path.txt", "localPath=/root/.gradle/caches/modules-2/files-2.1\n"
         ),
+    )
+    assert_redaction_fails(
+        "etc-local-path",
+        lambda out_dir: write_redaction_fixture_text(out_dir / "path.txt", "config=/etc/cryptad/config.ini\n"),
+    )
+    assert_redaction_fails(
+        "srv-local-path",
+        lambda out_dir: write_redaction_fixture_text(out_dir / "path.txt", "artifact=/srv/cryptad/release\n"),
     )
     assert_redaction_fails(
         "hostedtoolcache-path",

--- a/tools/release-certification/production_beta_release.py
+++ b/tools/release-certification/production_beta_release.py
@@ -3378,6 +3378,63 @@ def go_no_go_dashboard_artifact_failure(
     return None
 
 
+def write_rejected_launchable_dashboard_artifacts(
+    settings: Settings,
+    dashboard: dict[str, Any],
+    failure: str,
+) -> dict[str, Any]:
+    redaction = dashboard.get("redaction") if isinstance(dashboard.get("redaction"), dict) else {}
+    overridden = dict(dashboard)
+    blocker = {
+        "id": "production-beta.wrapper.rejected-launchable-dashboard",
+        "evidenceId": "production-beta.go-no-go-decision",
+        "domainId": "production-beta-release-pipeline",
+        "severity": "blocker",
+        "title": "Release wrapper rejected launchable dashboard decision",
+        "summary": failure,
+        "source": "production-beta-release",
+        "waivable": False,
+        "category": "pipeline",
+    }
+    blockers = [item for item in overridden.get("blockers", []) if isinstance(item, dict)]
+    if not any(item.get("id") == blocker["id"] for item in blockers):
+        blockers.append(blocker)
+    dashboard_summary = overridden.get("summary") if isinstance(overridden.get("summary"), dict) else {}
+    dashboard_summary = dict(dashboard_summary)
+    dashboard_summary["blockers"] = max(int(dashboard_summary.get("blockers", 0)), len(blockers))
+    dashboard_summary.setdefault("warnings", 0)
+    dashboard_summary.setdefault("waiversUsed", 0)
+    dashboard_summary.setdefault("criticalRedactionFindings", 0)
+    overridden.update(
+        {
+            "decision": "no-go",
+            "promotionReady": False,
+            "summary": dashboard_summary,
+            "blockers": blockers,
+            "redaction": redaction,
+            "recommendation": "Do not launch. Regenerate the dashboard after the production summary is promotion-ready.",
+        }
+    )
+    write_json(settings.out_dir / GO_NO_GO_DASHBOARD_JSON, overridden)
+    write_text(
+        settings.out_dir / GO_NO_GO_DASHBOARD_MARKDOWN,
+        "\n".join(
+            [
+                "# Production Beta Go/No-Go Dashboard",
+                "",
+                "Decision: `NO-GO`",
+                "",
+                "The production beta release wrapper rejected a launchable dashboard decision.",
+                "",
+                f"- Failure: {failure}",
+                f"- Mode: `{settings.mode}`",
+                "",
+            ]
+        ),
+    )
+    return overridden
+
+
 def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> dict[str, Any]:
     stale_clear_failures = clear_stale_go_no_go_dashboard_artifacts(state.settings.out_dir)
     for failure in stale_clear_failures:
@@ -3516,6 +3573,16 @@ def attach_go_no_go_dashboard(state: PipelineState, summary: dict[str, Any]) -> 
             if failure not in state.failures:
                 state.failures.append(failure)
             summary["failures"] = failures
+            dashboard = write_rejected_launchable_dashboard_artifacts(state.settings, dashboard, failure)
+            go_no_go["decision"] = "no-go"
+            dashboard_summary = dashboard.get("summary") if isinstance(dashboard.get("summary"), dict) else {}
+            go_no_go["waiversUsed"] = int(dashboard_summary.get("waiversUsed", 0))
+            blocking_gate_ids = list(go_no_go.get("blockingGateIds", []))
+            if "production-beta.go-no-go-decision" not in blocking_gate_ids:
+                blocking_gate_ids.append("production-beta.go-no-go-decision")
+            go_no_go["blockingGateIds"] = blocking_gate_ids
+            go_no_go["failedGateCount"] = max(int(go_no_go.get("failedGateCount", 0)), len(blocking_gate_ids))
+            summary["goNoGo"] = go_no_go
     write_json(state.settings.out_dir / "reports/production-beta-summary.json", summary)
     write_text(state.settings.out_dir / "reports/production-beta-summary.md", render_markdown_summary(summary))
     return summary
@@ -5037,11 +5104,23 @@ def assert_go_with_waivers_cannot_promote_failed_production_summary() -> None:
         finally:
             globals()["run_command"] = original_run_command
 
-        assert attached["goNoGo"]["decision"] == "go-with-waivers", attached
+        assert attached["goNoGo"]["decision"] == "no-go", attached
         assert attached["status"] == "fail", attached
         assert attached["promotionReady"] is False, attached
         assert attached["promotion"]["promotionReady"] is False, attached
+        assert "production-beta.go-no-go-decision" in attached["goNoGo"]["blockingGateIds"], attached
         assert release_exit_code(settings, attached) == 1, attached
+        regenerated_dashboard = read_json(out_dir / GO_NO_GO_DASHBOARD_JSON)
+        assert regenerated_dashboard["decision"] == "no-go", regenerated_dashboard
+        assert regenerated_dashboard["promotionReady"] is False, regenerated_dashboard
+        assert any(
+            blocker.get("id") == "production-beta.wrapper.rejected-launchable-dashboard"
+            for blocker in regenerated_dashboard.get("blockers", [])
+            if isinstance(blocker, dict)
+        ), regenerated_dashboard
+        regenerated_markdown = (out_dir / GO_NO_GO_DASHBOARD_MARKDOWN).read_text(encoding="utf-8")
+        assert "Decision: `NO-GO`" in regenerated_markdown, regenerated_markdown
+        assert "GO WITH WAIVERS" not in regenerated_markdown, regenerated_markdown
 
 
 def assert_missing_go_no_go_dashboard_fails_summary_and_exit() -> None:

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -8022,7 +8022,7 @@ def run_self_test(repo_root: Path) -> None:
                 target_doc = workspace / doc_path
                 target_doc.parent.mkdir(parents=True, exist_ok=True)
                 assert source_doc.is_file(), f"matrix doc path missing: {doc_path}"
-                shutil.copy2(source_doc, target_doc)
+                shutil.copy(source_doc, target_doc)
         docs_check_paths = {
             *app_platform_docs_check.REQUIRED_DOCS,
             *app_platform_docs_check.REQUIRED_PORTAL_LINKS,
@@ -8032,24 +8032,24 @@ def run_self_test(repo_root: Path) -> None:
         for source_doc in repo_root.glob("docs/**/*.md"):
             target_doc = workspace / source_doc.relative_to(repo_root)
             target_doc.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(source_doc, target_doc)
+            shutil.copy(source_doc, target_doc)
         for doc_path in sorted(docs_check_paths):
             source_doc = repo_root / doc_path
             target_doc = workspace / doc_path
             target_doc.parent.mkdir(parents=True, exist_ok=True)
             assert source_doc.is_file(), f"docs-check path missing: {doc_path}"
-            shutil.copy2(source_doc, target_doc)
-        shutil.copy2(fixture_dir / "self-test-interop-smoke.json", workspace / "build/interop-smoke/summary.json")
-        shutil.copy2(
+            shutil.copy(source_doc, target_doc)
+        shutil.copy(fixture_dir / "self-test-interop-smoke.json", workspace / "build/interop-smoke/summary.json")
+        shutil.copy(
             fixture_dir / "self-test-interop-extended.json",
             workspace / "build/interop-extended/summary.json",
         )
-        shutil.copy2(fixture_dir / "self-test-perf-smoke.json", workspace / "build/perf-smoke/summary.json")
-        shutil.copy2(
+        shutil.copy(fixture_dir / "self-test-perf-smoke.json", workspace / "build/perf-smoke/summary.json")
+        shutil.copy(
             fixture_dir / "self-test-app-platform-smoke.json",
             out_dir / "app-platform-smoke/summary.json",
         )
-        shutil.copy2(
+        shutil.copy(
             fixture_dir / "self-test-network-scale-soak.json",
             out_dir / "network-scale-soak/summary.json",
         )


### PR DESCRIPTION
## Summary
- Harden `production-beta` release runs so promotion cannot pass with fixture/test evidence, skipped required stages, non-production signing, missing live/sandbox/multi-node/previous-candidate evidence, or redaction findings.
- Make the production beta go/no-go dashboard authoritative by keeping production-critical evidence non-waivable while preserving the documented release-candidate waiver path.
- Update the protected production-beta workflow, release-manager docs, and regression fixtures for the real production beta run path.

## Test plan
- `python3 tools/release-certification/production_beta_release.py --self-test`
- `python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test`
- `python3 tools/release-certification/release_certification.py --self-test`
- `python3 tools/release-certification/app_platform_smoke.py --self-test`
- `python3 tools/release-certification/app_platform_docs_check.py --self-test`
- `python3 tools/release-certification/live_network_beta_smoke.py --self-test`
- `python3 tools/release-certification/network_scale_soak.py --self-test`
- `python3 tools/release-certification/multi_node_beta_soak.py --self-test`
- `python3 tools/release-certification/security_response_runbook.py verify`
- `python3 tools/release-certification/app_platform_docs_check.py --workspace-root . --output build/app-platform-docs-check.json`
- `actionlint .github/workflows/production-beta-release.yml`
- `./gradlew --version`
- `./gradlew tasks --all`
- `./gradlew :platform-devtools:installDist`
- `./gradlew stageFirstPartyApps`
- Developer dry run: `tools/release-certification/run-production-beta-release.sh --workspace-root . --out-dir build/production-beta-release-dry-run --mode developer-dry-run --catalog-channel stable --use-fixture-evidence --run-multi-node-soak --multi-node-mode simulated --allow-dirty-workspace`
- Strict production-beta negative path without protected inputs failed closed with a clear multi-node evidence error.

## Notes
- `./gradlew signFirstPartyApps verifyFirstPartyApps` was attempted and failed closed because `CRYPTAD_APP_SIGNING_KEY_ID` was not present in this environment.
- `./gradlew build` was attempted, but the repository-wide run encountered existing SpotBugs/JaCoCo failures and later stalled in `HttpLegacyAdminBoundaryTest.findMainJavaSources`; it was interrupted after the expected full-suite window.
- A real production-beta release was not run because protected signing, live-network, sandbox, and production multi-node evidence inputs are not available in this environment.