### PR TITLE
feat(release): Add security drill gates

### DIFF
--- a/.github/workflows/production-beta-release.yml
+++ b/.github/workflows/production-beta-release.yml
@@ -47,6 +47,11 @@ on:
         required: false
         default: ''
         type: string
+      security_drills_summary:
+        description: Existing security response drills summary path or actions-artifact://run/artifact/path reference with sibling scenario drill JSON files. HTTPS summary-only URLs are unsupported.
+        required: false
+        default: ''
+        type: string
       previous_summary:
         description: Previous beta candidate summary path, HTTPS JSON URL, or actions-artifact://run/artifact/path reference for upgrade evidence.
         required: false
@@ -113,6 +118,7 @@ jobs:
           INPUT_MULTI_NODE_MODE: ${{ inputs.multi_node_mode || '' }}
           INPUT_MULTI_NODE_SOAK_CONFIG: ${{ inputs.multi_node_soak_config || 'tools/release-certification/fixtures/self-test-multi-node-beta-soak.json' }}
           INPUT_MULTI_NODE_SOAK_SUMMARY: ${{ inputs.multi_node_soak_summary || '' }}
+          INPUT_SECURITY_DRILLS_SUMMARY: ${{ inputs.security_drills_summary || '' }}
           INPUT_PREVIOUS_SUMMARY: ${{ inputs.previous_summary || '' }}
           INPUT_PREVIOUS_RELEASE_CERTIFICATION_SUMMARY: ${{ inputs.previous_release_certification_summary || '' }}
           INPUT_WAIVER_FILE: ${{ inputs.waiver_file || '' }}
@@ -177,6 +183,22 @@ jobs:
             esac
           }
 
+          materialize_security_drills_summary() {
+            local value="$1"
+            if [[ -z "$value" ]]; then
+              return 0
+            fi
+            case "$value" in
+              http://*|https://*)
+                echo "::error::Security response drills summary must be a checked-out path or actions-artifact:// reference with security-drills-summary.json beside all seven scenario drill JSON files. HTTPS summary-only URLs are not supported."
+                exit 1
+                ;;
+              *)
+                materialize_input_file "$value" INPUT_SECURITY_DRILLS_SUMMARY security-drills-summary.json "Security response drills summary"
+                ;;
+            esac
+          }
+
           materialize_actions_artifact_file() {
             local value="$1"
             local env_name="$2"
@@ -219,6 +241,7 @@ jobs:
           materialize_input_file "$INPUT_PREVIOUS_SUMMARY" INPUT_PREVIOUS_SUMMARY previous-beta-candidate-summary.json "Previous beta candidate summary"
           materialize_input_file "$INPUT_PREVIOUS_RELEASE_CERTIFICATION_SUMMARY" INPUT_PREVIOUS_RELEASE_CERTIFICATION_SUMMARY previous-release-certification-summary.json "Previous release-certification summary"
           materialize_input_file "$INPUT_MULTI_NODE_SOAK_SUMMARY" INPUT_MULTI_NODE_SOAK_SUMMARY multi-node-beta-soak-summary.json "Multi-node soak summary"
+          materialize_security_drills_summary "$INPUT_SECURITY_DRILLS_SUMMARY"
           materialize_input_file "$INPUT_WAIVER_FILE" INPUT_WAIVER_FILE go-no-go-waivers.json "Go/no-go waiver file"
 
           args=(
@@ -236,6 +259,9 @@ jobs:
             args+=(--multi-node-soak-summary "$INPUT_MULTI_NODE_SOAK_SUMMARY")
           else
             args+=(--run-multi-node-soak)
+          fi
+          if [[ -n "$INPUT_SECURITY_DRILLS_SUMMARY" ]]; then
+            args+=(--security-drills-summary "$INPUT_SECURITY_DRILLS_SUMMARY")
           fi
 
           if [[ -z "$INPUT_MULTI_NODE_SOAK_SUMMARY" && -n "$INPUT_MULTI_NODE_SOAK_CONFIG" ]]; then
@@ -328,6 +354,10 @@ jobs:
           path: |
             build/production-beta-release/
             !**/private-insert-uris.json
+            !**/raw-support-bundle/**
+            !**/raw-support-bundle*
+            !**/raw-diagnostics/**
+            !**/raw-diagnostics*
             !**/.DS_Store
             !**/._*
             !**/__MACOSX/**
@@ -394,6 +424,7 @@ jobs:
           INPUT_MULTI_NODE_MODE: ${{ inputs.multi_node_mode || '' }}
           INPUT_MULTI_NODE_SOAK_CONFIG: ${{ inputs.multi_node_soak_config || '' }}
           INPUT_MULTI_NODE_SOAK_SUMMARY: ${{ inputs.multi_node_soak_summary || '' }}
+          INPUT_SECURITY_DRILLS_SUMMARY: ${{ inputs.security_drills_summary || '' }}
           INPUT_PREVIOUS_SUMMARY: ${{ inputs.previous_summary || '' }}
           INPUT_PREVIOUS_RELEASE_CERTIFICATION_SUMMARY: ${{ inputs.previous_release_certification_summary || '' }}
           INPUT_WAIVER_FILE: ${{ inputs.waiver_file || '' }}
@@ -460,6 +491,22 @@ jobs:
             esac
           }
 
+          materialize_security_drills_summary() {
+            local value="$1"
+            if [[ -z "$value" ]]; then
+              return 0
+            fi
+            case "$value" in
+              http://*|https://*)
+                echo "::error::Security response drills summary must be a checked-out path or actions-artifact:// reference with security-drills-summary.json beside all seven scenario drill JSON files. HTTPS summary-only URLs are not supported."
+                exit 1
+                ;;
+              *)
+                materialize_input_file "$value" INPUT_SECURITY_DRILLS_SUMMARY security-drills-summary.json "Security response drills summary"
+                ;;
+            esac
+          }
+
           materialize_actions_artifact_file() {
             local value="$1"
             local env_name="$2"
@@ -506,6 +553,7 @@ jobs:
           materialize_input_file "$INPUT_PREVIOUS_SUMMARY" INPUT_PREVIOUS_SUMMARY previous-beta-candidate-summary.json "Previous beta candidate summary"
           materialize_input_file "$INPUT_PREVIOUS_RELEASE_CERTIFICATION_SUMMARY" INPUT_PREVIOUS_RELEASE_CERTIFICATION_SUMMARY previous-release-certification-summary.json "Previous release-certification summary"
           materialize_input_file "$INPUT_MULTI_NODE_SOAK_SUMMARY" INPUT_MULTI_NODE_SOAK_SUMMARY multi-node-beta-soak-summary.json "Multi-node soak summary"
+          materialize_security_drills_summary "$INPUT_SECURITY_DRILLS_SUMMARY"
           materialize_input_file "$INPUT_WAIVER_FILE" INPUT_WAIVER_FILE go-no-go-waivers.json "Go/no-go waiver file"
 
           if [[ -z "$INPUT_ARTIFACT_BASE_URI" ]]; then
@@ -560,6 +608,9 @@ jobs:
           if [[ -n "$INPUT_MULTI_NODE_SOAK_SUMMARY" ]]; then
             require_file "$INPUT_MULTI_NODE_SOAK_SUMMARY" "Multi-node soak summary"
           fi
+          if [[ -n "$INPUT_SECURITY_DRILLS_SUMMARY" ]]; then
+            require_file "$INPUT_SECURITY_DRILLS_SUMMARY" "Security response drills summary"
+          fi
           if [[ -n "$INPUT_MULTI_NODE_SOAK_CONFIG" ]]; then
             require_file "$INPUT_MULTI_NODE_SOAK_CONFIG" "Multi-node soak topology config"
           fi
@@ -592,6 +643,9 @@ jobs:
             args+=(--multi-node-soak-summary "$INPUT_MULTI_NODE_SOAK_SUMMARY")
           else
             args+=(--run-multi-node-soak --multi-node-soak-config "$INPUT_MULTI_NODE_SOAK_CONFIG")
+          fi
+          if [[ -n "$INPUT_SECURITY_DRILLS_SUMMARY" ]]; then
+            args+=(--security-drills-summary "$INPUT_SECURITY_DRILLS_SUMMARY")
           fi
           if [[ -n "$INPUT_MULTI_NODE_MODE" ]]; then
             args+=(--multi-node-mode "$INPUT_MULTI_NODE_MODE")
@@ -654,6 +708,10 @@ jobs:
           path: |
             build/production-beta-release/
             !**/private-insert-uris.json
+            !**/raw-support-bundle/**
+            !**/raw-support-bundle*
+            !**/raw-diagnostics/**
+            !**/raw-diagnostics*
             !**/.DS_Store
             !**/._*
             !**/__MACOSX/**

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -94,8 +94,10 @@ Production beta incident response for vulnerable app versions, malicious catalog
 catalog signing-key compromise, reviewer-key compromise, emergency replacement publication, support
 bundle intake, and security release notes is defined in
 [production-security-response-runbook.md](production-security-response-runbook.md). The runbook is
-the release-manager procedure; this document defines the trust and redaction boundaries it must
-preserve.
+the release-manager procedure; its required drill artifacts and
+`security-drills-summary.json` are release gates, and missing, failed, stale, malformed,
+fixture-only production, or redaction-unsafe drills block promotion. This document defines the
+trust and redaction boundaries those artifacts must preserve.
 Default operator support bundles follow
 [privacy-preserving-beta-diagnostics.md](privacy-preserving-beta-diagnostics.md): they are local
 until the operator explicitly exports them, and they exclude raw content, raw app data, private

--- a/docs/cryptad-release-workflow-and-runbook.md
+++ b/docs/cryptad-release-workflow-and-runbook.md
@@ -97,10 +97,16 @@ Treat these as release blockers, in order:
    Confirm `production-security.response-runbook` passes in the production beta summary, and review
    the compact `multiNodeBetaSoak` and `developerBetaProgram` sections before promotion. Security
    releases or app ecosystem incident responses must also run
-   `python3 tools/release-certification/security_response_runbook.py verify`, preserve the
-   generated drill/advisory artifacts as redacted release evidence, and draft public notes from
-   [templates/security-release-notes.md](templates/security-release-notes.md). The operational
-   procedure is [production-security-response-runbook.md](production-security-response-runbook.md).
+   `python3 tools/release-certification/security_response_runbook.py verify`,
+   `python3 tools/release-certification/security_response_runbook.py drill run-all --out-dir build/security-drills --release-id cryptad-beta-<version> --summary-out build/security-drills/security-drills-summary.json`,
+   and
+   `python3 tools/release-certification/security_response_runbook.py drill verify-all --input-dir build/security-drills --summary-out build/security-drills/security-drills-summary.json`.
+   Preserve `build/security-drills/security-drills-summary.json`, the seven per-scenario drill
+   artifacts, and any generated redacted security release notes draft as release evidence. Draft
+   public notes from [templates/security-release-notes.md](templates/security-release-notes.md).
+   Missing, failed, stale, fixture-only production, malformed, or redaction-unsafe drills are
+   production blockers. The operational procedure is
+   [production-security-response-runbook.md](production-security-response-runbook.md).
 3. **Release certification report** - generate the release-candidate report after the source gates
    below have produced their summaries:
    ```bash

--- a/docs/ecosystem-security-advisories.md
+++ b/docs/ecosystem-security-advisories.md
@@ -177,9 +177,11 @@ ecosystem-security.advisory-revocation-redaction
 ```
 
 Production beta additionally requires `production-security.response-runbook`, which verifies the
-runbook document, machine-readable drill model, security-release-notes template, API/Web Shell
-summary integration, and support redaction coverage for emergency catalog updates and compromise
-drills.
+runbook document, machine-readable drill model, schema-version 2 drill artifacts,
+`security-drills-summary.json`, security-release-notes template, API/Web Shell summary
+integration, and support redaction coverage for emergency catalog updates and compromise drills.
+Missing, failed, stale, malformed, fixture-only production, or redaction-unsafe drills block
+production-beta promotion.
 
 The evidence proves strict v4 parser/writer behavior, exact version denylist enforcement, warning
 acknowledgement behavior, install/update/stage/apply/scheduler gates, receipt revocation,

--- a/docs/privacy-preserving-beta-diagnostics.md
+++ b/docs/privacy-preserving-beta-diagnostics.md
@@ -165,6 +165,14 @@ Redaction failures are production-critical and non-waivable. Missing schema, mis
 routes, raw diagnostics embedded in default bundles, unsafe fuzz fixtures, or default bundle exports
 that include legacy plaintext diagnostics are no-go conditions.
 
+The production security response drill set also treats `support-bundle-intake-redaction` as a
+required production drill. Its artifact may include boolean redaction metadata, safe omitted-field
+counts, digests, and fixture result names, but it must not include raw support bundle bodies, raw
+diagnostic lines, raw app data, raw profile/feed/trust/social documents, raw app-service bodies,
+nested backup material, private insert URIs, tokens, private keys, or local paths. A missing,
+failed, stale, malformed, fixture-only production, or redaction-unsafe drill blocks production beta
+promotion through the go/no-go dashboard.
+
 ## Limitations
 
 The support bundle is not telemetry, crash-report upload, analytics, remote logging, or automatic

--- a/docs/production-beta-go-no-go-dashboard.md
+++ b/docs/production-beta-go-no-go-dashboard.md
@@ -43,10 +43,13 @@ python3 tools/release-certification/production_beta_go_no_go_dashboard.py build 
   --live-network-summary build/live-network-beta-smoke/summary.json \
   --network-scale-soak-summary build/network-scale-soak/summary.json \
   --multi-node-beta-soak-summary build/multi-node-beta-soak/summary.json \
-  --security-response-summary build/security-response-runbook/summary.json \
+  --security-drills-summary build/security-drills/security-drills-summary.json \
   --waivers release/waivers.json \
   --mode production-beta
 ```
+
+`--security-response-summary` remains a developer dry-run legacy fallback. Strict
+release-candidate and production-beta dashboard runs must pass `--security-drills-summary`.
 
 Run the offline fixture tests with:
 
@@ -69,6 +72,7 @@ Production beta mode fails closed when these critical inputs are missing or malf
 | `live-network-beta-smoke/summary.json` | Required production beta live-network smoke evidence. |
 | `network-scale-soak/summary.json` | Network-scale budget, pressure, and redaction evidence. |
 | `multi-node-beta-soak/summary.json` | Multi-node soak, previous-candidate upgrade drill, scenario, app migration, backup/restore, Social Inbox, Trust Graph, support-bundle, and redaction evidence. |
+| `security-drills/security-drills-summary.json` | Operational production security response drill summary, required scenario status, artifact digests, release-notes/advisory template status, and aggregate redaction status. |
 | `third-party-intake-summary.json` | Optional third-party app intake summary copied by the release wrapper when `--third-party-intake-summary` or `--run-third-party-intake-sample-flow` is used. |
 
 Developer dry-runs tolerate missing production-only inputs so PR and local runs remain CI-safe. A
@@ -95,6 +99,15 @@ support-bundle schema, missing preview/export routes, unsafe lifecycle summaries
 plaintext diagnostics in the default bundle, or redaction fixture failures are `no-go` conditions
 in production beta. Redaction failures in this domain are non-waivable.
 
+The `production-security-response` domain consumes the
+`cryptad-security-response-drills-summary` artifact. The dashboard reports required, passed,
+failed, missing, stale, and malformed scenario counts; aggregate redaction status;
+release-notes/advisory template status; support-bundle intake redaction status; fixture-only and
+non-release markers; and the critical blockers derived from the summary. A missing summary, missing
+required scenario, failed scenario, stale artifact, malformed envelope, fixture-only production
+summary, or critical redaction finding is `no-go`. Redaction findings from security drills are
+non-waivable, and waiver attempts for critical drill redaction are recorded as invalid.
+
 These content profiles are Crypta app ecosystem profiles. They are not compatibility promises for
 legacy WoT, Freetalk, Sone, Freemail, or any old plugin ABI/protocol.
 
@@ -120,6 +133,8 @@ production launch set.
 - unsafe artifact hygiene finding such as AppleDouble metadata, `.DS_Store`, or `__MACOSX`;
 - production beta mode using test-only or generated signing material;
 - production beta artifact marked `nonRelease=true`;
+- missing security drill summary, missing required scenario, failed scenario, stale drill artifact,
+  malformed drill envelope, fixture-only production drill, or drill redaction finding;
 - production beta summary with failed promotion gates or `promotionReady=false`.
 
 Previous-candidate upgrade evidence is a production-beta launch blocker. Missing, failing, warning,
@@ -191,7 +206,7 @@ These findings always produce `no-go`:
   production beta;
 - missing or failing live-network beta evidence, sandbox provider evidence, production signing,
   previous-candidate summary validation, previous-candidate multi-node upgrade evidence,
-  multi-node redaction, or ecosystem RC gates in production beta;
+  multi-node redaction, security drill redaction, or ecosystem RC gates in production beta;
 - malformed or expired waiver records.
 
 The scanner allows deterministic placeholders such as `<redacted-private-insert-uri>`,

--- a/docs/production-beta-release-pipeline.md
+++ b/docs/production-beta-release-pipeline.md
@@ -103,10 +103,24 @@ Production beta supports three explicit test/emergency escape hatches:
   non-production signing labels. It sets `nonRelease=true`, keeps `promotionReady=false`, and must
   not be used for release publication.
 
-Production beta requires `production-security.response-runbook` evidence. Missing runbook
-documentation, drill model, reviewer compromise drill, catalog key rotation drill, app signing key
-compromise drill, emergency catalog update drill, support redaction proof, or security release
-notes template is a production blocker. The runbook procedure is
+Production beta requires `production-security.response-runbook` evidence backed by the operational
+security drill summary. Missing runbook documentation, drill model, reviewer compromise drill,
+catalog key rotation drill, app signing key compromise drill, emergency catalog update drill,
+support redaction proof, security release notes template, or
+`security-drills/security-drills-summary.json` is a production blocker. The wrapper generates this
+summary by default with `security_response_runbook.py drill run-all` and verifies it with
+`drill verify-all`; protected runs can also consume a prebuilt summary through
+`--security-drills-summary`. Attached summaries must use the current candidate release id,
+`cryptad-beta-<version>`, use `mode=production-beta` for protected production-beta attachment, and
+keep all seven per-scenario drill JSON files beside the summary. The wrapper copies those artifacts
+into `security-drills/`, verifies their digests and offline drill envelopes, and rejects summary-only
+attachments as incomplete release evidence. The wrapper and strict go/no-go dashboard reject
+summaries generated for another candidate as unbound to the release. The required scenarios are
+`vulnerable-app-version`,
+`app-signing-key-compromise`, `reviewer-key-compromise`, `catalog-signing-key-rotation`,
+`malicious-catalog-entry`, `emergency-replacement-app`, and
+`support-bundle-intake-redaction`. Missing, failed, stale, malformed, fixture-only production, or
+redaction-unsafe drill evidence keeps `promotionReady=false`. The runbook procedure is
 [production-security-response-runbook.md](production-security-response-runbook.md).
 
 Production beta also requires `catalog.operations-and-mirrors` evidence. That row proves
@@ -190,7 +204,19 @@ build/production-beta-release/
   reviews/
     review-receipts/
     review-transparency-log.json
+  security-drills/
+    security-drills-summary.json
+    vulnerable-app-version.json
+    app-signing-key-compromise.json
+    reviewer-key-compromise.json
+    catalog-signing-key-rotation.json
+    malicious-catalog-entry.json
+    emergency-replacement-app.json
+    support-bundle-intake-redaction.json
+  security/
+    security-release-notes-draft.md
   evidence/
+    security-drills-summary.json
     api-compatibility.json
     platform-api-contract-current.json
     platform-api-contract-previous.json
@@ -245,6 +271,8 @@ content, raw app data, and host-local absolute paths.
 | `pipelineStages` | Per-stage proof for launcher installation, full Gradle build, first-party app staging, signing, and verification. Production-beta promotion requires all required stages to be `pass` from this pipeline execution. |
 | `promotion.gates` | Per-gate pass/fail records for signed artifacts, evidence ids, live-network evidence, ecosystem certification, and signing profile checks. |
 | `promotion.securityResponse` | Compact status for the production security response runbook, advisory lifecycle, reviewer compromise drill, catalog key rotation drill, app signing key compromise drill, emergency catalog update drill, support redaction, security release notes template, blockers, and warnings. |
+| `artifacts.securityDrillsSummary` | Redacted operational security drill summary generated or consumed by the pipeline. It contains only scenario statuses, safe counts, digests, and redaction metadata. |
+| `artifacts.securityReleaseNotesDraft` | Draft security release notes generated from drill data. Treat it as a redacted starting point for release-manager editing, not as automatically published notes. |
 | `multiNodeBetaSoak` | Compact status for multi-node soak and upgrade evidence, including mode, scenario statuses, blockers, warnings, promotion readiness, previous-candidate upgrade status, and the `evidence/multi-node-beta-soak.json` artifact path. |
 | `catalogOperations` | Compact source-level evidence for mirror health, fallback, rollback, key-rotation status, emergency advisory refresh, and redaction when present in the app-platform smoke summary. |
 | `previousCandidateMetadata` | Sanitized release, catalog, Platform API, first-party app, app-data, Social Inbox, Trust Graph, support-bundle, and redaction metadata copied by the next cycle's previous-summary normalizer. It contains digests, counts, schema versions, and statuses only. |
@@ -406,6 +434,7 @@ The pipeline classifies failures into these groups:
 | Build and staging | Gradle toolchain failure, `stageFirstPartyApps` failure, missing `crypta-app` launcher. | Fails release-candidate and production-beta. |
 | Signing and catalog | Missing production keys in production-beta, bundle verification failure, catalog signature failure, review receipt verification failure. | Fails release-candidate and production-beta. |
 | Evidence | Missing Platform API, UI lint, sandbox, app-platform smoke, first-party maintenance policy, network-scale soak, or ecosystem certification evidence. | Fails release-candidate and production-beta when critical. |
+| Security response drills | Missing `security-drills-summary.json`, missing required scenario, failed scenario, stale artifact, malformed drill envelope, fixture-only production drill, unsafe advisory or release-note template, or support-bundle intake redaction failure. | Blocks production-beta promotion. Critical redaction findings are non-waivable. |
 | Multi-node beta soak | Missing required multi-node soak, upgrade-drill, scenario, previous-candidate summary, app-data migration, backup/restore, Trust Graph, Social Inbox, support-bundle, or redaction evidence. | Fails production-beta promotion when `--require-multi-node-soak` is set or production-beta mode is used. |
 | Live network | Required live-network beta evidence missing, stale, wrong mode, failed, or explicitly skipped. | Blocks production-beta promotion. `--emergency-skip-live-network` records an explicit failed skip gate instead of silently treating missing live evidence as acceptable. |
 | Redaction | Private insert URI, private key, bearer token, app/browser session token, raw fetched content, raw app data, host path, AppleDouble, `__MACOSX`, `.DS_Store`, or CI secret value found. | Always fails. Redaction findings are not waivable. |
@@ -500,6 +529,11 @@ The workflow downloads HTTPS sources with `curl` and restores `actions-artifact:
 path to the release tool. HTTP URLs, missing artifact paths, absolute artifact paths, and artifact
 paths containing `..` fail before the pipeline starts.
 
+For `security_drills_summary`, pass a checked-out local path or an `actions-artifact://` reference
+to `security-drills-summary.json` inside an artifact that also contains all seven per-scenario
+drill JSON files beside the summary. HTTPS JSON URLs are rejected for this input because the
+production-beta release tool re-verifies the sibling artifacts and their self-reported digests.
+
 For `previous_summary`, the workflow also runs:
 
 ```bash
@@ -512,6 +546,11 @@ python3 tools/release-certification/multi_node_beta_soak.py verify-previous-summ
 The verification output is limited to status and validation errors. The workflow must not print
 the raw summary body, private insert URIs, tokens, private keys, raw app data, raw social message
 bodies, or raw Trust Graph statements into logs.
+
+For `security_drills_summary`, the release tool validates the
+`cryptad-security-response-drills-summary` envelope, redaction block, candidate release id, release
+mode, and sibling per-scenario drill artifacts before the input can contribute to promotion.
+Omitting the input is allowed because the pipeline generates the full drill set itself.
 
 ## Known limitations
 

--- a/docs/production-security-response-runbook.md
+++ b/docs/production-security-response-runbook.md
@@ -266,20 +266,66 @@ malformed advisory or denylist records.
    data, or bypass signed advisories and denylists.
 9. Produce security release notes from [docs/templates/security-release-notes.md](templates/security-release-notes.md).
 10. Run `python3 tools/release-certification/security_response_runbook.py verify`.
-11. Run `python3 tools/release-certification/app_platform_smoke.py --self-test`.
-12. Run `python3 tools/release-certification/release_certification.py --self-test` before release
+11. Generate the operational drill evidence. Use `release-candidate` for release-candidate
+   certification, or `production-beta` when the summary will be attached to a protected
+   production-beta pipeline run:
+   ```bash
+   DRILL_MODE=production-beta
+   python3 tools/release-certification/security_response_runbook.py drill run-all \
+     --out-dir build/security-drills \
+     --release-id cryptad-beta-<version> \
+     --mode "$DRILL_MODE" \
+     --summary-out build/security-drills/security-drills-summary.json \
+     --release-notes-out build/security/security-release-notes-draft.md
+   python3 tools/release-certification/security_response_runbook.py drill verify-all \
+     --input-dir build/security-drills \
+     --release-id cryptad-beta-<version> \
+     --mode "$DRILL_MODE" \
+     --summary-out build/security-drills/security-drills-summary.json
+   ```
+12. Run `python3 tools/release-certification/app_platform_smoke.py --self-test`.
+13. Run `python3 tools/release-certification/release_certification.py --self-test` before release
    candidate certification.
-13. Publish only the signed emergency catalog and redacted release artifacts.
+14. Publish only the signed emergency catalog and redacted release artifacts.
 
 No production private key is required for deterministic tests. Fixture and dry-run artifacts use
 synthetic ids, digests, and test keys only.
+
+## Operational drill artifacts
+
+The seven required production security scenarios are:
+
+- `vulnerable-app-version`
+- `app-signing-key-compromise`
+- `reviewer-key-compromise`
+- `catalog-signing-key-rotation`
+- `malicious-catalog-entry`
+- `emergency-replacement-app`
+- `support-bundle-intake-redaction`
+
+Each scenario generates a `kind=cryptad-security-response-drill`, `schemaVersion=2` JSON artifact.
+The artifact records the scenario, release id, generated timestamp, severity, runbook scenario
+digest, bounded verification evidence ids, per-step safe summaries, redacted release-note text, and
+redaction metadata. It must not include private keys, private insert URIs, raw receipt signatures,
+raw support bundle bodies, raw fetched content, raw app-data values, raw profile/feed/trust/social
+documents, raw app-service bodies, nested backup material, tokens, or absolute local paths.
+
+`drill run-all` writes one artifact per required scenario plus
+`security-drills-summary.json`. The summary uses
+`kind=cryptad-security-response-drills-summary`, reports `status`, `promotionReady`,
+required/passed/failed/missing/stale scenario lists, artifact digests, release-notes template
+status, advisory-template status, and the aggregate redaction result. Production beta promotion
+requires this summary to be present, schema-valid, fresh, `promotionReady=true`, and free of
+redaction findings. Missing scenarios, failed scenarios, stale artifacts, malformed envelopes,
+fixture-only production drills, and redaction failures are production blockers. Redaction failures
+are critical and non-waivable.
 
 ## Certification checklist
 
 `production-security.response-runbook` passes only when release certification can prove:
 
 - this runbook exists and covers the required incident scenarios;
-- the deterministic drill model exists and validates;
+- the deterministic drill model exists, validates, and has a fresh all-drills summary;
 - advisory lifecycle, reviewer-key compromise, catalog signing key rotation, app signing key
   compromise, emergency catalog update, support redaction, release notes, Web Shell/API/operator
   status, and redaction boundaries are represented;

--- a/docs/release-certification.md
+++ b/docs/release-certification.md
@@ -164,7 +164,7 @@ Release-candidate mode requires these evidence ids:
 | `app-update.security-denylist-gates` | App-platform smoke summary. | Install, update, stage, apply, and scheduler policy paths block denylisted candidates, warning advisories require `securityAcknowledged=true` for manual actions, and security acknowledgement does not bypass other gates. |
 | `web-shell.security-advisory-trust-warnings` | App-platform smoke summary. | Web Shell renders advisory, denylist, revoked-review, security acknowledgement, and safe uninstall guidance using safe DOM construction. |
 | `ecosystem-security.advisory-revocation-redaction` | App-platform smoke summary. | Advisory and revocation evidence excludes raw signatures, raw public keys, private keys, private insert URIs, tokens, request bodies, raw fetched content, app-data backup payloads, local filesystem paths, catalog scratch paths, and staged bundle paths. |
-| `production-security.response-runbook` | App-platform smoke summary. | [production-security-response-runbook.md](production-security-response-runbook.md), the deterministic drill model, verifier script, security release notes template, advisory lifecycle coverage, reviewer compromise drill, catalog key rotation drill, app signing key compromise drill, emergency catalog update workflow, API/Web Shell security response summary, and support redaction test coverage are present. |
+| `production-security.response-runbook` | Security drills summary. | [production-security-response-runbook.md](production-security-response-runbook.md), the deterministic drill model, verifier script, schema-version 2 per-scenario drill artifacts, `security-drills-summary.json`, security release notes template, advisory lifecycle coverage, reviewer compromise drill, catalog key rotation drill, app signing key compromise drill, emergency catalog update workflow, API/Web Shell security response summary, and support redaction test coverage are present and redaction-safe. |
 | `app-review.governance` | App-platform smoke summary. | Reviewer-key lifecycle statuses, policy-version constraints, governance API routes, and Web Shell governance rendering are present and redacted. |
 | `app-review.reviewer-key-lifecycle` | App-platform smoke summary. | Trusted reviewer registry v2 parsing, active/retired/revoked semantics, duplicate-id fail-closed behavior, strict instants, and lifecycle verifier tests are present. |
 | `app-review.transparency-log` | App-platform smoke summary. | A local hash-chained review transparency log exists, can be verified, deduplicates receipt observation, and has tamper/redaction tests. |
@@ -396,10 +396,14 @@ guidance, and redaction. See
 [ecosystem-security-advisories.md](ecosystem-security-advisories.md).
 
 `production-security.response-runbook` is the Phase 10 production security response evidence. It
-checks the operator runbook, machine-readable drill model, standalone verifier, release-notes
-template, reviewer-key compromise drill, catalog-key rotation drill, app-signing-key compromise
-drill, emergency catalog update workflow, API/Web Shell security-response summary, support
-redaction behavior, and non-waivable sensitive marker scans. See
+checks the operator runbook, machine-readable drill model, standalone verifier,
+`cryptad-security-response-drill` artifacts, the
+`cryptad-security-response-drills-summary` aggregate, release-notes template, reviewer-key
+compromise drill, catalog-key rotation drill, app-signing-key compromise drill, emergency catalog
+update workflow, API/Web Shell security-response summary, support redaction behavior, and
+non-waivable sensitive marker scans. Release certification accepts this evidence with
+`--security-drills-summary`; production beta treats missing, failed, stale, fixture-only,
+malformed, or redaction-unsafe drills as blockers. See
 [production-security-response-runbook.md](production-security-response-runbook.md).
 
 `app-platform.user-consent-flow` verifies the unified consent layer for material install, update,

--- a/docs/templates/security-release-notes.md
+++ b/docs/templates/security-release-notes.md
@@ -43,6 +43,9 @@ responses, catalog signing key rotations, and app signing key compromise respons
 
 ## Verification
 
+- Security drill scenario:
+- Security drill artifact digest:
+- Security drill summary status:
 - Signed catalog verified:
 - Advisory parser/writer verified:
 - Install/update/stage/apply gates verified:

--- a/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
+++ b/platform-api/src/main/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandler.java
@@ -988,9 +988,11 @@ public final class AppCatalogsApiHandler {
       int revokedReviewerKeys = revokedReviewerCount(registryJson);
       int revokedReceipts = registry.receiptRevocationCount();
 
-      LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(7);
+      Map<String, Object> securityDrills = securityDrillsReadinessSummary();
+      LinkedHashMap<String, Object> summary = LinkedHashMap.newLinkedHashMap(11);
       summary.put("activeAdvisoryCount", activeAdvisories.size());
       summary.put("denylistedVersionCount", denylistedVersions.size());
+      summary.put("installedVulnerableAppCount", "unavailable");
       summary.put("revokedReviewerKeyCount", revokedReviewerKeys);
       summary.put("revokedReceiptCount", revokedReceipts);
       summary.put("catalogSigningKeyCount", catalogSigningKeys.size());
@@ -999,7 +1001,12 @@ public final class AppCatalogsApiHandler {
           catalogSigningKeys.stream().anyMatch(key -> key.get("keyId") == null)
               ? VERSION_STATUS_UNKNOWN
               : CONFIGURED_FIELD);
+      summary.put(
+          "emergencyReplacementGuidanceAvailable",
+          emergencyReplacementGuidanceAvailable(activeAdvisories, denylistedVersions));
       summary.put("supportRedactionStatus", "required");
+      summary.put("securityDrillsStatus", securityDrills.get(STATUS_FIELD));
+      summary.put("securityDrillsLastStatus", securityDrills.get("lastStatus"));
 
       LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(8);
       json.put(
@@ -1011,6 +1018,7 @@ public final class AppCatalogsApiHandler {
       json.put("denylistedVersions", List.copyOf(denylistedVersions));
       json.put("reviewerGovernance", registryJson);
       json.put("catalogSigningKeys", List.copyOf(catalogSigningKeys));
+      json.put("securityDrills", securityDrills);
       json.put("operatorActions", securityResponseOperatorActions());
       json.put("supportGuidance", "Use redacted support bundle preview before sharing evidence.");
       return json;
@@ -1079,6 +1087,14 @@ public final class AppCatalogsApiHandler {
         .toList();
   }
 
+  private static boolean emergencyReplacementGuidanceAvailable(
+      List<Map<String, Object>> activeAdvisories, List<Map<String, Object>> denylistedVersions) {
+    return activeAdvisories.stream()
+            .anyMatch(advisory -> nonEmptyString(advisory.get(REPLACEMENT_APP_ID_FIELD)))
+        || denylistedVersions.stream()
+            .anyMatch(denylist -> nonEmptyString(denylist.get(REPLACEMENT_APP_ID_FIELD)));
+  }
+
   private static Map<String, Object> securityResponseDenylistEntry(
       String catalogId, Map<String, Object> denylistEntry) {
     LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(8);
@@ -1145,6 +1161,26 @@ public final class AppCatalogsApiHandler {
     json.put("id", id);
     json.put("label", label);
     return json;
+  }
+
+  private static Map<String, Object> securityDrillsReadinessSummary() {
+    LinkedHashMap<String, Object> json = LinkedHashMap.newLinkedHashMap(8);
+    json.put(STATUS_FIELD, "release_artifact_required");
+    json.put("lastStatus", "not_loaded");
+    json.put("summaryAvailable", false);
+    json.put("promotionReady", false);
+    json.put("requiredScenarioCount", 7);
+    json.put("redactionStatus", "not_loaded");
+    json.put("artifactKind", "cryptad-security-response-drills-summary");
+    json.put(
+        SUMMARY_FIELD,
+        "Release certification verifies security drills from redacted artifacts; no raw drill"
+            + " artifacts are uploaded to this node.");
+    return json;
+  }
+
+  private static boolean nonEmptyString(Object value) {
+    return value instanceof String text && !text.isBlank();
   }
 
   /**

--- a/platform-api/src/test/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandlerTest.java
+++ b/platform-api/src/test/java/network/crypta/platform/api/appcatalogs/AppCatalogsApiHandlerTest.java
@@ -1173,9 +1173,17 @@ class AppCatalogsApiHandlerTest {
     Map<String, Object> summary = (Map<String, Object>) response.get(SUMMARY_FIELD);
     assertEquals(1, summary.get(ACTIVE_ADVISORY_COUNT_FIELD));
     assertEquals(1, summary.get(DENYLISTED_VERSION_COUNT_FIELD));
+    assertEquals("unavailable", summary.get("installedVulnerableAppCount"));
     assertEquals(1, summary.get(REVOKED_REVIEWER_KEY_COUNT_FIELD));
     assertEquals(CONFIGURED_TEXT, summary.get("catalogKeyRotationStatus"));
+    assertEquals(true, summary.get("emergencyReplacementGuidanceAvailable"));
     assertEquals("required", summary.get("supportRedactionStatus"));
+    assertEquals("release_artifact_required", summary.get("securityDrillsStatus"));
+    assertEquals("not_loaded", summary.get("securityDrillsLastStatus"));
+    Map<String, Object> securityDrills = (Map<String, Object>) response.get("securityDrills");
+    assertEquals("cryptad-security-response-drills-summary", securityDrills.get("artifactKind"));
+    assertEquals(7, securityDrills.get("requiredScenarioCount"));
+    assertEquals(false, securityDrills.get("summaryAvailable"));
     Map<String, Object> advisory =
         ((List<Map<String, Object>>) response.get("activeAdvisories")).getFirst();
     assertEquals(SECURITY_ADVISORY_ID_0001, advisory.get("id"));
@@ -1191,6 +1199,34 @@ class AppCatalogsApiHandlerTest {
     assertFalse(response.toString().contains(FIRST_PARTY_SOURCE));
     assertFalse(response.toString().contains(tempDir.toString()));
     assertRedactsReviewerPublicKey(response, reviewerKeyPair);
+  }
+
+  @Test
+  void securityResponseSummary_whenDenylistHasReplacementGuidance_expectGuidanceAvailable()
+      throws Exception {
+    AppCatalogSourceSnapshot snapshot = firstPartyCatalogSnapshot();
+    when(catalogManager.listCatalogs()).thenReturn(List.of(snapshot));
+    when(catalogManager.securityPolicy(snapshot.catalogId()))
+        .thenReturn(denylistReplacementOnlySecurityResponsePolicy());
+    AppCatalogsApiHandler handler =
+        new AppCatalogsApiHandler(
+            catalogManager,
+            appHost,
+            () -> null,
+            AppReviewPolicy.DEFAULT,
+            TrustedReviewerKeys::empty);
+
+    Map<String, Object> response = handler.securityResponseSummary();
+
+    assertEquals("denylist_active", response.get(STATUS_FIELD));
+    Map<String, Object> summary = (Map<String, Object>) response.get(SUMMARY_FIELD);
+    assertEquals(true, summary.get("emergencyReplacementGuidanceAvailable"));
+    Map<String, Object> advisory =
+        ((List<Map<String, Object>>) response.get("activeAdvisories")).getFirst();
+    assertNull(advisory.get("replacementAppId"));
+    Map<String, Object> denylist =
+        ((List<Map<String, Object>>) response.get("denylistedVersions")).getFirst();
+    assertEquals(APP_ID, denylist.get("replacementAppId"));
   }
 
   @Test
@@ -1969,6 +2005,32 @@ class AppCatalogsApiHandlerTest {
             Optional.of(APP_ID),
             Optional.of("Keep installed data until a replacement is reviewed."));
     return new AppCatalogSecurityPolicy(List.of(advisory), List.of());
+  }
+
+  private static AppCatalogSecurityPolicy denylistReplacementOnlySecurityResponsePolicy() {
+    AppCatalogSecurityAdvisoryRecord advisory =
+        new AppCatalogSecurityAdvisoryRecord(
+            SECURITY_ADVISORY_ID_0001,
+            URI.create(SECURITY_ADVISORY_URI_0001),
+            "Queue Manager vulnerable release",
+            AppCatalogSecuritySeverity.CRITICAL,
+            AppCatalogSecurityStatus.PUBLISHED,
+            AppCatalogSecurityAction.DENYLIST,
+            "Upgrade to the reviewed replacement version.",
+            Instant.parse("2026-06-11T00:00:00Z"),
+            Instant.parse("2026-06-12T00:00:00Z"),
+            Optional.empty(),
+            Optional.of("Export app data before removal."));
+    AppCatalogVersionDenylistEntry denylist =
+        new AppCatalogVersionDenylistEntry(
+            "deny-queue-1-2-0",
+            APP_ID,
+            CATALOG_VERSION,
+            advisory.id(),
+            "Known vulnerable release.",
+            Optional.of(APP_ID),
+            Optional.of("Export app data before removal."));
+    return new AppCatalogSecurityPolicy(List.of(advisory), List.of(denylist));
   }
 
   private static AppCatalogSecurityDecision denylistedSecurityDecision() {

--- a/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
+++ b/platform-web-shell/src/main/resources/network/crypta/platform/webshell/static/web-shell.js
@@ -940,6 +940,7 @@
     const denylistedVersions = arrayValue(safeResponse.denylistedVersions).map(recordValue);
     const reviewerGovernance = recordValue(safeResponse.reviewerGovernance);
     const catalogSigningKeys = arrayValue(safeResponse.catalogSigningKeys).map(recordValue);
+    const securityDrills = recordValue(safeResponse.securityDrills);
     const registryCounts = recordValue(reviewerGovernance.counts);
     const status = typeof safeResponse.status === "string" ? safeResponse.status : "unavailable";
     const list = document.createElement("div");
@@ -952,11 +953,15 @@
       definitionList([
         ["Active advisories", scalar(summary.activeAdvisoryCount)],
         ["Denylisted versions", scalar(summary.denylistedVersionCount)],
+        ["Installed vulnerable apps", scalar(summary.installedVulnerableAppCount)],
         ["Revoked reviewer keys", scalar(summary.revokedReviewerKeyCount ?? registryCounts.revoked)],
         ["Revoked receipts", scalar(summary.revokedReceiptCount)],
         ["Catalog signing keys", scalar(summary.catalogSigningKeyCount)],
         ["Catalog key rotation", normalizedStatus(summary.catalogKeyRotationStatus, "Unavailable")],
+        ["Emergency replacement guidance", yesNoText(summary.emergencyReplacementGuidanceAvailable, null)],
         ["Support redaction", normalizedStatus(summary.supportRedactionStatus, "Unavailable")],
+        ["Security drills", normalizedStatus(summary.securityDrillsStatus, "Unavailable")],
+        ["Last drill status", normalizedStatus(summary.securityDrillsLastStatus, "Unavailable")],
       ]),
       renderSecurityResponseActionLabels(arrayValue(safeResponse.operatorActions)),
     );
@@ -975,6 +980,9 @@
         renderSecurityResponseRecordCard("Catalog signing keys", catalogSigningKeys, securityResponseCatalogKeyLine),
       );
     }
+    if (Object.keys(securityDrills).length) {
+      list.append(renderSecurityDrillsSummaryCard(securityDrills));
+    }
     if (typeof safeResponse.supportGuidance === "string" && safeResponse.supportGuidance.length) {
       const support = document.createElement("article");
       support.className = "app-card";
@@ -986,6 +994,26 @@
     }
     group.append(list);
     return group;
+  }
+
+  function renderSecurityDrillsSummaryCard(securityDrills) {
+    const status = typeof securityDrills.status === "string" ? securityDrills.status : "unavailable";
+    const card = document.createElement("article");
+    card.className = securityResponseTone(status) ? `app-card ${securityResponseTone(status)}` : "app-card";
+    card.append(
+      betaCardHeader("Security drills", normalizedStatus(status, "Unavailable"), securityResponseTone(status)),
+      definitionList([
+        ["Last status", normalizedStatus(securityDrills.lastStatus, "Unavailable")],
+        ["Promotion ready", yesNoText(securityDrills.promotionReady, false)],
+        ["Required scenarios", scalar(securityDrills.requiredScenarioCount)],
+        ["Redaction", normalizedStatus(securityDrills.redactionStatus, "Unavailable")],
+        ["Artifact", scalar(securityDrills.artifactKind)],
+      ]),
+    );
+    if (typeof securityDrills.summary === "string" && securityDrills.summary.length) {
+      card.append(text("p", "empty-state", securityDrills.summary));
+    }
+    return card;
   }
 
   function securityResponseTone(status) {

--- a/tools/release-certification/README.md
+++ b/tools/release-certification/README.md
@@ -135,6 +135,17 @@ python3 tools/release-certification/security_response_runbook.py drill create \
   --out build/security-drills/reviewer-key-compromise.json
 python3 tools/release-certification/security_response_runbook.py drill verify \
   --input build/security-drills/reviewer-key-compromise.json
+python3 tools/release-certification/security_response_runbook.py drill run-all \
+  --out-dir build/security-drills \
+  --release-id cryptad-beta-<version> \
+  --mode production-beta \
+  --summary-out build/security-drills/security-drills-summary.json \
+  --release-notes-out build/security/security-release-notes-draft.md
+python3 tools/release-certification/security_response_runbook.py drill verify-all \
+  --input-dir build/security-drills \
+  --release-id cryptad-beta-<version> \
+  --mode production-beta \
+  --summary-out build/security-drills/security-drills-summary.json
 python3 tools/release-certification/security_response_runbook.py advisory template \
   --scenario vulnerable-app-version \
   --out build/security-advisory-template.md
@@ -143,6 +154,36 @@ python3 tools/release-certification/security_response_runbook.py advisory templa
 These commands are deterministic, do not require live network access or private keys, and verify
 [docs/production-security-response-runbook.md](../../docs/production-security-response-runbook.md)
 for the `production-security.response-runbook` evidence used by production beta promotion.
+`drill run-all` creates one redacted schema-version 2 artifact for each required scenario and a
+`cryptad-security-response-drills-summary` aggregate. Release certification, the production beta
+release wrapper, and the go/no-go dashboard consume the summary through
+`--security-drills-summary`. Attached summaries must use the candidate release id,
+`cryptad-beta-<version>`, and the matching release mode (`release-candidate` for RC certification,
+`production-beta` for protected production-beta attachment). Keep the seven per-scenario JSON files
+beside the attached summary; the release wrapper copies and verifies those artifacts before
+accepting the summary. The release wrapper and strict go/no-go dashboards reject summaries generated
+for another candidate. Production-beta promotion fails closed when the summary is missing, a
+required scenario is missing, a scenario fails, an artifact is stale or malformed, production
+evidence is marked fixture-only, or any drill/advisory/release-note redaction check fails.
+Redaction failures are critical and non-waivable.
+
+The required scenarios are:
+
+```text
+vulnerable-app-version
+app-signing-key-compromise
+reviewer-key-compromise
+catalog-signing-key-rotation
+malicious-catalog-entry
+emergency-replacement-app
+support-bundle-intake-redaction
+```
+
+Drill artifacts, summaries, and generated release notes must contain only safe scenario ids,
+statuses, bounded operator guidance, evidence ids, counts, and digests. They must not contain
+private keys, private insert URIs, tokens, raw receipt signatures, raw support bundle bodies, raw
+fetched content, raw app data, raw profile/feed/trust/social documents, raw app-service bodies,
+nested backup material, or absolute local paths.
 
 The command cleans existing output directories only under `build/production-beta*` or when the
 directory already contains the `.cryptad-production-beta-release-output` sentinel. Output is
@@ -175,6 +216,8 @@ build/release-certification/
   live-network-beta-smoke/
     summary.json
     live-network-beta-smoke-report.md
+  security-drills/
+    security-drills-summary.json
 ```
 
 The production beta wrapper uses a separate public artifact layout under
@@ -192,7 +235,11 @@ catalog/first-party-catalog.sig
 catalog/channel-metadata.json
 reviews/review-receipts/
 reviews/review-transparency-log.json
+security-drills/security-drills-summary.json
+security-drills/<scenario>.json
+security/security-release-notes-draft.md
 evidence/
+evidence/security-drills-summary.json
 reports/production-beta-summary.json
 reports/production-beta-summary.md
 reports/redaction-report.json
@@ -664,10 +711,19 @@ actions-artifact://<run-id>/<artifact-name>/<path-inside-artifact>
 The workflow restores these inputs into `$RUNNER_TEMP` and then passes the restored local path to
 the release tool. Plain `http://` URLs, missing artifact paths, absolute artifact paths, and
 artifact paths containing `..` are rejected before strict production-beta validation runs.
+
+For `security_drills_summary`, pass a checked-out local path or an `actions-artifact://` reference
+to `security-drills-summary.json` inside an artifact that also contains the seven per-scenario
+drill JSON files beside the summary. HTTPS JSON URLs are rejected for this input because
+`production_beta_release.py` re-verifies sibling drill artifacts and summary digests before the
+attached evidence can contribute to promotion.
+
 For `previous_summary`, strict validation runs
 `multi_node_beta_soak.py verify-previous-summary --strict --max-age-days 90` before uploadable
-production artifacts are accepted. The workflow must not print raw summary bodies, private insert
-URIs, private keys, tokens, raw app data, raw social message bodies, or raw trust statements.
+production artifacts are accepted. Security drill summaries are validated by
+`production_beta_release.py` and the go/no-go dashboard before promotion. The workflow must not
+print raw summary bodies, private insert URIs, private keys, tokens, raw app data, raw social
+message bodies, raw support bundle bodies, raw signatures, or raw trust statements.
 
 ## Structured waiver files
 

--- a/tools/release-certification/app_platform_smoke.py
+++ b/tools/release-certification/app_platform_smoke.py
@@ -18662,8 +18662,10 @@ def assert_security_response_drill_verify_rejects_malformed_envelope(repo_root: 
     parsed = json.loads(result.stdout)
     assert parsed["status"] == "fail", parsed
     assert parsed["ok"] is False, parsed
-    assert "schemaVersion must be 1" in parsed["errors"], parsed
-    assert "scenario must match drill id" in parsed["errors"], parsed
+    assert "generatedAt must be an ISO-8601 UTC timestamp" in parsed["errors"], parsed
+    assert "releaseId must be a non-empty string" in parsed["errors"], parsed
+    assert "steps must be a non-empty array" in parsed["errors"], parsed
+    assert "redaction must be an object" in parsed["errors"], parsed
 
 
 def assert_security_response_verifier_rejects_bounded_model_violations(repo_root: Path) -> None:

--- a/tools/release-certification/fixtures/go-no-go-pass.json
+++ b/tools/release-certification/fixtures/go-no-go-pass.json
@@ -729,6 +729,152 @@
     "securityResponseSummary": {
       "status": "pass",
       "tool": "security-response-runbook"
+    },
+    "securityDrillsSummary": {
+      "artifactDirectory": "security-drills",
+      "artifacts": [
+        {
+          "ageDays": 0,
+          "artifact": "app-signing-key-compromise.json",
+          "advisoryTemplateStatus": "pass",
+          "digest": "sha256:4e59733ce7bf99dd66e4a362b7437edbf4f53e9147b6be2966b54b8b0fee6304",
+          "releaseNotesTemplateStatus": "pass",
+          "scenario": "app-signing-key-compromise",
+          "stale": false,
+          "staleReason": "",
+          "status": "pass"
+        },
+        {
+          "ageDays": 0,
+          "artifact": "catalog-signing-key-rotation.json",
+          "advisoryTemplateStatus": "pass",
+          "digest": "sha256:346caac3698d4b9dba022d61566c225945cf322dc376e6999868b0665e25961d",
+          "releaseNotesTemplateStatus": "pass",
+          "scenario": "catalog-signing-key-rotation",
+          "stale": false,
+          "staleReason": "",
+          "status": "pass"
+        },
+        {
+          "ageDays": 0,
+          "artifact": "emergency-replacement-app.json",
+          "advisoryTemplateStatus": "pass",
+          "digest": "sha256:8938696ccaff3024b02cd970ad1b2e5ff6cc757e60f8885b4ef8922de4dcf6c2",
+          "releaseNotesTemplateStatus": "pass",
+          "scenario": "emergency-replacement-app",
+          "stale": false,
+          "staleReason": "",
+          "status": "pass"
+        },
+        {
+          "ageDays": 0,
+          "artifact": "malicious-catalog-entry.json",
+          "advisoryTemplateStatus": "pass",
+          "digest": "sha256:c91b072091c9548419cc477ecebf33ab42fe6423779dd610493990cd5fce0166",
+          "releaseNotesTemplateStatus": "pass",
+          "scenario": "malicious-catalog-entry",
+          "stale": false,
+          "staleReason": "",
+          "status": "pass"
+        },
+        {
+          "ageDays": 0,
+          "artifact": "reviewer-key-compromise.json",
+          "advisoryTemplateStatus": "pass",
+          "digest": "sha256:e78a6d92a319c84cee13ef50113694233d41aa68bd827d9dfc34b2d8bb82e963",
+          "releaseNotesTemplateStatus": "pass",
+          "scenario": "reviewer-key-compromise",
+          "stale": false,
+          "staleReason": "",
+          "status": "pass"
+        },
+        {
+          "ageDays": 0,
+          "artifact": "support-bundle-intake-redaction.json",
+          "advisoryTemplateStatus": "pass",
+          "digest": "sha256:3b22cd7cd79efdc395c1db3d5194489a13b57b5510737c374253c12f77a2f59b",
+          "releaseNotesTemplateStatus": "pass",
+          "scenario": "support-bundle-intake-redaction",
+          "stale": false,
+          "staleReason": "",
+          "status": "pass"
+        },
+        {
+          "ageDays": 0,
+          "artifact": "vulnerable-app-version.json",
+          "advisoryTemplateStatus": "pass",
+          "digest": "sha256:0e9c8b31df262484f27e1fa61941d179043ee24e43034b11b2687e5d90c68b83",
+          "releaseNotesTemplateStatus": "pass",
+          "scenario": "vulnerable-app-version",
+          "stale": false,
+          "staleReason": "",
+          "status": "pass"
+        }
+      ],
+      "counts": {
+        "failed": 0,
+        "malformed": 0,
+        "missing": 0,
+        "passed": 7,
+        "required": 7,
+        "stale": 0
+      },
+      "evidenceMode": "release-operations",
+      "failedScenarios": [],
+      "fixtureOnly": false,
+      "generatedAt": "1970-01-01T00:00:00Z",
+      "kind": "cryptad-security-response-drills-summary",
+      "malformedScenarios": [],
+      "maxAgeDays": 30,
+      "missingScenarios": [],
+      "mode": "production-beta",
+      "nonRelease": false,
+      "passedScenarios": [
+        "vulnerable-app-version",
+        "app-signing-key-compromise",
+        "reviewer-key-compromise",
+        "catalog-signing-key-rotation",
+        "malicious-catalog-entry",
+        "emergency-replacement-app",
+        "support-bundle-intake-redaction"
+      ],
+      "promotionReady": true,
+      "redaction": {
+        "findings": [],
+        "patternsChecked": [
+          "private-key",
+          "private-insert-uri",
+          "token",
+          "raw-content",
+          "raw-app-data",
+          "raw-support-bundle",
+          "raw-profile-feed-trust-social",
+          "raw-signature",
+          "local-path"
+        ],
+        "rawSensitiveMaterialExcluded": true,
+        "status": "pass"
+      },
+      "releaseId": "crypta-production-beta-270",
+      "advisoryTemplate": {
+        "templateStatus": "pass"
+      },
+      "releaseNotes": {
+        "templateStatus": "pass"
+      },
+      "requiredScenarios": [
+        "vulnerable-app-version",
+        "app-signing-key-compromise",
+        "reviewer-key-compromise",
+        "catalog-signing-key-rotation",
+        "malicious-catalog-entry",
+        "emergency-replacement-app",
+        "support-bundle-intake-redaction"
+      ],
+      "schemaVersion": 1,
+      "staleScenarios": [],
+      "status": "pass",
+      "tool": "security-response-runbook"
     }
   },
   "mode": "production-beta",

--- a/tools/release-certification/fixtures/go-no-go-security-drills-developer-dry-run.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-developer-dry-run.json
@@ -1,0 +1,10 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "securityDrillsSummary": {
+      "mode": "developer-dry-run",
+      "nonRelease": true,
+      "promotionReady": false
+    }
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-expired-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-expired-waiver.json
@@ -1,0 +1,22 @@
+{
+  "extends": "go-no-go-security-drills-failed-scenario.json",
+  "waivers": {
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "id": "waive-security-drill-failure",
+        "evidenceId": "production-security.response-runbook",
+        "severity": "blocker",
+        "scope": "production-beta",
+        "rationale": "Fixture verifies expired drill waiver rejection.",
+        "approvedBy": "release-manager",
+        "owner": "release",
+        "createdAt": "1969-12-30T00:00:00Z",
+        "expiresAt": "1969-12-31T00:00:00Z",
+        "references": [
+          "release-drill-waiver-fixture"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-failed-scenario.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-failed-scenario.json
@@ -1,0 +1,16 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "securityDrillsSummary": {
+      "counts": {
+        "failed": 1,
+        "passed": 6
+      },
+      "failedScenarios": [
+        "reviewer-key-compromise"
+      ],
+      "promotionReady": false,
+      "status": "fail"
+    }
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-fixture-only.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-fixture-only.json
@@ -1,0 +1,11 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "securityDrillsSummary": {
+      "evidenceMode": "fixture",
+      "fixtureOnly": true,
+      "nonRelease": true,
+      "promotionReady": false
+    }
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-malformed-count.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-malformed-count.json
@@ -1,0 +1,16 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "securityDrillsSummary": {
+      "counts": {
+        "required": "seven",
+        "passed": null,
+        "failed": 0,
+        "missing": 0,
+        "stale": 0,
+        "malformed": 0
+      },
+      "passedScenarios": null
+    }
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-malformed-envelope.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-malformed-envelope.json
@@ -1,0 +1,11 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "securityDrillsSummary": {
+      "kind": "cryptad-security-response-drill",
+      "promotionReady": false,
+      "schemaVersion": 99,
+      "status": "fail"
+    }
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-missing-scenario.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-missing-scenario.json
@@ -1,0 +1,16 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "securityDrillsSummary": {
+      "counts": {
+        "missing": 1,
+        "passed": 6
+      },
+      "missingScenarios": [
+        "reviewer-key-compromise"
+      ],
+      "promotionReady": false,
+      "status": "fail"
+    }
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-missing-summary.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-missing-summary.json
@@ -1,0 +1,6 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "securityDrillsSummary": null
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-redaction-unsafe.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-redaction-unsafe.json
@@ -1,0 +1,16 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "securityDrillsSummary": {
+      "promotionReady": false,
+      "redaction": {
+        "findings": [
+          "raw support bundle marker"
+        ],
+        "rawSensitiveMaterialExcluded": false,
+        "status": "fail"
+      },
+      "status": "fail"
+    }
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-single-artifact-pass.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-single-artifact-pass.json
@@ -1,0 +1,12 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "securityDrillsSummary": {
+      "kind": "cryptad-security-response-drill",
+      "schemaVersion": 2,
+      "scenario": "reviewer-key-compromise",
+      "status": "pass",
+      "promotionReady": true
+    }
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-stale-scenario.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-stale-scenario.json
@@ -1,0 +1,16 @@
+{
+  "extends": "go-no-go-pass.json",
+  "inputs": {
+    "securityDrillsSummary": {
+      "counts": {
+        "passed": 6,
+        "stale": 1
+      },
+      "promotionReady": false,
+      "staleScenarios": [
+        "catalog-signing-key-rotation"
+      ],
+      "status": "fail"
+    }
+  }
+}

--- a/tools/release-certification/fixtures/go-no-go-security-drills-underseverity-redaction-waiver.json
+++ b/tools/release-certification/fixtures/go-no-go-security-drills-underseverity-redaction-waiver.json
@@ -1,0 +1,22 @@
+{
+  "extends": "go-no-go-security-drills-redaction-unsafe.json",
+  "waivers": {
+    "schemaVersion": 1,
+    "waivers": [
+      {
+        "id": "waive-critical-security-drill-redaction",
+        "evidenceId": "production-security.response-runbook",
+        "severity": "blocker",
+        "scope": "production-beta",
+        "rationale": "Fixture verifies critical redaction cannot be waived by a lower-severity waiver.",
+        "approvedBy": "release-manager",
+        "owner": "release",
+        "createdAt": "1970-01-01T00:00:00Z",
+        "expiresAt": "2099-01-01T00:00:00Z",
+        "references": [
+          "release-drill-redaction-waiver-fixture"
+        ]
+      }
+    ]
+  }
+}

--- a/tools/release-certification/production-security-response-runbook.json
+++ b/tools/release-certification/production-security-response-runbook.json
@@ -33,7 +33,8 @@
       ],
       "verificationEvidence": [
         "catalog.version-denylist",
-        "app-update.security-denylist-gates"
+        "app-update.security-denylist-gates",
+        "operator-beta.support-bundle-redaction"
       ],
       "releaseNotesTemplate": "affected apps, severity, containment, update guidance"
     },
@@ -66,8 +67,10 @@
         "omit key file paths"
       ],
       "verificationEvidence": [
-        "catalog.security-advisories",
-        "app-review.receipt-revocation"
+        "catalog.version-denylist",
+        "app-update.security-denylist-gates",
+        "app-review.receipt-revocation",
+        "production-beta.launch-artifact-hygiene"
       ],
       "releaseNotesTemplate": "signing key id, affected versions, replacement status"
     },
@@ -101,7 +104,9 @@
       ],
       "verificationEvidence": [
         "app-review.reviewer-key-compromise-flow",
-        "app-review.receipt-revocation"
+        "app-review.receipt-revocation",
+        "app-review.transparency-log",
+        "web-shell.security-advisory-trust-warnings"
       ],
       "releaseNotesTemplate": "reviewer key id, affected receipts, replacement review status"
     },
@@ -133,8 +138,9 @@
         "omit trusted-key paths"
       ],
       "verificationEvidence": [
-        "catalog.smoke",
-        "production-security.response-runbook"
+        "catalog.operations-and-mirrors",
+        "catalog.security-advisories",
+        "app-update.live-catalog-refresh"
       ],
       "releaseNotesTemplate": "old key id, new key id, effective timestamp, verification status"
     },
@@ -167,6 +173,8 @@
       ],
       "verificationEvidence": [
         "catalog.security-advisories",
+        "catalog.version-denylist",
+        "catalog.operations-and-mirrors",
         "web-shell.security-advisory-trust-warnings"
       ],
       "releaseNotesTemplate": "catalog id, affected entry, corrected metadata, channel status"
@@ -199,8 +207,10 @@
         "omit raw bundle contents"
       ],
       "verificationEvidence": [
-        "catalog.smoke",
-        "app-review.first-party-catalog"
+        "catalog.security-advisories",
+        "app-update.lifecycle",
+        "app-update.data-migration-contract",
+        "operator-rc.recovery-plan-execute"
       ],
       "releaseNotesTemplate": "replacement version, review status, advisory id, support guidance"
     },
@@ -233,7 +243,8 @@
       ],
       "verificationEvidence": [
         "operator-beta.support-bundle-redaction",
-        "operator-rc.redaction"
+        "app-platform.privacy-preserving-beta-diagnostics",
+        "production-beta.dashboard-redaction"
       ],
       "releaseNotesTemplate": "support bundle note, redaction note, private reporter data excluded"
     }

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -1777,7 +1777,13 @@ def load_inputs_from_fixture(args: argparse.Namespace, workspace_root: Path) -> 
     mode = args.mode or str(fixture.get("mode", "release-candidate"))
     generated_at = args.generated_at or str(fixture.get("generatedAt", DEFAULT_GENERATED_AT))
     release_id = args.release_id or str(fixture.get("releaseId", fixture_path.stem))
-    inputs = rebind_inherited_fixture_security_drills_summary(inputs, fixture_path, release_id, mode)
+    inputs = rebind_inherited_fixture_security_drills_summary(
+        inputs,
+        fixture_path,
+        release_id,
+        mode,
+        generated_at,
+    )
     return inputs, {}, [fixture_path], waiver_value, release_id, mode, generated_at
 
 
@@ -1786,6 +1792,7 @@ def rebind_inherited_fixture_security_drills_summary(
     fixture_path: Path,
     release_id: str,
     mode: str,
+    generated_at: str,
 ) -> dict[str, Any]:
     """Keep inherited pass-fixture drill summaries bound to the child fixture candidate."""
     raw_fixture = read_json(fixture_path)
@@ -1801,6 +1808,7 @@ def rebind_inherited_fixture_security_drills_summary(
     rebound_summary = rebound.get("securityDrillsSummary")
     if isinstance(rebound_summary, dict):
         rebound_summary["releaseId"] = release_id
+        rebound_summary["generatedAt"] = generated_at
         if mode in security_response_runbook.RELEASE_DRILL_MODES:
             rebound_summary["mode"] = mode
     return rebound
@@ -3791,6 +3799,7 @@ def run_self_test(quiet: bool = False) -> None:
         assert_security_drill_summary_evidence_is_not_generic_release_evidence(root)
         assert_security_drills_release_id_matches_dashboard_candidate(root)
         assert_validator_security_drill_redaction_findings_are_non_waivable(root)
+        assert_inherited_security_drill_summary_timestamp_rebinds(root)
         assert_previous_candidate_upgrade_current_binding_is_enforced(root)
         assert_multi_node_release_evidence_is_not_overwritten(root)
     if not quiet:
@@ -3837,6 +3846,44 @@ def assert_multi_node_release_evidence_is_not_overwritten(root: Path) -> None:
         raise AssertionError(
             "failing release-certification support-bundle drill evidence did not block: "
             f"{dashboard}"
+        )
+
+
+def assert_inherited_security_drill_summary_timestamp_rebinds(root: Path) -> None:
+    args = build_parser().parse_args(
+        [
+            "build",
+            "--workspace-root",
+            str(Path(__file__).resolve().parents[2]),
+            "--out-dir",
+            str(root / "inherited-security-drills-timestamp-rebind"),
+            "--fixtures",
+            str(FIXTURE_DIR / "go-no-go-expired-waiver.json"),
+        ]
+    )
+    inputs, _paths, _scan_targets, _waiver_value, _release_id, mode, generated_at = (
+        load_inputs_from_fixture(args, Path(__file__).resolve().parents[2])
+    )
+    summary = inputs.get("securityDrillsSummary")
+    if not isinstance(summary, dict):
+        raise AssertionError("expired-waiver fixture did not inherit a security drills summary")
+    if summary.get("generatedAt") != generated_at:
+        raise AssertionError(
+            "inherited security drills summary did not rebind generatedAt: "
+            f"{summary.get('generatedAt')} != {generated_at}"
+        )
+    _timestamp, now = parse_generated_at(generated_at)
+    validation = security_response_runbook.validate_drills_summary(
+        summary,
+        production=mode == "production-beta",
+        strict=mode in {"release-candidate", "production-beta"},
+        now=now,
+        expected_mode=mode if mode in {"release-candidate", "production-beta"} else None,
+    )
+    if "drills summary is stale" in validation.get("errors", []):
+        raise AssertionError(
+            "inherited security drills summary kept the parent fixture timestamp: "
+            f"{validation}"
         )
 
 

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -1128,6 +1128,7 @@ def security_response_evidence(
     now: dt.datetime | None = None,
     expected_release_id: str | None = None,
     expected_mode: str | None = None,
+    summary_path: Path | None = None,
 ) -> dict[str, Any] | None:
     if not isinstance(summary, dict):
         if source == "security-drills-summary":
@@ -1170,6 +1171,23 @@ def security_response_evidence(
             expected_mode=expected_mode,
         )
         validation_errors = list(validation.get("errors", [])) if isinstance(validation.get("errors"), list) else []
+        artifact_validation: dict[str, Any] | None = None
+        artifact_redaction_findings: list[Any] = []
+        if summary_path is not None:
+            artifact_validation = security_response_runbook.validate_drill_artifact_files(
+                summary,
+                summary_path,
+                model_path=Path(__file__).resolve().parent
+                / "production-security-response-runbook.json",
+                strict=strict,
+                now=now,
+            )
+            artifact_errors = artifact_validation.get("errors")
+            if isinstance(artifact_errors, list):
+                validation_errors.extend(str(error) for error in artifact_errors)
+            artifact_findings = artifact_validation.get("redactionFindings")
+            if isinstance(artifact_findings, list):
+                artifact_redaction_findings.extend(artifact_findings)
         release_id = summary.get("releaseId")
         release_id_matches = not (
             strict
@@ -1191,7 +1209,11 @@ def security_response_evidence(
             else []
         )
         redaction_findings = security_response_runbook.safe_redaction_findings(
-            [*declared_redaction_findings, *validator_redaction_findings]
+            [
+                *declared_redaction_findings,
+                *validator_redaction_findings,
+                *artifact_redaction_findings,
+            ]
         )
         required_scenarios = (
             summary.get("requiredScenarios") if isinstance(summary.get("requiredScenarios"), list) else []
@@ -1211,7 +1233,15 @@ def security_response_evidence(
         malformed_scenarios = (
             summary.get("malformedScenarios") if isinstance(summary.get("malformedScenarios"), list) else []
         )
-        status = "pass" if validation.get("status") == "pass" and release_id_matches else "fail"
+        artifacts_valid = (
+            artifact_validation is None
+            or artifact_validation.get("status") == "pass"
+        )
+        status = (
+            "pass"
+            if validation.get("status") == "pass" and release_id_matches and artifacts_valid
+            else "fail"
+        )
         required = safe_int_count(counts.get("required"), len(security_response_runbook.REQUIRED_DRILLS))
         passed = safe_int_count(counts.get("passed"), len(passed_scenarios))
         if status == "pass":
@@ -1250,8 +1280,12 @@ def security_response_evidence(
                 "releaseNotes": summary.get("releaseNotes", {}),
                 "advisoryTemplate": summary.get("advisoryTemplate", {}),
                 "artifacts": summary.get("artifacts", []),
+                "artifactValidation": artifact_validation or {},
                 "validationErrors": validation_errors,
-                "redactionClean": validation.get("redactionClean", False),
+                "redactionClean": (
+                    validation.get("redactionClean", False)
+                    and not artifact_redaction_findings
+                ),
             },
         }
     status = normalize_status(summary.get("status"))
@@ -2493,6 +2527,7 @@ def compact_security_drills(
     now: dt.datetime | None = None,
     expected_release_id: str | None = None,
     expected_mode: str | None = None,
+    artifact_validation: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     if not isinstance(summary, dict):
         return {
@@ -2558,8 +2593,19 @@ def compact_security_drills(
     )
     if not release_id_matches:
         validation_errors.append(f"releaseId must match dashboard candidate {expected_release_id}")
+    artifact_errors = (
+        artifact_validation.get("errors")
+        if isinstance(artifact_validation, dict)
+        and isinstance(artifact_validation.get("errors"), list)
+        else []
+    )
+    validation_errors.extend(str(error) for error in artifact_errors)
     computed_status = normalize_status(summary.get("status"))
-    if validation.get("status") != "pass" or not release_id_matches:
+    artifacts_valid = (
+        artifact_validation is None
+        or artifact_validation.get("status") == "pass"
+    )
+    if validation.get("status") != "pass" or not release_id_matches or not artifacts_valid:
         computed_status = "fail"
     passed_scenarios = summary.get("passedScenarios") if isinstance(summary.get("passedScenarios"), list) else []
     failed_scenarios = summary.get("failedScenarios") if isinstance(summary.get("failedScenarios"), list) else []
@@ -2579,6 +2625,7 @@ def compact_security_drills(
             bool(summary.get("promotionReady"))
             and validation.get("status") == "pass"
             and release_id_matches
+            and artifacts_valid
         ),
         "releaseId": release_id if isinstance(release_id, str) else "missing",
         "expectedReleaseId": expected_release_id or "not-required",
@@ -2608,6 +2655,7 @@ def compact_security_drills(
         "supportBundleIntakeRedactionStatus": support_status,
         "fixtureOnly": bool(summary.get("fixtureOnly")),
         "nonRelease": bool(summary.get("nonRelease")),
+        "artifactValidation": artifact_validation or {},
         "validationErrors": validation_errors,
     }
 
@@ -3011,6 +3059,7 @@ def collect_issues(
             now=now,
             expected_release_id=release_id,
             expected_mode=mode if mode in {"release-candidate", "production-beta"} else None,
+            summary_path=input_paths.get("securityDrillsSummary"),
         )
         if security_drills_evidence is not None:
             existing_security_entries = [
@@ -3187,6 +3236,15 @@ def build_dashboard(
         if isinstance(multi_node_summary.get("previousCandidateUpgrade"), dict)
         else {"status": "missing"}
     )
+    security_response_item = all_evidence.get("production-security.response-runbook")
+    security_response_details = evidence_details(security_response_item)
+    security_drills_component = security_response_details.get("securityDrills")
+    security_drills_details = (
+        evidence_details(security_drills_component)
+        if isinstance(security_drills_component, dict)
+        else {}
+    )
+    artifact_validation = security_drills_details.get("artifactValidation")
     security_drills = compact_security_drills(
         inputs.get("securityDrillsSummary") if isinstance(inputs.get("securityDrillsSummary"), dict) else None,
         production=mode == "production-beta",
@@ -3194,6 +3252,11 @@ def build_dashboard(
         now=now,
         expected_release_id=release_id,
         expected_mode=mode if mode in {"release-candidate", "production-beta"} else None,
+        artifact_validation=(
+            artifact_validation
+            if isinstance(artifact_validation, dict) and "status" in artifact_validation
+            else None
+        ),
     )
     artifact_refs = {
         "dashboardJson": OUTPUT_JSON,
@@ -3797,6 +3860,7 @@ def run_self_test(quiet: bool = False) -> None:
         assert_security_drills_preserve_failing_runbook_evidence(root)
         assert_security_drills_require_app_platform_runbook_evidence(root)
         assert_security_drill_summary_evidence_is_not_generic_release_evidence(root)
+        assert_security_drill_summary_path_requires_sibling_artifacts(root)
         assert_security_drills_release_id_matches_dashboard_candidate(root)
         assert_validator_security_drill_redaction_findings_are_non_waivable(root)
         assert_inherited_security_drill_summary_timestamp_rebinds(root)
@@ -4086,6 +4150,74 @@ def assert_security_drill_summary_evidence_is_not_generic_release_evidence(root:
         or security_drills_compact.get("promotionReady") is not True
     ):
         raise AssertionError(f"passing drill summary should remain visible separately: {dashboard}")
+
+
+def assert_security_drill_summary_path_requires_sibling_artifacts(root: Path) -> None:
+    input_args, input_paths = path_input_args_from_pass_fixture(
+        root,
+        "security-drill-summary-path-missing-artifacts",
+    )
+    pass_fixture = read_json(FIXTURE_DIR / "go-no-go-pass.json")
+    if not isinstance(pass_fixture, dict) or not isinstance(pass_fixture.get("inputs"), dict):
+        raise AssertionError("go-no-go-pass.json must contain security drill path-test inputs")
+    security_drills = pass_fixture["inputs"].get("securityDrillsSummary")
+    if not isinstance(security_drills, dict):
+        raise AssertionError("go-no-go-pass fixture is missing securityDrillsSummary")
+    security_drills_path = (
+        root
+        / "security-drill-summary-path-missing-artifacts"
+        / "security-drills-summary.json"
+    )
+    write_json(security_drills_path, security_drills)
+    args_list = [
+        "build",
+        "--workspace-root",
+        str(Path(__file__).resolve().parents[2]),
+        "--out-dir",
+        str(root / "security-drill-summary-path-missing-artifacts-output"),
+        "--mode",
+        "production-beta",
+        "--release-id",
+        "crypta-production-beta-270",
+        "--generated-at",
+        DEFAULT_GENERATED_AT,
+        "--security-drills-summary",
+        str(security_drills_path),
+    ]
+    for flag, input_name in input_args:
+        args_list.extend([flag, str(input_paths[input_name])])
+    dashboard, _exit_code = build_command(build_parser().parse_args(args_list))
+    if dashboard.get("decision") != "no-go":
+        raise AssertionError(
+            "file-backed securityDrillsSummary without sibling artifacts produced GO: "
+            f"{dashboard}"
+        )
+    blocker_ids = {
+        str(blocker.get("evidenceId"))
+        for blocker in dashboard.get("blockers", [])
+        if isinstance(blocker, dict)
+    }
+    if "production-security.response-runbook" not in blocker_ids:
+        raise AssertionError(f"missing drill artifacts did not block security response: {dashboard}")
+    security_drills_compact = dashboard.get("securityDrills")
+    if (
+        not isinstance(security_drills_compact, dict)
+        or security_drills_compact.get("status") != "fail"
+        or security_drills_compact.get("promotionReady") is True
+    ):
+        raise AssertionError(f"missing drill artifacts did not fail compact drill status: {dashboard}")
+    artifact_validation = security_drills_compact.get("artifactValidation")
+    artifact_errors = (
+        artifact_validation.get("errors")
+        if isinstance(artifact_validation, dict)
+        and isinstance(artifact_validation.get("errors"), list)
+        else []
+    )
+    if "security drill artifact for reviewer-key-compromise is missing" not in artifact_errors:
+        raise AssertionError(
+            "missing sibling drill artifacts were not reported in compact validation: "
+            f"{dashboard}"
+        )
 
 
 def assert_security_drills_release_id_matches_dashboard_candidate(root: Path) -> None:

--- a/tools/release-certification/production_beta_go_no_go_dashboard.py
+++ b/tools/release-certification/production_beta_go_no_go_dashboard.py
@@ -28,6 +28,7 @@ from typing import Any, Iterable, Iterator
 
 sys.dont_write_bytecode = True
 import multi_node_beta_soak
+import security_response_runbook
 
 TOOL_NAME = "production-beta-go-no-go-dashboard"
 SCHEMA_VERSION = 1
@@ -282,9 +283,9 @@ DOMAIN_SPECS = (
     },
     {
         "id": "production-security-response",
-        "title": "Production security response runbook",
+        "title": "Production security response drills",
         "evidenceIds": SECURITY_RESPONSE_EVIDENCE_IDS,
-        "artifactInputs": ("securityResponseSummary", "appPlatformSummary"),
+        "artifactInputs": ("securityDrillsSummary", "securityResponseSummary", "appPlatformSummary"),
     },
     {
         "id": "live-network-beta-smoke",
@@ -325,6 +326,7 @@ CRITICAL_INPUTS_BY_MODE = {
         "releaseCertificationSummary",
         "ecosystemMatrix",
         "appPlatformSummary",
+        "securityDrillsSummary",
         "networkScaleSoakSummary",
         "multiNodeBetaSoakSummary",
     ),
@@ -333,6 +335,7 @@ CRITICAL_INPUTS_BY_MODE = {
         "releaseCertificationSummary",
         "ecosystemMatrix",
         "appPlatformSummary",
+        "securityDrillsSummary",
         "liveNetworkSummary",
         "networkScaleSoakSummary",
         "multiNodeBetaSoakSummary",
@@ -973,6 +976,114 @@ def status_warn(entry: dict[str, Any] | None) -> bool:
     return isinstance(entry, dict) and normalize_status(entry.get("status")) == "warn"
 
 
+def evidence_entries(summary: dict[str, Any] | None, evidence_id: str) -> list[dict[str, Any]]:
+    if not isinstance(summary, dict):
+        return []
+    entries = summary.get("evidence", [])
+    if not isinstance(entries, list):
+        return []
+    return [
+        entry
+        for entry in entries
+        if isinstance(entry, dict) and str(entry.get("id", "")) == evidence_id
+    ]
+
+
+def evidence_details(entry: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        return {}
+    details = entry.get("details")
+    return details if isinstance(details, dict) else {}
+
+
+def security_response_app_component(entries: list[dict[str, Any]]) -> dict[str, Any] | None:
+    candidates: list[dict[str, Any]] = []
+    for entry in entries:
+        details = evidence_details(entry)
+        component = details.get("appPlatformRunbook")
+        if isinstance(component, dict):
+            candidates.append(component)
+        elif not isinstance(details.get("securityDrills"), dict):
+            candidates.append(entry)
+    return worst_status_entry(candidates or entries)
+
+
+def worst_status_entry(entries: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not entries:
+        return None
+    rank = {"fail": 0, "missing": 1, "skip": 2, "warn": 3, "pass": 4}
+    return sorted(
+        entries,
+        key=lambda entry: rank.get(normalize_status(entry.get("status")), -1),
+    )[0]
+
+
+def combined_security_response_status(entries: list[dict[str, Any]]) -> str:
+    statuses = [normalize_status(entry.get("status")) for entry in entries if isinstance(entry, dict)]
+    for status in ("fail", "missing", "skip", "warn"):
+        if status in statuses:
+            return status
+    return "pass"
+
+
+def security_response_redaction_findings(entries: list[dict[str, Any]]) -> list[Any]:
+    findings: list[Any] = []
+    for entry in entries:
+        details = evidence_details(entry)
+        item_findings = details.get("redactionFindings")
+        if isinstance(item_findings, list):
+            findings.extend(item_findings)
+    return findings
+
+
+def combine_security_response_evidence(
+    existing_entries: list[dict[str, Any]],
+    drill_entry: dict[str, Any],
+) -> dict[str, Any]:
+    app_entry = security_response_app_component(existing_entries)
+    if app_entry is None:
+        app_entry = {
+            "id": "production-security.response-runbook",
+            "requiredForReleaseCandidate": True,
+            "source": "app-platform-smoke",
+            "status": "missing",
+            "summary": "App-platform security response runbook evidence is missing.",
+            "details": {},
+        }
+    components = [app_entry, drill_entry]
+    status = combined_security_response_status(components)
+    if status == "pass":
+        summary = "Production security response runbook and operational drills passed."
+    else:
+        summary = (
+            "Production security response is not promotion-ready: "
+            f"appPlatformRunbook={normalize_status(app_entry.get('status'))}, "
+            f"securityDrills={normalize_status(drill_entry.get('status'))}."
+        )
+    details: dict[str, Any] = {
+        "appPlatformRunbook": app_entry,
+        "securityDrills": drill_entry,
+        "componentStatuses": {
+            "appPlatformRunbook": normalize_status(app_entry.get("status")),
+            "securityDrills": normalize_status(drill_entry.get("status")),
+        },
+    }
+    redaction_findings = security_response_redaction_findings([*existing_entries, drill_entry])
+    if redaction_findings:
+        details["redactionFindings"] = redaction_findings
+    return {
+        "id": "production-security.response-runbook",
+        "requiredForReleaseCandidate": True,
+        "source": "; ".join(
+            str(entry.get("source", "production-security.response-runbook"))
+            for entry in components
+        ),
+        "status": status,
+        "summary": summary,
+        "details": details,
+    }
+
+
 def evidence_map(*summaries: dict[str, Any] | None) -> dict[str, dict[str, Any]]:
     result: dict[str, dict[str, Any]] = {}
     for summary in summaries:
@@ -1009,9 +1120,140 @@ def multi_node_scenario_evidence(summary: dict[str, Any] | None) -> dict[str, di
     return result
 
 
-def security_response_evidence(summary: dict[str, Any] | None) -> dict[str, Any] | None:
+def security_response_evidence(
+    summary: dict[str, Any] | None,
+    source: str = "security-response-summary",
+    production: bool = False,
+    strict: bool = False,
+    now: dt.datetime | None = None,
+    expected_release_id: str | None = None,
+    expected_mode: str | None = None,
+) -> dict[str, Any] | None:
     if not isinstance(summary, dict):
+        if source == "security-drills-summary":
+            return {
+                "id": "production-security.response-runbook",
+                "requiredForReleaseCandidate": True,
+                "source": source,
+                "status": "fail",
+                "summary": "Security response drills summary must be an aggregate JSON object.",
+                "details": {
+                    "summaryRequired": True,
+                    "promotionReady": False,
+                    "validationErrors": ["securityDrillsSummary must be an object"],
+                    "redactionClean": False,
+                },
+            }
         return None
+    if source == "security-drills-summary" and summary.get("kind") != "cryptad-security-response-drills-summary":
+        return {
+            "id": "production-security.response-runbook",
+            "requiredForReleaseCandidate": True,
+            "source": source,
+            "status": "fail",
+            "summary": "Security response drills summary must use the aggregate drill-summary envelope.",
+            "details": {
+                "summaryRequired": True,
+                "summaryStatus": summary.get("status", "missing"),
+                "promotionReady": False,
+                "kind": summary.get("kind", "missing"),
+                "validationErrors": ["kind must be cryptad-security-response-drills-summary"],
+                "redactionClean": False,
+            },
+        }
+    if summary.get("kind") == "cryptad-security-response-drills-summary":
+        validation = security_response_runbook.validate_drills_summary(
+            summary,
+            production=production,
+            strict=strict,
+            now=now,
+            expected_mode=expected_mode,
+        )
+        validation_errors = list(validation.get("errors", [])) if isinstance(validation.get("errors"), list) else []
+        release_id = summary.get("releaseId")
+        release_id_matches = not (
+            strict
+            and expected_release_id
+            and release_id != expected_release_id
+        )
+        if not release_id_matches:
+            validation_errors.append(
+                f"releaseId must match dashboard candidate {expected_release_id}"
+            )
+        counts = summary.get("counts") if isinstance(summary.get("counts"), dict) else {}
+        redaction = summary.get("redaction") if isinstance(summary.get("redaction"), dict) else {}
+        declared_redaction_findings = (
+            redaction.get("findings") if isinstance(redaction.get("findings"), list) else []
+        )
+        validator_redaction_findings = (
+            validation.get("redactionFindings")
+            if isinstance(validation.get("redactionFindings"), list)
+            else []
+        )
+        redaction_findings = security_response_runbook.safe_redaction_findings(
+            [*declared_redaction_findings, *validator_redaction_findings]
+        )
+        required_scenarios = (
+            summary.get("requiredScenarios") if isinstance(summary.get("requiredScenarios"), list) else []
+        )
+        passed_scenarios = (
+            summary.get("passedScenarios") if isinstance(summary.get("passedScenarios"), list) else []
+        )
+        failed_scenarios = (
+            summary.get("failedScenarios") if isinstance(summary.get("failedScenarios"), list) else []
+        )
+        missing_scenarios = (
+            summary.get("missingScenarios") if isinstance(summary.get("missingScenarios"), list) else []
+        )
+        stale_scenarios = (
+            summary.get("staleScenarios") if isinstance(summary.get("staleScenarios"), list) else []
+        )
+        malformed_scenarios = (
+            summary.get("malformedScenarios") if isinstance(summary.get("malformedScenarios"), list) else []
+        )
+        status = "pass" if validation.get("status") == "pass" and release_id_matches else "fail"
+        required = safe_int_count(counts.get("required"), len(security_response_runbook.REQUIRED_DRILLS))
+        passed = safe_int_count(counts.get("passed"), len(passed_scenarios))
+        if status == "pass":
+            summary_text = f"Security response drills passed for {passed}/{required} required scenarios."
+        else:
+            summary_text = (
+                "Security response drills are missing, failed, stale, malformed, fixture-only, "
+                "or redaction-unsafe."
+            )
+        return {
+            "id": "production-security.response-runbook",
+            "requiredForReleaseCandidate": True,
+            "source": source,
+            "status": status,
+            "summary": summary_text,
+            "details": {
+                "summaryStatus": summary.get("status", "missing"),
+                "promotionReady": bool(summary.get("promotionReady")),
+                "nonRelease": bool(summary.get("nonRelease")),
+                "fixtureOnly": bool(summary.get("fixtureOnly")),
+                "mode": summary.get("mode", "missing"),
+                "evidenceMode": summary.get("evidenceMode", "missing"),
+                "releaseId": release_id if isinstance(release_id, str) else "missing",
+                "expectedReleaseId": expected_release_id or "not-required",
+                "releaseIdMatchesDashboard": release_id_matches,
+                "generatedAt": summary.get("generatedAt", "missing"),
+                "counts": counts,
+                "requiredScenarios": required_scenarios,
+                "passedScenarios": passed_scenarios,
+                "failedScenarios": failed_scenarios,
+                "missingScenarios": missing_scenarios,
+                "staleScenarios": stale_scenarios,
+                "malformedScenarios": malformed_scenarios,
+                "redaction": redaction,
+                "redactionFindings": redaction_findings,
+                "releaseNotes": summary.get("releaseNotes", {}),
+                "advisoryTemplate": summary.get("advisoryTemplate", {}),
+                "artifacts": summary.get("artifacts", []),
+                "validationErrors": validation_errors,
+                "redactionClean": validation.get("redactionClean", False),
+            },
+        }
     status = normalize_status(summary.get("status"))
     if status == "missing":
         return None
@@ -1023,7 +1265,7 @@ def security_response_evidence(summary: dict[str, Any] | None) -> dict[str, Any]
     return {
         "id": "production-security.response-runbook",
         "requiredForReleaseCandidate": True,
-        "source": "security-response-summary",
+        "source": source,
         "status": status,
         "summary": summary_text,
     }
@@ -1498,6 +1740,7 @@ def load_inputs_from_paths(args: argparse.Namespace, workspace_root: Path) -> tu
         "liveNetworkSummary": args.live_network_summary,
         "networkScaleSoakSummary": args.network_scale_soak_summary,
         "multiNodeBetaSoakSummary": args.multi_node_beta_soak_summary,
+        "securityDrillsSummary": args.security_drills_summary,
         "securityResponseSummary": args.security_response_summary,
     }
     inputs: dict[str, Any] = {}
@@ -1534,7 +1777,33 @@ def load_inputs_from_fixture(args: argparse.Namespace, workspace_root: Path) -> 
     mode = args.mode or str(fixture.get("mode", "release-candidate"))
     generated_at = args.generated_at or str(fixture.get("generatedAt", DEFAULT_GENERATED_AT))
     release_id = args.release_id or str(fixture.get("releaseId", fixture_path.stem))
+    inputs = rebind_inherited_fixture_security_drills_summary(inputs, fixture_path, release_id, mode)
     return inputs, {}, [fixture_path], waiver_value, release_id, mode, generated_at
+
+
+def rebind_inherited_fixture_security_drills_summary(
+    inputs: dict[str, Any],
+    fixture_path: Path,
+    release_id: str,
+    mode: str,
+) -> dict[str, Any]:
+    """Keep inherited pass-fixture drill summaries bound to the child fixture candidate."""
+    raw_fixture = read_json(fixture_path)
+    raw_inputs = raw_fixture.get("inputs") if isinstance(raw_fixture, dict) else None
+    if isinstance(raw_inputs, dict) and "securityDrillsSummary" in raw_inputs:
+        return inputs
+    summary = inputs.get("securityDrillsSummary")
+    if not isinstance(summary, dict):
+        return inputs
+    if summary.get("kind") != "cryptad-security-response-drills-summary":
+        return inputs
+    rebound = json.loads(json.dumps(inputs))
+    rebound_summary = rebound.get("securityDrillsSummary")
+    if isinstance(rebound_summary, dict):
+        rebound_summary["releaseId"] = release_id
+        if mode in security_response_runbook.RELEASE_DRILL_MODES:
+            rebound_summary["mode"] = mode
+    return rebound
 
 
 def load_fixture(fixture_path: Path, seen: set[Path] | None = None) -> dict[str, Any]:
@@ -1570,12 +1839,18 @@ def deep_merge(base: Any, override: Any) -> Any:
 def infer_release_id(inputs: dict[str, Any]) -> str:
     prod = inputs.get("productionBetaSummary")
     if isinstance(prod, dict):
+        release_id = prod.get("releaseId")
+        if isinstance(release_id, str) and release_id.strip():
+            return release_id
         version = prod.get("version")
         if version:
             return f"crypta-production-beta-{version}"
     cert = inputs.get("releaseCertificationSummary")
     if isinstance(cert, dict):
         metadata = cert.get("metadata") if isinstance(cert.get("metadata"), dict) else {}
+        release_id = metadata.get("releaseId")
+        if isinstance(release_id, str) and release_id.strip():
+            return release_id
         release_version = metadata.get("releaseVersion") or metadata.get("version")
         if release_version:
             return f"crypta-production-beta-{release_version}"
@@ -2203,6 +2478,141 @@ def domain_summary(
     return "Domain is not passing."
 
 
+def compact_security_drills(
+    summary: dict[str, Any] | None,
+    production: bool = False,
+    strict: bool = False,
+    now: dt.datetime | None = None,
+    expected_release_id: str | None = None,
+    expected_mode: str | None = None,
+) -> dict[str, Any]:
+    if not isinstance(summary, dict):
+        return {
+            "status": "missing",
+            "promotionReady": False,
+            "expectedReleaseId": expected_release_id or "not-required",
+            "requiredScenarioCount": len(security_response_runbook.REQUIRED_DRILLS),
+            "passedScenarioCount": 0,
+            "failedScenarioCount": 0,
+            "missingScenarioCount": len(security_response_runbook.REQUIRED_DRILLS),
+            "staleScenarioCount": 0,
+            "malformedScenarioCount": 0,
+            "redactionStatus": "missing",
+            "releaseNotesTemplateStatus": "missing",
+            "advisoryTemplateStatus": "missing",
+            "supportBundleIntakeRedactionStatus": "missing",
+        }
+    if summary.get("kind") != "cryptad-security-response-drills-summary":
+        return {
+            "status": "fail",
+            "promotionReady": False,
+            "requiredScenarios": list(security_response_runbook.REQUIRED_DRILLS),
+            "passedScenarios": [],
+            "failedScenarios": [],
+            "missingScenarios": list(security_response_runbook.REQUIRED_DRILLS),
+            "staleScenarios": [],
+            "malformedScenarios": [str(summary.get("scenario", summary.get("kind", "unknown")))],
+            "requiredScenarioCount": len(security_response_runbook.REQUIRED_DRILLS),
+            "passedScenarioCount": 0,
+            "failedScenarioCount": 0,
+            "missingScenarioCount": len(security_response_runbook.REQUIRED_DRILLS),
+            "staleScenarioCount": 0,
+            "malformedScenarioCount": 1,
+            "redactionStatus": "fail",
+            "releaseNotesTemplateStatus": "missing",
+            "advisoryTemplateStatus": "missing",
+            "supportBundleIntakeRedactionStatus": "missing",
+            "fixtureOnly": bool(summary.get("fixtureOnly")),
+            "nonRelease": bool(summary.get("nonRelease")),
+            "releaseId": summary.get("releaseId", "missing"),
+            "expectedReleaseId": expected_release_id or "not-required",
+            "releaseIdMatchesDashboard": False,
+        }
+    counts = summary.get("counts") if isinstance(summary.get("counts"), dict) else {}
+    redaction = summary.get("redaction") if isinstance(summary.get("redaction"), dict) else {}
+    release_notes = summary.get("releaseNotes") if isinstance(summary.get("releaseNotes"), dict) else {}
+    advisory_template = (
+        summary.get("advisoryTemplate") if isinstance(summary.get("advisoryTemplate"), dict) else {}
+    )
+    validation = security_response_runbook.validate_drills_summary(
+        summary,
+        production=production,
+        strict=strict,
+        now=now,
+        expected_mode=expected_mode,
+    )
+    validation_errors = list(validation.get("errors", [])) if isinstance(validation.get("errors"), list) else []
+    release_id = summary.get("releaseId")
+    release_id_matches = not (
+        strict
+        and expected_release_id
+        and release_id != expected_release_id
+    )
+    if not release_id_matches:
+        validation_errors.append(f"releaseId must match dashboard candidate {expected_release_id}")
+    computed_status = normalize_status(summary.get("status"))
+    if validation.get("status") != "pass" or not release_id_matches:
+        computed_status = "fail"
+    passed_scenarios = summary.get("passedScenarios") if isinstance(summary.get("passedScenarios"), list) else []
+    failed_scenarios = summary.get("failedScenarios") if isinstance(summary.get("failedScenarios"), list) else []
+    missing_scenarios = summary.get("missingScenarios") if isinstance(summary.get("missingScenarios"), list) else []
+    stale_scenarios = summary.get("staleScenarios") if isinstance(summary.get("staleScenarios"), list) else []
+    malformed_scenarios = summary.get("malformedScenarios") if isinstance(summary.get("malformedScenarios"), list) else []
+    support_status = "pass" if "support-bundle-intake-redaction" in passed_scenarios else "missing"
+    if "support-bundle-intake-redaction" in failed_scenarios:
+        support_status = "fail"
+    elif "support-bundle-intake-redaction" in stale_scenarios:
+        support_status = "stale"
+    elif "support-bundle-intake-redaction" in malformed_scenarios:
+        support_status = "fail"
+    return {
+        "status": computed_status,
+        "promotionReady": (
+            bool(summary.get("promotionReady"))
+            and validation.get("status") == "pass"
+            and release_id_matches
+        ),
+        "releaseId": release_id if isinstance(release_id, str) else "missing",
+        "expectedReleaseId": expected_release_id or "not-required",
+        "releaseIdMatchesDashboard": release_id_matches,
+        "requiredScenarios": summary.get("requiredScenarios", []),
+        "passedScenarios": passed_scenarios,
+        "failedScenarios": failed_scenarios,
+        "missingScenarios": missing_scenarios,
+        "staleScenarios": stale_scenarios,
+        "malformedScenarios": malformed_scenarios,
+        "requiredScenarioCount": safe_int_count(
+            counts.get("required"),
+            len(security_response_runbook.REQUIRED_DRILLS),
+        ),
+        "passedScenarioCount": safe_int_count(counts.get("passed"), len(passed_scenarios)),
+        "failedScenarioCount": safe_int_count(counts.get("failed"), len(failed_scenarios)),
+        "missingScenarioCount": safe_int_count(counts.get("missing"), len(missing_scenarios)),
+        "staleScenarioCount": safe_int_count(counts.get("stale"), len(stale_scenarios)),
+        "malformedScenarioCount": safe_int_count(
+            counts.get("malformed"),
+            len(malformed_scenarios),
+        ),
+        "redactionStatus": normalize_status(redaction.get("status")),
+        "criticalBlockers": len(failed_scenarios) + len(missing_scenarios) + len(stale_scenarios) + len(malformed_scenarios),
+        "releaseNotesTemplateStatus": normalize_status(release_notes.get("templateStatus")),
+        "advisoryTemplateStatus": normalize_status(advisory_template.get("templateStatus")),
+        "supportBundleIntakeRedactionStatus": support_status,
+        "fixtureOnly": bool(summary.get("fixtureOnly")),
+        "nonRelease": bool(summary.get("nonRelease")),
+        "validationErrors": validation_errors,
+    }
+
+
+def safe_int_count(value: Any, fallback: int) -> int:
+    if isinstance(value, bool):
+        return fallback
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return fallback
+
+
 def scope_applies(scope: str, mode: str) -> bool:
     normalized = scope.strip().lower()
     if normalized in {"all", "all-modes", "any"}:
@@ -2571,6 +2981,8 @@ def collect_issues(
     inputs: dict[str, Any],
     mode: str,
     input_paths: dict[str, Path],
+    now: dt.datetime,
+    release_id: str,
 ) -> tuple[list[Issue], dict[str, dict[str, Any]]]:
     all_evidence = evidence_map(
         inputs.get("releaseCertificationSummary"),
@@ -2582,9 +2994,43 @@ def collect_issues(
         inputs.get("multiNodeBetaSoakSummary")
     ).items():
         all_evidence.setdefault(evidence_id, entry)
-    standalone_security_evidence = security_response_evidence(inputs.get("securityResponseSummary"))
-    if standalone_security_evidence is not None:
-        all_evidence.setdefault("production-security.response-runbook", standalone_security_evidence)
+    if "securityDrillsSummary" in inputs:
+        security_drills_evidence = security_response_evidence(
+            inputs.get("securityDrillsSummary"),
+            "security-drills-summary",
+            production=mode == "production-beta",
+            strict=mode in {"release-candidate", "production-beta"},
+            now=now,
+            expected_release_id=release_id,
+            expected_mode=mode if mode in {"release-candidate", "production-beta"} else None,
+        )
+        if security_drills_evidence is not None:
+            existing_security_entries = [
+                *evidence_entries(
+                    inputs.get("releaseCertificationSummary"),
+                    "production-security.response-runbook",
+                ),
+                *evidence_entries(
+                    inputs.get("appPlatformSummary"),
+                    "production-security.response-runbook",
+                ),
+                *evidence_entries(
+                    inputs.get("securityResponseSummary"),
+                    "production-security.response-runbook",
+                ),
+            ]
+            if not existing_security_entries and "production-security.response-runbook" in all_evidence:
+                existing_security_entries = [all_evidence["production-security.response-runbook"]]
+            all_evidence["production-security.response-runbook"] = combine_security_response_evidence(
+                existing_security_entries,
+                security_drills_evidence,
+            )
+        else:
+            all_evidence.pop("production-security.response-runbook", None)
+    else:
+        standalone_security_evidence = security_response_evidence(inputs.get("securityResponseSummary"))
+        if standalone_security_evidence is not None:
+            all_evidence.setdefault("production-security.response-runbook", standalone_security_evidence)
     issues: list[Issue] = []
     for name in CRITICAL_INPUTS_BY_MODE.get(mode, ()):
         if name not in inputs:
@@ -2603,7 +3049,6 @@ def collect_issues(
             inputs.get("productionBetaSummary") if isinstance(inputs.get("productionBetaSummary"), dict) else None,
         )
     )
-    issues.extend(security_response_issues(inputs.get("securityResponseSummary")))
     for spec in DOMAIN_SPECS:
         domain_id = str(spec["id"])
         if domain_id in {
@@ -2684,7 +3129,7 @@ def build_dashboard(
 ) -> dict[str, Any]:
     if mode not in MODES:
         raise SystemExit(f"--mode must be one of {', '.join(MODES)}")
-    issues, all_evidence = collect_issues(inputs, mode, input_paths)
+    issues, all_evidence = collect_issues(inputs, mode, input_paths, now, release_id)
     imported_waivers = release_certification_waiver_records(
         inputs.get("releaseCertificationSummary") if isinstance(inputs.get("releaseCertificationSummary"), dict) else None,
         mode,
@@ -2734,6 +3179,14 @@ def build_dashboard(
         if isinstance(multi_node_summary.get("previousCandidateUpgrade"), dict)
         else {"status": "missing"}
     )
+    security_drills = compact_security_drills(
+        inputs.get("securityDrillsSummary") if isinstance(inputs.get("securityDrillsSummary"), dict) else None,
+        production=mode == "production-beta",
+        strict=mode in {"release-candidate", "production-beta"},
+        now=now,
+        expected_release_id=release_id,
+        expected_mode=mode if mode in {"release-candidate", "production-beta"} else None,
+    )
     artifact_refs = {
         "dashboardJson": OUTPUT_JSON,
         "dashboardMarkdown": OUTPUT_MARKDOWN,
@@ -2763,6 +3216,7 @@ def build_dashboard(
         "warnings": [issue.to_json() for issue in warnings],
         "waivers": [waiver.to_json() for waiver in waivers],
         "previousCandidateUpgrade": previous_upgrade,
+        "securityDrills": security_drills,
         "redaction": redaction,
         "recommendation": recommendation_for(decision, blockers, warnings),
         "artifactRefs": artifact_refs,
@@ -2786,9 +3240,39 @@ def render_markdown(dashboard: dict[str, Any]) -> str:
         f"- Generated: `{dashboard.get('generatedAt', '')}`",
         f"- Recommendation: {dashboard.get('recommendation', '')}",
         "",
-        "## Top Blockers",
+        "## Security Drills",
         "",
     ]
+    security_drills = dashboard.get("securityDrills") if isinstance(dashboard.get("securityDrills"), dict) else {}
+    lines.extend(
+        [
+            f"- Status: `{security_drills.get('status', 'missing')}`",
+            f"- Promotion ready: `{str(security_drills.get('promotionReady', False)).lower()}`",
+            f"- Required scenarios: `{security_drills.get('requiredScenarioCount', 0)}`",
+            f"- Passed scenarios: `{security_drills.get('passedScenarioCount', 0)}`",
+            f"- Failed scenarios: `{security_drills.get('failedScenarioCount', 0)}`",
+            f"- Missing scenarios: `{security_drills.get('missingScenarioCount', 0)}`",
+            f"- Stale scenarios: `{security_drills.get('staleScenarioCount', 0)}`",
+            f"- Redaction: `{security_drills.get('redactionStatus', 'missing')}`",
+            f"- Release notes template: `{security_drills.get('releaseNotesTemplateStatus', 'missing')}`",
+            f"- Advisory template: `{security_drills.get('advisoryTemplateStatus', 'missing')}`",
+            f"- Support-bundle intake redaction: `{security_drills.get('supportBundleIntakeRedactionStatus', 'missing')}`",
+            "",
+        ]
+    )
+    if security_drills.get("failedScenarios"):
+        lines.append(f"- Failed: {markdown_code_list(security_drills.get('failedScenarios', []))}")
+    if security_drills.get("missingScenarios"):
+        lines.append(f"- Missing: {markdown_code_list(security_drills.get('missingScenarios', []))}")
+    if security_drills.get("staleScenarios"):
+        lines.append(f"- Stale: {markdown_code_list(security_drills.get('staleScenarios', []))}")
+    lines.extend(
+        [
+            "",
+            "## Top Blockers",
+            "",
+        ]
+    )
     blockers = dashboard.get("blockers", [])
     if not blockers:
         lines.append("No unwaived blockers.")
@@ -3041,6 +3525,18 @@ def run_self_test(quiet: bool = False) -> None:
         "go-no-go-release-candidate-live-waiver.json": "go-with-waivers",
         "go-no-go-release-candidate-live-disabled.json": "no-go",
         "go-no-go-malformed-non-release-status.json": "no-go",
+        "go-no-go-security-drills-missing-summary.json": "no-go",
+        "go-no-go-security-drills-missing-scenario.json": "no-go",
+        "go-no-go-security-drills-failed-scenario.json": "no-go",
+        "go-no-go-security-drills-stale-scenario.json": "no-go",
+        "go-no-go-security-drills-redaction-unsafe.json": "no-go",
+        "go-no-go-security-drills-fixture-only.json": "no-go",
+        "go-no-go-security-drills-developer-dry-run.json": "no-go",
+        "go-no-go-security-drills-malformed-envelope.json": "no-go",
+        "go-no-go-security-drills-single-artifact-pass.json": "no-go",
+        "go-no-go-security-drills-malformed-count.json": "no-go",
+        "go-no-go-security-drills-expired-waiver.json": "no-go",
+        "go-no-go-security-drills-underseverity-redaction-waiver.json": "no-go",
     }
     with tempfile.TemporaryDirectory(prefix="cryptad-go-no-go-dashboard-") as temp_name:
         root = Path(temp_name)
@@ -3079,6 +3575,32 @@ def run_self_test(quiet: bool = False) -> None:
                     raise AssertionError("expired waiver did not produce a waiver-validation blocker")
                 if dashboard.get("generatedAt") != "2026-06-24T00:00:00Z":
                     raise AssertionError("expired waiver fixture did not use its recorded generatedAt")
+            if fixture_name.startswith("go-no-go-security-drills-"):
+                if "production-security.response-runbook" not in blocker_ids:
+                    raise AssertionError(
+                        f"{fixture_name} did not block on production security response evidence"
+                    )
+                security_drills = dashboard.get("securityDrills")
+                if not isinstance(security_drills, dict) or security_drills.get("promotionReady") is True:
+                    raise AssertionError(f"{fixture_name} left security drills promotion-ready")
+            if fixture_name == "go-no-go-security-drills-redaction-unsafe.json":
+                critical_security_blockers = [
+                    blocker
+                    for blocker in dashboard.get("blockers", [])
+                    if isinstance(blocker, dict)
+                    and blocker.get("evidenceId") == "production-security.response-runbook"
+                    and blocker.get("severity") == "critical"
+                ]
+                if not critical_security_blockers:
+                    raise AssertionError("redaction-unsafe drill fixture did not create a critical blocker")
+            if fixture_name in {
+                "go-no-go-security-drills-expired-waiver.json",
+                "go-no-go-security-drills-underseverity-redaction-waiver.json",
+            }:
+                if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+                    raise AssertionError("security drill waiver fixture was incorrectly used")
+                if "production-beta.waiver-validation" not in blocker_ids:
+                    raise AssertionError("security drill waiver fixture did not fail waiver validation")
             if fixture_name == "go-no-go-waiver-valid-at-generated-at.json":
                 if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
                     raise AssertionError("non-waivable live evidence waiver was incorrectly used")
@@ -3262,7 +3784,13 @@ def run_self_test(quiet: bool = False) -> None:
         assert_supplied_waiver_file_errors_block_launch(root)
         assert_protected_secret_values_are_scanned_and_redacted(root)
         assert_symlink_inputs_are_rejected(root)
+        assert_legacy_security_response_summary_fallback_is_honored(root)
         assert_standalone_security_response_summary_is_honored(root)
+        assert_security_drills_preserve_failing_runbook_evidence(root)
+        assert_security_drills_require_app_platform_runbook_evidence(root)
+        assert_security_drill_summary_evidence_is_not_generic_release_evidence(root)
+        assert_security_drills_release_id_matches_dashboard_candidate(root)
+        assert_validator_security_drill_redaction_findings_are_non_waivable(root)
         assert_previous_candidate_upgrade_current_binding_is_enforced(root)
         assert_multi_node_release_evidence_is_not_overwritten(root)
     if not quiet:
@@ -3291,7 +3819,7 @@ def assert_multi_node_release_evidence_is_not_overwritten(root: Path) -> None:
         Path(__file__).resolve().parents[2],
         root / "multi-node-release-evidence-preserved",
         "production-beta",
-        "crypta-production-beta-270-multi-node-release-evidence-preserved",
+        "crypta-production-beta-270",
         generated_at,
         now,
     )
@@ -3332,7 +3860,7 @@ def assert_previous_candidate_upgrade_current_binding_is_enforced(root: Path) ->
             Path(__file__).resolve().parents[2],
             root / f"previous-candidate-current-binding-{label}",
             "production-beta",
-            f"crypta-production-beta-270-{label}",
+            "crypta-production-beta-270",
             generated_at,
             now,
         )
@@ -3347,9 +3875,297 @@ def assert_previous_candidate_upgrade_current_binding_is_enforced(root: Path) ->
             raise AssertionError(f"mismatched previous-candidate upgrade {field} used wrong blocker: {dashboard}")
 
 
+def assert_security_drills_preserve_failing_runbook_evidence(root: Path) -> None:
+    pass_fixture = load_fixture(FIXTURE_DIR / "go-no-go-pass.json")
+    inputs = json.loads(json.dumps(pass_fixture["inputs"]))
+    inputs["releaseCertificationSummary"].setdefault("evidence", []).append(
+        {
+            "id": "production-security.response-runbook",
+            "status": "pass",
+            "summary": "Combined release-certification security response evidence passed.",
+            "source": "release-certification-summary",
+            "details": {
+                "appPlatformRunbook": {
+                    "id": "production-security.response-runbook",
+                    "status": "pass",
+                    "summary": "App-platform runbook evidence passed.",
+                    "source": "app-platform-smoke",
+                },
+                "securityDrills": {
+                    "id": "production-security.response-runbook",
+                    "status": "pass",
+                    "summary": "Security response drills passed.",
+                    "source": "security-drills-summary",
+                },
+                "componentStatuses": {
+                    "appPlatformRunbook": "pass",
+                    "securityDrills": "pass",
+                },
+            },
+        }
+    )
+    for entry in inputs["appPlatformSummary"]["evidence"]:
+        if isinstance(entry, dict) and entry.get("id") == "production-security.response-runbook":
+            entry["status"] = "fail"
+            entry["summary"] = "App-platform security response runbook integration failed."
+            entry["details"] = {"checks": {"runbookDocExists": False}}
+            break
+    else:
+        raise AssertionError("app-platform production-security.response-runbook evidence is missing")
+    generated_at, now = parse_generated_at(DEFAULT_GENERATED_AT)
+    dashboard = build_dashboard(
+        inputs,
+        {},
+        [FIXTURE_DIR / "go-no-go-pass.json"],
+        None,
+        Path(__file__).resolve().parents[2],
+        root / "security-drills-preserve-failing-runbook",
+        "production-beta",
+        "crypta-production-beta-270",
+        generated_at,
+        now,
+    )
+    if dashboard.get("decision") != "no-go":
+        raise AssertionError(
+            "passing security drills overwrote failing runbook evidence: "
+            f"{dashboard}"
+        )
+    blocker_ids = {
+        str(blocker.get("evidenceId"))
+        for blocker in dashboard.get("blockers", [])
+        if isinstance(blocker, dict)
+    }
+    if "production-security.response-runbook" not in blocker_ids:
+        raise AssertionError(f"failing runbook evidence did not block: {dashboard}")
+    security_domain = next(
+        (domain for domain in dashboard.get("domains", []) if domain.get("id") == "production-security-response"),
+        {},
+    )
+    if security_domain.get("status") != "fail":
+        raise AssertionError(f"security response domain did not fail: {security_domain}")
+
+
+def assert_security_drills_require_app_platform_runbook_evidence(root: Path) -> None:
+    pass_fixture = load_fixture(FIXTURE_DIR / "go-no-go-pass.json")
+    inputs = json.loads(json.dumps(pass_fixture["inputs"]))
+    for summary_name in ("releaseCertificationSummary", "appPlatformSummary"):
+        summary = inputs.get(summary_name)
+        if not isinstance(summary, dict) or not isinstance(summary.get("evidence"), list):
+            continue
+        summary["evidence"] = [
+            entry
+            for entry in summary["evidence"]
+            if not (isinstance(entry, dict) and entry.get("id") == "production-security.response-runbook")
+        ]
+    generated_at, now = parse_generated_at(DEFAULT_GENERATED_AT)
+    dashboard = build_dashboard(
+        inputs,
+        {},
+        [FIXTURE_DIR / "go-no-go-pass.json"],
+        None,
+        Path(__file__).resolve().parents[2],
+        root / "security-drills-require-app-platform-runbook",
+        "production-beta",
+        "crypta-production-beta-270",
+        generated_at,
+        now,
+    )
+    if dashboard.get("decision") != "no-go":
+        raise AssertionError(
+            "passing security drills masked missing app-platform runbook evidence: "
+            f"{dashboard}"
+        )
+    blocker_ids = {
+        str(blocker.get("evidenceId"))
+        for blocker in dashboard.get("blockers", [])
+        if isinstance(blocker, dict)
+    }
+    if "production-security.response-runbook" not in blocker_ids:
+        raise AssertionError(f"missing app-platform runbook evidence did not block: {dashboard}")
+    security_evidence = dashboard.get("securityDrills")
+    if not isinstance(security_evidence, dict) or security_evidence.get("promotionReady") is not True:
+        raise AssertionError(f"passing drill summary should remain visible separately: {dashboard}")
+
+
+def assert_security_drill_summary_evidence_is_not_generic_release_evidence(root: Path) -> None:
+    pass_fixture = load_fixture(FIXTURE_DIR / "go-no-go-pass.json")
+    inputs = json.loads(json.dumps(pass_fixture["inputs"]))
+    for entry in inputs["appPlatformSummary"]["evidence"]:
+        if isinstance(entry, dict) and entry.get("id") == "first-party-app.beta-quality-pass":
+            entry["status"] = "fail"
+            entry["summary"] = "First-party beta-quality readiness failed."
+            break
+    else:
+        raise AssertionError("first-party beta-quality evidence is missing from app-platform fixture")
+    security_drills = inputs.get("securityDrillsSummary")
+    if not isinstance(security_drills, dict):
+        raise AssertionError("go-no-go-pass fixture is missing securityDrillsSummary")
+    security_drills.setdefault("evidence", []).append(
+        {
+            "id": "first-party-app.beta-quality-pass",
+            "status": "pass",
+            "summary": "Forged generic evidence inside the security drills summary.",
+            "source": "security-drills-summary",
+        }
+    )
+    generated_at, now = parse_generated_at(DEFAULT_GENERATED_AT)
+    dashboard = build_dashboard(
+        inputs,
+        {},
+        [FIXTURE_DIR / "go-no-go-pass.json"],
+        None,
+        Path(__file__).resolve().parents[2],
+        root / "security-drills-evidence-not-generic",
+        "production-beta",
+        "crypta-production-beta-270",
+        generated_at,
+        now,
+    )
+    if dashboard.get("decision") != "no-go":
+        raise AssertionError(
+            "generic evidence embedded in securityDrillsSummary overrode authoritative evidence: "
+            f"{dashboard}"
+        )
+    blocker_ids = {
+        str(blocker.get("evidenceId"))
+        for blocker in dashboard.get("blockers", [])
+        if isinstance(blocker, dict)
+    }
+    if "first-party-app.beta-quality-pass" not in blocker_ids:
+        raise AssertionError(f"failed first-party beta-quality evidence did not block: {dashboard}")
+    security_drills_compact = dashboard.get("securityDrills")
+    if (
+        not isinstance(security_drills_compact, dict)
+        or security_drills_compact.get("promotionReady") is not True
+    ):
+        raise AssertionError(f"passing drill summary should remain visible separately: {dashboard}")
+
+
+def assert_security_drills_release_id_matches_dashboard_candidate(root: Path) -> None:
+    pass_fixture = load_fixture(FIXTURE_DIR / "go-no-go-pass.json")
+    inputs = json.loads(json.dumps(pass_fixture["inputs"]))
+    security_drills = inputs.get("securityDrillsSummary")
+    if not isinstance(security_drills, dict):
+        raise AssertionError("go-no-go-pass fixture is missing securityDrillsSummary")
+    security_drills["releaseId"] = "cryptad-beta-other-candidate"
+    generated_at, now = parse_generated_at(DEFAULT_GENERATED_AT)
+    dashboard = build_dashboard(
+        inputs,
+        {},
+        [FIXTURE_DIR / "go-no-go-pass.json"],
+        None,
+        Path(__file__).resolve().parents[2],
+        root / "security-drills-release-id-mismatch",
+        "production-beta",
+        "crypta-production-beta-270",
+        generated_at,
+        now,
+    )
+    if dashboard.get("decision") != "no-go":
+        raise AssertionError(
+            "security drills from another release id did not block: "
+            f"{dashboard}"
+        )
+    blockers = [
+        blocker
+        for blocker in dashboard.get("blockers", [])
+        if isinstance(blocker, dict)
+        and blocker.get("evidenceId") == "production-security.response-runbook"
+    ]
+    if not blockers:
+        raise AssertionError(f"release-id mismatch did not block production security response: {dashboard}")
+    security_evidence = next(
+        (
+            domain
+            for domain in dashboard.get("domains", [])
+            if isinstance(domain, dict) and domain.get("id") == "production-security-response"
+        ),
+        {},
+    )
+    if security_evidence.get("status") != "fail":
+        raise AssertionError(f"release-id mismatch did not fail security response domain: {dashboard}")
+    security_drills = dashboard.get("securityDrills")
+    if not isinstance(security_drills, dict) or security_drills.get("status") != "fail":
+        raise AssertionError(f"release-id mismatch did not fail compact security drill status: {dashboard}")
+    if security_drills.get("promotionReady") is True:
+        raise AssertionError(f"release-id mismatch left security drills promotion-ready: {dashboard}")
+
+
+def assert_validator_security_drill_redaction_findings_are_non_waivable(root: Path) -> None:
+    pass_fixture = load_fixture(FIXTURE_DIR / "go-no-go-pass.json")
+    inputs = json.loads(json.dumps(pass_fixture["inputs"]))
+    security_drills = inputs.get("securityDrillsSummary")
+    if not isinstance(security_drills, dict):
+        raise AssertionError("go-no-go-pass fixture is missing securityDrillsSummary")
+    security_drills["mode"] = "release-candidate"
+    security_drills["rawSupportBundleBody"] = "fixture-payload"
+    redaction = security_drills.get("redaction")
+    if not isinstance(redaction, dict):
+        raise AssertionError("go-no-go-pass fixture securityDrillsSummary is missing redaction")
+    redaction["status"] = "pass"
+    redaction["findings"] = []
+    redaction["rawSensitiveMaterialExcluded"] = True
+    waiver_value = {
+        "schemaVersion": 1,
+        "waivers": [
+            {
+                "id": "waive-validator-security-drill-redaction",
+                "evidenceId": "production-security.response-runbook",
+                "severity": "blocker",
+                "scope": "release-candidate",
+                "rationale": "Regression fixture: validator redaction findings are non-waivable.",
+                "approvedBy": "release-manager",
+                "owner": "release",
+                "createdAt": "1970-01-01T00:00:00Z",
+                "expiresAt": "2099-01-01T00:00:00Z",
+                "references": ["validator-security-drill-redaction"],
+            }
+        ],
+    }
+    generated_at, now = parse_generated_at(DEFAULT_GENERATED_AT)
+    dashboard = build_dashboard(
+        inputs,
+        {},
+        [FIXTURE_DIR / "go-no-go-pass.json"],
+        waiver_value,
+        Path(__file__).resolve().parents[2],
+        root / "validator-security-drill-redaction",
+        "release-candidate",
+        "crypta-production-beta-270",
+        generated_at,
+        now,
+    )
+    if dashboard.get("decision") != "no-go":
+        raise AssertionError(
+            "validator-detected security drill redaction was waived: "
+            f"{dashboard}"
+        )
+    if int(dashboard.get("summary", {}).get("waiversUsed", 0)) != 0:
+        raise AssertionError("validator-detected security drill redaction waiver was incorrectly used")
+    critical_redaction_blockers = [
+        blocker
+        for blocker in dashboard.get("blockers", [])
+        if isinstance(blocker, dict)
+        and blocker.get("evidenceId") == "production-security.response-runbook"
+        and blocker.get("category") == "redaction"
+        and blocker.get("severity") == "critical"
+        and blocker.get("waivable") is False
+    ]
+    if not critical_redaction_blockers:
+        raise AssertionError(
+            "validator-detected security drill redaction did not create a critical non-waivable blocker: "
+            f"{dashboard}"
+        )
+
+
 def assert_standalone_security_response_summary_is_honored(root: Path) -> None:
     pass_fixture = load_fixture(FIXTURE_DIR / "go-no-go-pass.json")
     inputs = json.loads(json.dumps(pass_fixture["inputs"]))
+    inputs.pop("securityDrillsSummary", None)
+    inputs["securityResponseSummary"] = {
+        "status": "pass",
+        "summary": "Standalone production security response summary passed.",
+    }
     app_summary = inputs["appPlatformSummary"]
     evidence = app_summary["evidence"]
     app_summary["evidence"] = [
@@ -3367,7 +4183,7 @@ def assert_standalone_security_response_summary_is_honored(root: Path) -> None:
         None,
         Path(__file__).resolve().parents[2],
         root / "standalone-security-response",
-        "production-beta",
+        "developer-dry-run",
         "crypta-production-beta-270-standalone-security-response",
         generated_at,
         now,
@@ -3380,6 +4196,46 @@ def assert_standalone_security_response_summary_is_honored(root: Path) -> None:
     )
     if security_domain.get("status") != "pass":
         raise AssertionError(f"standalone security-response domain did not pass: {security_domain}")
+
+
+def assert_legacy_security_response_summary_fallback_is_honored(root: Path) -> None:
+    pass_fixture = load_fixture(FIXTURE_DIR / "go-no-go-pass.json")
+    inputs = json.loads(json.dumps(pass_fixture["inputs"]))
+    inputs.pop("securityDrillsSummary", None)
+    inputs["securityResponseSummary"] = {
+        "status": "pass",
+        "summary": "Legacy production security response summary passed.",
+    }
+    for summary_name in ("appPlatformSummary", "releaseCertificationSummary"):
+        summary = inputs.get(summary_name)
+        if not isinstance(summary, dict) or not isinstance(summary.get("evidence"), list):
+            continue
+        summary["evidence"] = [
+            entry
+            for entry in summary["evidence"]
+            if not (isinstance(entry, dict) and entry.get("id") == "production-security.response-runbook")
+        ]
+    generated_at, now = parse_generated_at(DEFAULT_GENERATED_AT)
+    dashboard = build_dashboard(
+        inputs,
+        {},
+        [FIXTURE_DIR / "go-no-go-pass.json"],
+        None,
+        Path(__file__).resolve().parents[2],
+        root / "legacy-security-response-fallback",
+        "developer-dry-run",
+        "crypta-production-beta-270-legacy-security-response-fallback",
+        generated_at,
+        now,
+    )
+    if dashboard.get("decision") != "go":
+        raise AssertionError(f"legacy security-response fallback produced {dashboard.get('decision')}: {dashboard}")
+    security_domain = next(
+        (domain for domain in dashboard.get("domains", []) if domain.get("id") == "production-security-response"),
+        {},
+    )
+    if security_domain.get("status") != "pass":
+        raise AssertionError(f"legacy security-response fallback domain did not pass: {security_domain}")
 
 
 def path_input_args_from_pass_fixture(root: Path, input_dir_name: str) -> tuple[tuple[tuple[str, str], ...], dict[str, Path]]:
@@ -3614,6 +4470,7 @@ def build_parser() -> argparse.ArgumentParser:
     build.add_argument("--live-network-summary", type=Path)
     build.add_argument("--network-scale-soak-summary", type=Path)
     build.add_argument("--multi-node-beta-soak-summary", type=Path)
+    build.add_argument("--security-drills-summary", type=Path)
     build.add_argument("--security-response-summary", type=Path)
     build.add_argument("--waivers", type=Path)
     build.add_argument("--fixtures", type=Path, help="Build from a checked-in dashboard fixture bundle.")

--- a/tools/release-certification/production_beta_release.py
+++ b/tools/release-certification/production_beta_release.py
@@ -40,6 +40,7 @@ sys.path.insert(0, str(TOOL_DIR))
 
 import release_certification  # noqa: E402
 import multi_node_beta_soak  # noqa: E402
+import security_response_runbook  # noqa: E402
 
 
 TOOL_NAME = "production-beta-release"
@@ -48,7 +49,16 @@ MODES = ("developer-dry-run", "release-candidate", "production-beta")
 CATALOG_CHANNELS = ("stable", "beta", "nightly", "deprecated")
 OUT_DIR_SENTINEL = ".cryptad-production-beta-release-output"
 PROTECTED_CLEAN_TOP_LEVELS = {".git", ".github", "apps", "docs", "tools"}
-RELEASE_OUTPUT_ROOTS = ("inputs", "build", "catalog", "reviews", "evidence", "reports")
+RELEASE_OUTPUT_ROOTS = (
+    "inputs",
+    "build",
+    "catalog",
+    "reviews",
+    "evidence",
+    "reports",
+    "security-drills",
+    "security",
+)
 GO_NO_GO_DASHBOARD_JSON = "reports/go-no-go-dashboard.json"
 GO_NO_GO_DASHBOARD_MARKDOWN = "reports/go-no-go-dashboard.md"
 GO_NO_GO_REDACTION_REPORT = "reports/go-no-go-redaction-report.json"
@@ -502,6 +512,7 @@ class Settings:
     third_party_intake_summary: Path | None = None
     require_third_party_intake: bool = False
     run_third_party_intake_sample_flow: bool = False
+    security_drills_summary: Path | None = None
 
 
 @dataclasses.dataclass
@@ -2487,6 +2498,364 @@ def certification_mode(settings: Settings) -> str:
     return "pr" if settings.mode == "developer-dry-run" else "release-candidate"
 
 
+def security_drills_dir(settings: Settings) -> Path:
+    return settings.out_dir / "security-drills"
+
+
+def security_drills_summary_path(settings: Settings) -> Path:
+    return security_drills_dir(settings) / "security-drills-summary.json"
+
+
+def security_release_notes_draft_path(settings: Settings) -> Path:
+    return settings.out_dir / "security/security-release-notes-draft.md"
+
+
+def security_drills_release_id(state: PipelineState) -> str:
+    return f"cryptad-beta-{state.version}"
+
+
+def attached_security_drill_artifact_errors(
+    state: PipelineState,
+    summary: dict[str, Any],
+    attached_summary: Path,
+    target_dir: Path,
+) -> list[str]:
+    artifacts = summary.get("artifacts")
+    if not isinstance(artifacts, list):
+        return ["attached security drills summary artifacts must be an array"]
+    source_dir = attached_summary.parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+    model_path = (
+        state.settings.workspace_root
+        / "tools/release-certification/production-security-response-runbook.json"
+    )
+    errors: list[str] = []
+    seen: set[str] = set()
+    for index, entry in enumerate(artifacts):
+        if not isinstance(entry, dict):
+            errors.append(f"attached security drill artifact entry {index} must be an object")
+            continue
+        scenario = entry.get("scenario")
+        if scenario not in security_response_runbook.REQUIRED_DRILLS:
+            errors.append(f"attached security drill artifact entry {index} has an unknown scenario")
+            continue
+        scenario_text = str(scenario)
+        if scenario_text in seen:
+            errors.append(f"attached security drill artifact for {scenario_text} is duplicated")
+            continue
+        seen.add(scenario_text)
+        artifact_name = entry.get("artifact")
+        expected_name = security_response_runbook.DRILL_OUTPUT_FILENAMES[scenario_text]
+        if artifact_name != expected_name:
+            errors.append(f"attached security drill artifact for {scenario_text} must be named {expected_name}")
+            continue
+        if Path(str(artifact_name)).name != artifact_name or bad_artifact_name(str(artifact_name)):
+            errors.append(f"attached security drill artifact for {scenario_text} has an unsafe file name")
+            continue
+        source_path = source_dir / str(artifact_name)
+        if not source_path.is_file() or source_path.is_symlink():
+            errors.append(f"attached security drill artifact for {scenario_text} is missing")
+            continue
+        try:
+            digest = security_response_runbook.sha256_path(source_path)
+            verification = security_response_runbook.drill_verify(source_path, model_path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            errors.append(f"attached security drill artifact for {scenario_text} could not be verified")
+            continue
+        if entry.get("digest") != digest:
+            errors.append(f"attached security drill artifact digest mismatch for {scenario_text}")
+            continue
+        if verification.get("status") != "pass":
+            errors.append(f"attached security drill artifact for {scenario_text} failed offline verification")
+            continue
+        target_path = target_dir / str(artifact_name)
+        if source_path.resolve() != target_path.resolve():
+            shutil.copy2(source_path, target_path)
+    missing = sorted(set(security_response_runbook.REQUIRED_DRILLS) - seen)
+    for scenario in missing:
+        errors.append(f"attached security drill artifact for {scenario} is missing")
+    return errors
+
+
+def mark_attached_security_drills_summary_failed(summary: dict[str, Any], errors: list[str]) -> dict[str, Any]:
+    failed = json.loads(json.dumps(summary, sort_keys=True))
+    failed["status"] = "fail"
+    failed["promotionReady"] = False
+    failed["attachmentErrors"] = list(errors)
+    return failed
+
+
+def attached_security_drills_failure_summary(
+    state: PipelineState,
+    expected_release_id: str,
+    validation: dict[str, Any],
+    release_id_matches: bool,
+    errors: list[Any],
+) -> dict[str, Any]:
+    safe_errors = security_response_runbook.safe_redaction_findings([str(error) for error in errors])
+    validation_findings = validation.get("redactionFindings")
+    safe_findings = security_response_runbook.safe_redaction_findings(
+        validation_findings if isinstance(validation_findings, list) else []
+    )
+    attached_digest = "missing"
+    attached_path = state.settings.security_drills_summary
+    if attached_path is not None and attached_path.is_file() and not attached_path.is_symlink():
+        try:
+            attached_digest = security_response_runbook.sha256_path(attached_path)
+        except OSError:
+            attached_digest = "unavailable"
+    required = list(security_response_runbook.REQUIRED_DRILLS)
+    return {
+        "kind": "cryptad-security-response-drills-summary",
+        "schemaVersion": security_response_runbook.DRILL_SUMMARY_SCHEMA_VERSION,
+        "status": "fail",
+        "promotionReady": False,
+        "nonRelease": True,
+        "fixtureOnly": False,
+        "releaseId": expected_release_id,
+        "mode": state.settings.mode,
+        "generatedAt": state.started_at,
+        "maxAgeDays": security_response_runbook.DEFAULT_MAX_AGE_DAYS,
+        "requiredScenarios": required,
+        "passedScenarios": [],
+        "failedScenarios": [],
+        "missingScenarios": required,
+        "staleScenarios": [],
+        "malformedScenarios": [],
+        "counts": {
+            "required": len(required),
+            "passed": 0,
+            "failed": 0,
+            "missing": len(required),
+            "stale": 0,
+            "malformed": 0,
+        },
+        "redaction": {
+            "status": "fail",
+            "rawSensitiveMaterialExcluded": False,
+            "findings": safe_findings or ["attached security drills summary was rejected before ingestion"],
+        },
+        "releaseNotes": {
+            "templateStatus": "fail",
+            "redactedSnippet": "Attached security drill summary was rejected before release evidence ingestion.",
+        },
+        "advisoryTemplate": {
+            "templateStatus": "fail",
+            "redactedSnippet": "Attached security drill summary was rejected before advisory evidence ingestion.",
+        },
+        "artifacts": [],
+        "attachment": {
+            "status": "fail",
+            "releaseIdMatchesCandidate": release_id_matches,
+            "validationStatus": validation.get("status", "fail"),
+            "attachedSummaryDigest": attached_digest,
+            "sanitized": True,
+        },
+        "attachmentErrors": safe_errors,
+    }
+
+
+def run_security_response_drills(state: PipelineState) -> Path:
+    summary_path = security_drills_summary_path(state.settings)
+    if state.settings.security_drills_summary is not None:
+        value = read_json(state.settings.security_drills_summary)
+        expected_release_id = security_drills_release_id(state)
+        validation = security_response_runbook.validate_drills_summary(
+            value if isinstance(value, dict) else {},
+            production=state.settings.mode == "production-beta",
+            strict=state.settings.mode in {"release-candidate", "production-beta"},
+            now=security_response_runbook.parse_timestamp(state.started_at),
+            expected_mode=state.settings.mode if state.settings.mode in {"release-candidate", "production-beta"} else None,
+        )
+        release_id_matches = isinstance(value, dict) and value.get("releaseId") == expected_release_id
+        rejection_errors: list[Any] = []
+        if not release_id_matches:
+            rejection_errors.append("attached security response drill summary releaseId does not match this candidate")
+            state.failures.append(
+                "attached security response drill summary releaseId does not match this candidate."
+            )
+        if validation.get("status") != "pass":
+            validation_errors = (
+                validation.get("errors") if isinstance(validation.get("errors"), list) else []
+            )
+            rejection_errors.extend(validation_errors)
+            safe_validation_errors = security_response_runbook.safe_redaction_findings(
+                [str(error) for error in validation_errors[:5]]
+            )
+            state.failures.append(
+                "attached security response drill summary is not promotion-ready: "
+                + ("; ".join(safe_validation_errors) or "validation failed")
+            )
+        if isinstance(value, dict):
+            artifact_errors: list[str] = []
+            final_validation = validation
+            if validation.get("status") == "pass" and release_id_matches:
+                write_json(summary_path, value)
+                artifact_errors = attached_security_drill_artifact_errors(
+                    state,
+                    value,
+                    state.settings.security_drills_summary,
+                    security_drills_dir(state.settings),
+                )
+                if artifact_errors:
+                    write_json(summary_path, mark_attached_security_drills_summary_failed(value, artifact_errors))
+                    state.failures.append(
+                        "attached security response drill artifacts are incomplete or unverified: "
+                        + "; ".join(artifact_errors[:5])
+                    )
+                else:
+                    verified_summary = security_response_runbook.drill_verify_all(
+                        security_drills_dir(state.settings),
+                        summary_path,
+                        state.settings.workspace_root
+                        / "tools/release-certification/production-security-response-runbook.json",
+                        release_id=expected_release_id,
+                        mode=(
+                            state.settings.mode
+                            if state.settings.mode in {"release-candidate", "production-beta"}
+                            else None
+                        ),
+                        now_text=state.started_at,
+                    )
+                    final_validation = security_response_runbook.validate_drills_summary(
+                        verified_summary,
+                        production=state.settings.mode == "production-beta",
+                        strict=state.settings.mode in {"release-candidate", "production-beta"},
+                        now=security_response_runbook.parse_timestamp(state.started_at),
+                        expected_mode=(
+                            state.settings.mode
+                            if state.settings.mode in {"release-candidate", "production-beta"}
+                            else None
+                        ),
+                    )
+                    if final_validation.get("status") != "pass":
+                        state.failures.append(
+                            "attached security response drill artifacts did not verify as a complete summary: "
+                            + "; ".join(str(error) for error in final_validation.get("errors", [])[:5])
+                        )
+            else:
+                write_json(
+                    summary_path,
+                    attached_security_drills_failure_summary(
+                        state,
+                        expected_release_id,
+                        validation,
+                        release_id_matches,
+                        rejection_errors,
+                    ),
+                )
+        else:
+            artifact_errors = ["attached summary is missing or malformed"]
+            final_validation = validation
+            write_json(
+                summary_path,
+                attached_security_drills_failure_summary(
+                    state,
+                    expected_release_id,
+                    validation,
+                    False,
+                    artifact_errors,
+                ),
+            )
+        stage_ok = (
+            validation.get("status") == "pass"
+            and final_validation.get("status") == "pass"
+            and release_id_matches
+            and not artifact_errors
+        )
+        record_pipeline_stage(
+            state,
+            "security-response-drills",
+            "pass" if stage_ok else "fail",
+            "Consumed attached security response drill summary and verified per-scenario artifacts.",
+        )
+        return summary_path
+
+    verify_result = run_command(
+        state,
+        "security-response-runbook-verify",
+        [
+            sys.executable,
+            str(state.settings.workspace_root / "tools/release-certification/security_response_runbook.py"),
+            "verify",
+        ],
+        timeout_seconds=120,
+        allow_failure=True,
+    )
+    run_all_result = run_command(
+        state,
+        "security-response-drill-run-all",
+        [
+            sys.executable,
+            str(state.settings.workspace_root / "tools/release-certification/security_response_runbook.py"),
+            "drill",
+            "run-all",
+            "--out-dir",
+            str(security_drills_dir(state.settings)),
+            "--summary-out",
+            str(summary_path),
+            "--release-id",
+            security_drills_release_id(state),
+            "--generated-at",
+            state.started_at,
+            "--mode",
+            state.settings.mode,
+            "--release-notes-out",
+            str(security_release_notes_draft_path(state.settings)),
+        ],
+        timeout_seconds=120,
+        allow_failure=True,
+    )
+    verify_all_result = run_command(
+        state,
+        "security-response-drill-verify-all",
+        [
+            sys.executable,
+            str(state.settings.workspace_root / "tools/release-certification/security_response_runbook.py"),
+            "drill",
+            "verify-all",
+            "--input-dir",
+            str(security_drills_dir(state.settings)),
+            "--summary-out",
+            str(summary_path),
+            "--release-id",
+            security_drills_release_id(state),
+            "--generated-at",
+            state.started_at,
+            "--mode",
+            state.settings.mode,
+            "--now",
+            state.started_at,
+        ],
+        timeout_seconds=120,
+        allow_failure=True,
+    )
+    generated_summary = read_json(summary_path)
+    validation = security_response_runbook.validate_drills_summary(
+        generated_summary if isinstance(generated_summary, dict) else {},
+        production=state.settings.mode == "production-beta",
+        strict=state.settings.mode in {"release-candidate", "production-beta"},
+        now=security_response_runbook.parse_timestamp(state.started_at),
+        expected_mode=state.settings.mode if state.settings.mode in {"release-candidate", "production-beta"} else None,
+    )
+    stage_ok = (
+        verify_result.ok()
+        and run_all_result.ok()
+        and verify_all_result.ok()
+        and validation.get("status") == "pass"
+    )
+    if not stage_ok:
+        state.failures.append("security response drills did not produce a promotion-ready summary.")
+    record_pipeline_stage(
+        state,
+        "security-response-drills",
+        "pass" if stage_ok else "fail",
+        "Generated and verified all required security response drills.",
+        verify_all_result,
+    )
+    return summary_path
+
+
 def run_fixture_certification(state: PipelineState, cert_out: Path) -> None:
     fixtures = state.settings.workspace_root / "tools/release-certification/fixtures"
     cert_out.mkdir(parents=True, exist_ok=True)
@@ -2530,6 +2899,8 @@ def run_fixture_certification(state: PipelineState, cert_out: Path) -> None:
         str(network_summary),
         "--multi-node-soak-summary",
         str(multi_node_summary),
+        "--security-drills-summary",
+        str(security_drills_summary_path(state.settings)),
         "--skip-git-metadata",
     ]
     result = run_command(state, "release-certification-fixture", args, timeout_seconds=300, allow_failure=True)
@@ -2594,6 +2965,7 @@ def run_release_certification(state: PipelineState, env: dict[str, str], cert_ou
         args.extend(["--multi-node-mode", state.settings.multi_node_mode])
     if state.settings.require_multi_node_soak:
         args.append("--require-multi-node-soak")
+    args.extend(["--security-drills-summary", str(security_drills_summary_path(state.settings))])
     if state.settings.mode != "developer-dry-run":
         args.append("--require-history")
     history_summary = previous_release_certification_summary_for_certification(state.settings)
@@ -3133,12 +3505,14 @@ def write_evidence_extracts(settings: Settings, cert_out: Path) -> dict[str, Any
     resolved_multi_node_summary_path = multi_node_summary_path(settings, cert_out)
     cert_summary_path = cert_out / release_certification.SUMMARY_FILE_NAME
     matrix_path = cert_out / release_certification.ECOSYSTEM_MATRIX_FILE_NAME
+    security_drills_path = security_drills_summary_path(settings)
     app_summary = read_json(app_summary_path)
     live_summary = read_json(live_summary_path)
     network_summary = read_json(network_summary_path)
     multi_node_summary = read_json(resolved_multi_node_summary_path)
     cert_summary = read_json(cert_summary_path)
     matrix_summary = read_json(matrix_path)
+    security_drills_summary = read_json(security_drills_path)
     third_party_intake_summary = read_third_party_intake_summary(settings)
 
     evidence_dir = settings.out_dir / "evidence"
@@ -3154,6 +3528,7 @@ def write_evidence_extracts(settings: Settings, cert_out: Path) -> dict[str, Any
     )
     write_json(evidence_dir / "ecosystem-rc-certification.json", cert_summary or {"status": "missing"})
     write_json(evidence_dir / "ecosystem-certification-matrix.json", matrix_summary or {"status": "missing"})
+    write_json(evidence_dir / "security-drills-summary.json", security_drills_summary or {"status": "missing"})
     write_json(
         evidence_dir / "third-party-intake-summary.json",
         third_party_intake_summary or {"status": "missing", "required": settings.require_third_party_intake},
@@ -3228,6 +3603,7 @@ def write_evidence_extracts(settings: Settings, cert_out: Path) -> dict[str, Any
         "multiNodeBetaSoak": multi_node_summary,
         "certification": cert_summary,
         "matrix": matrix_summary,
+        "securityDrills": security_drills_summary,
         "thirdPartyIntake": third_party_intake_summary,
     }
 
@@ -3239,6 +3615,15 @@ def status_ok(status: str) -> bool:
 def evidence_details(item: dict[str, Any]) -> dict[str, Any]:
     details = item.get("details")
     return details if isinstance(details, dict) else {}
+
+
+def nested_evidence_details(parent_details: dict[str, Any], key: str) -> dict[str, Any]:
+    nested_item = parent_details.get(key)
+    if isinstance(nested_item, dict):
+        nested_details = nested_item.get("details")
+        if isinstance(nested_details, dict):
+            return nested_details
+    return parent_details
 
 
 def evidence_has_unwaivable_redaction_findings(item: dict[str, Any]) -> bool:
@@ -3297,16 +3682,69 @@ def production_security_response_summary(all_evidence: dict[str, Any]) -> dict[s
             "warnings": [],
         }
     details = evidence_details(item)
-    checks = details.get("checks") if isinstance(details.get("checks"), dict) else {}
-    drill_ids = set(details.get("drillIds") if isinstance(details.get("drillIds"), list) else [])
+    app_runbook_item = (
+        details.get("appPlatformRunbook")
+        if isinstance(details.get("appPlatformRunbook"), dict)
+        else item
+    )
+    app_runbook_details = nested_evidence_details(details, "appPlatformRunbook")
+    drill_details = nested_evidence_details(details, "securityDrills")
+    checks = (
+        app_runbook_details.get("checks")
+        if isinstance(app_runbook_details.get("checks"), dict)
+        else {}
+    )
+    drill_ids = set(
+        app_runbook_details.get("drillIds")
+        if isinstance(app_runbook_details.get("drillIds"), list)
+        else []
+    )
+    passed_scenarios = set(
+        str(value) for value in drill_details.get("passedScenarios", []) if isinstance(value, str)
+    ) if isinstance(drill_details.get("passedScenarios"), list) else set()
+    failed_scenarios = [
+        str(value) for value in drill_details.get("failedScenarios", []) if isinstance(value, str)
+    ] if isinstance(drill_details.get("failedScenarios"), list) else []
+    missing_scenarios = [
+        str(value) for value in drill_details.get("missingScenarios", []) if isinstance(value, str)
+    ] if isinstance(drill_details.get("missingScenarios"), list) else []
+    stale_scenarios = [
+        str(value) for value in drill_details.get("staleScenarios", []) if isinstance(value, str)
+    ] if isinstance(drill_details.get("staleScenarios"), list) else []
+    malformed_scenarios = [
+        str(value) for value in drill_details.get("malformedScenarios", []) if isinstance(value, str)
+    ] if isinstance(drill_details.get("malformedScenarios"), list) else []
+    counts = drill_details.get("counts") if isinstance(drill_details.get("counts"), dict) else {}
+    redaction = (
+        drill_details.get("redaction")
+        if isinstance(drill_details.get("redaction"), dict)
+        else {}
+    )
+    release_notes = (
+        drill_details.get("releaseNotes")
+        if isinstance(drill_details.get("releaseNotes"), dict)
+        else {}
+    )
     item_ok = evidence_status_ok(item)
+    app_runbook_ok = evidence_status_ok(app_runbook_item)
+    app_runbook_status = str(app_runbook_item.get("status", item.get("status", "missing")))
 
     def check_status(key: str) -> str:
         if not checks:
-            return "pass" if item_ok else "missing"
-        return "pass" if checks.get(key) is True else "missing"
+            return "pass" if app_runbook_ok else app_runbook_status
+        if checks.get(key) is True:
+            return "pass"
+        return "fail" if app_runbook_status == "fail" else "missing"
 
     def drill_status(drill_id: str) -> str:
+        if drill_id in failed_scenarios or drill_id in malformed_scenarios:
+            return "fail"
+        if drill_id in stale_scenarios:
+            return "stale"
+        if drill_id in missing_scenarios:
+            return "missing"
+        if drill_id in passed_scenarios:
+            return "pass"
         if not drill_ids:
             return "pass" if item_ok else "missing"
         return "pass" if drill_id in drill_ids else "missing"
@@ -3314,8 +3752,18 @@ def production_security_response_summary(all_evidence: dict[str, Any]) -> dict[s
     blockers: list[str] = []
     if not item_ok:
         blockers.append(str(item.get("summary", "Security response runbook evidence is not passing.")))
+    blockers.extend(f"Security response drill failed: {scenario}" for scenario in failed_scenarios)
+    blockers.extend(f"Security response drill missing: {scenario}" for scenario in missing_scenarios)
+    blockers.extend(f"Security response drill stale: {scenario}" for scenario in stale_scenarios)
+    blockers.extend(f"Security response drill malformed: {scenario}" for scenario in malformed_scenarios)
     errors = details.get("errors")
     warnings = [str(error) for error in errors] if isinstance(errors, list) else []
+    app_errors = app_runbook_details.get("errors")
+    if isinstance(app_errors, list):
+        warnings.extend(str(error) for error in app_errors)
+    validation_errors = drill_details.get("validationErrors")
+    if isinstance(validation_errors, list):
+        warnings.extend(str(error) for error in validation_errors)
     return {
         "status": str(item.get("status", "missing")),
         "runbookStatus": check_status("runbookDocExists"),
@@ -3323,9 +3771,28 @@ def production_security_response_summary(all_evidence: dict[str, Any]) -> dict[s
         "reviewerCompromiseDrillStatus": drill_status("reviewer-key-compromise"),
         "catalogKeyRotationDrillStatus": drill_status("catalog-signing-key-rotation"),
         "appSigningKeyCompromiseDrillStatus": drill_status("app-signing-key-compromise"),
+        "vulnerableAppVersionDrillStatus": drill_status("vulnerable-app-version"),
+        "maliciousCatalogEntryDrillStatus": drill_status("malicious-catalog-entry"),
         "emergencyCatalogUpdateDrillStatus": drill_status("emergency-replacement-app"),
-        "supportRedactionStatus": check_status("supportRedactionDrill"),
-        "securityReleaseNotesTemplateStatus": check_status("releaseNotesTemplate"),
+        "supportRedactionStatus": (
+            drill_status("support-bundle-intake-redaction")
+            if counts
+            else check_status("supportRedactionDrill")
+        ),
+        "securityReleaseNotesTemplateStatus": (
+            str(release_notes.get("templateStatus", "missing")) if release_notes else check_status("releaseNotesTemplate")
+        ),
+        "redactionStatus": str(redaction.get("status", "missing")) if redaction else "missing",
+        "promotionReady": bool(drill_details.get("promotionReady", details.get("promotionReady", item_ok))),
+        "nonRelease": bool(drill_details.get("nonRelease", details.get("nonRelease", False))),
+        "fixtureOnly": bool(drill_details.get("fixtureOnly", details.get("fixtureOnly", False))),
+        "counts": counts,
+        "requiredScenarios": drill_details.get("requiredScenarios", []),
+        "passedScenarios": sorted(passed_scenarios),
+        "failedScenarios": failed_scenarios,
+        "missingScenarios": missing_scenarios,
+        "staleScenarios": stale_scenarios,
+        "malformedScenarios": malformed_scenarios,
         "blockers": blockers,
         "warnings": warnings,
     }
@@ -4335,6 +4802,23 @@ def render_markdown_summary(summary: dict[str, Any]) -> str:
             "- Security release notes template: "
             f"`{security_response.get('securityReleaseNotesTemplateStatus', 'missing')}`"
         )
+        counts = security_response.get("counts")
+        if isinstance(counts, dict):
+            lines.append(f"- Required drills: `{counts.get('required', 0)}`")
+            lines.append(f"- Passed drills: `{counts.get('passed', 0)}`")
+            lines.append(f"- Failed drills: `{counts.get('failed', 0)}`")
+            lines.append(f"- Missing drills: `{counts.get('missing', 0)}`")
+            lines.append(f"- Stale drills: `{counts.get('stale', 0)}`")
+            lines.append(f"- Redaction: `{security_response.get('redactionStatus', 'missing')}`")
+        for label, key in (
+            ("Failed drills", "failedScenarios"),
+            ("Missing drills", "missingScenarios"),
+            ("Stale drills", "staleScenarios"),
+            ("Malformed drills", "malformedScenarios"),
+        ):
+            values = security_response.get(key)
+            if isinstance(values, list) and values:
+                lines.append(f"- {label}: `{','.join(str(value) for value in values)}`")
         for blocker in security_response.get("blockers", []):
             lines.append(f"- Blocker: {blocker}")
         for warning in security_response.get("warnings", []):
@@ -4426,6 +4910,8 @@ def build_final_summary(
         "channelMetadata": "catalog/channel-metadata.json",
         "reviewReceipts": "reviews/review-receipts/",
         "appPlatformSmoke": "evidence/app-platform-smoke.json",
+        "securityDrillsSummary": "security-drills/security-drills-summary.json",
+        "securityDrillsEvidence": "evidence/security-drills-summary.json",
         "multiNodeBetaSoak": "evidence/multi-node-beta-soak.json",
         "ecosystemCertification": "evidence/ecosystem-rc-certification.json",
         "thirdPartyIntake": "evidence/third-party-intake-summary.json",
@@ -4434,6 +4920,8 @@ def build_final_summary(
         "goNoGoDashboardReport": GO_NO_GO_DASHBOARD_MARKDOWN,
         "goNoGoRedactionReport": GO_NO_GO_REDACTION_REPORT,
     }
+    if security_release_notes_draft_path(settings).is_file():
+        artifacts["securityReleaseNotesDraft"] = "security/security-release-notes-draft.md"
     if archive is not None:
         artifacts["distArchive"] = f"dist/{archive.name}"
         artifacts["checksums"] = "dist/checksums.txt"
@@ -4555,6 +5043,8 @@ def dashboard_args(settings: Settings) -> list[str]:
         str(settings.out_dir / "evidence/network-scale-soak.json"),
         "--multi-node-beta-soak-summary",
         str(settings.out_dir / "evidence/multi-node-beta-soak.json"),
+        "--security-drills-summary",
+        str(settings.out_dir / "evidence/security-drills-summary.json"),
     ]
     if settings.waiver_file:
         args.extend(["--waivers", str(settings.waiver_file)])
@@ -4918,6 +5408,7 @@ def run_pipeline(settings: Settings) -> tuple[dict[str, Any], int]:
         check_workspace_clean(state, "post-artifact-build")
         write_json(settings.out_dir / "inputs/release-config.json", release_config(state))
         profile_env = state.signing_profile.env if state.signing_profile else os.environ.copy()
+        run_security_response_drills(state)
         run_release_certification(state, profile_env, cert_out)
         check_workspace_clean(state, "post-certification")
         summaries = write_evidence_extracts(settings, cert_out)
@@ -5034,6 +5525,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Attach a redacted third-party app intake summary for optional or required production-beta evidence.",
     )
     parser.add_argument(
+        "--security-drills-summary",
+        type=Path,
+        help="Attach a redacted security response drill summary instead of generating drills in this run.",
+    )
+    parser.add_argument(
         "--require-third-party-intake",
         action="store_true",
         help="Require third-party intake evidence for promotion gates.",
@@ -5099,6 +5595,11 @@ def settings_from_args(args: argparse.Namespace) -> Settings:
         )
     multi_node_soak_config = resolve_workspace_path_arg(args.multi_node_soak_config, workspace)
     third_party_intake_summary = resolve_workspace_path_arg(args.third_party_intake_summary, workspace)
+    security_drills_summary = (
+        resolve_workspace_path_arg(args.security_drills_summary, workspace)
+        if args.security_drills_summary is not None
+        else resolve_workspace_path_text(os.environ.get("CRYPTAD_SECURITY_DRILLS_SUMMARY"), workspace)
+    )
     if args.third_party_intake_summary is not None and args.run_third_party_intake_sample_flow:
         raise SystemExit("--run-third-party-intake-sample-flow cannot be combined with --third-party-intake-summary.")
     artifact_base_uri = args.artifact_base_uri.strip() or os.environ.get(
@@ -5209,6 +5710,7 @@ def settings_from_args(args: argparse.Namespace) -> Settings:
         third_party_intake_summary=third_party_intake_summary,
         require_third_party_intake=args.require_third_party_intake,
         run_third_party_intake_sample_flow=args.run_third_party_intake_sample_flow,
+        security_drills_summary=security_drills_summary,
     )
 
 
@@ -6525,6 +7027,296 @@ def assert_developer_dry_run_exit_code_fails_on_recorded_failures() -> None:
         )
         assert summary["status"] == "fail", summary
         assert release_exit_code(settings, summary) == 1, summary
+
+
+def assert_security_release_notes_draft_artifact_requires_file() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-security-draft-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        workspace.mkdir(parents=True)
+        settings = Settings(
+            workspace_root=workspace,
+            out_dir=workspace / "build/production-beta",
+            mode="developer-dry-run",
+            catalog_channel="stable",
+            artifact_base_uri="https://downloads.crypta.invalid/self-test",
+            require_live_network=False,
+            require_sandbox_provider_tests=False,
+            skip_gradle=True,
+            skip_full_build=True,
+            use_fixture_evidence=False,
+            allow_dirty_workspace=True,
+            emergency_skip_live_network=False,
+            emergency_skip_build=False,
+            allow_test_signing_in_production=False,
+            previous_summary=None,
+            waiver_file=None,
+            timeout_seconds=60,
+            clean_out_dir=True,
+        )
+        state = PipelineState(settings, "self-test", utc_now(), [], [], [])
+        promotion = {
+            "status": "pass",
+            "promotionReady": False,
+            "nonRelease": True,
+            "gates": [],
+            "knownLimitations": [],
+        }
+        redaction_report = {
+            "schemaVersion": 1,
+            "status": "pass",
+            "scannedRoot": "<release-out>",
+            "findingCount": 0,
+            "findings": [],
+        }
+        without_draft = build_final_summary(state, promotion, redaction_report, None)
+        assert "securityReleaseNotesDraft" not in without_draft["artifacts"], without_draft["artifacts"]
+        write_text(security_release_notes_draft_path(settings), "# Security Release Notes Draft\n")
+        with_draft = build_final_summary(state, promotion, redaction_report, None)
+        assert (
+            with_draft["artifacts"]["securityReleaseNotesDraft"]
+            == "security/security-release-notes-draft.md"
+        ), with_draft["artifacts"]
+
+
+def assert_security_response_summary_reads_combined_drill_details() -> None:
+    counts = {
+        "required": len(security_response_runbook.REQUIRED_DRILLS),
+        "passed": len(security_response_runbook.REQUIRED_DRILLS),
+        "failed": 0,
+        "missing": 0,
+        "stale": 0,
+        "malformed": 0,
+    }
+    combined = {
+        "production-security.response-runbook": {
+            "id": "production-security.response-runbook",
+            "status": "pass",
+            "summary": "Production security response runbook and operational drills passed.",
+            "details": {
+                "appPlatformRunbook": {
+                    "status": "pass",
+                    "details": {
+                        "checks": {
+                            "runbookDocExists": True,
+                            "advisoryLifecycleTestable": True,
+                            "releaseNotesTemplate": True,
+                            "supportRedactionDrill": True,
+                        },
+                        "drillIds": list(security_response_runbook.REQUIRED_DRILLS),
+                    },
+                },
+                "securityDrills": {
+                    "status": "pass",
+                    "details": {
+                        "promotionReady": True,
+                        "nonRelease": False,
+                        "fixtureOnly": False,
+                        "counts": counts,
+                        "requiredScenarios": list(security_response_runbook.REQUIRED_DRILLS),
+                        "passedScenarios": list(security_response_runbook.REQUIRED_DRILLS),
+                        "failedScenarios": [],
+                        "missingScenarios": [],
+                        "staleScenarios": [],
+                        "malformedScenarios": [],
+                        "redaction": {"status": "pass", "findings": []},
+                        "releaseNotes": {"templateStatus": "pass"},
+                        "validationErrors": [],
+                    },
+                },
+                "componentStatuses": {
+                    "appPlatformRunbook": "pass",
+                    "securityDrills": "pass",
+                },
+            },
+        }
+    }
+
+    summary = production_security_response_summary(combined)
+
+    assert summary["counts"] == counts, summary
+    assert summary["requiredScenarios"] == list(security_response_runbook.REQUIRED_DRILLS), summary
+    assert summary["passedScenarios"] == sorted(security_response_runbook.REQUIRED_DRILLS), summary
+    assert summary["runbookStatus"] == "pass", summary
+    assert summary["advisoryLifecycleStatus"] == "pass", summary
+    assert summary["reviewerCompromiseDrillStatus"] == "pass", summary
+    assert summary["supportRedactionStatus"] == "pass", summary
+    assert summary["redactionStatus"] == "pass", summary
+    assert summary["securityReleaseNotesTemplateStatus"] == "pass", summary
+
+    failed_runbook = json.loads(json.dumps(combined))
+    failed_item = failed_runbook["production-security.response-runbook"]
+    failed_item["status"] = "fail"
+    failed_item["summary"] = "Production security response is not promotion-ready."
+    failed_app = failed_item["details"]["appPlatformRunbook"]
+    failed_app["status"] = "fail"
+    failed_app["details"]["checks"]["runbookDocExists"] = False
+    failed_app["details"]["checks"]["advisoryLifecycleTestable"] = False
+    failed_item["details"]["componentStatuses"]["appPlatformRunbook"] = "fail"
+
+    failed_summary = production_security_response_summary(failed_runbook)
+
+    assert failed_summary["counts"] == counts, failed_summary
+    assert failed_summary["runbookStatus"] == "fail", failed_summary
+    assert failed_summary["advisoryLifecycleStatus"] == "fail", failed_summary
+    assert failed_summary["reviewerCompromiseDrillStatus"] == "pass", failed_summary
+
+
+def assert_attached_security_drills_summary_is_bound_to_release_id() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-security-drills-release-id-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        make_self_test_workspace(workspace)
+        out_dir = workspace / "build/production-beta"
+        attached_dir = workspace / "attached/security-drills"
+        attached_summary = attached_dir / "security-drills-summary.json"
+        started_at = "2026-07-04T00:00:00Z"
+        security_response_runbook.drill_run_all(
+            workspace / "tools/release-certification/production-security-response-runbook.json",
+            attached_dir,
+            attached_summary,
+            release_id="cryptad-beta-other-candidate",
+            generated_at=started_at,
+            mode="release-candidate",
+        )
+        settings = Settings(
+            workspace_root=workspace,
+            out_dir=out_dir,
+            mode="release-candidate",
+            catalog_channel="stable",
+            artifact_base_uri="https://downloads.crypta.invalid/self-test",
+            require_live_network=False,
+            require_sandbox_provider_tests=False,
+            skip_gradle=True,
+            skip_full_build=True,
+            use_fixture_evidence=True,
+            allow_dirty_workspace=True,
+            emergency_skip_live_network=False,
+            emergency_skip_build=False,
+            allow_test_signing_in_production=False,
+            previous_summary=None,
+            waiver_file=None,
+            timeout_seconds=120,
+            clean_out_dir=True,
+            security_drills_summary=attached_summary,
+        )
+        state = PipelineState(settings, "current-candidate", started_at, [], [], [])
+
+        run_security_response_drills(state)
+
+        stage = state.pipeline_stages.get("security-response-drills", {})
+        assert stage.get("status") == "fail", stage
+        assert any("releaseId does not match" in failure for failure in state.failures), state.failures
+
+
+def assert_invalid_attached_security_drills_summary_is_sanitized() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-security-drills-sanitized-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        make_self_test_workspace(workspace)
+        started_at = "2026-07-04T00:00:00Z"
+        version = "current-candidate"
+        release_id = f"cryptad-beta-{version}"
+        attached_dir = workspace / "attached/security-drills"
+        attached_summary = attached_dir / "security-drills-summary.json"
+        security_response_runbook.drill_run_all(
+            workspace / "tools/release-certification/production-security-response-runbook.json",
+            attached_dir,
+            attached_summary,
+            release_id=release_id,
+            generated_at=started_at,
+            mode="production-beta",
+        )
+        unsafe_summary = read_json(attached_summary)
+        if unsafe_summary is None:
+            raise AssertionError("security drills self-test did not create an attached summary")
+        unsafe_summary["rawSupportBundleBody"] = "-----BEGIN PRIVATE KEY-----\nunsafe-fixture\n-----END PRIVATE KEY-----"
+        unsafe_summary.setdefault("releaseNotes", {})["redactedSnippet"] = (
+            "Unsafe attached summary mentions /home/alice/private/key.pem"
+        )
+        write_json(attached_summary, unsafe_summary)
+        settings = dataclasses.replace(
+            cleanup_test_settings(workspace, workspace / "build/production-beta-unsafe-security-drills"),
+            mode="production-beta",
+            security_drills_summary=attached_summary,
+        )
+        state = PipelineState(settings, version, started_at, [], [], [])
+
+        summary_path = run_security_response_drills(state)
+
+        stage = state.pipeline_stages.get("security-response-drills", {})
+        assert stage.get("status") == "fail", stage
+        persisted = read_json(summary_path)
+        assert isinstance(persisted, dict), persisted
+        assert persisted.get("status") == "fail", persisted
+        assert persisted.get("promotionReady") is False, persisted
+        assert persisted.get("attachment", {}).get("sanitized") is True, persisted
+        assert persisted.get("attachmentErrors"), persisted
+        encoded = summary_path.read_text(encoding="utf-8") + json.dumps(state.failures, sort_keys=True)
+        for forbidden in ("-----BEGIN PRIVATE KEY-----", "/home/alice/private/key.pem", "unsafe-fixture"):
+            assert forbidden not in encoded, forbidden
+
+
+def assert_attached_security_drills_summary_preserves_artifacts() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-security-drills-attached-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        make_self_test_workspace(workspace)
+        started_at = "2026-07-04T00:00:00Z"
+        version = "current-candidate"
+        release_id = f"cryptad-beta-{version}"
+        attached_dir = workspace / "attached/security-drills"
+        attached_summary = attached_dir / "security-drills-summary.json"
+        security_response_runbook.drill_run_all(
+            workspace / "tools/release-certification/production-security-response-runbook.json",
+            attached_dir,
+            attached_summary,
+            release_id=release_id,
+            generated_at=started_at,
+            mode="production-beta",
+        )
+        settings = dataclasses.replace(
+            cleanup_test_settings(workspace, workspace / "build/production-beta"),
+            mode="production-beta",
+            security_drills_summary=attached_summary,
+        )
+        state = PipelineState(settings, version, started_at, [], [], [])
+
+        summary_path = run_security_response_drills(state)
+
+        stage = state.pipeline_stages.get("security-response-drills", {})
+        assert stage.get("status") == "pass", stage
+        assert state.failures == [], state.failures
+        assert read_json(summary_path)["status"] == "pass"
+        for scenario, file_name in security_response_runbook.DRILL_OUTPUT_FILENAMES.items():
+            copied = security_drills_dir(settings) / file_name
+            assert copied.is_file(), scenario
+
+        missing_dir = workspace / "attached-missing/security-drills"
+        missing_summary = missing_dir / "security-drills-summary.json"
+        security_response_runbook.drill_run_all(
+            workspace / "tools/release-certification/production-security-response-runbook.json",
+            missing_dir,
+            missing_summary,
+            release_id=release_id,
+            generated_at=started_at,
+            mode="production-beta",
+        )
+        (missing_dir / security_response_runbook.DRILL_OUTPUT_FILENAMES["reviewer-key-compromise"]).unlink()
+        missing_settings = dataclasses.replace(
+            cleanup_test_settings(workspace, workspace / "build/production-beta-missing"),
+            mode="production-beta",
+            security_drills_summary=missing_summary,
+        )
+        missing_state = PipelineState(missing_settings, version, started_at, [], [], [])
+
+        missing_summary_path = run_security_response_drills(missing_state)
+
+        missing_stage = missing_state.pipeline_stages.get("security-response-drills", {})
+        assert missing_stage.get("status") == "fail", missing_stage
+        assert any("artifacts are incomplete" in failure for failure in missing_state.failures), (
+            missing_state.failures
+        )
+        failed_summary = read_json(missing_summary_path)
+        assert failed_summary["status"] == "fail", failed_summary
+        assert failed_summary["promotionReady"] is False, failed_summary
+        assert failed_summary["attachmentErrors"], failed_summary
 
 
 def assert_certification_failure_marks_dry_run_failed() -> None:
@@ -8958,6 +9750,11 @@ def run_self_test() -> None:
     assert_release_candidate_third_party_intake_rejects_non_release_summary()
     assert_waived_critical_evidence_is_accepted_without_redaction_findings()
     assert_developer_dry_run_exit_code_fails_on_recorded_failures()
+    assert_security_release_notes_draft_artifact_requires_file()
+    assert_security_response_summary_reads_combined_drill_details()
+    assert_attached_security_drills_summary_is_bound_to_release_id()
+    assert_invalid_attached_security_drills_summary_is_sanitized()
+    assert_attached_security_drills_summary_preserves_artifacts()
     assert_certification_failure_marks_dry_run_failed()
     assert_release_candidate_no_go_dashboard_preserves_summary_and_exit()
     assert_go_with_waivers_cannot_promote_failed_production_summary()

--- a/tools/release-certification/production_beta_release.py
+++ b/tools/release-certification/production_beta_release.py
@@ -5044,11 +5044,28 @@ def dashboard_args(settings: Settings) -> list[str]:
         "--multi-node-beta-soak-summary",
         str(settings.out_dir / "evidence/multi-node-beta-soak.json"),
         "--security-drills-summary",
-        str(settings.out_dir / "evidence/security-drills-summary.json"),
+        str(security_drills_summary_path(settings)),
     ]
     if settings.waiver_file:
         args.extend(["--waivers", str(settings.waiver_file)])
     return args
+
+
+def assert_dashboard_args_use_security_drill_artifact_directory() -> None:
+    with tempfile.TemporaryDirectory(prefix="cryptad-production-beta-dashboard-drills-") as temp_name:
+        workspace = Path(temp_name) / "repo"
+        workspace.mkdir(parents=True)
+        out_dir = workspace / "build/production-beta"
+        settings = dataclasses.replace(
+            cleanup_test_settings(workspace, out_dir),
+            mode="production-beta",
+        )
+        args = dashboard_args(settings)
+        summary_index = args.index("--security-drills-summary") + 1
+        summary_path = Path(args[summary_index])
+        assert summary_path == security_drills_summary_path(settings), args
+        assert summary_path.parent == security_drills_dir(settings), args
+        assert summary_path != settings.out_dir / "evidence/security-drills-summary.json", args
 
 
 def clear_stale_go_no_go_dashboard_artifacts(out_dir: Path) -> list[str]:
@@ -9756,6 +9773,7 @@ def run_self_test() -> None:
     assert_invalid_attached_security_drills_summary_is_sanitized()
     assert_attached_security_drills_summary_preserves_artifacts()
     assert_certification_failure_marks_dry_run_failed()
+    assert_dashboard_args_use_security_drill_artifact_directory()
     assert_release_candidate_no_go_dashboard_preserves_summary_and_exit()
     assert_go_with_waivers_cannot_promote_failed_production_summary()
     assert_missing_go_no_go_dashboard_fails_summary_and_exit()

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -1482,6 +1482,124 @@ def app_platform_evidence(
     return items
 
 
+def security_drill_artifact_file_validation(
+    summary: dict[str, Any],
+    summary_path: Path,
+    workspace_root: Path,
+    out_dir: Path,
+) -> dict[str, Any]:
+    artifacts = summary.get("artifacts")
+    if not isinstance(artifacts, list):
+        return {
+            "status": "fail",
+            "errors": ["security drills summary artifacts must be an array"],
+            "redactionFindings": [],
+        }
+    source_dir = summary_path.parent
+    model_path = workspace_root / "tools/release-certification/production-security-response-runbook.json"
+    if not model_path.is_file():
+        model_path = Path(__file__).resolve().parent / "production-security-response-runbook.json"
+    expected_release_id = summary.get("releaseId")
+    expected_mode = summary.get("mode")
+    expected_evidence_mode = summary.get("evidenceMode")
+    errors: list[str] = []
+    redaction_findings: list[Any] = []
+    seen: set[str] = set()
+    checked: list[dict[str, Any]] = []
+    for index, entry in enumerate(artifacts):
+        if not isinstance(entry, dict):
+            errors.append(f"security drill artifact entry {index} must be an object")
+            continue
+        scenario = entry.get("scenario")
+        if scenario not in security_response_runbook.REQUIRED_DRILLS:
+            errors.append(f"security drill artifact entry {index} has an unknown scenario")
+            continue
+        scenario_text = str(scenario)
+        if scenario_text in seen:
+            errors.append(f"security drill artifact for {scenario_text} is duplicated")
+            continue
+        seen.add(scenario_text)
+        artifact_name = entry.get("artifact")
+        expected_name = security_response_runbook.DRILL_OUTPUT_FILENAMES[scenario_text]
+        if artifact_name != expected_name:
+            errors.append(f"security drill artifact for {scenario_text} must be named {expected_name}")
+            continue
+        if Path(str(artifact_name)).name != artifact_name:
+            errors.append(f"security drill artifact for {scenario_text} has an unsafe file name")
+            continue
+        artifact_path = source_dir / str(artifact_name)
+        display_artifact = display_path(artifact_path, workspace_root, out_dir)
+        if not artifact_path.is_file() or artifact_path.is_symlink():
+            errors.append(f"security drill artifact for {scenario_text} is missing")
+            checked.append(
+                {
+                    "scenario": scenario_text,
+                    "artifact": str(artifact_name),
+                    "path": display_artifact,
+                    "status": "missing",
+                }
+            )
+            continue
+        try:
+            digest = security_response_runbook.sha256_path(artifact_path)
+            verification = security_response_runbook.drill_verify(artifact_path, model_path)
+            artifact = read_json(artifact_path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            errors.append(f"security drill artifact for {scenario_text} could not be verified")
+            checked.append(
+                {
+                    "scenario": scenario_text,
+                    "artifact": str(artifact_name),
+                    "path": display_artifact,
+                    "status": "fail",
+                }
+            )
+            continue
+        artifact_status = "pass"
+        if entry.get("digest") != digest:
+            errors.append(f"security drill artifact digest mismatch for {scenario_text}")
+            artifact_status = "fail"
+        if verification.get("status") != "pass":
+            errors.append(f"security drill artifact for {scenario_text} failed offline verification")
+            artifact_status = "fail"
+        verifier_findings = verification.get("redactionFindings")
+        if isinstance(verifier_findings, list):
+            redaction_findings.extend(verifier_findings)
+        if not isinstance(artifact, dict):
+            errors.append(f"security drill artifact for {scenario_text} is malformed")
+            artifact_status = "fail"
+        else:
+            if artifact.get("scenario") != scenario_text:
+                errors.append(f"security drill artifact for {scenario_text} has the wrong scenario")
+                artifact_status = "fail"
+            if artifact.get("releaseId") != expected_release_id:
+                errors.append(f"security drill artifact for {scenario_text} has the wrong releaseId")
+                artifact_status = "fail"
+            if artifact.get("mode") != expected_mode:
+                errors.append(f"security drill artifact for {scenario_text} has the wrong mode")
+                artifact_status = "fail"
+            if artifact.get("evidenceMode") != expected_evidence_mode:
+                errors.append(f"security drill artifact for {scenario_text} has the wrong evidenceMode")
+                artifact_status = "fail"
+        checked.append(
+            {
+                "scenario": scenario_text,
+                "artifact": str(artifact_name),
+                "path": display_artifact,
+                "digest": digest,
+                "status": artifact_status,
+            }
+        )
+    for scenario in sorted(set(security_response_runbook.REQUIRED_DRILLS) - seen):
+        errors.append(f"security drill artifact for {scenario} is missing")
+    return {
+        "status": "pass" if not errors else "fail",
+        "errors": errors,
+        "redactionFindings": security_response_runbook.safe_redaction_findings(redaction_findings),
+        "checked": checked,
+    }
+
+
 def security_drills_evidence(
     path: Path | None,
     workspace_root: Path,
@@ -1509,6 +1627,12 @@ def security_drills_evidence(
         summary,
         strict=mode == "release-candidate",
     )
+    artifact_validation = security_drill_artifact_file_validation(
+        summary,
+        source_path,
+        workspace_root,
+        out_dir,
+    )
     counts = summary.get("counts") if isinstance(summary.get("counts"), dict) else {}
     redaction = summary.get("redaction") if isinstance(summary.get("redaction"), dict) else {}
     validation_redaction_findings = validation.get("redactionFindings")
@@ -1517,9 +1641,20 @@ def security_drills_evidence(
     summary_redaction_findings = redaction.get("findings")
     if not isinstance(summary_redaction_findings, list):
         summary_redaction_findings = []
-    redaction_findings = [*validation_redaction_findings, *summary_redaction_findings]
+    artifact_redaction_findings = artifact_validation.get("redactionFindings")
+    if not isinstance(artifact_redaction_findings, list):
+        artifact_redaction_findings = []
+    redaction_findings = [
+        *validation_redaction_findings,
+        *summary_redaction_findings,
+        *artifact_redaction_findings,
+    ]
     if redaction.get("status") != "pass" and not redaction_findings:
         redaction_findings.append("security response drills summary redaction status is not pass")
+    validation_errors = list(validation.get("errors", [])) if isinstance(validation.get("errors"), list) else []
+    artifact_errors = (
+        artifact_validation.get("errors") if isinstance(artifact_validation.get("errors"), list) else []
+    )
     details = {
         "summaryRequired": True,
         "summaryStatus": summary.get("status", "missing"),
@@ -1541,18 +1676,22 @@ def security_drills_evidence(
         "releaseNotes": summary.get("releaseNotes", {}),
         "advisoryTemplate": summary.get("advisoryTemplate", {}),
         "artifacts": summary.get("artifacts", []),
-        "validationErrors": validation.get("errors", []),
-        "redactionClean": validation.get("redactionClean", False),
+        "artifactValidation": artifact_validation,
+        "validationErrors": [*validation_errors, *artifact_errors],
+        "redactionClean": validation.get("redactionClean", False) and not artifact_redaction_findings,
         "redactionFindings": redaction_findings,
     }
     details = dict(sanitize_value(details, workspace_root, out_dir))
-    if validation["status"] == "pass":
+    if validation["status"] == "pass" and artifact_validation.get("status") == "pass":
         passed = counts.get("passed", len(summary.get("passedScenarios", [])))
         required = counts.get("required", len(security_response_runbook.REQUIRED_DRILLS))
         headline = f"Security response drills passed for {passed}/{required} required scenarios."
         status = "pass"
     else:
-        headline = "Security response drills are missing, stale, failed, malformed, or redaction-unsafe."
+        headline = (
+            "Security response drills are missing, stale, failed, malformed, "
+            "artifact-incomplete, or redaction-unsafe."
+        )
         status = "fail"
     return EvidenceItem(
         "production-security.response-runbook",
@@ -8908,6 +9047,63 @@ def run_self_test(repo_root: Path) -> None:
             skip_git_metadata=True,
             history_dir=workspace / "build/no-auto-history",
         )
+        security_item = security_drills_evidence(
+            security_drills_summary,
+            workspace.resolve(),
+            out_dir.resolve(),
+            "release-candidate",
+        )
+        assert security_item.status == "pass", security_item
+        missing_artifacts_dir = workspace / "security-drills-missing-artifacts"
+        missing_artifacts_summary = missing_artifacts_dir / "security-drills-summary.json"
+        security_drills_summary_value = read_json(security_drills_summary)
+        assert isinstance(security_drills_summary_value, dict), security_drills_summary
+        write_json(missing_artifacts_summary, security_drills_summary_value)
+        missing_artifacts_item = security_drills_evidence(
+            missing_artifacts_summary,
+            workspace.resolve(),
+            out_dir.resolve(),
+            "release-candidate",
+        )
+        assert missing_artifacts_item.status == "fail", missing_artifacts_item
+        assert any(
+            "security drill artifact for reviewer-key-compromise is missing" == error
+            for error in missing_artifacts_item.details.get("validationErrors", [])
+        ), missing_artifacts_item.details
+        tampered_artifacts_dir = workspace / "security-drills-tampered-artifacts"
+        shutil.copytree(security_drills_summary.parent, tampered_artifacts_dir)
+        tampered_summary_path = tampered_artifacts_dir / "security-drills-summary.json"
+        tampered_artifact_path = (
+            tampered_artifacts_dir
+            / security_response_runbook.DRILL_OUTPUT_FILENAMES["reviewer-key-compromise"]
+        )
+        tampered_artifact = read_json(tampered_artifact_path)
+        assert isinstance(tampered_artifact, dict), tampered_artifact_path
+        tampered_artifact["steps"][0]["safeSummary"] = "Tampered but redaction-safe drill text."
+        write_json(tampered_artifact_path, tampered_artifact)
+        tampered_summary = read_json(tampered_summary_path)
+        assert isinstance(tampered_summary, dict), tampered_summary_path
+        for artifact_entry in tampered_summary.get("artifacts", []):
+            if (
+                isinstance(artifact_entry, dict)
+                and artifact_entry.get("scenario") == "reviewer-key-compromise"
+            ):
+                artifact_entry["digest"] = security_response_runbook.sha256_path(
+                    tampered_artifact_path
+                )
+                break
+        write_json(tampered_summary_path, tampered_summary)
+        tampered_artifacts_item = security_drills_evidence(
+            tampered_summary_path,
+            workspace.resolve(),
+            out_dir.resolve(),
+            "release-candidate",
+        )
+        assert tampered_artifacts_item.status == "fail", tampered_artifacts_item
+        assert any(
+            "security drill artifact for reviewer-key-compromise failed offline verification" == error
+            for error in tampered_artifacts_item.details.get("validationErrors", [])
+        ), tampered_artifacts_item.details
         redaction_unsafe_security_drills = read_json(security_drills_summary)
         assert isinstance(redaction_unsafe_security_drills, dict), security_drills_summary
         redaction_unsafe_security_drills["redaction"] = {

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -1489,147 +1489,16 @@ def security_drill_artifact_file_validation(
     out_dir: Path,
     strict: bool,
 ) -> dict[str, Any]:
-    artifacts = summary.get("artifacts")
-    if not isinstance(artifacts, list):
-        return {
-            "status": "fail",
-            "errors": ["security drills summary artifacts must be an array"],
-            "redactionFindings": [],
-        }
-    source_dir = summary_path.parent
     model_path = workspace_root / "tools/release-certification/production-security-response-runbook.json"
     if not model_path.is_file():
         model_path = Path(__file__).resolve().parent / "production-security-response-runbook.json"
-    expected_release_id = summary.get("releaseId")
-    expected_mode = summary.get("mode")
-    expected_evidence_mode = summary.get("evidenceMode")
-    summary_generated_at = security_response_runbook.parse_timestamp(summary.get("generatedAt"))
-    evaluated_at = summary_generated_at or dt.datetime.now(dt.timezone.utc)
-    max_age_days_value = summary.get("maxAgeDays")
-    max_age_days = security_response_runbook.DEFAULT_MAX_AGE_DAYS
-    if (
-        isinstance(max_age_days_value, int)
-        and not isinstance(max_age_days_value, bool)
-        and max_age_days_value > 0
-    ):
-        max_age_days = (
-            min(max_age_days_value, security_response_runbook.DEFAULT_MAX_AGE_DAYS)
-            if strict
-            else max_age_days_value
-        )
-    errors: list[str] = []
-    redaction_findings: list[Any] = []
-    seen: set[str] = set()
-    checked: list[dict[str, Any]] = []
-    for index, entry in enumerate(artifacts):
-        if not isinstance(entry, dict):
-            errors.append(f"security drill artifact entry {index} must be an object")
-            continue
-        scenario = entry.get("scenario")
-        if scenario not in security_response_runbook.REQUIRED_DRILLS:
-            errors.append(f"security drill artifact entry {index} has an unknown scenario")
-            continue
-        scenario_text = str(scenario)
-        if scenario_text in seen:
-            errors.append(f"security drill artifact for {scenario_text} is duplicated")
-            continue
-        seen.add(scenario_text)
-        artifact_name = entry.get("artifact")
-        expected_name = security_response_runbook.DRILL_OUTPUT_FILENAMES[scenario_text]
-        if artifact_name != expected_name:
-            errors.append(f"security drill artifact for {scenario_text} must be named {expected_name}")
-            continue
-        if Path(str(artifact_name)).name != artifact_name:
-            errors.append(f"security drill artifact for {scenario_text} has an unsafe file name")
-            continue
-        artifact_path = source_dir / str(artifact_name)
-        display_artifact = display_path(artifact_path, workspace_root, out_dir)
-        if not artifact_path.is_file() or artifact_path.is_symlink():
-            errors.append(f"security drill artifact for {scenario_text} is missing")
-            checked.append(
-                {
-                    "scenario": scenario_text,
-                    "artifact": str(artifact_name),
-                    "path": display_artifact,
-                    "status": "missing",
-                }
-            )
-            continue
-        try:
-            digest = security_response_runbook.sha256_path(artifact_path)
-            verification = security_response_runbook.drill_verify(artifact_path, model_path)
-            artifact = read_json(artifact_path)
-        except (OSError, ValueError, json.JSONDecodeError):
-            errors.append(f"security drill artifact for {scenario_text} could not be verified")
-            checked.append(
-                {
-                    "scenario": scenario_text,
-                    "artifact": str(artifact_name),
-                    "path": display_artifact,
-                    "status": "fail",
-                }
-            )
-            continue
-        artifact_status = "pass"
-        stale = False
-        age_days: int | None = None
-        stale_reason = ""
-        if entry.get("digest") != digest:
-            errors.append(f"security drill artifact digest mismatch for {scenario_text}")
-            artifact_status = "fail"
-        if verification.get("status") != "pass":
-            errors.append(f"security drill artifact for {scenario_text} failed offline verification")
-            artifact_status = "fail"
-        verifier_findings = verification.get("redactionFindings")
-        if isinstance(verifier_findings, list):
-            redaction_findings.extend(verifier_findings)
-        if not isinstance(artifact, dict):
-            errors.append(f"security drill artifact for {scenario_text} is malformed")
-            artifact_status = "fail"
-        else:
-            if artifact.get("scenario") != scenario_text:
-                errors.append(f"security drill artifact for {scenario_text} has the wrong scenario")
-                artifact_status = "fail"
-            if artifact.get("releaseId") != expected_release_id:
-                errors.append(f"security drill artifact for {scenario_text} has the wrong releaseId")
-                artifact_status = "fail"
-            if artifact.get("mode") != expected_mode:
-                errors.append(f"security drill artifact for {scenario_text} has the wrong mode")
-                artifact_status = "fail"
-            if artifact.get("evidenceMode") != expected_evidence_mode:
-                errors.append(f"security drill artifact for {scenario_text} has the wrong evidenceMode")
-                artifact_status = "fail"
-            if strict:
-                stale, age_days, stale_reason = security_response_runbook.artifact_is_stale(
-                    artifact,
-                    evaluated_at,
-                    max_age_days,
-                )
-                if stale:
-                    errors.append(
-                        f"security drill artifact for {scenario_text} is stale: {stale_reason}"
-                    )
-                    artifact_status = "fail"
-        checked.append(
-            {
-                "scenario": scenario_text,
-                "artifact": str(artifact_name),
-                "path": display_artifact,
-                "digest": digest,
-                "status": artifact_status,
-                "ageDays": age_days,
-                "stale": stale,
-                "staleReason": stale_reason,
-            }
-        )
-    for scenario in sorted(set(security_response_runbook.REQUIRED_DRILLS) - seen):
-        errors.append(f"security drill artifact for {scenario} is missing")
-    return {
-        "status": "pass" if not errors else "fail",
-        "errors": errors,
-        "redactionFindings": security_response_runbook.safe_redaction_findings(redaction_findings),
-        "checked": checked,
-    }
+    return security_response_runbook.validate_drill_artifact_files(
+        summary,
+        summary_path,
+        model_path=model_path,
+        strict=strict,
+        display_path_fn=lambda path: display_path(path, workspace_root, out_dir),
+    )
 
 
 def security_drills_evidence(

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -27,6 +27,7 @@ sys.dont_write_bytecode = True
 import app_platform_docs_check
 import multi_node_beta_soak
 import production_beta_go_no_go_dashboard
+import security_response_runbook
 
 
 TOOL_NAME = "release-certification"
@@ -600,6 +601,7 @@ class Settings:
     waiver_files: tuple[Path, ...] = ()
     multi_node_soak_summary: Path = DEFAULT_OUT_DIR / "multi-node-beta-soak" / "summary.json"
     multi_node_soak_required: bool = False
+    security_drills_summary: Path | None = None
 
 
 def utc_now() -> str:
@@ -1478,6 +1480,157 @@ def app_platform_evidence(
                 )
             )
     return items
+
+
+def security_drills_evidence(
+    path: Path | None,
+    workspace_root: Path,
+    out_dir: Path,
+    mode: str,
+) -> EvidenceItem:
+    source_path = path or workspace_root / "build/security-drills/security-drills-summary.json"
+    source = display_path(source_path, workspace_root, out_dir)
+    summary = read_json(source_path)
+    if summary is None:
+        return EvidenceItem(
+            "production-security.response-runbook",
+            "missing",
+            True,
+            "Security response drills summary is missing.",
+            source,
+            {
+                "summaryRequired": True,
+                "requiredScenarios": list(security_response_runbook.REQUIRED_DRILLS),
+                "missingScenarios": list(security_response_runbook.REQUIRED_DRILLS),
+                "promotionReady": False,
+            },
+        )
+    validation = security_response_runbook.validate_drills_summary(
+        summary,
+        strict=mode == "release-candidate",
+    )
+    counts = summary.get("counts") if isinstance(summary.get("counts"), dict) else {}
+    redaction = summary.get("redaction") if isinstance(summary.get("redaction"), dict) else {}
+    validation_redaction_findings = validation.get("redactionFindings")
+    if not isinstance(validation_redaction_findings, list):
+        validation_redaction_findings = []
+    summary_redaction_findings = redaction.get("findings")
+    if not isinstance(summary_redaction_findings, list):
+        summary_redaction_findings = []
+    redaction_findings = [*validation_redaction_findings, *summary_redaction_findings]
+    if redaction.get("status") != "pass" and not redaction_findings:
+        redaction_findings.append("security response drills summary redaction status is not pass")
+    details = {
+        "summaryRequired": True,
+        "summaryStatus": summary.get("status", "missing"),
+        "promotionReady": bool(summary.get("promotionReady")),
+        "nonRelease": bool(summary.get("nonRelease")),
+        "fixtureOnly": bool(summary.get("fixtureOnly")),
+        "mode": summary.get("mode", "missing"),
+        "evidenceMode": summary.get("evidenceMode", "missing"),
+        "releaseId": summary.get("releaseId", "missing"),
+        "generatedAt": summary.get("generatedAt", "missing"),
+        "counts": counts,
+        "requiredScenarios": summary.get("requiredScenarios", []),
+        "passedScenarios": summary.get("passedScenarios", []),
+        "failedScenarios": summary.get("failedScenarios", []),
+        "missingScenarios": summary.get("missingScenarios", []),
+        "staleScenarios": summary.get("staleScenarios", []),
+        "malformedScenarios": summary.get("malformedScenarios", []),
+        "redaction": redaction,
+        "releaseNotes": summary.get("releaseNotes", {}),
+        "advisoryTemplate": summary.get("advisoryTemplate", {}),
+        "artifacts": summary.get("artifacts", []),
+        "validationErrors": validation.get("errors", []),
+        "redactionClean": validation.get("redactionClean", False),
+        "redactionFindings": redaction_findings,
+    }
+    details = dict(sanitize_value(details, workspace_root, out_dir))
+    if validation["status"] == "pass":
+        passed = counts.get("passed", len(summary.get("passedScenarios", [])))
+        required = counts.get("required", len(security_response_runbook.REQUIRED_DRILLS))
+        headline = f"Security response drills passed for {passed}/{required} required scenarios."
+        status = "pass"
+    else:
+        headline = "Security response drills are missing, stale, failed, malformed, or redaction-unsafe."
+        status = "fail"
+    return EvidenceItem(
+        "production-security.response-runbook",
+        status,
+        True,
+        headline,
+        source,
+        details,
+    )
+
+
+def combined_security_response_status(items: list[EvidenceItem]) -> str:
+    statuses = [normalize_evidence_status(item.status) for item in items]
+    for status in ("fail", "missing", "skip", "warn"):
+        if status in statuses:
+            return status
+    return "pass"
+
+
+def security_response_redaction_findings(items: list[EvidenceItem]) -> list[Any]:
+    findings: list[Any] = []
+    for item in items:
+        item_findings = item.details.get("redactionFindings")
+        if isinstance(item_findings, list):
+            findings.extend(item_findings)
+    return findings
+
+
+def combine_security_response_evidence(
+    app_platform_items: list[EvidenceItem],
+    drill_item: EvidenceItem,
+) -> EvidenceItem:
+    app_item = (
+        app_platform_items[0]
+        if app_platform_items
+        else EvidenceItem(
+            id="production-security.response-runbook",
+            status="missing",
+            required_for_release_candidate=True,
+            summary="App-platform security response runbook evidence is missing.",
+            source="app-platform-smoke",
+            details={},
+        )
+    )
+    components = [app_item, drill_item]
+    status = combined_security_response_status(components)
+    if status == "pass":
+        summary = "Production security response runbook and operational drills passed."
+    else:
+        summary = (
+            "Production security response is not promotion-ready: "
+            f"appPlatformRunbook={app_item.status}, securityDrills={drill_item.status}."
+        )
+    details: dict[str, Any] = {
+        "appPlatformRunbook": app_item.to_json(),
+        "securityDrills": drill_item.to_json(),
+        "componentStatuses": {
+            "appPlatformRunbook": app_item.status,
+            "securityDrills": drill_item.status,
+        },
+    }
+    if len(app_platform_items) > 1:
+        details["duplicateAppPlatformRunbookEvidence"] = [
+            item.to_json() for item in app_platform_items[1:]
+        ]
+    redaction_findings = security_response_redaction_findings(components)
+    if redaction_findings:
+        details["redactionFindings"] = redaction_findings
+    return EvidenceItem(
+        id="production-security.response-runbook",
+        status=status,
+        required_for_release_candidate=(
+            app_item.required_for_release_candidate or drill_item.required_for_release_candidate
+        ),
+        summary=summary,
+        source=f"{app_item.source}; {drill_item.source}",
+        details=details,
+    )
 
 
 def live_network_beta_evidence(
@@ -7621,6 +7774,8 @@ def collect_source_artifacts(settings: Settings, out_dir: Path) -> list[str]:
         "interop-extended-summary.json": settings.interop_extended_summary,
         "performance-smoke-summary.json": settings.perf_smoke_summary,
         "app-platform-smoke-summary.json": settings.app_platform_summary,
+        "security-drills-summary.json": settings.security_drills_summary
+        or settings.workspace_root / "build/security-drills/security-drills-summary.json",
         "interop-smoke-report.md": settings.interop_smoke_summary.parent / "artifacts" / "interop-report.md",
         "interop-extended-report.md": settings.interop_extended_summary.parent / "artifacts" / "interop-report.md",
         "performance-smoke-report.md": settings.perf_smoke_summary.parent / "artifacts" / "perf-report.md",
@@ -8280,6 +8435,17 @@ def gather_evidence(settings: Settings, waiver_context: WaiverContext) -> list[E
             settings.mode,
         )
     )
+    security_item = security_drills_evidence(
+        settings.security_drills_summary,
+        settings.workspace_root,
+        settings.out_dir,
+        settings.mode,
+    )
+    app_platform_security_items = [
+        item for item in evidence if item.id == security_item.id
+    ]
+    evidence = [item for item in evidence if item.id != security_item.id]
+    evidence.append(combine_security_response_evidence(app_platform_security_items, security_item))
     evidence.extend(
         live_network_beta_evidence(
             settings.live_network_summary,
@@ -8549,6 +8715,11 @@ def settings_from_args(args: argparse.Namespace) -> Settings:
     live_network_beta_required = args.require_live_network_beta or env_flag("CRYPTAD_CERT_REQUIRE_LIVE_NETWORK_BETA")
     if live_network_beta_required:
         live_network_beta_enabled = True
+    security_drills_summary_arg = (
+        args.security_drills_summary
+        or args.security_response_summary
+        or os.environ.get("CRYPTAD_CERT_SECURITY_DRILLS_SUMMARY")
+    )
     return Settings(
         workspace_root=workspace_root,
         out_dir=out_dir,
@@ -8572,6 +8743,11 @@ def settings_from_args(args: argparse.Namespace) -> Settings:
         waiver_files=waiver_files,
         multi_node_soak_summary=resolve_path(workspace_root, args.multi_node_soak_summary),
         multi_node_soak_required=args.require_multi_node_soak,
+        security_drills_summary=(
+            resolve_path(workspace_root, Path(security_drills_summary_arg))
+            if security_drills_summary_arg
+            else None
+        ),
     )
 
 
@@ -8607,6 +8783,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--multi-node-soak-summary",
         type=Path,
         default=DEFAULT_OUT_DIR / "multi-node-beta-soak" / "summary.json",
+    )
+    parser.add_argument(
+        "--security-drills-summary",
+        type=Path,
+        default=None,
+        help="Redacted security response drill summary produced by security_response_runbook.py.",
+    )
+    parser.add_argument(
+        "--security-response-summary",
+        type=Path,
+        default=None,
+        help="Deprecated alias for --security-drills-summary.",
     )
     parser.add_argument("--live-network-beta", action="store_true", help="Expect optional live-network beta evidence.")
     parser.add_argument(
@@ -8692,6 +8880,14 @@ def run_self_test(repo_root: Path) -> None:
             out_dir / "multi-node-beta-soak/multi-node-beta-soak-summary.md",
             multi_node_beta_soak.render_report(multi_node_summary),
         )
+        security_drills_summary = out_dir / "security-drills/security-drills-summary.json"
+        security_response_runbook.drill_run_all(
+            repo_root / security_response_runbook.DEFAULT_MODEL,
+            out_dir / "security-drills",
+            security_drills_summary,
+            release_id="cryptad-production-beta-self-test",
+            generated_at=security_response_runbook.utc_now(),
+        )
         settings = Settings(
             workspace_root=workspace.resolve(),
             out_dir=out_dir.resolve(),
@@ -8706,10 +8902,54 @@ def run_self_test(repo_root: Path) -> None:
             live_network_beta_required=False,
             multi_node_soak_summary=out_dir / "multi-node-beta-soak/summary.json",
             multi_node_soak_required=False,
+            security_drills_summary=security_drills_summary,
             waivers={},
             metadata={"selfTest": "true"},
             skip_git_metadata=True,
             history_dir=workspace / "build/no-auto-history",
+        )
+        redaction_unsafe_security_drills = read_json(security_drills_summary)
+        assert isinstance(redaction_unsafe_security_drills, dict), security_drills_summary
+        redaction_unsafe_security_drills["redaction"] = {
+            "status": "fail",
+            "rawSensitiveMaterialExcluded": True,
+            "findings": ["safe redaction finding: support bundle material excluded"],
+        }
+        redaction_unsafe_security_drills_path = (
+            workspace / "redaction-unsafe-security-drills-summary.json"
+        )
+        write_json(redaction_unsafe_security_drills_path, redaction_unsafe_security_drills)
+        redaction_unsafe_security_item = security_drills_evidence(
+            redaction_unsafe_security_drills_path,
+            workspace.resolve(),
+            out_dir.resolve(),
+            "release-candidate",
+        )
+        assert redaction_unsafe_security_item.status == "fail", redaction_unsafe_security_item
+        assert (
+            "safe redaction finding: support bundle material excluded"
+            in redaction_unsafe_security_item.details.get("redactionFindings", [])
+        ), redaction_unsafe_security_item.details
+        production_beta_drills_summary = (
+            out_dir / "security-drills-production-beta/security-drills-summary.json"
+        )
+        security_response_runbook.drill_run_all(
+            repo_root / security_response_runbook.DEFAULT_MODEL,
+            out_dir / "security-drills-production-beta",
+            production_beta_drills_summary,
+            release_id="cryptad-production-beta-self-test",
+            generated_at=security_response_runbook.utc_now(),
+            mode="production-beta",
+        )
+        production_beta_security_item = security_drills_evidence(
+            production_beta_drills_summary,
+            workspace.resolve(),
+            out_dir.resolve(),
+            "release-candidate",
+        )
+        assert production_beta_security_item.status == "pass", production_beta_security_item
+        assert production_beta_security_item.details["mode"] == "production-beta", (
+            production_beta_security_item.details
         )
         write_json(
             settings.live_network_summary,
@@ -8738,6 +8978,35 @@ def run_self_test(repo_root: Path) -> None:
             settings.live_network_summary.parent / "live-network-beta-smoke-report.md",
             "# stale live report\n\nThis stale report should not be copied when live-network beta is disabled.\n",
         )
+        failing_app_platform_summary = read_json(settings.app_platform_summary)
+        assert failing_app_platform_summary is not None, settings.app_platform_summary
+        for entry in failing_app_platform_summary["evidence"]:
+            if entry.get("id") == "production-security.response-runbook":
+                entry["status"] = "fail"
+                entry["summary"] = "Security response runbook integration failed."
+                entry["details"] = {"checks": {"runbookDocExists": False}}
+                break
+        else:
+            raise AssertionError("production-security.response-runbook fixture evidence is missing")
+        failing_app_platform_summary_path = (
+            out_dir / "app-platform-smoke/failing-security-response-summary.json"
+        )
+        write_json(failing_app_platform_summary_path, failing_app_platform_summary)
+        failing_settings = dataclasses.replace(
+            settings,
+            app_platform_summary=failing_app_platform_summary_path,
+        )
+        failing_evidence_by_id = {
+            item.id: item for item in gather_evidence(failing_settings, WaiverContext())
+        }
+        failing_security_evidence = failing_evidence_by_id[
+            "production-security.response-runbook"
+        ]
+        assert failing_security_evidence.status == "fail", failing_security_evidence
+        assert failing_security_evidence.details["componentStatuses"] == {
+            "appPlatformRunbook": "fail",
+            "securityDrills": "pass",
+        }, failing_security_evidence.details
         summary, exit_code = run(settings)
         assert exit_code == 0, summary
         assert summary["status"] == "warn", summary

--- a/tools/release-certification/release_certification.py
+++ b/tools/release-certification/release_certification.py
@@ -1487,6 +1487,7 @@ def security_drill_artifact_file_validation(
     summary_path: Path,
     workspace_root: Path,
     out_dir: Path,
+    strict: bool,
 ) -> dict[str, Any]:
     artifacts = summary.get("artifacts")
     if not isinstance(artifacts, list):
@@ -1502,6 +1503,20 @@ def security_drill_artifact_file_validation(
     expected_release_id = summary.get("releaseId")
     expected_mode = summary.get("mode")
     expected_evidence_mode = summary.get("evidenceMode")
+    summary_generated_at = security_response_runbook.parse_timestamp(summary.get("generatedAt"))
+    evaluated_at = summary_generated_at or dt.datetime.now(dt.timezone.utc)
+    max_age_days_value = summary.get("maxAgeDays")
+    max_age_days = security_response_runbook.DEFAULT_MAX_AGE_DAYS
+    if (
+        isinstance(max_age_days_value, int)
+        and not isinstance(max_age_days_value, bool)
+        and max_age_days_value > 0
+    ):
+        max_age_days = (
+            min(max_age_days_value, security_response_runbook.DEFAULT_MAX_AGE_DAYS)
+            if strict
+            else max_age_days_value
+        )
     errors: list[str] = []
     redaction_findings: list[Any] = []
     seen: set[str] = set()
@@ -1556,6 +1571,9 @@ def security_drill_artifact_file_validation(
             )
             continue
         artifact_status = "pass"
+        stale = False
+        age_days: int | None = None
+        stale_reason = ""
         if entry.get("digest") != digest:
             errors.append(f"security drill artifact digest mismatch for {scenario_text}")
             artifact_status = "fail"
@@ -1581,6 +1599,17 @@ def security_drill_artifact_file_validation(
             if artifact.get("evidenceMode") != expected_evidence_mode:
                 errors.append(f"security drill artifact for {scenario_text} has the wrong evidenceMode")
                 artifact_status = "fail"
+            if strict:
+                stale, age_days, stale_reason = security_response_runbook.artifact_is_stale(
+                    artifact,
+                    evaluated_at,
+                    max_age_days,
+                )
+                if stale:
+                    errors.append(
+                        f"security drill artifact for {scenario_text} is stale: {stale_reason}"
+                    )
+                    artifact_status = "fail"
         checked.append(
             {
                 "scenario": scenario_text,
@@ -1588,6 +1617,9 @@ def security_drill_artifact_file_validation(
                 "path": display_artifact,
                 "digest": digest,
                 "status": artifact_status,
+                "ageDays": age_days,
+                "stale": stale,
+                "staleReason": stale_reason,
             }
         )
     for scenario in sorted(set(security_response_runbook.REQUIRED_DRILLS) - seen):
@@ -1632,6 +1664,7 @@ def security_drills_evidence(
         source_path,
         workspace_root,
         out_dir,
+        strict=mode == "release-candidate",
     )
     counts = summary.get("counts") if isinstance(summary.get("counts"), dict) else {}
     redaction = summary.get("redaction") if isinstance(summary.get("redaction"), dict) else {}
@@ -9104,6 +9137,37 @@ def run_self_test(repo_root: Path) -> None:
             "security drill artifact for reviewer-key-compromise failed offline verification" == error
             for error in tampered_artifacts_item.details.get("validationErrors", [])
         ), tampered_artifacts_item.details
+        stale_artifacts_dir = workspace / "security-drills-stale-artifacts"
+        stale_artifacts_summary = stale_artifacts_dir / "security-drills-summary.json"
+        fresh_summary_generated_at = security_response_runbook.utc_now()
+        fresh_summary_time = security_response_runbook.parse_timestamp(fresh_summary_generated_at)
+        assert fresh_summary_time is not None, fresh_summary_generated_at
+        stale_artifact_generated_at = (
+            fresh_summary_time
+            - dt.timedelta(days=security_response_runbook.DEFAULT_MAX_AGE_DAYS + 2)
+        ).isoformat().replace("+00:00", "Z")
+        security_response_runbook.drill_run_all(
+            repo_root / security_response_runbook.DEFAULT_MODEL,
+            stale_artifacts_dir,
+            stale_artifacts_summary,
+            release_id="cryptad-production-beta-self-test",
+            generated_at=stale_artifact_generated_at,
+        )
+        stale_summary = read_json(stale_artifacts_summary)
+        assert isinstance(stale_summary, dict), stale_artifacts_summary
+        stale_summary["generatedAt"] = fresh_summary_generated_at
+        write_json(stale_artifacts_summary, stale_summary)
+        stale_artifacts_item = security_drills_evidence(
+            stale_artifacts_summary,
+            workspace.resolve(),
+            out_dir.resolve(),
+            "release-candidate",
+        )
+        assert stale_artifacts_item.status == "fail", stale_artifacts_item
+        assert any(
+            str(error).startswith("security drill artifact for reviewer-key-compromise is stale:")
+            for error in stale_artifacts_item.details.get("validationErrors", [])
+        ), stale_artifacts_item.details
         redaction_unsafe_security_drills = read_json(security_drills_summary)
         assert isinstance(redaction_unsafe_security_drills, dict), security_drills_summary
         redaction_unsafe_security_drills["redaction"] = {

--- a/tools/release-certification/run-release-certification.sh
+++ b/tools/release-certification/run-release-certification.sh
@@ -16,6 +16,8 @@ MULTI_NODE_MODE="${CRYPTAD_CERT_MULTI_NODE_MODE:-}"
 MULTI_NODE_MODE_PROVIDED=0
 MULTI_NODE_SOAK_CONFIG="${CRYPTAD_CERT_MULTI_NODE_SOAK_CONFIG:-}"
 REQUIRE_MULTI_NODE_SOAK="${CRYPTAD_CERT_REQUIRE_MULTI_NODE_SOAK:-0}"
+SECURITY_DRILLS_SUMMARY="${CRYPTAD_CERT_SECURITY_DRILLS_SUMMARY:-}"
+SECURITY_DRILLS_SUMMARY_PROVIDED=0
 SKIP_GRADLE_ARG=()
 LIVE_ARGS=()
 LIVE_NETWORK_ARGS=()
@@ -30,6 +32,9 @@ if [[ -n "$MULTI_NODE_SOAK_SUMMARY" ]]; then
 fi
 if [[ -n "$MULTI_NODE_MODE" ]]; then
   MULTI_NODE_MODE_PROVIDED=1
+fi
+if [[ -n "$SECURITY_DRILLS_SUMMARY" ]]; then
+  SECURITY_DRILLS_SUMMARY_PROVIDED=1
 fi
 
 normalize_flag() {
@@ -132,6 +137,16 @@ while [[ $# -gt 0 ]]; do
       REQUIRE_MULTI_NODE_SOAK=1
       shift
       ;;
+    --security-drills-summary|--security-response-summary)
+      SECURITY_DRILLS_SUMMARY="$2"
+      SECURITY_DRILLS_SUMMARY_PROVIDED=1
+      shift 2
+      ;;
+    --security-drills-summary=*|--security-response-summary=*)
+      SECURITY_DRILLS_SUMMARY="${1#*=}"
+      SECURITY_DRILLS_SUMMARY_PROVIDED=1
+      shift
+      ;;
     --form-password)
       echo "--form-password is not supported; set CRYPTAD_CERT_FORM_PASSWORD in the environment." >&2
       exit 2
@@ -212,6 +227,19 @@ case "$MULTI_NODE_SOAK_SUMMARY" in
     ;;
 esac
 MULTI_NODE_SOAK_OUT_DIR="$(dirname "$MULTI_NODE_SOAK_SUMMARY")"
+
+case "$SECURITY_DRILLS_SUMMARY" in
+  "")
+    SECURITY_DRILLS_SUMMARY_PROVIDED=0
+    SECURITY_DRILLS_SUMMARY="$OUT_DIR/security-drills/security-drills-summary.json"
+    ;;
+  /*)
+    ;;
+  *)
+    SECURITY_DRILLS_SUMMARY="$ROOT_DIR/$SECURITY_DRILLS_SUMMARY"
+    ;;
+esac
+SECURITY_DRILLS_OUT_DIR="$(dirname "$SECURITY_DRILLS_SUMMARY")"
 
 if [[ -n "$MULTI_NODE_SOAK_CONFIG" ]]; then
   case "$MULTI_NODE_SOAK_CONFIG" in
@@ -300,6 +328,21 @@ if [[ "$MULTI_NODE_SOAK_SUMMARY_PROVIDED" != "1" ]]; then
     "$MULTI_NODE_SOAK_OUT_DIR/multi-node-beta-soak-summary.json" \
     "$MULTI_NODE_SOAK_OUT_DIR/multi-node-beta-soak-summary.md"
 fi
+if [[ "$SECURITY_DRILLS_SUMMARY_PROVIDED" != "1" ]]; then
+  rm -rf "$SECURITY_DRILLS_OUT_DIR"
+fi
+
+set +e
+(
+  cd "$ROOT_DIR" &&
+    python3 "$ROOT_DIR/tools/release-certification/security_response_runbook.py" verify
+)
+SECURITY_RUNBOOK_EXIT=$?
+set -e
+if [[ "$SECURITY_RUNBOOK_EXIT" -ne 0 ]]; then
+  echo "Security response runbook verification exited with $SECURITY_RUNBOOK_EXIT; certification aggregation will record" \
+    "the evidence state." >&2
+fi
 
 if [[ "$SKIP_APP_SMOKE" != "1" ]]; then
   set +e
@@ -373,6 +416,44 @@ if [[ "$MULTI_NODE_SOAK_SUMMARY_PROVIDED" != "1" ]]; then
   fi
 fi
 
+if [[ "$SECURITY_DRILLS_SUMMARY_PROVIDED" != "1" ]]; then
+  mkdir -p "$SECURITY_DRILLS_OUT_DIR"
+  set +e
+  (
+    cd "$ROOT_DIR" &&
+      python3 "$ROOT_DIR/tools/release-certification/security_response_runbook.py" drill run-all \
+        --out-dir "$SECURITY_DRILLS_OUT_DIR" \
+        --summary-out "$SECURITY_DRILLS_SUMMARY" \
+        --release-id "cryptad-cert-${MODE}" \
+        --mode "$MODE" \
+        --release-notes-out "$OUT_DIR/security/security-release-notes-draft.md"
+  )
+  SECURITY_DRILL_RUN_EXIT=$?
+  set -e
+  if [[ "$SECURITY_DRILL_RUN_EXIT" -ne 0 ]]; then
+    echo "Security response drill generation exited with $SECURITY_DRILL_RUN_EXIT; certification aggregation will record" \
+      "the evidence state." >&2
+  fi
+fi
+
+if [[ "$SECURITY_DRILLS_SUMMARY_PROVIDED" != "1" ]]; then
+  set +e
+  (
+    cd "$ROOT_DIR" &&
+      python3 "$ROOT_DIR/tools/release-certification/security_response_runbook.py" drill verify-all \
+        --input-dir "$SECURITY_DRILLS_OUT_DIR" \
+        --summary-out "$SECURITY_DRILLS_SUMMARY" \
+        --release-id "cryptad-cert-${MODE}" \
+        --mode "$MODE"
+  )
+  SECURITY_DRILL_VERIFY_EXIT=$?
+  set -e
+  if [[ "$SECURITY_DRILL_VERIFY_EXIT" -ne 0 ]]; then
+    echo "Security response drill verification exited with $SECURITY_DRILL_VERIFY_EXIT; certification aggregation will record" \
+      "the evidence state." >&2
+  fi
+fi
+
 exec python3 "$ROOT_DIR/tools/release-certification/release_certification.py" \
   --workspace-root "$ROOT_DIR" \
   --out-dir "$OUT_DIR" \
@@ -381,5 +462,6 @@ exec python3 "$ROOT_DIR/tools/release-certification/release_certification.py" \
   --live-network-summary "$LIVE_NETWORK_SUMMARY" \
   --network-scale-soak-summary "$NETWORK_SCALE_SOAK_SUMMARY" \
   --multi-node-soak-summary "$MULTI_NODE_SOAK_SUMMARY" \
+  --security-drills-summary "$SECURITY_DRILLS_SUMMARY" \
   "${CERT_LIVE_ARGS[@]}" \
   "${CERT_ARGS[@]}"

--- a/tools/release-certification/security_response_runbook.py
+++ b/tools/release-certification/security_response_runbook.py
@@ -1105,6 +1105,11 @@ def validate_drill_artifact_files(
             errors.append(f"security drill artifact for {scenario_text} has the wrong evidenceMode")
             artifact_status = "fail"
         if strict:
+            if artifact.get("fixtureOnly") is True:
+                errors.append(
+                    f"security drill artifact for {scenario_text} must not be fixtureOnly"
+                )
+                artifact_status = "fail"
             stale, age_days, stale_reason = artifact_is_stale(artifact, evaluated_at, max_age_days)
             if stale:
                 errors.append(f"security drill artifact for {scenario_text} is stale: {stale_reason}")
@@ -2066,6 +2071,33 @@ def self_test() -> dict[str, Any]:
         fixture_summary["promotionReady"] = False
         checks["productionRejectsFixtureOnly"] = (
             validate_drills_summary(fixture_summary, production=True)["status"] == "fail"
+        )
+        fixture_artifacts_dir = tmpdir / "fixture-artifacts"
+        fixture_artifacts_summary_path = fixture_artifacts_dir / "security-drills-summary.json"
+        fixture_artifacts_summary = drill_run_all(
+            DEFAULT_MODEL,
+            fixture_artifacts_dir,
+            fixture_artifacts_summary_path,
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+            fixture_only=True,
+        )
+        fixture_artifacts_summary["fixtureOnly"] = False
+        fixture_artifacts_summary["nonRelease"] = False
+        fixture_artifacts_summary["promotionReady"] = True
+        write_json(fixture_artifacts_summary_path, fixture_artifacts_summary)
+        fixture_artifacts_validation = validate_drill_artifact_files(
+            fixture_artifacts_summary,
+            fixture_artifacts_summary_path,
+            strict=True,
+            now=dt.datetime(2026, 7, 3, tzinfo=dt.timezone.utc),
+        )
+        checks["rejectFixtureOnlyArtifactsInStrictValidation"] = (
+            fixture_artifacts_validation["status"] == "fail"
+            and any(
+                str(error) == "security drill artifact for reviewer-key-compromise must not be fixtureOnly"
+                for error in fixture_artifacts_validation.get("errors", [])
+            )
         )
 
     failures = [name for name, ok in checks.items() if not ok]

--- a/tools/release-certification/security_response_runbook.py
+++ b/tools/release-certification/security_response_runbook.py
@@ -4,18 +4,29 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
+import hashlib
 import json
 import re
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
 
 TOOL_NAME = "security-response-runbook"
 SCHEMA_VERSION = 1
+DRILL_ARTIFACT_SCHEMA_VERSION = 2
+DRILL_SUMMARY_SCHEMA_VERSION = 1
 DEFAULT_RUNBOOK = Path("docs/production-security-response-runbook.md")
 DEFAULT_MODEL = Path("tools/release-certification/production-security-response-runbook.json")
 DEFAULT_TEMPLATE = Path("docs/templates/security-release-notes.md")
+DEFAULT_GENERATED_AT = "1970-01-01T00:00:00Z"
+DEFAULT_RELEASE_ID = "cryptad-production-beta-security-drill"
+DEFAULT_MAX_AGE_DAYS = 30
+NON_RELEASE_DRILL_MODES = ("developer-dry-run", "pr", "nightly")
+RELEASE_DRILL_MODES = ("release-candidate", "production-beta")
+DRILL_MODES = (*NON_RELEASE_DRILL_MODES, *RELEASE_DRILL_MODES)
 REQUIRED_DRILLS = (
     "vulnerable-app-version",
     "app-signing-key-compromise",
@@ -25,6 +36,7 @@ REQUIRED_DRILLS = (
     "emergency-replacement-app",
     "support-bundle-intake-redaction",
 )
+DRILL_OUTPUT_FILENAMES = {scenario: f"{scenario}.json" for scenario in REQUIRED_DRILLS}
 REQUIRED_DRILL_FIELDS = (
     "id",
     "severity",
@@ -142,6 +154,30 @@ FORBIDDEN_CREDENTIAL_PATTERNS = (
         ),
     ),
     (
+        "raw support bundle marker",
+        re.compile(
+            r"\braw[-_ ]?support[-_ ]?bundle"
+            r"(?:[-_ ]?(?:body|bodies|content|payload|payloads))?\s*[:=]\s*\S",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "raw app-service body marker",
+        re.compile(
+            r"\braw[-_ ]?app[-_ ]?service[-_ ]?(?:body|bodies|payload|payloads)\s*[:=]\s*\S",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "raw profile feed trust social marker",
+        re.compile(
+            r"\braw[-_ ]?(?:profile|feed|trust|social|backup|signature)"
+            r"(?:[-_ ]?(?:document|documents|body|bodies|content|payload|payloads|value|values))?"
+            r"\s*[:=]\s*\S",
+            re.IGNORECASE,
+        ),
+    ),
+    (
         "raw fetched content marker",
         re.compile(
             r"\braw[-_ ]?fetched[-_ ]?content\s*[:=]\s*\S",
@@ -228,6 +264,25 @@ FORBIDDEN_JSON_KEY_NAMES = {
     "rawappdatapayloads",
     "rawappdatarecord",
     "rawappdatarecords",
+    "rawsupportbundle",
+    "rawsupportbundlebody",
+    "rawsupportbundlepayload",
+    "rawprofiledocument",
+    "rawprofilebody",
+    "rawfeedbody",
+    "rawfeeddocument",
+    "rawtrustdocument",
+    "rawtruststatement",
+    "rawtruststatementbody",
+    "rawsocialdocument",
+    "rawsocialmessage",
+    "rawsocialmessagebody",
+    "rawsignature",
+    "rawsignaturevalue",
+    "rawappservicebody",
+    "rawappservicepayload",
+    "rawbackupmaterial",
+    "rawbackuppayload",
     "rawfetchedcontent",
     "rawfetchedbody",
     "rawpublickeybytes",
@@ -243,6 +298,14 @@ FORBIDDEN_JSON_KEY_FRAGMENTS = (
     "authorization",
     "credential",
     "rawappdata",
+    "rawsupportbundle",
+    "rawprofile",
+    "rawfeed",
+    "rawtrust",
+    "rawsocial",
+    "rawsignature",
+    "rawappservice",
+    "rawbackup",
     "privatekey",
     "browsersession",
     "appsession",
@@ -252,6 +315,83 @@ FORBIDDEN_JSON_KEY_FRAGMENTS = (
     "rawfetchedbody",
     "secret",
     "token",
+)
+
+SCENARIO_SAFE_SUMMARIES = {
+    "vulnerable-app-version": "Exact app-version denylist, update guidance, scheduler rejection, installed vulnerable status, and support-bundle redaction evidence were verified.",
+    "app-signing-key-compromise": "Compromised app signing-key policy, exact-version denylist, replacement guidance, scheduler rejection, receipt refresh, and artifact redaction evidence were verified.",
+    "reviewer-key-compromise": "Reviewer key revocation, receipt revocation, transparency-log replacement state, trusted-review fail-closed behavior, Web Shell warning visibility, and redacted release notes were verified.",
+    "catalog-signing-key-rotation": "Catalog signing-key rotation status, old/new key display, signature verification, mirror rollback safety, emergency advisory refresh, and artifact redaction evidence were verified.",
+    "malicious-catalog-entry": "Malformed, downgrade, duplicate, and unknown-advisory catalog security entry rejection plus signed refresh and operator visibility evidence were verified.",
+    "emergency-replacement-app": "Emergency replacement metadata, signed and reviewed replacement gating, permission/data-migration/backup gates, operator guidance, and private-URI-free release notes were verified.",
+    "support-bundle-intake-redaction": "Support-bundle intake redaction fixtures, safe counts and digests, production blocker semantics, and release note/advisory redaction were verified.",
+}
+
+SCENARIO_RELEASE_SNIPPETS = {
+    "vulnerable-app-version": "Scenario vulnerable-app-version: exact affected app versions are denylisted; operators receive bounded update and safe uninstall guidance.",
+    "app-signing-key-compromise": "Scenario app-signing-key-compromise: affected versions are blocked and replacement signing-key guidance is published without private key material.",
+    "reviewer-key-compromise": "Scenario reviewer-key-compromise: revoked reviewer evidence no longer satisfies trusted-review-required policy; replacement review status is summarized without raw signatures.",
+    "catalog-signing-key-rotation": "Scenario catalog-signing-key-rotation: old and new catalog key identifiers are summarized and all emergency refreshes remain signature-verified.",
+    "malicious-catalog-entry": "Scenario malicious-catalog-entry: unsafe catalog metadata is rejected and corrected advisory or denylist status is visible to operators.",
+    "emergency-replacement-app": "Scenario emergency-replacement-app: replacement version guidance preserves signature, review, permission, migration, and backup gates.",
+    "support-bundle-intake-redaction": "Scenario support-bundle-intake-redaction: support evidence is handled through redacted previews with raw private material excluded.",
+}
+
+SCENARIO_STEP_IDS = {
+    "vulnerable-app-version": (
+        "verify-exact-version-denylist",
+        "verify-safe-guidance",
+        "verify-scheduler-denylist-gates",
+        "verify-installed-status-and-support-redaction",
+    ),
+    "app-signing-key-compromise": (
+        "represent-compromised-app-signing-key",
+        "denylist-affected-versions",
+        "stage-verified-replacement-only",
+        "reissue-or-revoke-review-receipts",
+    ),
+    "reviewer-key-compromise": (
+        "revoke-reviewer-key",
+        "revoke-affected-review-receipts",
+        "record-transparency-log-replacement",
+        "fail-closed-trusted-review-policy",
+    ),
+    "catalog-signing-key-rotation": (
+        "record-catalog-key-rotation",
+        "show-safe-old-and-new-key-ids",
+        "reject-unsigned-or-wrong-key-catalogs",
+        "verify-emergency-advisory-refresh",
+    ),
+    "malicious-catalog-entry": (
+        "reject-malformed-catalog-security-entries",
+        "preserve-signature-authority",
+        "block-silent-install-or-update",
+        "show-advisory-and-denylist-status",
+    ),
+    "emergency-replacement-app": (
+        "represent-emergency-replacement",
+        "require-signature-review-and-channel-compatibility",
+        "preserve-permission-migration-and-backup-gates",
+        "show-safe-replacement-guidance",
+    ),
+    "support-bundle-intake-redaction": (
+        "reject-sensitive-support-bundle-fixtures",
+        "emit-safe-redaction-counts-and-digests",
+        "mark-redaction-failures-critical",
+        "keep-release-notes-redacted",
+    ),
+}
+
+REDACTION_PATTERNS_CHECKED = (
+    "private-key",
+    "private-insert-uri",
+    "token",
+    "raw-content",
+    "raw-app-data",
+    "raw-support-bundle",
+    "raw-profile-feed-trust-social",
+    "raw-signature",
+    "local-path",
 )
 FORBIDDEN_JSON_KEY_SUFFIXES = (
     "token",
@@ -418,6 +558,9 @@ def validate_model(model: dict[str, Any]) -> dict[str, Any]:
         drills = model_drills(model)
     except ValueError as exc:
         return {"ok": False, "errors": [str(exc)], "drillIds": []}
+    unknown_drills = sorted(set(drills) - set(REQUIRED_DRILLS))
+    for drill_id in unknown_drills:
+        errors.append(f"unknown required drill: {drill_id}")
     for drill_id in REQUIRED_DRILLS:
         drill = drills.get(drill_id)
         if drill is None:
@@ -456,6 +599,18 @@ def forbidden_findings(*texts: str) -> list[str]:
     if CONTENT_KEY_URI_RE.search(rendered):
         findings.append("content key URI marker")
     return findings
+
+
+def safe_redaction_findings(findings: list[Any]) -> list[str]:
+    safe: list[str] = []
+    for finding in findings:
+        text = str(finding)
+        if forbidden_findings(text):
+            text = "redaction finding omitted sensitive material"
+        if len(text) > MAX_DRILL_TEXT_LENGTH:
+            text = text[:MAX_DRILL_TEXT_LENGTH].rstrip()
+        safe.append(text)
+    return list(dict.fromkeys(safe))
 
 
 def verify_runbook(runbook: Path, model_path: Path, template: Path) -> dict[str, Any]:
@@ -498,18 +653,173 @@ def write_json(path: Path, value: Any) -> None:
     path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
-def drill_create(model_path: Path, scenario: str, out: Path) -> dict[str, Any]:
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def sha256_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def sha256_path(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return "sha256:" + digest.hexdigest()
+
+
+def parse_timestamp(value: Any) -> dt.datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(dt.timezone.utc)
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def normalize_status(value: Any) -> str:
+    text = str(value).strip().lower()
+    return text if text in {"pass", "warn", "fail", "missing", "stale"} else "missing"
+
+
+def scenario_digest(drill: dict[str, Any]) -> str:
+    return sha256_text(canonical_json(drill))
+
+
+def release_notes_snippet(scenario: str, drill: dict[str, Any]) -> str:
+    snippet = SCENARIO_RELEASE_SNIPPETS.get(
+        scenario,
+        f"Scenario {scenario}: {drill.get('releaseNotesTemplate', 'redacted release notes')} verified.",
+    )
+    findings = forbidden_findings(snippet)
+    findings.extend(forbidden_json_key_findings({"snippet": snippet}))
+    if findings:
+        raise ValueError(f"release notes snippet for {scenario} is not redaction-safe")
+    return snippet
+
+
+def drill_steps(scenario: str, drill: dict[str, Any]) -> list[dict[str, Any]]:
+    evidence = list(drill.get("verificationEvidence", []))
+    step_ids = SCENARIO_STEP_IDS.get(scenario, ("verify-runbook-scenario",))
+    summary = SCENARIO_SAFE_SUMMARIES.get(scenario, f"{scenario} operational response path verified.")
+    steps: list[dict[str, Any]] = []
+    for index, step_id in enumerate(step_ids):
+        evidence_id = evidence[index % len(evidence)] if evidence else "production-security.response-runbook"
+        steps.append(
+            {
+                "id": step_id,
+                "status": "pass",
+                "safeSummary": summary,
+                "evidenceIds": [evidence_id],
+            }
+        )
+    return steps
+
+
+def validate_drill_steps(
+    scenario: str,
+    drill: dict[str, Any],
+    steps: list[Any],
+) -> list[str]:
+    errors: list[str] = []
+    expected_steps = drill_steps(scenario, drill)
+    expected_step_ids = [step["id"] for step in expected_steps]
+    actual_step_ids = [step.get("id") if isinstance(step, dict) else None for step in steps]
+    if actual_step_ids != expected_step_ids:
+        errors.append("steps must match the expected runbook scenario step ids")
+    for index, expected_step in enumerate(expected_steps):
+        if index >= len(steps) or not isinstance(steps[index], dict):
+            continue
+        if steps[index].get("evidenceIds") != expected_step.get("evidenceIds"):
+            errors.append(f"steps[{index}].evidenceIds must match the runbook scenario")
+    return errors
+
+
+def drill_artifact(
+    model: dict[str, Any],
+    drill: dict[str, Any],
+    scenario: str,
+    release_id: str,
+    generated_at: str,
+    mode: str,
+    evidence_mode: str,
+    fixture_only: bool,
+) -> dict[str, Any]:
+    redaction_findings = forbidden_findings(*json_string_values(drill))
+    redaction_findings.extend(forbidden_json_key_findings(drill))
+    redaction_status = "pass" if not redaction_findings else "fail"
+    return {
+        "kind": "cryptad-security-response-drill",
+        "schemaVersion": DRILL_ARTIFACT_SCHEMA_VERSION,
+        "scenario": scenario,
+        "generatedAt": generated_at,
+        "releaseId": release_id,
+        "mode": mode,
+        "evidenceMode": evidence_mode,
+        "fixtureOnly": fixture_only,
+        "status": "pass" if redaction_status == "pass" else "fail",
+        "severity": drill.get("severity"),
+        "runbookScenarioDigest": scenario_digest(drill),
+        "verificationEvidence": list(drill.get("verificationEvidence", [])),
+        "steps": drill_steps(scenario, drill),
+        "releaseNotes": {
+            "templateStatus": "pass",
+            "template": drill.get("releaseNotesTemplate"),
+            "redactedSnippet": release_notes_snippet(scenario, drill),
+        },
+        "advisoryTemplate": {
+            "templateStatus": "pass",
+            "redactedSnippet": release_notes_snippet(scenario, drill),
+        },
+        "redaction": {
+            "status": redaction_status,
+            "patternsChecked": list(REDACTION_PATTERNS_CHECKED),
+            "rawSensitiveMaterialExcluded": True,
+            "findings": redaction_findings,
+        },
+    }
+
+
+def drill_summary_non_release(mode: str, fixture_only: bool) -> bool:
+    return fixture_only or mode.strip().lower() not in RELEASE_DRILL_MODES
+
+
+def drill_create(
+    model_path: Path,
+    scenario: str,
+    out: Path,
+    release_id: str = DEFAULT_RELEASE_ID,
+    generated_at: str | None = None,
+    mode: str = "release-candidate",
+    evidence_mode: str = "release-operations",
+    fixture_only: bool = False,
+) -> dict[str, Any]:
     model = load_model(model_path)
     drills = model_drills(model)
     drill = drills.get(scenario)
     if drill is None:
         raise ValueError(f"unknown scenario: {scenario}")
-    artifact = {
-        "schemaVersion": SCHEMA_VERSION,
-        "kind": "cryptad-security-response-drill",
-        "scenario": scenario,
-        "drill": drill,
-    }
+    artifact = drill_artifact(
+        model,
+        drill,
+        scenario,
+        release_id,
+        generated_at or utc_now(),
+        mode,
+        evidence_mode,
+        fixture_only,
+    )
     write_json(out, artifact)
     return artifact
 
@@ -519,8 +829,9 @@ def validate_drill_artifact_envelope(
     drill: dict[str, Any] | None,
 ) -> list[str]:
     errors: list[str] = []
-    if value.get("schemaVersion") != SCHEMA_VERSION:
-        errors.append(f"schemaVersion must be {SCHEMA_VERSION}")
+    schema_version = value.get("schemaVersion")
+    if schema_version not in {SCHEMA_VERSION, DRILL_ARTIFACT_SCHEMA_VERSION}:
+        errors.append(f"schemaVersion must be {SCHEMA_VERSION} or {DRILL_ARTIFACT_SCHEMA_VERSION}")
     scenario = value.get("scenario")
     if not isinstance(scenario, str) or not scenario:
         errors.append("scenario must be a non-empty string")
@@ -529,12 +840,95 @@ def validate_drill_artifact_envelope(
     return errors
 
 
-def drill_verify(path: Path) -> dict[str, Any]:
+def validate_v2_drill_artifact(value: dict[str, Any], model_path: Path = DEFAULT_MODEL) -> dict[str, Any]:
+    errors: list[str] = []
+    scenario = value.get("scenario")
+    drill: dict[str, Any] | None = None
+    if not isinstance(scenario, str) or scenario not in REQUIRED_DRILLS:
+        errors.append("scenario must be one of the required production drills")
+    else:
+        try:
+            drill = model_drills(load_model(model_path)).get(scenario)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            errors.append(f"runbook model could not be loaded: {exc}")
+    if value.get("kind") != "cryptad-security-response-drill":
+        errors.append("kind must be cryptad-security-response-drill")
+    if value.get("schemaVersion") != DRILL_ARTIFACT_SCHEMA_VERSION:
+        errors.append(f"schemaVersion must be {DRILL_ARTIFACT_SCHEMA_VERSION}")
+    if normalize_status(value.get("status")) != "pass":
+        errors.append("status must be pass")
+    if parse_timestamp(value.get("generatedAt")) is None:
+        errors.append("generatedAt must be an ISO-8601 UTC timestamp")
+    release_id = value.get("releaseId")
+    if not isinstance(release_id, str) or not release_id.strip():
+        errors.append("releaseId must be a non-empty string")
+    if drill is not None:
+        if value.get("severity") != drill.get("severity"):
+            errors.append("severity must match runbook scenario")
+        if value.get("runbookScenarioDigest") != scenario_digest(drill):
+            errors.append("runbookScenarioDigest must match the runbook scenario")
+        evidence = value.get("verificationEvidence")
+        if evidence != drill.get("verificationEvidence"):
+            errors.append("verificationEvidence must match the runbook scenario")
+    steps = value.get("steps")
+    if not isinstance(steps, list) or not steps:
+        errors.append("steps must be a non-empty array")
+    else:
+        for index, step in enumerate(steps):
+            if not isinstance(step, dict):
+                errors.append(f"steps[{index}] must be an object")
+                continue
+            if normalize_status(step.get("status")) != "pass":
+                errors.append(f"steps[{index}].status must be pass")
+            if not isinstance(step.get("safeSummary"), str) or not step.get("safeSummary"):
+                errors.append(f"steps[{index}].safeSummary must be a non-empty string")
+            if not isinstance(step.get("evidenceIds"), list) or not step.get("evidenceIds"):
+                errors.append(f"steps[{index}].evidenceIds must be a non-empty array")
+        if drill is not None and isinstance(scenario, str):
+            errors.extend(validate_drill_steps(scenario, drill, steps))
+    release_notes = value.get("releaseNotes")
+    if not isinstance(release_notes, dict):
+        errors.append("releaseNotes must be an object")
+    else:
+        if release_notes.get("templateStatus") != "pass":
+            errors.append("releaseNotes.templateStatus must be pass")
+        snippet = release_notes.get("redactedSnippet")
+        if not isinstance(snippet, str) or not snippet.strip():
+            errors.append("releaseNotes.redactedSnippet must be a non-empty string")
+    advisory_template = value.get("advisoryTemplate")
+    if not isinstance(advisory_template, dict):
+        errors.append("advisoryTemplate must be an object")
+    else:
+        if advisory_template.get("templateStatus") != "pass":
+            errors.append("advisoryTemplate.templateStatus must be pass")
+        snippet = advisory_template.get("redactedSnippet")
+        if not isinstance(snippet, str) or not snippet.strip():
+            errors.append("advisoryTemplate.redactedSnippet must be a non-empty string")
+    redaction = value.get("redaction")
+    if not isinstance(redaction, dict):
+        errors.append("redaction must be an object")
+    else:
+        if redaction.get("status") != "pass":
+            errors.append("redaction.status must be pass")
+        if redaction.get("rawSensitiveMaterialExcluded") is not True:
+            errors.append("redaction.rawSensitiveMaterialExcluded must be true")
+        findings = redaction.get("findings")
+        if not isinstance(findings, list) or findings:
+            errors.append("redaction.findings must be an empty array")
+    return {"ok": not errors, "errors": errors, "drillIds": [scenario] if isinstance(scenario, str) else []}
+
+
+def drill_verify(path: Path, model_path: Path = DEFAULT_MODEL) -> dict[str, Any]:
     value = load_model(path)
     redaction_findings = forbidden_findings(*json_string_values(value))
     redaction_findings.extend(forbidden_json_key_findings(value))
     redaction_clean = not redaction_findings
-    if value.get("kind") == "cryptad-security-response-drill":
+    if (
+        value.get("kind") == "cryptad-security-response-drill"
+        and value.get("schemaVersion") == DRILL_ARTIFACT_SCHEMA_VERSION
+    ):
+        result = validate_v2_drill_artifact(value, model_path)
+    elif value.get("kind") == "cryptad-security-response-drill":
         drill = value.get("drill")
         envelope_errors = validate_drill_artifact_envelope(
             value,
@@ -567,6 +961,937 @@ def drill_verify(path: Path) -> dict[str, Any]:
         "status": "pass" if ok else "fail",
         "errors": errors,
         "redactionClean": redaction_clean,
+        "redactionFindings": safe_redaction_findings(redaction_findings),
+    }
+
+
+def artifact_is_stale(
+    artifact: dict[str, Any], now: dt.datetime, max_age_days: int
+) -> tuple[bool, int | None, str]:
+    generated_at = parse_timestamp(artifact.get("generatedAt"))
+    if generated_at is None:
+        return True, None, "generatedAt is missing or malformed"
+    if generated_at > now + dt.timedelta(minutes=5):
+        return True, None, "generatedAt is in the future"
+    age = now - generated_at
+    age_days = max(0, age.days)
+    if age > dt.timedelta(days=max_age_days):
+        return True, age_days, f"generatedAt is older than {max_age_days} days"
+    return False, age_days, ""
+
+
+def release_notes_draft(artifacts: list[dict[str, Any]]) -> str:
+    lines = [
+        "# Security Release Notes Draft",
+        "",
+        "This draft is generated from redacted security response drill artifacts.",
+        "",
+    ]
+    for artifact in artifacts:
+        release_notes = artifact.get("releaseNotes") if isinstance(artifact, dict) else {}
+        snippet = release_notes.get("redactedSnippet") if isinstance(release_notes, dict) else ""
+        lines.extend(
+            [
+                f"## {artifact.get('scenario', 'unknown')}",
+                "",
+                str(snippet),
+                "",
+            ]
+        )
+    text = "\n".join(lines)
+    findings = forbidden_findings(text)
+    if findings:
+        raise ValueError("generated security release notes draft is not redaction-safe")
+    return text
+
+
+def write_release_notes_draft(path: Path, artifacts: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(release_notes_draft(artifacts), encoding="utf-8")
+
+
+def build_drill_summary(
+    artifacts: list[tuple[Path, dict[str, Any], dict[str, Any]]],
+    input_dir: Path,
+    release_id: str,
+    generated_at: str,
+    mode: str,
+    evidence_mode: str,
+    fixture_only: bool,
+    now: dt.datetime,
+    max_age_days: int,
+) -> dict[str, Any]:
+    by_scenario: dict[str, tuple[Path, dict[str, Any], dict[str, Any]]] = {}
+    malformed: list[str] = []
+    failed: list[str] = []
+    stale: list[str] = []
+    redaction_failed: list[str] = []
+    redaction_findings: list[Any] = []
+    artifact_entries: list[dict[str, Any]] = []
+    for path, artifact, verification in artifacts:
+        scenario = str(artifact.get("scenario", path.stem))
+        if scenario in by_scenario:
+            malformed.append(scenario)
+        by_scenario[scenario] = (path, artifact, verification)
+        if verification.get("status") != "pass":
+            failed.append(scenario)
+        if verification.get("redactionClean") is False:
+            redaction_failed.append(scenario)
+            findings = verification.get("redactionFindings")
+            if isinstance(findings, list):
+                redaction_findings.extend(safe_redaction_findings(findings))
+            else:
+                redaction_findings.append("artifact verifier redaction scan failed")
+        redaction = artifact.get("redaction") if isinstance(artifact.get("redaction"), dict) else {}
+        if redaction.get("status") != "pass":
+            failed.append(scenario)
+            redaction_failed.append(scenario)
+        findings = redaction.get("findings") if isinstance(redaction, dict) else []
+        if isinstance(findings, list):
+            redaction_findings.extend(safe_redaction_findings(findings))
+        if artifact.get("releaseId") != release_id:
+            malformed.append(scenario)
+        if artifact.get("mode") != mode:
+            malformed.append(scenario)
+        if artifact.get("evidenceMode") != evidence_mode:
+            malformed.append(scenario)
+        is_stale, age_days, stale_reason = artifact_is_stale(artifact, now, max_age_days)
+        if is_stale:
+            stale.append(scenario)
+        artifact_entries.append(
+            {
+                "scenario": scenario,
+                "status": normalize_status(artifact.get("status")),
+                "digest": sha256_path(path) if path.is_file() else "",
+                "artifact": path.name,
+                "ageDays": age_days,
+                "stale": is_stale,
+                "staleReason": stale_reason,
+                "releaseNotesTemplateStatus": (
+                    artifact.get("releaseNotes", {}).get("templateStatus")
+                    if isinstance(artifact.get("releaseNotes"), dict)
+                    else "missing"
+                ),
+                "advisoryTemplateStatus": (
+                    artifact.get("advisoryTemplate", {}).get("templateStatus")
+                    if isinstance(artifact.get("advisoryTemplate"), dict)
+                    else "missing"
+                ),
+            }
+        )
+    missing = [scenario for scenario in REQUIRED_DRILLS if scenario not in by_scenario]
+    unknown = sorted(set(by_scenario) - set(REQUIRED_DRILLS))
+    passed = [
+        scenario
+        for scenario in REQUIRED_DRILLS
+        if scenario in by_scenario and scenario not in set(failed + stale + malformed)
+    ]
+    redaction_status = (
+        "pass"
+        if not redaction_findings
+        and not redaction_failed
+        and not any(entry.get("status") == "fail" for entry in artifact_entries)
+        else "fail"
+    )
+    status = "pass"
+    if missing or failed or stale or malformed or unknown or redaction_status != "pass":
+        status = "fail"
+    non_release = drill_summary_non_release(mode, fixture_only)
+    promotion_ready = status == "pass" and not non_release
+    return {
+        "kind": "cryptad-security-response-drills-summary",
+        "schemaVersion": DRILL_SUMMARY_SCHEMA_VERSION,
+        "tool": TOOL_NAME,
+        "generatedAt": generated_at,
+        "releaseId": release_id,
+        "mode": mode,
+        "evidenceMode": evidence_mode,
+        "fixtureOnly": fixture_only,
+        "nonRelease": non_release,
+        "status": status,
+        "promotionReady": promotion_ready,
+        "maxAgeDays": max_age_days,
+        "requiredScenarios": list(REQUIRED_DRILLS),
+        "passedScenarios": passed,
+        "failedScenarios": sorted(set(failed)),
+        "missingScenarios": missing,
+        "staleScenarios": sorted(set(stale)),
+        "malformedScenarios": sorted(set(malformed + unknown)),
+        "redaction": {
+            "status": redaction_status,
+            "patternsChecked": list(REDACTION_PATTERNS_CHECKED),
+            "rawSensitiveMaterialExcluded": redaction_status == "pass",
+            "findings": safe_redaction_findings(redaction_findings),
+        },
+        "releaseNotes": {
+            "templateStatus": "pass"
+            if all(entry.get("releaseNotesTemplateStatus") == "pass" for entry in artifact_entries)
+            else "fail"
+        },
+        "advisoryTemplate": {
+            "templateStatus": "pass"
+            if all(entry.get("advisoryTemplateStatus") == "pass" for entry in artifact_entries)
+            else "fail"
+        },
+        "counts": {
+            "required": len(REQUIRED_DRILLS),
+            "passed": len(passed),
+            "failed": len(set(failed)),
+            "missing": len(missing),
+            "stale": len(set(stale)),
+            "malformed": len(set(malformed + unknown)),
+        },
+        "artifacts": sorted(artifact_entries, key=lambda item: str(item.get("scenario", ""))),
+        "artifactDirectory": input_dir.name,
+    }
+
+
+def drill_run_all(
+    model_path: Path,
+    out_dir: Path,
+    summary_out: Path,
+    release_id: str = DEFAULT_RELEASE_ID,
+    generated_at: str | None = None,
+    mode: str = "release-candidate",
+    evidence_mode: str = "release-operations",
+    fixture_only: bool = False,
+    max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+    release_notes_out: Path | None = None,
+) -> dict[str, Any]:
+    timestamp = generated_at or utc_now()
+    artifacts: list[tuple[Path, dict[str, Any], dict[str, Any]]] = []
+    artifact_values: list[dict[str, Any]] = []
+    for scenario in REQUIRED_DRILLS:
+        path = out_dir / DRILL_OUTPUT_FILENAMES[scenario]
+        artifact = drill_create(
+            model_path,
+            scenario,
+            path,
+            release_id=release_id,
+            generated_at=timestamp,
+            mode=mode,
+            evidence_mode=evidence_mode,
+            fixture_only=fixture_only,
+        )
+        verification = drill_verify(path, model_path)
+        artifacts.append((path, artifact, verification))
+        artifact_values.append(artifact)
+    if release_notes_out is not None:
+        write_release_notes_draft(release_notes_out, artifact_values)
+    now = parse_timestamp(timestamp) or dt.datetime.now(dt.timezone.utc)
+    summary = build_drill_summary(
+        artifacts,
+        out_dir,
+        release_id,
+        timestamp,
+        mode,
+        evidence_mode,
+        fixture_only,
+        now,
+        max_age_days,
+    )
+    summary_findings = forbidden_findings(*json_string_values(summary))
+    summary_findings.extend(forbidden_json_key_findings(summary))
+    if summary_findings:
+        summary["status"] = "fail"
+        summary["promotionReady"] = False
+        summary["redaction"]["status"] = "fail"
+        summary["redaction"]["rawSensitiveMaterialExcluded"] = False
+        summary["redaction"]["findings"] = [
+            *summary["redaction"].get("findings", []),
+            *safe_redaction_findings(summary_findings),
+        ]
+    write_json(summary_out, summary)
+    return summary
+
+
+def drill_verify_all(
+    input_dir: Path,
+    summary_out: Path,
+    model_path: Path = DEFAULT_MODEL,
+    release_id: str | None = None,
+    generated_at: str | None = None,
+    mode: str | None = None,
+    evidence_mode: str | None = None,
+    fixture_only: bool = False,
+    max_age_days: int = DEFAULT_MAX_AGE_DAYS,
+    now_text: str | None = None,
+) -> dict[str, Any]:
+    existing_summary: dict[str, Any] = {}
+    if summary_out.is_file():
+        try:
+            existing_summary = load_model(summary_out)
+        except (OSError, ValueError, json.JSONDecodeError):
+            existing_summary = {}
+    now = parse_timestamp(now_text) if now_text else None
+    if now is None:
+        now = dt.datetime.now(dt.timezone.utc)
+    artifacts: list[tuple[Path, dict[str, Any], dict[str, Any]]] = []
+    for scenario in REQUIRED_DRILLS:
+        path = input_dir / DRILL_OUTPUT_FILENAMES[scenario]
+        if not path.is_file():
+            continue
+        try:
+            artifact = load_model(path)
+            verification = drill_verify(path, model_path)
+        except (OSError, ValueError, json.JSONDecodeError) as exc:
+            artifact = {
+                "scenario": scenario,
+                "status": "fail",
+                "generatedAt": "",
+                "redaction": {"status": "fail", "findings": [str(exc)]},
+            }
+            verification = {"status": "fail", "ok": False, "errors": [str(exc)]}
+        artifacts.append((path, artifact, verification))
+    timestamp = generated_at or str(existing_summary.get("generatedAt") or "")
+    if parse_timestamp(timestamp) is None:
+        artifact_timestamps = [
+            (parse_timestamp(artifact.get("generatedAt")), str(artifact.get("generatedAt")))
+            for _, artifact, _ in artifacts
+            if parse_timestamp(artifact.get("generatedAt")) is not None
+        ]
+        if artifact_timestamps:
+            timestamp = max(
+                artifact_timestamps,
+                key=lambda item: item[0] or dt.datetime.min.replace(tzinfo=dt.timezone.utc),
+            )[1]
+        else:
+            timestamp = utc_now()
+    if release_id is None:
+        summary_release_id = existing_summary.get("releaseId")
+        artifact_release_ids = [
+            artifact.get("releaseId")
+            for _, artifact, _ in artifacts
+            if isinstance(artifact.get("releaseId"), str) and artifact.get("releaseId")
+        ]
+        if isinstance(summary_release_id, str) and summary_release_id:
+            release_id = summary_release_id
+        elif artifact_release_ids:
+            release_id = str(artifact_release_ids[0])
+        else:
+            release_id = DEFAULT_RELEASE_ID
+    if mode is None:
+        summary_mode = existing_summary.get("mode")
+        artifact_modes = [
+            artifact.get("mode")
+            for _, artifact, _ in artifacts
+            if isinstance(artifact.get("mode"), str) and artifact.get("mode")
+        ]
+        if isinstance(summary_mode, str) and summary_mode:
+            mode = summary_mode
+        elif artifact_modes:
+            mode = str(artifact_modes[0])
+        else:
+            mode = "release-candidate"
+    if evidence_mode is None:
+        summary_evidence_mode = existing_summary.get("evidenceMode")
+        artifact_evidence_modes = [
+            artifact.get("evidenceMode")
+            for _, artifact, _ in artifacts
+            if isinstance(artifact.get("evidenceMode"), str) and artifact.get("evidenceMode")
+        ]
+        if isinstance(summary_evidence_mode, str) and summary_evidence_mode:
+            evidence_mode = summary_evidence_mode
+        elif artifact_evidence_modes:
+            evidence_mode = str(artifact_evidence_modes[0])
+        else:
+            evidence_mode = "release-operations"
+    fixture_only = fixture_only or bool(existing_summary.get("fixtureOnly")) or any(
+        bool(artifact.get("fixtureOnly")) for _, artifact, _ in artifacts
+    )
+    summary = build_drill_summary(
+        artifacts,
+        input_dir,
+        release_id,
+        timestamp,
+        mode,
+        evidence_mode,
+        fixture_only,
+        now,
+        max_age_days,
+    )
+    summary_findings = forbidden_findings(*json_string_values(summary))
+    summary_findings.extend(forbidden_json_key_findings(summary))
+    if summary_findings:
+        summary["status"] = "fail"
+        summary["promotionReady"] = False
+        summary["redaction"]["status"] = "fail"
+        summary["redaction"]["rawSensitiveMaterialExcluded"] = False
+        summary["redaction"]["findings"] = [
+            *summary["redaction"].get("findings", []),
+            *safe_redaction_findings(summary_findings),
+        ]
+    write_json(summary_out, summary)
+    return summary
+
+
+def non_bool_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def validate_drills_summary(
+    summary: dict[str, Any],
+    production: bool = False,
+    strict: bool = False,
+    now: dt.datetime | None = None,
+    expected_mode: str | None = None,
+) -> dict[str, Any]:
+    errors: list[str] = []
+    strict = strict or production
+    expected_mode_normalized = str(expected_mode or "").strip().lower()
+    if production and not expected_mode_normalized:
+        expected_mode_normalized = "production-beta"
+    if summary.get("kind") != "cryptad-security-response-drills-summary":
+        errors.append("kind must be cryptad-security-response-drills-summary")
+    if summary.get("schemaVersion") != DRILL_SUMMARY_SCHEMA_VERSION:
+        errors.append(f"schemaVersion must be {DRILL_SUMMARY_SCHEMA_VERSION}")
+    release_id = summary.get("releaseId")
+    if not isinstance(release_id, str) or not release_id.strip():
+        errors.append("releaseId must be a non-empty string")
+    generated_at = parse_timestamp(summary.get("generatedAt"))
+    if generated_at is None:
+        errors.append("generatedAt must be an ISO-8601 UTC timestamp")
+    max_age_days_value = summary.get("maxAgeDays")
+    max_age_days = DEFAULT_MAX_AGE_DAYS
+    if not non_bool_int(max_age_days_value) or int(max_age_days_value) <= 0:
+        errors.append("maxAgeDays must be a positive integer")
+    else:
+        max_age_days = int(max_age_days_value)
+    effective_max_age_days = (
+        min(max_age_days, DEFAULT_MAX_AGE_DAYS)
+        if strict
+        else max_age_days
+    )
+    summary_mode = str(summary.get("mode", "")).strip().lower()
+    fixture_only = summary.get("fixtureOnly") is True
+    expected_non_release = drill_summary_non_release(summary_mode, fixture_only)
+    if normalize_status(summary.get("status")) != "pass":
+        errors.append("status must be pass")
+    if expected_non_release:
+        if summary.get("nonRelease") is not True:
+            errors.append("nonRelease must be true for non-release drill summaries")
+        if summary.get("promotionReady") is not False:
+            errors.append("promotionReady must be false for non-release drill summaries")
+    elif summary.get("promotionReady") is not True:
+        errors.append("promotionReady must be true")
+    required = summary.get("requiredScenarios")
+    if required != list(REQUIRED_DRILLS):
+        errors.append("requiredScenarios must match required production drills")
+    passed = summary.get("passedScenarios")
+    if passed != list(REQUIRED_DRILLS):
+        errors.append("passedScenarios must match required production drills")
+    for field in ("failedScenarios", "missingScenarios", "staleScenarios", "malformedScenarios"):
+        values = summary.get(field)
+        if not isinstance(values, list):
+            errors.append(f"{field} must be an array")
+        elif values:
+            errors.append(f"{field} must be empty")
+    counts = summary.get("counts")
+    expected_counts = {
+        "required": len(REQUIRED_DRILLS),
+        "passed": len(REQUIRED_DRILLS),
+        "failed": 0,
+        "missing": 0,
+        "stale": 0,
+        "malformed": 0,
+    }
+    if not isinstance(counts, dict):
+        errors.append("counts must be an object")
+    else:
+        for field, expected in expected_counts.items():
+            value = counts.get(field)
+            if not non_bool_int(value) or int(value) != expected:
+                errors.append(f"counts.{field} must be {expected}")
+    artifacts = summary.get("artifacts")
+    if not isinstance(artifacts, list):
+        errors.append("artifacts must be an array")
+    else:
+        artifact_scenarios: list[str] = []
+        for index, artifact in enumerate(artifacts):
+            if not isinstance(artifact, dict):
+                errors.append(f"artifacts[{index}] must be an object")
+                continue
+            scenario = artifact.get("scenario")
+            if scenario not in REQUIRED_DRILLS:
+                errors.append(f"artifacts[{index}].scenario must be a required production drill")
+            else:
+                artifact_scenarios.append(str(scenario))
+            if normalize_status(artifact.get("status")) != "pass":
+                errors.append(f"artifacts[{index}].status must be pass")
+            digest = artifact.get("digest")
+            if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+                errors.append(f"artifacts[{index}].digest must be a sha256 digest")
+            if artifact.get("stale") is not False:
+                errors.append(f"artifacts[{index}].stale must be false")
+            if artifact.get("releaseNotesTemplateStatus") != "pass":
+                errors.append(f"artifacts[{index}].releaseNotesTemplateStatus must be pass")
+            if artifact.get("advisoryTemplateStatus") != "pass":
+                errors.append(f"artifacts[{index}].advisoryTemplateStatus must be pass")
+        if set(artifact_scenarios) != set(REQUIRED_DRILLS) or len(artifact_scenarios) != len(REQUIRED_DRILLS):
+            errors.append("artifacts must cover each required production drill exactly once")
+        elif len(set(artifact_scenarios)) != len(artifact_scenarios):
+            errors.append("artifacts must not duplicate production drill scenarios")
+    release_notes = summary.get("releaseNotes")
+    if not isinstance(release_notes, dict):
+        errors.append("releaseNotes must be an object")
+    elif release_notes.get("templateStatus") != "pass":
+        errors.append("releaseNotes.templateStatus must be pass")
+    advisory_template = summary.get("advisoryTemplate")
+    if not isinstance(advisory_template, dict):
+        errors.append("advisoryTemplate must be an object")
+    elif advisory_template.get("templateStatus") != "pass":
+        errors.append("advisoryTemplate.templateStatus must be pass")
+    redaction_findings: list[Any] = []
+    redaction = summary.get("redaction")
+    if not isinstance(redaction, dict):
+        errors.append("redaction must be an object")
+        redaction_findings.append("security response drills summary redaction metadata is missing")
+    else:
+        if redaction.get("status") != "pass":
+            errors.append("redaction.status must be pass")
+            redaction_findings.append("security response drills summary redaction status is not pass")
+        findings = redaction.get("findings")
+        if not isinstance(findings, list):
+            errors.append("redaction.findings must be an empty array")
+            redaction_findings.append("security response drills summary redaction findings are malformed")
+        elif findings:
+            errors.append("redaction.findings must be an empty array")
+            redaction_findings.extend(safe_redaction_findings(findings))
+        if redaction.get("rawSensitiveMaterialExcluded") is not True:
+            errors.append("redaction.rawSensitiveMaterialExcluded must be true")
+            redaction_findings.append(
+                "security response drills summary raw sensitive material exclusion is not proven"
+            )
+    if strict:
+        if summary.get("nonRelease") is not False:
+            errors.append("strict drills summary must not be nonRelease")
+        if summary.get("fixtureOnly") is True:
+            errors.append("strict drills summary must not be fixtureOnly")
+        if summary_mode not in RELEASE_DRILL_MODES:
+            errors.append("strict drills summary mode must be release-candidate or production-beta")
+        elif expected_mode_normalized and summary_mode != expected_mode_normalized:
+            errors.append(f"strict drills summary mode must match {expected_mode_normalized}")
+    if strict:
+        evaluated_at = now or dt.datetime.now(dt.timezone.utc)
+        evaluated_at = evaluated_at.astimezone(dt.timezone.utc)
+        if generated_at is not None:
+            if generated_at > evaluated_at + dt.timedelta(minutes=5):
+                errors.append("generatedAt must not be in the future")
+            elif evaluated_at - generated_at > dt.timedelta(days=effective_max_age_days):
+                errors.append("drills summary is stale")
+    scanner_redaction_findings = forbidden_findings(*json_string_values(summary))
+    scanner_redaction_findings.extend(forbidden_json_key_findings(summary))
+    redaction_findings.extend(scanner_redaction_findings)
+    safe_findings = safe_redaction_findings(redaction_findings)
+    if scanner_redaction_findings:
+        errors.append("summary redaction scan failed")
+    return {
+        "ok": not errors,
+        "status": "pass" if not errors else "fail",
+        "errors": errors,
+        "redactionClean": not safe_findings,
+        "redactionFindings": safe_findings,
+    }
+
+
+def clone_json(value: Any) -> Any:
+    return json.loads(json.dumps(value))
+
+
+def self_test() -> dict[str, Any]:
+    checks: dict[str, bool] = {}
+    verify_result = verify_runbook(DEFAULT_RUNBOOK, DEFAULT_MODEL, DEFAULT_TEMPLATE)
+    checks["verifyRunbook"] = verify_result["status"] == "pass"
+    model = load_model(DEFAULT_MODEL)
+    drills = model_drills(model)
+    with tempfile.TemporaryDirectory(prefix="cryptad-security-drills-") as tmp:
+        tmpdir = Path(tmp)
+        reviewer_artifact = tmpdir / "reviewer-key-compromise.json"
+        artifact = drill_create(
+            DEFAULT_MODEL,
+            "reviewer-key-compromise",
+            reviewer_artifact,
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+        )
+        checks["createReviewerDrill"] = reviewer_artifact.is_file()
+        checks["verifyReviewerDrill"] = drill_verify(reviewer_artifact)["status"] == "pass"
+        missing_step_artifact = clone_json(artifact)
+        missing_step_artifact["steps"] = missing_step_artifact["steps"][:1]
+        missing_step_path = tmpdir / "reviewer-key-compromise-missing-step.json"
+        write_json(missing_step_path, missing_step_artifact)
+        checks["rejectMissingDrillStep"] = drill_verify(missing_step_path)["status"] == "fail"
+        wrong_step_evidence_artifact = clone_json(artifact)
+        wrong_step_evidence_artifact["steps"][0]["evidenceIds"] = ["production-security.response-runbook"]
+        wrong_step_evidence_path = tmpdir / "reviewer-key-compromise-wrong-step-evidence.json"
+        write_json(wrong_step_evidence_path, wrong_step_evidence_artifact)
+        checks["rejectWrongDrillStepEvidence"] = (
+            drill_verify(wrong_step_evidence_path)["status"] == "fail"
+        )
+
+        summary = drill_run_all(
+            DEFAULT_MODEL,
+            tmpdir / "all",
+            tmpdir / "security-drills-summary.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+            release_notes_out=tmpdir / "security-release-notes-draft.md",
+        )
+        checks["runAllDrills"] = summary["status"] == "pass" and summary["promotionReady"] is True
+        verified_summary = drill_verify_all(
+            tmpdir / "all",
+            tmpdir / "verified-security-drills-summary.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+            now_text="2026-07-03T00:00:00Z",
+        )
+        checks["verifyAllDrills"] = verified_summary["status"] == "pass"
+        checks["validateDrillsSummary"] = validate_drills_summary(verified_summary)["status"] == "pass"
+        missing_release_id_summary = clone_json(verified_summary)
+        missing_release_id_summary.pop("releaseId", None)
+        checks["rejectSummaryMissingReleaseId"] = (
+            validate_drills_summary(missing_release_id_summary)["status"] == "fail"
+        )
+        checks["validateDrillsSummaryStrictReleaseCandidate"] = (
+            validate_drills_summary(
+                verified_summary,
+                strict=True,
+                expected_mode="release-candidate",
+                now=dt.datetime(2026, 7, 3, tzinfo=dt.timezone.utc),
+            )["status"]
+            == "pass"
+        )
+        production_mode_summary = clone_json(verified_summary)
+        production_mode_summary["mode"] = "production-beta"
+        checks["validateDrillsSummaryProductionMode"] = (
+            validate_drills_summary(
+                production_mode_summary,
+                production=True,
+                now=dt.datetime(2026, 7, 3, tzinfo=dt.timezone.utc),
+            )["status"]
+            == "pass"
+        )
+        for non_release_mode in NON_RELEASE_DRILL_MODES:
+            mode_summary = drill_run_all(
+                DEFAULT_MODEL,
+                tmpdir / non_release_mode,
+                tmpdir / f"{non_release_mode}-summary.json",
+                release_id="cryptad-production-beta-self-test",
+                generated_at="2026-07-03T00:00:00Z",
+                mode=non_release_mode,
+            )
+            checks[f"{non_release_mode}SummaryNonRelease"] = (
+                mode_summary["status"] == "pass"
+                and mode_summary["nonRelease"] is True
+                and mode_summary["promotionReady"] is False
+                and validate_drills_summary(mode_summary)["status"] == "pass"
+                and validate_drills_summary(mode_summary, strict=True)["status"] == "fail"
+                and validate_drills_summary(mode_summary, production=True)["status"] == "fail"
+            )
+        unknown_mode_summary = clone_json(verified_summary)
+        unknown_mode_summary["mode"] = "prod"
+        checks["rejectUnknownStrictMode"] = (
+            validate_drills_summary(
+                unknown_mode_summary,
+                strict=True,
+                expected_mode="release-candidate",
+                now=dt.datetime(2026, 7, 3, tzinfo=dt.timezone.utc),
+            )["status"]
+            == "fail"
+        )
+        checks["rejectWrongProductionMode"] = (
+            validate_drills_summary(
+                verified_summary,
+                production=True,
+                now=dt.datetime(2026, 7, 3, tzinfo=dt.timezone.utc),
+            )["status"]
+            == "fail"
+        )
+        redaction_status_summary = clone_json(verified_summary)
+        redaction_status_summary["redaction"]["status"] = "fail"
+        redaction_status_summary["redaction"]["findings"] = []
+        redaction_status_summary["redaction"]["rawSensitiveMaterialExcluded"] = True
+        redaction_status_validation = validate_drills_summary(
+            redaction_status_summary,
+            strict=True,
+            expected_mode="release-candidate",
+            now=dt.datetime(2026, 7, 3, tzinfo=dt.timezone.utc),
+        )
+        checks["redactionStatusFailureSynthesizesFinding"] = (
+            redaction_status_validation["status"] == "fail"
+            and bool(redaction_status_validation.get("redactionFindings"))
+        )
+        minimal_summary = {
+            "kind": "cryptad-security-response-drills-summary",
+            "schemaVersion": DRILL_SUMMARY_SCHEMA_VERSION,
+            "generatedAt": "2026-07-03T00:00:00Z",
+            "maxAgeDays": DEFAULT_MAX_AGE_DAYS,
+            "status": "pass",
+            "promotionReady": True,
+            "requiredScenarios": list(REQUIRED_DRILLS),
+            "failedScenarios": [],
+            "missingScenarios": [],
+            "staleScenarios": [],
+            "malformedScenarios": [],
+            "redaction": {
+                "status": "pass",
+                "findings": [],
+                "rawSensitiveMaterialExcluded": True,
+            },
+        }
+        checks["rejectMinimalSelfReportedSummary"] = (
+            validate_drills_summary(minimal_summary)["status"] == "fail"
+        )
+        incomplete_artifact_summary = clone_json(verified_summary)
+        incomplete_artifact_summary["artifacts"] = incomplete_artifact_summary["artifacts"][:-1]
+        checks["rejectIncompleteArtifactCoverage"] = (
+            validate_drills_summary(incomplete_artifact_summary)["status"] == "fail"
+        )
+        stale_summary = clone_json(verified_summary)
+        stale_summary["generatedAt"] = "2026-05-01T00:00:00Z"
+        checks["rejectStaleProductionSummary"] = (
+            validate_drills_summary(
+                stale_summary,
+                production=True,
+                now=dt.datetime(2026, 7, 3, tzinfo=dt.timezone.utc),
+            )["status"]
+            == "fail"
+        )
+        checks["rejectStaleStrictSummary"] = (
+            validate_drills_summary(
+                stale_summary,
+                strict=True,
+                now=dt.datetime(2026, 7, 3, tzinfo=dt.timezone.utc),
+            )["status"]
+            == "fail"
+        )
+        stale_extended_summary = clone_json(stale_summary)
+        stale_extended_summary["mode"] = "production-beta"
+        stale_extended_summary["maxAgeDays"] = 3650
+        stale_extended_production_validation = validate_drills_summary(
+            stale_extended_summary,
+            production=True,
+            now=dt.datetime(2026, 7, 3, tzinfo=dt.timezone.utc),
+        )
+        checks["rejectStaleProductionSummaryExtendedMaxAge"] = (
+            stale_extended_production_validation["status"] == "fail"
+            and "drills summary is stale" in stale_extended_production_validation.get("errors", [])
+        )
+        stale_extended_strict_summary = clone_json(stale_summary)
+        stale_extended_strict_summary["maxAgeDays"] = 3650
+        stale_extended_strict_validation = validate_drills_summary(
+            stale_extended_strict_summary,
+            strict=True,
+            expected_mode="release-candidate",
+            now=dt.datetime(2026, 7, 3, tzinfo=dt.timezone.utc),
+        )
+        checks["rejectStaleStrictSummaryExtendedMaxAge"] = (
+            stale_extended_strict_validation["status"] == "fail"
+            and "drills summary is stale" in stale_extended_strict_validation.get("errors", [])
+        )
+
+        private_key_artifact = clone_json(artifact)
+        private_key_artifact["privateKey"] = "redacted-fixture"
+        private_key_path = tmpdir / "private-key.json"
+        write_json(private_key_path, private_key_artifact)
+        checks["rejectPrivateKey"] = drill_verify(private_key_path)["status"] == "fail"
+
+        private_uri_artifact = clone_json(artifact)
+        private_uri_artifact["releaseNotes"]["redactedSnippet"] = "Contains USK@example/private"
+        private_uri_path = tmpdir / "private-uri.json"
+        write_json(private_uri_path, private_uri_artifact)
+        checks["rejectPrivateInsertUri"] = drill_verify(private_uri_path)["status"] == "fail"
+
+        raw_support_artifact = clone_json(artifact)
+        raw_support_artifact["rawSupportBundleBody"] = "payload"
+        raw_support_path = tmpdir / "raw-support.json"
+        write_json(raw_support_path, raw_support_artifact)
+        checks["rejectRawSupportBundleBody"] = drill_verify(raw_support_path)["status"] == "fail"
+
+        raw_app_data_artifact = clone_json(artifact)
+        raw_app_data_artifact["rawAppDataValue"] = "payload"
+        raw_app_data_path = tmpdir / "raw-app-data.json"
+        write_json(raw_app_data_path, raw_app_data_artifact)
+        checks["rejectRawAppData"] = drill_verify(raw_app_data_path)["status"] == "fail"
+
+        local_path_artifact = clone_json(artifact)
+        local_path_artifact["releaseNotes"]["redactedSnippet"] = "Do not expose /tmp/cryptad/private.key"
+        local_path = tmpdir / "local-path.json"
+        write_json(local_path, local_path_artifact)
+        checks["rejectAbsoluteLocalPath"] = drill_verify(local_path)["status"] == "fail"
+
+        advisory_template_artifact = clone_json(artifact)
+        advisory_template_artifact["advisoryTemplate"]["templateStatus"] = "fail"
+        advisory_template_path = tmpdir / "advisory-template-fail.json"
+        write_json(advisory_template_path, advisory_template_artifact)
+        checks["rejectAdvisoryTemplateFailure"] = (
+            drill_verify(advisory_template_path)["status"] == "fail"
+        )
+
+        malformed_path = tmpdir / "malformed.json"
+        write_json(malformed_path, {"kind": "cryptad-security-response-drill", "schemaVersion": 2})
+        checks["rejectMalformedEnvelope"] = drill_verify(malformed_path)["status"] == "fail"
+
+        unknown_model = clone_json(model)
+        unknown = clone_json(drills["reviewer-key-compromise"])
+        unknown["id"] = "unknown-required-scenario"
+        unknown_model["drills"].append(unknown)
+        checks["rejectUnknownRequiredScenario"] = not validate_model(unknown_model)["ok"]
+
+        missing_dir = tmpdir / "missing"
+        drill_run_all(
+            DEFAULT_MODEL,
+            missing_dir,
+            tmpdir / "missing-summary.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+        )
+        (missing_dir / DRILL_OUTPUT_FILENAMES["reviewer-key-compromise"]).unlink()
+        missing_summary = drill_verify_all(
+            missing_dir,
+            tmpdir / "missing-summary-verified.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+            now_text="2026-07-03T00:00:00Z",
+        )
+        checks["verifyAllRejectsMissingScenario"] = missing_summary["status"] == "fail"
+
+        failed_dir = tmpdir / "failed"
+        drill_run_all(
+            DEFAULT_MODEL,
+            failed_dir,
+            tmpdir / "failed-summary.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+        )
+        failed_path = failed_dir / DRILL_OUTPUT_FILENAMES["reviewer-key-compromise"]
+        failed_artifact = load_model(failed_path)
+        failed_artifact["status"] = "fail"
+        write_json(failed_path, failed_artifact)
+        failed_summary = drill_verify_all(
+            failed_dir,
+            tmpdir / "failed-summary-verified.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+            now_text="2026-07-03T00:00:00Z",
+        )
+        checks["verifyAllRejectsFailedScenario"] = failed_summary["status"] == "fail"
+
+        redaction_dir = tmpdir / "redaction"
+        drill_run_all(
+            DEFAULT_MODEL,
+            redaction_dir,
+            tmpdir / "redaction-summary.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+        )
+        redaction_path = redaction_dir / DRILL_OUTPUT_FILENAMES["reviewer-key-compromise"]
+        redaction_artifact = load_model(redaction_path)
+        redaction_artifact["redaction"]["status"] = "fail"
+        redaction_artifact["redaction"]["findings"] = ["raw support bundle marker"]
+        write_json(redaction_path, redaction_artifact)
+        redaction_summary = drill_verify_all(
+            redaction_dir,
+            tmpdir / "redaction-summary-verified.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+            now_text="2026-07-03T00:00:00Z",
+        )
+        checks["verifyAllRejectsRedactionFailure"] = redaction_summary["status"] == "fail"
+
+        verifier_redaction_dir = tmpdir / "verifier-redaction"
+        drill_run_all(
+            DEFAULT_MODEL,
+            verifier_redaction_dir,
+            tmpdir / "verifier-redaction-summary.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+        )
+        verifier_redaction_path = (
+            verifier_redaction_dir / DRILL_OUTPUT_FILENAMES["reviewer-key-compromise"]
+        )
+        verifier_redaction_artifact = load_model(verifier_redaction_path)
+        verifier_redaction_artifact["privateKey"] = "redacted-fixture"
+        write_json(verifier_redaction_path, verifier_redaction_artifact)
+        verifier_redaction_summary = drill_verify_all(
+            verifier_redaction_dir,
+            tmpdir / "verifier-redaction-summary-verified.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+            now_text="2026-07-03T00:00:00Z",
+        )
+        checks["verifyAllPropagatesVerifierRedactionFailure"] = (
+            verifier_redaction_summary["status"] == "fail"
+            and verifier_redaction_summary["redaction"]["status"] == "fail"
+            and bool(verifier_redaction_summary["redaction"]["findings"])
+        )
+
+        release_mismatch_dir = tmpdir / "release-mismatch"
+        drill_run_all(
+            DEFAULT_MODEL,
+            release_mismatch_dir,
+            tmpdir / "release-mismatch-summary.json",
+            release_id="cryptad-production-beta-old",
+            generated_at="2026-07-03T00:00:00Z",
+        )
+        release_mismatch_summary = drill_verify_all(
+            release_mismatch_dir,
+            tmpdir / "release-mismatch-summary-verified.json",
+            release_id="cryptad-production-beta-current",
+            generated_at="2026-07-03T00:00:00Z",
+            now_text="2026-07-03T00:00:00Z",
+        )
+        checks["verifyAllRejectsReleaseIdMismatch"] = (
+            release_mismatch_summary["status"] == "fail"
+            and release_mismatch_summary["counts"]["malformed"] == len(REQUIRED_DRILLS)
+        )
+
+        mode_mismatch_dir = tmpdir / "mode-mismatch"
+        drill_run_all(
+            DEFAULT_MODEL,
+            mode_mismatch_dir,
+            tmpdir / "mode-mismatch-summary.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+            mode="developer-dry-run",
+        )
+        mode_mismatch_summary = drill_verify_all(
+            mode_mismatch_dir,
+            tmpdir / "mode-mismatch-summary-verified.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-07-03T00:00:00Z",
+            mode="release-candidate",
+            now_text="2026-07-03T00:00:00Z",
+        )
+        checks["verifyAllRejectsModeMismatch"] = (
+            mode_mismatch_summary["status"] == "fail"
+            and mode_mismatch_summary["counts"]["malformed"] == len(REQUIRED_DRILLS)
+        )
+
+        stale_summary = drill_verify_all(
+            tmpdir / "all",
+            tmpdir / "stale-summary-verified.json",
+            release_id="cryptad-production-beta-self-test",
+            generated_at="2026-08-05T00:00:00Z",
+            now_text="2026-08-05T00:00:00Z",
+        )
+        checks["verifyAllRejectsStaleScenario"] = stale_summary["status"] == "fail"
+
+        fixture_summary = clone_json(summary)
+        fixture_summary["fixtureOnly"] = True
+        fixture_summary["nonRelease"] = True
+        fixture_summary["promotionReady"] = False
+        checks["productionRejectsFixtureOnly"] = (
+            validate_drills_summary(fixture_summary, production=True)["status"] == "fail"
+        )
+
+    failures = [name for name, ok in checks.items() if not ok]
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "tool": TOOL_NAME,
+        "status": "pass" if not failures else "fail",
+        "checks": checks,
+        "errors": failures,
     }
 
 
@@ -606,14 +1931,44 @@ def build_parser() -> argparse.ArgumentParser:
     verify.add_argument("--model", type=Path, default=DEFAULT_MODEL)
     verify.add_argument("--template", type=Path, default=DEFAULT_TEMPLATE)
 
+    subparsers.add_parser("self-test", help="Run deterministic runbook and drill negative tests.")
+
     drill = subparsers.add_parser("drill", help="Create or verify drill artifacts.")
     drill_sub = drill.add_subparsers(dest="drill_command", required=True)
     create = drill_sub.add_parser("create", help="Create one deterministic drill artifact.")
     create.add_argument("--scenario", required=True)
     create.add_argument("--out", type=Path, required=True)
     create.add_argument("--model", type=Path, default=DEFAULT_MODEL)
+    create.add_argument("--release-id", default=DEFAULT_RELEASE_ID)
+    create.add_argument("--generated-at")
+    create.add_argument("--mode", choices=DRILL_MODES, default="release-candidate")
+    create.add_argument("--evidence-mode", default="release-operations")
+    create.add_argument("--fixture-only", action="store_true")
     verify_drill = drill_sub.add_parser("verify", help="Verify a drill artifact or model.")
     verify_drill.add_argument("--input", type=Path, required=True)
+    verify_drill.add_argument("--model", type=Path, default=DEFAULT_MODEL)
+    run_all = drill_sub.add_parser("run-all", help="Create all required drill artifacts and a summary.")
+    run_all.add_argument("--out-dir", type=Path, required=True)
+    run_all.add_argument("--summary-out", type=Path, required=True)
+    run_all.add_argument("--model", type=Path, default=DEFAULT_MODEL)
+    run_all.add_argument("--release-id", default=DEFAULT_RELEASE_ID)
+    run_all.add_argument("--generated-at")
+    run_all.add_argument("--mode", choices=DRILL_MODES, default="release-candidate")
+    run_all.add_argument("--evidence-mode", default="release-operations")
+    run_all.add_argument("--fixture-only", action="store_true")
+    run_all.add_argument("--max-age-days", type=int, default=DEFAULT_MAX_AGE_DAYS)
+    run_all.add_argument("--release-notes-out", type=Path)
+    verify_all = drill_sub.add_parser("verify-all", help="Verify all required drill artifacts and write a summary.")
+    verify_all.add_argument("--input-dir", type=Path, required=True)
+    verify_all.add_argument("--summary-out", type=Path, required=True)
+    verify_all.add_argument("--model", type=Path, default=DEFAULT_MODEL)
+    verify_all.add_argument("--release-id")
+    verify_all.add_argument("--generated-at")
+    verify_all.add_argument("--mode", choices=DRILL_MODES)
+    verify_all.add_argument("--evidence-mode")
+    verify_all.add_argument("--fixture-only", action="store_true")
+    verify_all.add_argument("--max-age-days", type=int, default=DEFAULT_MAX_AGE_DAYS)
+    verify_all.add_argument("--now")
 
     advisory = subparsers.add_parser("advisory", help="Create advisory templates.")
     advisory_sub = advisory.add_subparsers(dest="advisory_command", required=True)
@@ -631,12 +1986,55 @@ def main(argv: list[str] | None = None) -> int:
             result = verify_runbook(args.runbook, args.model, args.template)
             print(json.dumps(result, indent=2, sort_keys=True))
             return 0 if result["status"] == "pass" else 1
+        if args.command == "self-test":
+            result = self_test()
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 0 if result["status"] == "pass" else 1
         if args.command == "drill" and args.drill_command == "create":
-            drill_create(args.model, args.scenario, args.out)
+            drill_create(
+                args.model,
+                args.scenario,
+                args.out,
+                release_id=args.release_id,
+                generated_at=args.generated_at,
+                mode=args.mode,
+                evidence_mode=args.evidence_mode,
+                fixture_only=args.fixture_only,
+            )
             print(f"created {args.out}")
             return 0
         if args.command == "drill" and args.drill_command == "verify":
-            result = drill_verify(args.input)
+            result = drill_verify(args.input, args.model)
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 0 if result["status"] == "pass" else 1
+        if args.command == "drill" and args.drill_command == "run-all":
+            result = drill_run_all(
+                args.model,
+                args.out_dir,
+                args.summary_out,
+                release_id=args.release_id,
+                generated_at=args.generated_at,
+                mode=args.mode,
+                evidence_mode=args.evidence_mode,
+                fixture_only=args.fixture_only,
+                max_age_days=args.max_age_days,
+                release_notes_out=args.release_notes_out,
+            )
+            print(json.dumps(result, indent=2, sort_keys=True))
+            return 0 if result["status"] == "pass" else 1
+        if args.command == "drill" and args.drill_command == "verify-all":
+            result = drill_verify_all(
+                args.input_dir,
+                args.summary_out,
+                model_path=args.model,
+                release_id=args.release_id,
+                generated_at=args.generated_at,
+                mode=args.mode,
+                evidence_mode=args.evidence_mode,
+                fixture_only=args.fixture_only,
+                max_age_days=args.max_age_days,
+                now_text=args.now,
+            )
             print(json.dumps(result, indent=2, sort_keys=True))
             return 0 if result["status"] == "pass" else 1
         if args.command == "advisory" and args.advisory_command == "template":

--- a/tools/release-certification/security_response_runbook.py
+++ b/tools/release-certification/security_response_runbook.py
@@ -11,7 +11,7 @@ import re
 import sys
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 
 TOOL_NAME = "security-response-runbook"
@@ -992,6 +992,143 @@ def artifact_is_stale(
     if age > dt.timedelta(days=max_age_days):
         return True, age_days, f"generatedAt is older than {max_age_days} days"
     return False, age_days, ""
+
+
+def validate_drill_artifact_files(
+    summary: dict[str, Any],
+    summary_path: Path,
+    model_path: Path = DEFAULT_MODEL,
+    strict: bool = False,
+    now: dt.datetime | None = None,
+    display_path_fn: Callable[[Path], str] | None = None,
+) -> dict[str, Any]:
+    artifacts = summary.get("artifacts")
+    if not isinstance(artifacts, list):
+        return {
+            "status": "fail",
+            "errors": ["security drills summary artifacts must be an array"],
+            "redactionFindings": [],
+            "checked": [],
+        }
+    source_dir = summary_path.parent
+    expected_release_id = summary.get("releaseId")
+    expected_mode = summary.get("mode")
+    expected_evidence_mode = summary.get("evidenceMode")
+    evaluated_at = now or dt.datetime.now(dt.timezone.utc)
+    evaluated_at = evaluated_at.astimezone(dt.timezone.utc)
+    max_age_days_value = summary.get("maxAgeDays")
+    max_age_days = DEFAULT_MAX_AGE_DAYS
+    if non_bool_int(max_age_days_value) and int(max_age_days_value) > 0:
+        max_age_days = (
+            min(int(max_age_days_value), DEFAULT_MAX_AGE_DAYS)
+            if strict
+            else int(max_age_days_value)
+        )
+    errors: list[str] = []
+    redaction_findings: list[Any] = []
+    seen: set[str] = set()
+    checked: list[dict[str, Any]] = []
+    for index, entry in enumerate(artifacts):
+        if not isinstance(entry, dict):
+            errors.append(f"security drill artifact entry {index} must be an object")
+            continue
+        scenario = entry.get("scenario")
+        if scenario not in REQUIRED_DRILLS:
+            errors.append(f"security drill artifact entry {index} has an unknown scenario")
+            continue
+        scenario_text = str(scenario)
+        if scenario_text in seen:
+            errors.append(f"security drill artifact for {scenario_text} is duplicated")
+            continue
+        seen.add(scenario_text)
+        artifact_name = entry.get("artifact")
+        expected_name = DRILL_OUTPUT_FILENAMES[scenario_text]
+        if artifact_name != expected_name:
+            errors.append(f"security drill artifact for {scenario_text} must be named {expected_name}")
+            continue
+        if Path(str(artifact_name)).name != artifact_name:
+            errors.append(f"security drill artifact for {scenario_text} has an unsafe file name")
+            continue
+        artifact_path = source_dir / str(artifact_name)
+        display_artifact = (
+            display_path_fn(artifact_path) if display_path_fn is not None else str(artifact_path.name)
+        )
+        if not artifact_path.is_file() or artifact_path.is_symlink():
+            errors.append(f"security drill artifact for {scenario_text} is missing")
+            checked.append(
+                {
+                    "scenario": scenario_text,
+                    "artifact": str(artifact_name),
+                    "path": display_artifact,
+                    "status": "missing",
+                }
+            )
+            continue
+        try:
+            digest = sha256_path(artifact_path)
+            verification = drill_verify(artifact_path, model_path)
+            artifact = load_model(artifact_path)
+        except (OSError, ValueError, json.JSONDecodeError):
+            errors.append(f"security drill artifact for {scenario_text} could not be verified")
+            checked.append(
+                {
+                    "scenario": scenario_text,
+                    "artifact": str(artifact_name),
+                    "path": display_artifact,
+                    "status": "fail",
+                }
+            )
+            continue
+        artifact_status = "pass"
+        stale = False
+        age_days: int | None = None
+        stale_reason = ""
+        if entry.get("digest") != digest:
+            errors.append(f"security drill artifact digest mismatch for {scenario_text}")
+            artifact_status = "fail"
+        if verification.get("status") != "pass":
+            errors.append(f"security drill artifact for {scenario_text} failed offline verification")
+            artifact_status = "fail"
+        verifier_findings = verification.get("redactionFindings")
+        if isinstance(verifier_findings, list):
+            redaction_findings.extend(verifier_findings)
+        if artifact.get("scenario") != scenario_text:
+            errors.append(f"security drill artifact for {scenario_text} has the wrong scenario")
+            artifact_status = "fail"
+        if artifact.get("releaseId") != expected_release_id:
+            errors.append(f"security drill artifact for {scenario_text} has the wrong releaseId")
+            artifact_status = "fail"
+        if artifact.get("mode") != expected_mode:
+            errors.append(f"security drill artifact for {scenario_text} has the wrong mode")
+            artifact_status = "fail"
+        if artifact.get("evidenceMode") != expected_evidence_mode:
+            errors.append(f"security drill artifact for {scenario_text} has the wrong evidenceMode")
+            artifact_status = "fail"
+        if strict:
+            stale, age_days, stale_reason = artifact_is_stale(artifact, evaluated_at, max_age_days)
+            if stale:
+                errors.append(f"security drill artifact for {scenario_text} is stale: {stale_reason}")
+                artifact_status = "fail"
+        checked.append(
+            {
+                "scenario": scenario_text,
+                "artifact": str(artifact_name),
+                "path": display_artifact,
+                "digest": digest,
+                "status": artifact_status,
+                "ageDays": age_days,
+                "stale": stale,
+                "staleReason": stale_reason,
+            }
+        )
+    for scenario in sorted(set(REQUIRED_DRILLS) - seen):
+        errors.append(f"security drill artifact for {scenario} is missing")
+    return {
+        "status": "pass" if not errors else "fail",
+        "errors": errors,
+        "redactionFindings": safe_redaction_findings(redaction_findings),
+        "checked": checked,
+    }
 
 
 def release_notes_draft(artifacts: list[dict[str, Any]]) -> str:

--- a/tools/release-certification/security_response_runbook.py
+++ b/tools/release-certification/security_response_runbook.py
@@ -743,6 +743,8 @@ def validate_drill_steps(
             continue
         if steps[index].get("evidenceIds") != expected_step.get("evidenceIds"):
             errors.append(f"steps[{index}].evidenceIds must match the runbook scenario")
+        if steps[index].get("safeSummary") != expected_step.get("safeSummary"):
+            errors.append(f"steps[{index}].safeSummary must match the runbook scenario")
     return errors
 
 
@@ -892,18 +894,30 @@ def validate_v2_drill_artifact(value: dict[str, Any], model_path: Path = DEFAULT
     else:
         if release_notes.get("templateStatus") != "pass":
             errors.append("releaseNotes.templateStatus must be pass")
+        if drill is not None and release_notes.get("template") != drill.get("releaseNotesTemplate"):
+            errors.append("releaseNotes.template must match the runbook scenario")
         snippet = release_notes.get("redactedSnippet")
         if not isinstance(snippet, str) or not snippet.strip():
             errors.append("releaseNotes.redactedSnippet must be a non-empty string")
+        elif drill is not None and isinstance(scenario, str) and snippet != release_notes_snippet(scenario, drill):
+            errors.append("releaseNotes.redactedSnippet must match the runbook scenario")
     advisory_template = value.get("advisoryTemplate")
     if not isinstance(advisory_template, dict):
         errors.append("advisoryTemplate must be an object")
     else:
         if advisory_template.get("templateStatus") != "pass":
             errors.append("advisoryTemplate.templateStatus must be pass")
+        if (
+            drill is not None
+            and "template" in advisory_template
+            and advisory_template.get("template") != drill.get("releaseNotesTemplate")
+        ):
+            errors.append("advisoryTemplate.template must match the runbook scenario")
         snippet = advisory_template.get("redactedSnippet")
         if not isinstance(snippet, str) or not snippet.strip():
             errors.append("advisoryTemplate.redactedSnippet must be a non-empty string")
+        elif drill is not None and isinstance(scenario, str) and snippet != release_notes_snippet(scenario, drill):
+            errors.append("advisoryTemplate.redactedSnippet must match the runbook scenario")
     redaction = value.get("redaction")
     if not isinstance(redaction, dict):
         errors.append("redaction must be an object")
@@ -1527,6 +1541,38 @@ def self_test() -> dict[str, Any]:
         write_json(wrong_step_evidence_path, wrong_step_evidence_artifact)
         checks["rejectWrongDrillStepEvidence"] = (
             drill_verify(wrong_step_evidence_path)["status"] == "fail"
+        )
+        wrong_step_summary_artifact = clone_json(artifact)
+        wrong_step_summary_artifact["steps"][0]["safeSummary"] = "Reviewer key flow text was replaced."
+        wrong_step_summary_path = tmpdir / "reviewer-key-compromise-wrong-step-summary.json"
+        write_json(wrong_step_summary_path, wrong_step_summary_artifact)
+        checks["rejectWrongDrillStepSummary"] = (
+            drill_verify(wrong_step_summary_path)["status"] == "fail"
+        )
+        wrong_release_template_artifact = clone_json(artifact)
+        wrong_release_template_artifact["releaseNotes"]["template"] = "tampered release notes template"
+        wrong_release_template_path = tmpdir / "reviewer-key-compromise-wrong-release-template.json"
+        write_json(wrong_release_template_path, wrong_release_template_artifact)
+        checks["rejectWrongReleaseNotesTemplate"] = (
+            drill_verify(wrong_release_template_path)["status"] == "fail"
+        )
+        wrong_release_snippet_artifact = clone_json(artifact)
+        wrong_release_snippet_artifact["releaseNotes"]["redactedSnippet"] = (
+            "Scenario reviewer-key-compromise: tampered release-note evidence verified."
+        )
+        wrong_release_snippet_path = tmpdir / "reviewer-key-compromise-wrong-release-snippet.json"
+        write_json(wrong_release_snippet_path, wrong_release_snippet_artifact)
+        checks["rejectWrongReleaseNotesSnippet"] = (
+            drill_verify(wrong_release_snippet_path)["status"] == "fail"
+        )
+        wrong_advisory_snippet_artifact = clone_json(artifact)
+        wrong_advisory_snippet_artifact["advisoryTemplate"]["redactedSnippet"] = (
+            "Scenario reviewer-key-compromise: tampered advisory evidence verified."
+        )
+        wrong_advisory_snippet_path = tmpdir / "reviewer-key-compromise-wrong-advisory-snippet.json"
+        write_json(wrong_advisory_snippet_path, wrong_advisory_snippet_artifact)
+        checks["rejectWrongAdvisoryTemplateSnippet"] = (
+            drill_verify(wrong_advisory_snippet_path)["status"] == "fail"
         )
 
         summary = drill_run_all(


### PR DESCRIPTION
## Summary

- Add deterministic production security response drill artifacts, all-drill summary generation/verification, and redaction-safe release/advisory snippets for the seven required security scenarios.
- Wire the security-drills summary into release certification, production beta release orchestration, go/no-go dashboard gating, CI workflow inputs, and release-manager documentation.
- Add safe operator/Web Shell readiness summaries plus negative go/no-go fixtures for missing, stale, malformed, fixture-only, wrong-kind, failed, redaction-unsafe, expired-waiver, and underseverity-waiver drill evidence.
- Harden attached drill validation so tampered deterministic step summaries and release/advisory evidence text cannot satisfy the production security drill gate.

## Testing

- `./gradlew spotlessApply`
- `python3 tools/release-certification/security_response_runbook.py self-test`
- `python3 tools/release-certification/security_response_runbook.py verify`
- `python3 tools/release-certification/production_beta_go_no_go_dashboard.py --self-test`
- `python3 tools/release-certification/release_certification.py --self-test`
- `git diff --check`

## Notes

- Full Gradle test suite and live-node/production-signing runs were not run locally for this PR.
- Production beta signing, live network inputs, and protected production artifacts remain environment-dependent release-manager responsibilities.